### PR TITLE
fix: specify CommonJS namedExports for dist/components build

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -126,6 +126,11 @@ export const create: () => Config = () => ({
   preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-components/blob/master/LICENSE.md for details.\nv${version}`,
   extras: {
     scriptDataOpts: true
+  },
+  commonjs: {
+    namedExports: {
+      "@esri/calcite-components/dist/components": ["setAssetPath", "setPlatformOptions"]
+    }
   }
 });
 


### PR DESCRIPTION
**Related Issue:** #5077

## Summary

Fixes a module resolution error coming from CC. 
![image](https://user-images.githubusercontent.com/10986395/184991923-c1d81d10-c64e-4c0f-9a4f-7a905bc23679.png)

This will not fix the repro sample from the issue since it is using sveltekit with @arcgis/core which can't render on the server. The solution is to use dynamic imports, like in [this sample](https://github.com/benelan/arcgis-esm-samples/blob/main/jsapi-sveltekit-template/src/routes/index.svelte#L7). 

Putting aside the repro sample using the JSAPI, a different error will appear when using sveltekit with the `dist/components` build because it doesn't have any CJS files.
![image](https://user-images.githubusercontent.com/10986395/184991862-731a0aaa-7b6e-4608-b415-ff35fbdbdea7.png)

My understanding is that CommonJS files are only used by the [`hydrate`](https://stenciljs.com/docs/hydrate-app) build, but I'll need to do some additional investigation. [Here is an example](https://github.com/benelan/calcite-samples/blob/master/ssr-frameworks/next/server.js#L1) using `hydrate` to prerender the components in NextJS.
<!--

Please make sure the PR title and/or commit message adheres to the https://www.conventionalcommits.org/en/v1.0.0/ specification.

Note: If your PR only has one commit and it is NOT semantic, you will need to either

a. add another commit and wait for the check to update
b. proceed to squash merge, but make sure the commit message is the same as the title.

This is because of the way GitHub handles single-commit squash merges (see https://github.com/zeke/semantic-pull-requests/issues/17)

If this is component-related, please verify that:

- [ ] feature or fix has a corresponding test
- [ ] changes have been tested with demo page in Edge

---

If this is skipping an unstable test:

- include info about the test failure
- submit an unstable-test issue by [choosing](https://github.com/Esri/calcite-components/issues/new/choose) the unstable test template and filling it out

-->
