### PR TITLE
chore(linting): set up no-restricted-syntax rule to ensure all E2E test pages are created initially

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,6 +81,13 @@
       }
     ],
     "no-new-func": "error",
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.name='newE2EPage'][arguments.length>0]",
+        "message": "Calling newE2EPage with arguments is not allowed. Use setContent to pass the test page content"
+      }
+    ],
     "no-unneeded-ternary": "error",
     "react/forbid-component-props": [
       "warn",

--- a/src/components/accordion/accordion.e2e.ts
+++ b/src/components/accordion/accordion.e2e.ts
@@ -26,10 +26,7 @@ describe("calcite-accordion", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion>
-    ${accordionContent}
-    </calcite-accordion>`);
+    await page.setContent(html` <calcite-accordion> ${accordionContent} </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     expect(element).toEqualAttribute("appearance", "solid");
     expect(element).toEqualAttribute("icon-position", "end");
@@ -40,9 +37,14 @@ describe("calcite-accordion", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion appearance="solid" icon-position="start" scale="l" selection-mode="single-persist" icon-type="caret">
-    ${accordionContent}
+    await page.setContent(html` <calcite-accordion
+      appearance="solid"
+      icon-position="start"
+      scale="l"
+      selection-mode="single-persist"
+      icon-type="caret"
+    >
+      ${accordionContent}
     </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     expect(element).toEqualAttribute("appearance", "solid");
@@ -54,14 +56,22 @@ describe("calcite-accordion", () => {
 
   it("renders icon if requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion appearance="solid" icon-position="start"  scale="l" selection-mode="single-persist" icon-type="caret">
-    <calcite-accordion-item heading="Accordion Title 1" icon-start="car" id="1">Accordion Item Content
-    </calcite-accordion-item>
-    <calcite-accordion-item heading="Accordion Title 1" id="2" expanded>Accordion Item Content
-    </calcite-accordion-item>
-    <calcite-accordion-item heading="Accordion Title 3" icon-start="car" id="3">Accordion Item Content
-    </calcite-accordion-item>
+    await page.setContent(html` <calcite-accordion
+      appearance="solid"
+      icon-position="start"
+      scale="l"
+      selection-mode="single-persist"
+      icon-type="caret"
+    >
+      <calcite-accordion-item heading="Accordion Title 1" icon-start="car" id="1"
+        >Accordion Item Content
+      </calcite-accordion-item>
+      <calcite-accordion-item heading="Accordion Title 1" id="2" expanded
+        >Accordion Item Content
+      </calcite-accordion-item>
+      <calcite-accordion-item heading="Accordion Title 3" icon-start="car" id="3"
+        >Accordion Item Content
+      </calcite-accordion-item>
     </calcite-accordion>`);
     const icon1 = await page.find(`calcite-accordion-item[id='1'] >>> .${CSS.iconStart}`);
     const icon2 = await page.find(`calcite-accordion-item[id='2'] >>> .${CSS.iconStart}`);
@@ -73,10 +83,7 @@ describe("calcite-accordion", () => {
 
   it("renders expanded item based on attribute in dom", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion>
-    ${accordionContent}
-    </calcite-accordion>`);
+    await page.setContent(html` <calcite-accordion> ${accordionContent} </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     const [item1, item2, item3] = await element.findAll("calcite-accordion-item");
     const [item1Content, item2Content, item3Content] = await element.findAll(
@@ -96,10 +103,7 @@ describe("calcite-accordion", () => {
 
   it("renders multiple expanded items when in multiple selection mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion>
-    ${accordionContent}
-    </calcite-accordion>`);
+    await page.setContent(html` <calcite-accordion> ${accordionContent} </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     expect(element).toEqualAttribute("selection-mode", "multiple");
     const [item1, item2, item3] = await element.findAll("calcite-accordion-item");
@@ -121,10 +125,7 @@ describe("calcite-accordion", () => {
 
   it("renders just one expanded item when in single selection mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion selection-mode="single">
-    ${accordionContent}
-    </calcite-accordion>`);
+    await page.setContent(html` <calcite-accordion selection-mode="single"> ${accordionContent} </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     expect(element).toEqualAttribute("selection-mode", "single");
     const [item1, item2, item3] = await element.findAll("calcite-accordion-item");
@@ -146,10 +147,11 @@ describe("calcite-accordion", () => {
   });
 
   it("clicking on an accordion with selection-mode=single does not toggle unrelated accordions with the same selection mode", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-accordion selection-mode="single" id="first"> ${accordionContent} </calcite-accordion>
-        <calcite-accordion selection-mode="single" id="second"> ${accordionContent} </calcite-accordion>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-accordion selection-mode="single" id="first">
+        ${accordionContent}
+      </calcite-accordion>
+      <calcite-accordion selection-mode="single" id="second"> ${accordionContent} </calcite-accordion>`);
     await page.waitForChanges();
 
     const firstAccordion = await page.find("calcite-accordion[id='first']");
@@ -169,9 +171,8 @@ describe("calcite-accordion", () => {
 
   it("prevents closing the last expanded item when in single-persist selection mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion selection-mode="single-persist">
-    ${accordionContent}
+    await page.setContent(html` <calcite-accordion selection-mode="single-persist">
+      ${accordionContent}
     </calcite-accordion>`);
 
     const element = await page.find("calcite-accordion");
@@ -195,10 +196,7 @@ describe("calcite-accordion", () => {
 
   it("renders multiple expanded items when selection mode changes from single to multiple", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-accordion selection-mode="single">
-    ${accordionContent}
-    </calcite-accordion>`);
+    await page.setContent(html` <calcite-accordion selection-mode="single"> ${accordionContent} </calcite-accordion>`);
     const element = await page.find("calcite-accordion");
     expect(element).toEqualAttribute("selection-mode", "single");
     element.setAttribute("selection-mode", "multiple");

--- a/src/components/action-bar/action-bar.e2e.ts
+++ b/src/components/action-bar/action-bar.e2e.ts
@@ -45,18 +45,17 @@ describe("calcite-action-bar", () => {
 
   describe("expand functionality", () => {
     it("should not modify actions within an action-menu", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-bar expanded>
-          <calcite-action-group>
-            <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
-          </calcite-action-group>
-          <calcite-action-group>
-            <calcite-action-menu label="Save and open">
-              <calcite-action id="menu-action" text-enabled text="Save" label="Save" icon="save"></calcite-action>
-            </calcite-action-menu>
-          </calcite-action-group>
-        </calcite-action-bar>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-bar expanded>
+        <calcite-action-group>
+          <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+        </calcite-action-group>
+        <calcite-action-group>
+          <calcite-action-menu label="Save and open">
+            <calcite-action id="menu-action" text-enabled text="Save" label="Save" icon="save"></calcite-action>
+          </calcite-action-menu>
+        </calcite-action-group>
+      </calcite-action-bar>`);
       await page.waitForChanges();
       const actionBar = await page.find("calcite-action-bar");
       const actionBarAction = await page.find("#my-action");
@@ -72,10 +71,7 @@ describe("calcite-action-bar", () => {
 
     it("should be expandable by default", async () => {
       const page = await newE2EPage();
-
       await page.setContent("<calcite-action-bar></calcite-action-bar>");
-
-      await page.waitForChanges();
 
       const expandAction = await page.find("calcite-action-bar >>> calcite-action");
 
@@ -84,10 +80,7 @@ describe("calcite-action-bar", () => {
 
     it("allows disabling expandable behavior", async () => {
       const page = await newE2EPage();
-
       await page.setContent("<calcite-action-bar expand-disabled></calcite-action-bar>");
-
-      await page.waitForChanges();
 
       const expandAction = await page.find("calcite-action-bar >>> calcite-action");
 
@@ -95,7 +88,8 @@ describe("calcite-action-bar", () => {
     });
 
     it("should toggle expanded", async () => {
-      const page = await newE2EPage({ html: "<calcite-action-bar></calcite-action-bar>" });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-action-bar></calcite-action-bar>");
 
       const bar = await page.find("calcite-action-bar");
 
@@ -290,7 +284,8 @@ describe("calcite-action-bar", () => {
   });
 
   it("should honor scale of expand icon", async () => {
-    const page = await newE2EPage({ html: html`<calcite-action-bar scale="l"></calcite-action-bar>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-bar scale="l"></calcite-action-bar>`);
 
     const buttonGroup = await page.find(`calcite-action-bar >>> .${CSS.actionGroupBottom}`);
 
@@ -304,23 +299,22 @@ describe("calcite-action-bar", () => {
 
   describe("overflow actions", () => {
     it("should slot 'menu-actions' on sublist changes", async () => {
-      const page = await newE2EPage({
-        html: html`<div style="width:500px; height:500px;">
-          <calcite-action-bar style="height: 290px">
-            <calcite-action-group id="dynamic-group"
-              ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
-              <calcite-action id="second-action" text="Styles" icon="shapes"></calcite-action
-            ></calcite-action-group>
-            <calcite-action-group>
-              <calcite-action text="Save" icon="save" disabled></calcite-action>
-              <calcite-action icon="layers" text="Layers"></calcite-action>
-            </calcite-action-group>
-            <calcite-action-group slot="bottom-actions">
-              <calcite-action text="Tips" icon="lightbulb"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div style="width:500px; height:500px;">
+        <calcite-action-bar style="height: 290px">
+          <calcite-action-group id="dynamic-group"
+            ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
+            <calcite-action id="second-action" text="Styles" icon="shapes"></calcite-action
+          ></calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Save" icon="save" disabled></calcite-action>
+            <calcite-action icon="layers" text="Layers"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group slot="bottom-actions">
+            <calcite-action text="Tips" icon="lightbulb"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>`);
       await page.waitForTimeout(overflowActionsDebounceInMs);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(2);
@@ -346,29 +340,28 @@ describe("calcite-action-bar", () => {
     });
 
     it.skip("should slot 'menu-actions' on resize of component", async () => {
-      const page = await newE2EPage({
-        html: html`<div style="width:500px; height:500px;">
-          <calcite-action-bar style="height: 290px">
-            <calcite-action-group id="dynamic-group"
-              ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
-              <calcite-action text="Styles" icon="shapes"></calcite-action>
-              <calcite-action text="Styles" icon="shapes"></calcite-action>
-              <calcite-action text="Filter" icon="layer-filter"></calcite-action>
-              <calcite-action text="Configure pop-ups" icon="popup"></calcite-action>
-              <calcite-action text="Configure attributes" icon="feature-details"></calcite-action>
-              <calcite-action text="Labels" icon="label" active></calcite-action>
-              <calcite-action text="Table" icon="table"></calcite-action
-            ></calcite-action-group>
-            <calcite-action-group>
-              <calcite-action text="Save" icon="save" disabled></calcite-action>
-              <calcite-action icon="layers" text="Layers"></calcite-action>
-            </calcite-action-group>
-            <calcite-action-group slot="bottom-actions">
-              <calcite-action text="Tips" icon="lightbulb"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div style="width:500px; height:500px;">
+        <calcite-action-bar style="height: 290px">
+          <calcite-action-group id="dynamic-group"
+            ><calcite-action text="Layer properties" icon="sliders-horizontal"></calcite-action>
+            <calcite-action text="Styles" icon="shapes"></calcite-action>
+            <calcite-action text="Styles" icon="shapes"></calcite-action>
+            <calcite-action text="Filter" icon="layer-filter"></calcite-action>
+            <calcite-action text="Configure pop-ups" icon="popup"></calcite-action>
+            <calcite-action text="Configure attributes" icon="feature-details"></calcite-action>
+            <calcite-action text="Labels" icon="label" active></calcite-action>
+            <calcite-action text="Table" icon="table"></calcite-action
+          ></calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Save" icon="save" disabled></calcite-action>
+            <calcite-action icon="layers" text="Layers"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group slot="bottom-actions">
+            <calcite-action text="Tips" icon="lightbulb"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>`);
       await page.waitForTimeout(overflowActionsDebounceInMs + 10);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);

--- a/src/components/action-group/action-group.e2e.ts
+++ b/src/components/action-group/action-group.e2e.ts
@@ -31,7 +31,8 @@ describe("calcite-action-group", () => {
   it("has slots", () => slots("calcite-action-group", SLOTS));
 
   it("should honor scale of expand icon", async () => {
-    const page = await newE2EPage({ html: actionGroupHTML });
+    const page = await newE2EPage();
+    await page.setContent(actionGroupHTML);
     const menu = await page.find(`calcite-action-group >>> calcite-action-menu`);
     expect(await menu.getProperty("scale")).toBe("l");
   });

--- a/src/components/action-menu/action-menu.e2e.ts
+++ b/src/components/action-menu/action-menu.e2e.ts
@@ -1,8 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { html } from "../../../support/formatting";
 import { accessible, defaults, focusable, hidden, reflects, renders, slots } from "../../tests/commonTests";
 import { TOOLTIP_DELAY_MS } from "../tooltip/resources";
 import { CSS, SLOTS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-action-menu", () => {
   describe("renders", () => {
@@ -75,11 +75,10 @@ describe("calcite-action-menu", () => {
     ]));
 
   it("should emit 'calciteActionMenuOpen' event", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-menu>
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-menu>
       <calcite-action text="Add" icon="plus"></calcite-action>
-    </calcite-action-menu>`
-    });
+    </calcite-action-menu>`);
 
     await page.waitForChanges();
 
@@ -109,16 +108,15 @@ describe("calcite-action-menu", () => {
     ));
 
   it("should close menu if clicked outside", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-menu open>
-          <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
-        </calcite-action-menu>
-        <div>
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-menu open>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+      </calcite-action-menu>
+      <div>
         <button id="outside">outside</button>
-        </div>`
-    });
+      </div>`);
 
     await page.waitForChanges();
 
@@ -136,16 +134,15 @@ describe("calcite-action-menu", () => {
   });
 
   it("should close menu if slotted action is clicked", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-menu open>
-          <calcite-action id="triggerAction" slot="${SLOTS.trigger}" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="slottedAction" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
-        </calcite-action-menu>
-        <div>
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-menu open>
+        <calcite-action id="triggerAction" slot="${SLOTS.trigger}" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="slottedAction" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action text="Add" icon="plus" text-enabled></calcite-action>
+      </calcite-action-menu>
+      <div>
         <button id="outside">outside</button>
-        </div>`
-    });
+      </div>`);
 
     await page.waitForChanges();
 
@@ -166,7 +163,8 @@ describe("calcite-action-menu", () => {
   });
 
   it("should honor scale of expand icon", async () => {
-    const page = await newE2EPage({ html: `<calcite-action-menu scale="l"></calcite-action-menu>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-menu scale="l"></calcite-action-menu>`);
 
     const trigger = await page.find(`calcite-action-menu >>> .${CSS.defaultTrigger}`);
 
@@ -174,15 +172,14 @@ describe("calcite-action-menu", () => {
   });
 
   it("should close tooltip when open", async () => {
-    const page = await newE2EPage({
-      html: `
-    <calcite-action-menu label="test">
-    <calcite-action id="trigger" slot="${SLOTS.trigger}" text="Add" icon="plus"></calcite-action>
-      <calcite-tooltip slot="${SLOTS.tooltip}">Bits and bobs.</calcite-tooltip>
-      <calcite-action text="Add" icon="plus"></calcite-action>
-    </calcite-action-menu>
-    `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-action-menu label="test">
+        <calcite-action id="trigger" slot="${SLOTS.trigger}" text="Add" icon="plus"></calcite-action>
+        <calcite-tooltip slot="${SLOTS.tooltip}">Bits and bobs.</calcite-tooltip>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+      </calcite-action-menu>
+    `);
 
     const actionMenu = await page.find("calcite-action-menu");
     const tooltip = await page.find("calcite-tooltip");
@@ -203,13 +200,12 @@ describe("calcite-action-menu", () => {
 
   describe("Keyboard navigation", () => {
     it("should handle ArrowDown navigation", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-menu>
-          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
-          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
-        </calcite-action-menu> `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-menu>
+        <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+        <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+      </calcite-action-menu>`);
 
       await page.waitForChanges();
 
@@ -239,13 +235,12 @@ describe("calcite-action-menu", () => {
     });
 
     it("should handle ArrowUp navigation", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-menu>
-          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
-          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
-        </calcite-action-menu> `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-menu>
+        <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+        <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+      </calcite-action-menu>`);
 
       await page.waitForChanges();
 
@@ -275,13 +270,12 @@ describe("calcite-action-menu", () => {
     });
 
     it("should handle Enter, Home, End and ESC navigation", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-menu>
-          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
-          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
-        </calcite-action-menu> `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-menu>
+        <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+        <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+      </calcite-action-menu>`);
 
       await page.waitForChanges();
 
@@ -333,13 +327,12 @@ describe("calcite-action-menu", () => {
     });
 
     it("should handle TAB navigation", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-menu>
-          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
-          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
-        </calcite-action-menu> `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-menu>
+        <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+        <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+      </calcite-action-menu>`);
 
       await page.waitForChanges();
 
@@ -367,13 +360,12 @@ describe("calcite-action-menu", () => {
     });
 
     it("should click the active action and close the menu", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-action-menu>
-          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
-          <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
-          <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
-        </calcite-action-menu> `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-action-menu>
+        <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+        <calcite-action id="second" text="Add" icon="minus" text-enabled></calcite-action>
+        <calcite-action id="third" text="Add" icon="banana" text-enabled></calcite-action>
+      </calcite-action-menu>`);
 
       await page.waitForChanges();
 

--- a/src/components/action-pad/action-pad.e2e.ts
+++ b/src/components/action-pad/action-pad.e2e.ts
@@ -49,10 +49,7 @@ describe("calcite-action-pad", () => {
   describe("expand functionality", () => {
     it("should be expandable by default", async () => {
       const page = await newE2EPage();
-
       await page.setContent("<calcite-action-pad></calcite-action-pad>");
-
-      await page.waitForChanges();
 
       const expandAction = await page.find("calcite-action-pad >>> calcite-action");
 
@@ -61,10 +58,7 @@ describe("calcite-action-pad", () => {
 
     it("allows disabling expandable behavior", async () => {
       const page = await newE2EPage();
-
       await page.setContent("<calcite-action-pad expand-disabled></calcite-action-pad>");
-
-      await page.waitForChanges();
 
       const expandAction = await page.find("calcite-action-pad >>> calcite-action");
 
@@ -72,7 +66,8 @@ describe("calcite-action-pad", () => {
     });
 
     it("should toggle expanded", async () => {
-      const page = await newE2EPage({ html: "<calcite-action-pad></calcite-action-pad>" });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-action-pad></calcite-action-pad>");
 
       const pad = await page.find("calcite-action-pad");
 
@@ -138,7 +133,7 @@ describe("calcite-action-pad", () => {
   it("should not have bottomGroup when not expandable", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-action-pad expand-disabled></calcite-action-pad>`);
+    await page.setContent(html`<calcite-action-pad expand-disabled></calcite-action-pad>`);
 
     const buttonGroup = await page.find(`calcite-action-pad >>> .${CSS.actionGroupBottom}`);
 
@@ -203,25 +198,24 @@ describe("calcite-action-pad", () => {
   it("has slots", () => slots("calcite-action-pad", SLOTS));
 
   it("'calciteActionMenuOpen' event should set other 'calcite-action-group' - 'menuOpen' to false", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-action-pad>
-          <calcite-action-group>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
-            <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
-          </calcite-action-group>
-          <calcite-action-group menu-open>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus"></calcite-action>
-            <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
-            <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
-          </calcite-action-group>
-        </calcite-action-pad>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-pad>
+      <calcite-action-group>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
+        <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group menu-open>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
+        <calcite-action text="Add" icon="plus" slot="menu-actions"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-pad>`);
 
     const eventSpy = await page.spyOnEvent("calciteActionMenuOpen", "window");
 
@@ -246,7 +240,8 @@ describe("calcite-action-pad", () => {
   });
 
   it("should honor scale of expand icon", async () => {
-    const page = await newE2EPage({ html: `<calcite-action-pad scale="l"></calcite-action-pad>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-action-pad scale="l"></calcite-action-pad>`);
 
     const buttonGroup = await page.find(`calcite-action-pad >>> .${CSS.actionGroupBottom}`);
 

--- a/src/components/action/action.e2e.ts
+++ b/src/components/action/action.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, disabled, hidden, renders, slots, t9n, defaults } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-action", () => {
   it("has property defaults", async () =>
@@ -51,7 +52,7 @@ describe("calcite-action", () => {
 
   it("should have visible text when text is enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action text="hello world" text-enabled></calcite-action>`);
+    await page.setContent(html`<calcite-action text="hello world" text-enabled></calcite-action>`);
 
     const textContainer = await page.find(`calcite-action >>> .${CSS.textContainer}`);
     const isVisible = await textContainer.isVisible();
@@ -61,7 +62,7 @@ describe("calcite-action", () => {
 
   it("should not have visible text when text is not enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action text="hello world"></calcite-action>`);
+    await page.setContent(html`<calcite-action text="hello world"></calcite-action>`);
 
     const textContainer = await page.find(`calcite-action >>> .${CSS.textContainer}`);
     const isVisible = await textContainer.isVisible();
@@ -71,7 +72,7 @@ describe("calcite-action", () => {
 
   it("should have icon container with icon prop", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action icon="hamburger"></calcite-action>`);
+    await page.setContent(html`<calcite-action icon="hamburger"></calcite-action>`);
 
     const iconContainer = await page.find(`calcite-action >>> .${CSS.iconContainer}`);
     expect(iconContainer).not.toBeNull();
@@ -79,7 +80,9 @@ describe("calcite-action", () => {
 
   it("should have icon container with calcite-icon", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action><calcite-icon icon="hamburger" scale="s"></calcite-icon></calcite-action>`);
+    await page.setContent(
+      html`<calcite-action><calcite-icon icon="hamburger" scale="s"></calcite-icon></calcite-action>`
+    );
 
     const iconContainer = await page.find(`calcite-action >>> .${CSS.iconContainer}`);
     expect(iconContainer).not.toBeNull();
@@ -87,7 +90,7 @@ describe("calcite-action", () => {
 
   it("should have icon container with calcite-icon: after delay", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action></calcite-action>`);
+    await page.setContent(html`<calcite-action></calcite-action>`);
 
     const action = await page.find("calcite-action");
 
@@ -103,7 +106,7 @@ describe("calcite-action", () => {
 
   it("should have icon container with svg", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action><svg></svg></calcite-action>`);
+    await page.setContent(html`<calcite-action><svg></svg></calcite-action>`);
 
     const iconContainer = await page.find(`calcite-action >>> .${CSS.iconContainer}`);
     expect(iconContainer).not.toBeNull();
@@ -111,7 +114,7 @@ describe("calcite-action", () => {
 
   it("should not have icon container if no icon present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action></calcite-action>`);
+    await page.setContent(html`<calcite-action></calcite-action>`);
 
     const iconContainer = await page.find(`calcite-action >>> .${CSS.iconContainer}`);
     expect(iconContainer).toBeNull();
@@ -119,7 +122,7 @@ describe("calcite-action", () => {
 
   it("should have icon container if loading", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action loading></calcite-action>`);
+    await page.setContent(html`<calcite-action loading></calcite-action>`);
 
     const iconContainer = await page.find(`calcite-action >>> .${CSS.iconContainer}`);
     expect(iconContainer).not.toBeNull();
@@ -127,7 +130,7 @@ describe("calcite-action", () => {
 
   it("should use text prop for a11y attributes when text is not enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action text="hello world"></calcite-action>`);
+    await page.setContent(html`<calcite-action text="hello world"></calcite-action>`);
 
     const button = await page.find(`calcite-action >>> .${CSS.button}`);
     expect(button.getAttribute("aria-label")).toBe("hello world");
@@ -135,7 +138,7 @@ describe("calcite-action", () => {
 
   it("should set aria-label with indicator", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action indicator text="hello world"></calcite-action>`);
+    await page.setContent(html`<calcite-action indicator text="hello world"></calcite-action>`);
 
     const button = await page.find(`calcite-action >>> .${CSS.button}`);
     expect(button.getAttribute("aria-label")).toBe(`hello world (Indicator present)`);
@@ -143,7 +146,7 @@ describe("calcite-action", () => {
 
   it("should have label", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action text="hello world" label="hi"></calcite-action>`);
+    await page.setContent(html`<calcite-action text="hello world" label="hi"></calcite-action>`);
 
     const button = await page.find(`calcite-action >>> .${CSS.button}`);
     expect(button.getAttribute("aria-label")).toBe("hi");
@@ -151,7 +154,7 @@ describe("calcite-action", () => {
 
   it("should have appearance=solid", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action text="hello world"></calcite-action>`);
+    await page.setContent(html`<calcite-action text="hello world"></calcite-action>`);
 
     const action = await page.find("calcite-action");
     expect(action.getAttribute("appearance")).toBe("solid");
@@ -179,8 +182,7 @@ describe("calcite-action", () => {
 
   it("should have a indicator live region", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-action></calcite-action>`);
-    await page.waitForChanges();
+    await page.setContent(html`<calcite-action></calcite-action>`);
 
     const action = await page.find("calcite-action");
     const liveRegion = await page.find(`calcite-action >>> .${CSS.indicatorText}`);

--- a/src/components/alert/alert.e2e.ts
+++ b/src/components/alert/alert.e2e.ts
@@ -29,10 +29,7 @@ describe("calcite-alert", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert>
-    ${alertContent}
-    </calcite-alert>`);
+    await page.setContent(html` <calcite-alert> ${alertContent} </calcite-alert>`);
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
     const icon = await page.find("calcite-alert >>> .alert-icon");
@@ -43,9 +40,8 @@ describe("calcite-alert", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert kind="warning" auto-close-duration="fast" auto-close>
-    ${alertContent}
+    await page.setContent(html` <calcite-alert kind="warning" auto-close-duration="fast" auto-close>
+      ${alertContent}
     </calcite-alert>`);
 
     const element = await page.find("calcite-alert");
@@ -58,10 +54,7 @@ describe("calcite-alert", () => {
 
   it("renders with an icon", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert icon>
-    ${alertContent}
-    </calcite-alert>`);
+    await page.setContent(html` <calcite-alert icon> ${alertContent} </calcite-alert>`);
 
     const element = await page.find("calcite-alert");
     const close = await page.find("calcite-alert >>> .alert-close");
@@ -103,12 +96,11 @@ describe("calcite-alert", () => {
 
   it("opens and then closes a single alert", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <div>
-    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('open', '')">open alert-1</calcite-button>
-    <calcite-alert id="alert-1">
-    ${alertContent}
-    </calcite-alert>
+    await page.setContent(html` <div>
+      <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('open', '')"
+        >open alert-1</calcite-button
+      >
+      <calcite-alert id="alert-1"> ${alertContent} </calcite-alert>
     </div>`);
 
     const alert1 = await page.find("#alert-1");
@@ -128,20 +120,19 @@ describe("calcite-alert", () => {
 
   it("opens the correct alert when multiple have been opened at once", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <div>
-    <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('open', '')">open alert-1</calcite-button>
-    <calcite-button id="button-2" onclick="document.querySelector('#alert-2').setAttribute('open', '')">open alert-2</calcite-button>
-    <calcite-button id="button-3" onclick="document.querySelector('#alert-3').setAttribute('open', '')">open alert-3</calcite-button>
-    <calcite-alert id="alert-1">
-    ${alertContent}
-    </calcite-alert>
-    <calcite-alert id="alert-2">
-    ${alertContent}
-    </calcite-alert>
-    <calcite-alert id="alert-3">
-    ${alertContent}
-    </calcite-alert>
+    await page.setContent(html` <div>
+      <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('open', '')"
+        >open alert-1</calcite-button
+      >
+      <calcite-button id="button-2" onclick="document.querySelector('#alert-2').setAttribute('open', '')"
+        >open alert-2</calcite-button
+      >
+      <calcite-button id="button-3" onclick="document.querySelector('#alert-3').setAttribute('open', '')"
+        >open alert-3</calcite-button
+      >
+      <calcite-alert id="alert-1"> ${alertContent} </calcite-alert>
+      <calcite-alert id="alert-2"> ${alertContent} </calcite-alert>
+      <calcite-alert id="alert-3"> ${alertContent} </calcite-alert>
     </div>`);
 
     const alert1 = await page.find("#alert-1");
@@ -171,10 +162,7 @@ describe("calcite-alert", () => {
 
   it("correctly assigns a default placement class", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert>
-    ${alertContent}
-    </calcite-alert>`);
+    await page.setContent(html` <calcite-alert> ${alertContent} </calcite-alert>`);
 
     const container = await page.find("calcite-alert >>> .container");
     expect(container).toHaveClass("bottom");
@@ -182,10 +170,7 @@ describe("calcite-alert", () => {
 
   it("correctly assigns a requested placement class", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-alert placement="top-end">
-    ${alertContent}
-    </calcite-alert>`);
+    await page.setContent(html` <calcite-alert placement="top-end"> ${alertContent} </calcite-alert>`);
 
     const container = await page.find("calcite-alert >>> .container");
     expect(container).not.toHaveClass("bottom");
@@ -220,7 +205,8 @@ describe("calcite-alert", () => {
     let progressBarStyles;
 
     it("should have defined CSS custom properties", async () => {
-      page = await newE2EPage({ html: alertSnippet });
+      page = await newE2EPage();
+      await page.setContent(alertSnippet);
       progressBarStyles = await page.evaluate(() => {
         const alert = document.querySelector("calcite-alert");
         alert.style.setProperty("--calcite-alert-dismiss-progress-background", "white");
@@ -231,7 +217,8 @@ describe("calcite-alert", () => {
 
     describe("when mode attribute is not provided", () => {
       it("should render alert dismiss progress bar with default value tied to light mode", async () => {
-        page = await newE2EPage({ html: alertSnippet });
+        page = await newE2EPage();
+        await page.setContent(alertSnippet);
         await page.waitForTimeout(animationDurationInMs);
         alertDismissProgressBar = await page.find("calcite-alert[open] >>> .alert-dismiss-progress");
         progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
@@ -241,9 +228,8 @@ describe("calcite-alert", () => {
 
     describe("when mode attribute is dark", () => {
       it("should render alert dismiss progress bar with value tied to dark mode", async () => {
-        page = await newE2EPage({
-          html: `<div class="calcite-mode-dark">${alertSnippet}</div>`
-        });
+        page = await newE2EPage();
+        await page.setContent(html`<div class="calcite-mode-dark">${alertSnippet}</div>`);
         await page.waitForTimeout(animationDurationInMs);
         alertDismissProgressBar = await page.find("calcite-alert[open] >>> .alert-dismiss-progress");
         progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
@@ -253,15 +239,13 @@ describe("calcite-alert", () => {
 
     it("should allow the CSS custom property to be overridden", async () => {
       const overrideStyle = "rgba(255, 0, 0, 0.5)";
-      page = await newE2EPage({
-        html: `
-        <style>
+      page = await newE2EPage();
+      await page.setContent(html` <style>
           :root {
             --calcite-alert-dismiss-progress-background: ${overrideStyle};
           }
         </style>
-        <div>${alertSnippet}</div>`
-      });
+        <div>${alertSnippet}</div>`);
       await page.waitForTimeout(animationDurationInMs);
       alertDismissProgressBar = await page.find("calcite-alert[open] >>> .alert-dismiss-progress");
       progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");

--- a/src/components/block-section/block-section.e2e.ts
+++ b/src/components/block-section/block-section.e2e.ts
@@ -50,23 +50,24 @@ describe("calcite-block-section", () => {
     });
 
     it("can display/hide content", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section toggle-display="switch"><div>some content</div></calcite-block-section>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block-section toggle-display="switch"><div>some content</div></calcite-block-section>`
+      );
       await assertContentIsDisplayedAndHidden(page);
     });
 
     it("can be toggled", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section toggle-display="switch"></calcite-block-section>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-block-section toggle-display="switch"></calcite-block-section>`);
       await assertToggleBehavior(page);
     });
 
     it("renders section text", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section text="test text" open toggle-display="switch"></calcite-block-section>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-block-section text="test text" open toggle-display="switch"></calcite-block-section>`
+      );
       const element = await page.find(`calcite-block-section >>> .${CSS.toggle}`);
       expect(element.textContent).toBe("test text");
     });
@@ -84,21 +85,22 @@ describe("calcite-block-section", () => {
     });
 
     it("can display/hide content", async () => {
-      const page = await newE2EPage({ html: "<calcite-block-section><div>some content</div></calcite-block-section>" });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-block-section><div>some content</div></calcite-block-section>");
       await assertContentIsDisplayedAndHidden(page);
     });
 
     it("can be toggled", async () => {
-      const page = await newE2EPage({ html: "<calcite-block-section></calcite-block-section>" });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-block-section></calcite-block-section>");
       await assertToggleBehavior(page);
     });
   });
 
   describe("status = 'invalid'", () => {
     it("displays a status indicator when `status` is an accepted value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section status="invalid"><div>content</div></calcite-block-section>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-block-section status="invalid"><div>content</div></calcite-block-section>`);
       const statusIconEl = await page.find(`calcite-block-section >>> .${CSS.statusIcon}`);
       expect(statusIconEl).not.toBeNull();
     });
@@ -106,9 +108,8 @@ describe("calcite-block-section", () => {
 
   describe("status = 'foo'", () => {
     it("does not display a status indicator when `status` is not an accepted value", async () => {
-      const page2 = await newE2EPage({
-        html: `<calcite-block-section status="foo"><div>content</div></calcite-block-section>`
-      });
+      const page2 = await newE2EPage();
+      await page2.setContent(html`<calcite-block-section status="foo"><div>content</div></calcite-block-section>`);
       const statusIconEl2 = await page2.find(`calcite-block-section >>> .${CSS.statusIcon}`);
       await page2.waitForChanges();
       expect(statusIconEl2).toBeNull();

--- a/src/components/block/block.e2e.ts
+++ b/src/components/block/block.e2e.ts
@@ -42,13 +42,12 @@ describe("calcite-block", () => {
     disabled(html`<calcite-block heading="heading" description="description" collapsible></calcite-block>`));
 
   it("has a loading state", async () => {
-    const page = await newE2EPage({
-      html: `
-        <calcite-block heading="heading" description="description" open collapsible>
-          <div class="content">content</div>
-        </calcite-block>
-    `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-block heading="heading" description="description" open collapsible>
+        <div class="content">content</div>
+      </calcite-block>
+    `);
 
     await page.waitForChanges();
 
@@ -95,7 +94,8 @@ describe("calcite-block", () => {
   });
 
   it("allows toggling its content", async () => {
-    const page = await newE2EPage({ html: "<calcite-block collapsible></calcite-block>" });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-block collapsible></calcite-block>");
 
     const element = await page.find("calcite-block");
     const toggleSpy = await element.spyOnEvent("calciteBlockToggle");
@@ -126,7 +126,7 @@ describe("calcite-block", () => {
     it("renders a heading", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-block heading="test-heading"></calcite-block>`);
+      await page.setContent(html`<calcite-block heading="test-heading"></calcite-block>`);
 
       const heading = await page.find(`calcite-block >>> .${CSS.heading}`);
       expect(heading).toBeTruthy();
@@ -139,7 +139,9 @@ describe("calcite-block", () => {
     it("renders a heading with optional description", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-block heading="test-heading" description="test-description"></calcite-block>`);
+      await page.setContent(
+        html`<calcite-block heading="test-heading" description="test-description"></calcite-block>`
+      );
 
       const heading = await page.find(`calcite-block >>> .${CSS.heading}`);
       expect(heading).toBeTruthy();
@@ -217,11 +219,10 @@ describe("calcite-block", () => {
     });
 
     it("allows users to slot in actions in a header menu", async () => {
-      const page = await newE2EPage({
-        html: html` <calcite-block heading="With header actions" description="has header actions">
-          <calcite-action label="Add" icon="plus" slot="header-menu-actions"></calcite-action>
-        </calcite-block>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-block heading="With header actions" description="has header actions">
+        <calcite-action label="Add" icon="plus" slot="header-menu-actions"></calcite-action>
+      </calcite-block>`);
 
       const menuSlot = await page.find(`calcite-block >>> calcite-action-menu slot[name=${SLOTS.headerMenuActions}]`);
       expect(menuSlot).toBeDefined();

--- a/src/components/button/button.e2e.ts
+++ b/src/components/button/button.e2e.ts
@@ -89,7 +89,7 @@ describe("calcite-button", () => {
 
   it("renders as a button with default props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button>Continue</calcite-button>`);
 
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
@@ -137,7 +137,8 @@ describe("calcite-button", () => {
   it("can be disabled", () => disabled("calcite-button"));
 
   it("should update childElType when href changes", async () => {
-    const page = await newE2EPage({ html: `<calcite-button>Continue</calcite-button>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-button>Continue</calcite-button>`);
     const link = await page.find("calcite-button");
     let elementAsLink: E2EElement;
     let elementAsSpan: E2EElement;
@@ -158,7 +159,7 @@ describe("calcite-button", () => {
 
   it("renders as a link with default props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button href="/">Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button href="/">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -250,7 +251,9 @@ describe("calcite-button", () => {
 
   it("passes attributes to rendered child button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button type="reset" name="myname" class="mycustomclass">Continue</calcite-button>`);
+    await page.setContent(
+      html`<calcite-button type="reset" name="myname" class="mycustomclass">Continue</calcite-button>`
+    );
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -269,7 +272,7 @@ describe("calcite-button", () => {
 
   it("renders with an icon-start", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button icon-start='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button icon-start="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -286,7 +289,7 @@ describe("calcite-button", () => {
 
   it("renders with an icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button icon-end='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button icon-end="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -303,7 +306,7 @@ describe("calcite-button", () => {
 
   it("renders with an icon-start and icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button icon-start='plus' icon-end='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button icon-start="plus" icon-end="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -320,7 +323,7 @@ describe("calcite-button", () => {
 
   it("renders hidden icon when both icon and loader are requested, no text", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button loading icon-start='plus'></calcite-button>`);
+    await page.setContent(html`<calcite-button loading icon-start="plus"></calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const iconStart = await page.find(`calcite-button >>> .${CSS.iconStart}`);
@@ -335,7 +338,7 @@ describe("calcite-button", () => {
 
   it("renders with a loader and an icon-start when both icon-start and loader are requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button loading icon-start='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button loading icon-start="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -352,7 +355,7 @@ describe("calcite-button", () => {
 
   it("renders with a loader and an icon-end when both icon-end and loader are requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button loading icon-end='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button loading icon-end="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -369,7 +372,7 @@ describe("calcite-button", () => {
 
   it("renders with a loader and an icon-start and icon-end when all are requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button loading icon-start='plus' icon-end='plus'>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button loading icon-start="plus" icon-end="plus">Continue</calcite-button>`);
     const element = await page.find("calcite-button");
     const elementAsButton = await page.find("calcite-button >>> button");
     const elementAsLink = await page.find("calcite-button >>> a");
@@ -395,28 +398,28 @@ describe("calcite-button", () => {
 
   it("hascontent class is present on rendered child when content (as text) is present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button>Continue</calcite-button>`);
+    await page.setContent(html`<calcite-button>Continue</calcite-button>`);
     const elementAsButton = await page.find("calcite-button >>> button");
     expect(elementAsButton).toHaveClass(CSS.contentSlotted);
   });
 
   it("hascontent class is present on rendered child when content (as element) is present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button><calcite-icon icon="banana" /></calcite-button>`);
+    await page.setContent(html`<calcite-button><calcite-icon icon="banana" /></calcite-button>`);
     const elementAsButton = await page.find("calcite-button >>> button");
     expect(elementAsButton).toHaveClass(CSS.contentSlotted);
   });
 
   it("hascontent class is present on rendered child when content (as text and element) is present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button>Banana <calcite-icon icon="banana" /></calcite-button>`);
+    await page.setContent(html`<calcite-button>Banana <calcite-icon icon="banana" /></calcite-button>`);
     const elementAsButton = await page.find("calcite-button >>> button");
     expect(elementAsButton).toHaveClass(CSS.contentSlotted);
   });
 
   it("hascontent class is not present on rendered child when content is not present", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-button icon-start='plus'></calcite-button>`);
+    await page.setContent(html`<calcite-button icon-start="plus"></calcite-button>`);
     const elementAsButton = await page.find("calcite-button >>> button");
     expect(elementAsButton).not.toHaveClass(CSS.contentSlotted);
   });
@@ -439,7 +442,8 @@ describe("calcite-button", () => {
     let buttonHoverStyle;
 
     it("should have defined CSS custom properties", async () => {
-      page = await newE2EPage({ html: buttonSnippet });
+      page = await newE2EPage();
+      await page.setContent(buttonSnippet);
       const buttonStyles = await page.evaluate(() => {
         buttonEl = document.querySelector("calcite-button");
         buttonEl.style.setProperty("--calcite-button-transparent-hover", "rgba(34, 23, 200, 0.4)");
@@ -455,7 +459,8 @@ describe("calcite-button", () => {
 
     describe("when mode attribute is not provided", () => {
       it("should render button pseudo classes with default values tied to light mode", async () => {
-        page = await newE2EPage({ html: buttonSnippet });
+        page = await newE2EPage();
+        await page.setContent(buttonSnippet);
         buttonEl = await page.find("calcite-button >>> button");
         await buttonEl.focus();
         await page.waitForChanges();
@@ -471,9 +476,8 @@ describe("calcite-button", () => {
 
     describe("when mode attribute is dark", () => {
       it("should render button pseudo classes with value tied to dark mode", async () => {
-        page = await newE2EPage({
-          html: `<div class="calcite-mode-dark">${buttonSnippet}</div>`
-        });
+        page = await newE2EPage();
+        await page.setContent(html`<div class="calcite-mode-dark">${buttonSnippet}</div>`);
         buttonEl = await page.find("calcite-button >>> button");
         await buttonEl.focus();
         await page.waitForChanges();
@@ -489,15 +493,13 @@ describe("calcite-button", () => {
 
     it("should allow the CSS custom property to be overridden", async () => {
       const overrideStyle = "rgba(255, 255, 0, 0.9)";
-      page = await newE2EPage({
-        html: `
-        <style>
+      page = await newE2EPage();
+      await page.setContent(html` <style>
           :root {
             --calcite-button-transparent-hover: ${overrideStyle};
           }
         </style>
-        <div>${buttonSnippet}</div>`
-      });
+        <div>${buttonSnippet}</div>`);
       buttonEl = await page.find("calcite-button >>> button");
       await buttonEl.focus();
       await page.waitForChanges();
@@ -514,10 +516,10 @@ describe("calcite-button", () => {
   describe("when loading changes", () => {
     it("should render loader with loading-in class when new value is true", async () => {
       const page = await newE2EPage();
-      await page.setContent(`
-        <calcite-button id="one-icon" icon-start='plus'></calcite-button>
-        <calcite-button id="two-icons" icon-start='arrow-right' icon-end='download'></calcite-button>
-        <calcite-button id="icons-and-text" icon-start='arrow-right' icon-end='download'>Go!</calcite-button>
+      await page.setContent(html`
+        <calcite-button id="one-icon" icon-start="plus"></calcite-button>
+        <calcite-button id="two-icons" icon-start="arrow-right" icon-end="download"></calcite-button>
+        <calcite-button id="icons-and-text" icon-start="arrow-right" icon-end="download">Go!</calcite-button>
       `);
       const button1 = await page.find("calcite-button[id='one-icon']");
       const button2 = await page.find("calcite-button[id='two-icons']");
@@ -536,10 +538,10 @@ describe("calcite-button", () => {
 
     it("should render loader with loading-out class when new value is false", async () => {
       const page = await newE2EPage();
-      await page.setContent(`
-        <calcite-button loading id="one-icon" icon-start='plus'></calcite-button>
-        <calcite-button loading id="two-icons" icon-start='arrow-right' icon-end='download'></calcite-button>
-        <calcite-button loading id="icons-and-text" icon-start='arrow-right' icon-end='download'>Go!</calcite-button>
+      await page.setContent(html`
+        <calcite-button loading id="one-icon" icon-start="plus"></calcite-button>
+        <calcite-button loading id="two-icons" icon-start="arrow-right" icon-end="download"></calcite-button>
+        <calcite-button loading id="icons-and-text" icon-start="arrow-right" icon-end="download">Go!</calcite-button>
       `);
       await page.waitForChanges();
       const button1 = await page.find("calcite-button[id='one-icon']");
@@ -559,7 +561,7 @@ describe("calcite-button", () => {
 
     it("should remove calcite-loader from dom when new value is false", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-button loading icon-start='plus'></calcite-button>`);
+      await page.setContent(html`<calcite-button loading icon-start="plus"></calcite-button>`);
       const animationDurationInMs = 300;
       const element = await page.find("calcite-button");
       await element.setProperty("loading", false);

--- a/src/components/card/card.e2e.ts
+++ b/src/components/card/card.e2e.ts
@@ -30,10 +30,9 @@ describe("calcite-card", () => {
 
   it("renders with default props if none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-card>
-        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
-      </calcite-card>`);
+    await page.setContent(html` <calcite-card>
+      <img slot="thumbnail" src="${placeholder}" alt="Test image" />
+    </calcite-card>`);
 
     const element = await page.find("calcite-card");
     expect(element).not.toHaveAttribute("disabled");
@@ -44,10 +43,9 @@ describe("calcite-card", () => {
 
   it("renders with requsted props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-card loading selectable selected disabled>
-        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
-      </calcite-card>`);
+    await page.setContent(html` <calcite-card loading selectable selected disabled>
+      <img slot="thumbnail" src="${placeholder}" alt="Test image" />
+    </calcite-card>`);
 
     const element = await page.find("calcite-card");
     expect(element).toHaveAttribute("disabled");
@@ -58,7 +56,7 @@ describe("calcite-card", () => {
 
   it("should have a thumbnail container", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-card>
         <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>
@@ -71,9 +69,9 @@ describe("calcite-card", () => {
 
   it("should render a checkbox if selectable", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-card selectable>
-      <img slot="thumbnail" src="${placeholder}" alt="Test image" />
+        <img slot="thumbnail" src="${placeholder}" alt="Test image" />
       </calcite-card>
     `);
 
@@ -85,15 +83,15 @@ describe("calcite-card", () => {
   describe("when a card is selectable", () => {
     it("should update the card's selected state when its checkbox is clicked", async () => {
       const page = await newE2EPage();
-      await page.setContent(`
-      <div style="width:260px">
-        <calcite-card selectable>
-          <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
-          <span slot="subtitle">
-            A great example of a study description that might wrap to a line or two, but isn't overly verbose.
-          </span>
-        </calcite-card>
-      </div>
+      await page.setContent(html`
+        <div style="width:260px">
+          <calcite-card selectable>
+            <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+            <span slot="subtitle">
+              A great example of a study description that might wrap to a line or two, but isn't overly verbose.
+            </span>
+          </calcite-card>
+        </div>
       `);
       const card = await page.find("calcite-card");
       const checkbox = await page.find(`calcite-card >>> .${CSS.checkboxWrapper} calcite-checkbox`);

--- a/src/components/checkbox/checkbox.e2e.ts
+++ b/src/components/checkbox/checkbox.e2e.ts
@@ -8,6 +8,7 @@ import {
   labelable,
   hidden
 } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-checkbox", () => {
   it("honors hidden attribute", async () => hidden("calcite-checkbox"));
@@ -67,7 +68,7 @@ describe("calcite-checkbox", () => {
 
   it("appropriately triggers the custom change event", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-checkbox></calcite-checkbox>`);
+    await page.setContent(html`<calcite-checkbox></calcite-checkbox>`);
 
     const calciteCheckbox = await page.find("calcite-checkbox");
 
@@ -108,7 +109,7 @@ describe("calcite-checkbox", () => {
 
   it("behaves as expected when wrapped in a calcite-label with inline layout mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-label layout="inline"><calcite-checkbox></calcite-checkbox>Label</calcite-label>
     `);
 
@@ -118,7 +119,7 @@ describe("calcite-checkbox", () => {
 
   it("behaves as expected when wrapped in a calcite-label with inline-space-between layout mode", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-label layout="inline-space-between"><calcite-checkbox></calcite-checkbox>Label</calcite-label>
     `);
 
@@ -128,7 +129,7 @@ describe("calcite-checkbox", () => {
 
   it("resets to initial value when form reset event is triggered", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <form>
         <calcite-checkbox id="unchecked"></calcite-checkbox>
         <calcite-checkbox id="checked" checked></calcite-checkbox>

--- a/src/components/chip/chip.e2e.ts
+++ b/src/components/chip/chip.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, disabled, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
@@ -21,7 +22,7 @@ describe("calcite-chip", () => {
 
   it("should not emit event after the chip is clicked if interactive if not set", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip id="chip-1" >cheetos</calcite-chip>`);
+    await page.setContent(html`<calcite-chip id="chip-1">cheetos</calcite-chip>`);
 
     const eventSpy = await page.spyOnEvent("calciteChipSelect", "window");
 
@@ -34,7 +35,7 @@ describe("calcite-chip", () => {
 
   it("should emit event after the chip button is clicked when interactive", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip id="chip-1" interactive>cheetos</calcite-chip>`);
+    await page.setContent(html`<calcite-chip id="chip-1" interactive>cheetos</calcite-chip>`);
 
     const eventSpy = await page.spyOnEvent("calciteChipSelect", "window");
 
@@ -47,7 +48,7 @@ describe("calcite-chip", () => {
 
   it("should emit event after the close button is clicked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip closable>cheetos</calcite-chip>`);
+    await page.setContent(html`<calcite-chip closable>cheetos</calcite-chip>`);
 
     const eventSpy = await page.spyOnEvent("calciteChipClose", "window");
 
@@ -60,7 +61,7 @@ describe("calcite-chip", () => {
 
   it("should receive focus when clicked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip id="chip-1">cheetos</calcite-chip>`);
+    await page.setContent(html`<calcite-chip id="chip-1">cheetos</calcite-chip>`);
 
     const chip1 = await page.find("#chip-1");
     await chip1.click();
@@ -70,7 +71,7 @@ describe("calcite-chip", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip>Chip content</calcite-chip>`);
+    await page.setContent(html`<calcite-chip>Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "solid");
@@ -80,7 +81,7 @@ describe("calcite-chip", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip appearance="outline" kind="brand" scale="l">Chip content</calcite-chip>`);
+    await page.setContent(html`<calcite-chip appearance="outline" kind="brand" scale="l">Chip content</calcite-chip>`);
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "outline");
@@ -90,7 +91,9 @@ describe("calcite-chip", () => {
 
   it("renders outline-fill chip when appearance='outline-fill'", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip appearance="outline-fill" kind="brand" scale="l">Chip content</calcite-chip>`);
+    await page.setContent(
+      html`<calcite-chip appearance="outline-fill" kind="brand" scale="l">Chip content</calcite-chip>`
+    );
 
     const element = await page.find("calcite-chip");
     expect(element).toEqualAttribute("appearance", "outline-fill");
@@ -100,7 +103,7 @@ describe("calcite-chip", () => {
 
   it("renders a close button when requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip closable>Chip content</calcite-chip>`);
+    await page.setContent(html`<calcite-chip closable>Chip content</calcite-chip>`);
 
     const close = await page.find("calcite-chip >>> button.close");
     expect(close).not.toBeNull();
@@ -108,7 +111,7 @@ describe("calcite-chip", () => {
 
   it("does not render a close button when not requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-chip>Chip content</calcite-chip>`);
+    await page.setContent(html`<calcite-chip>Chip content</calcite-chip>`);
 
     const close = await page.find("calcite-chip >>> button.close");
     expect(close).toBeNull();
@@ -132,7 +135,8 @@ describe("calcite-chip", () => {
     let chipCloseButtonHoverStyle;
 
     it("should have defined CSS custom properties", async () => {
-      page = await newE2EPage({ html: chipSnippet });
+      page = await newE2EPage();
+      await page.setContent(chipSnippet);
       const chipStyles = await page.evaluate(() => {
         const chip = document.querySelector("calcite-chip");
         chip.style.setProperty("--calcite-chip-transparent-hover", "rgba(3, 2, 20, 0.14)");
@@ -148,7 +152,8 @@ describe("calcite-chip", () => {
 
     describe("when mode attribute is not provided", () => {
       it("should render chip pseudo classes with default values tied to mode", async () => {
-        page = await newE2EPage({ html: chipSnippet });
+        page = await newE2EPage();
+        await page.setContent(chipSnippet);
         chipCloseButton = await page.find("calcite-chip >>> button");
         await chipCloseButton.focus();
         await page.waitForChanges();
@@ -164,9 +169,8 @@ describe("calcite-chip", () => {
 
     describe("when mode attribute is dark", () => {
       it("should render button pseudo classes with value tied to dark mode", async () => {
-        page = await newE2EPage({
-          html: `<div class="calcite-mode-dark">${chipSnippet}</div>`
-        });
+        page = await newE2EPage();
+        await page.setContent(html`<div class="calcite-mode-dark">${chipSnippet}</div>`);
         chipCloseButton = await page.find("calcite-chip >>> button");
         await chipCloseButton.focus();
         await page.waitForChanges();
@@ -182,15 +186,13 @@ describe("calcite-chip", () => {
 
     it("should allow the CSS custom property to be overridden", async () => {
       const overrideStyle = "rgba(55, 5, 10, 0.19)";
-      page = await newE2EPage({
-        html: `
-        <style>
+      page = await newE2EPage();
+      await page.setContent(html` <style>
           :root {
             --calcite-button-transparent-hover: ${overrideStyle};
           }
         </style>
-        <div>${chipSnippet}</div>`
-      });
+        <div>${chipSnippet}</div>`);
       chipCloseButton = await page.find("calcite-chip >>> button");
       await chipCloseButton.focus();
       await page.waitForChanges();
@@ -205,7 +207,7 @@ describe("calcite-chip", () => {
 
     it("should not render chip when closed set to true", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<div class="calcite-mode-dark">${chipSnippet}</div>`);
+      await page.setContent(html`<div class="calcite-mode-dark">${chipSnippet}</div>`);
 
       const chipEl = await page.find(`calcite-chip`);
       chipEl.setAttribute("closed", true);

--- a/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
+++ b/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
@@ -3,6 +3,7 @@ import { accessible, defaults, focusable, hidden, reflects, renders } from "../.
 import { selectText } from "../../tests/utils";
 import { isValidHex, normalizeHex } from "../color-picker/utils";
 import { CSS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-color-picker-hex-input", () => {
   describe("renders", () => {
@@ -40,9 +41,8 @@ describe("calcite-color-picker-hex-input", () => {
   it("can be focused", async () => focusable("calcite-color-picker-hex-input"));
 
   it("supports no color", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input allow-empty></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input allow-empty></calcite-color-picker-hex-input>");
 
     const input = await page.find(`calcite-color-picker-hex-input`);
     await input.setProperty("value", null);
@@ -59,9 +59,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("accepts shorthand hex", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input></calcite-color-picker-hex-input>");
 
     const input = await page.find(`calcite-color-picker-hex-input`);
     await input.setProperty("value", "#fff");
@@ -71,9 +70,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("allows entering text if it has a selection", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input value='#ffffff'></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input value='#ffffff'></calcite-color-picker-hex-input>");
     const input = await page.find(`calcite-color-picker-hex-input`);
 
     await selectText(input);
@@ -85,9 +83,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("accepts longhand hex", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input></calcite-color-picker-hex-input>");
 
     const input = await page.find(`calcite-color-picker-hex-input`);
     await input.setProperty("value", "#fafafa");
@@ -97,10 +94,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("normalizes value when initialized", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input value='#f0f'></calcite-color-picker-hex-input>"
-    });
-    await page.waitForChanges();
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input value='#f0f'></calcite-color-picker-hex-input>");
     const input = await page.find(`calcite-color-picker-hex-input`);
 
     expect(await input.getProperty("value")).toBe("#ff00ff");
@@ -108,9 +103,8 @@ describe("calcite-color-picker-hex-input", () => {
 
   it("ignores invalid hex", async () => {
     const hex = "#b33f33";
-    const page = await newE2EPage({
-      html: `<calcite-color-picker-hex-input value='${hex}'></calcite-color-picker-hex-input>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-color-picker-hex-input value="${hex}"></calcite-color-picker-hex-input>`);
     const input = await page.find(`calcite-color-picker-hex-input`);
 
     await input.setProperty("value", null);
@@ -150,9 +144,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("emits event when color changes via user and not programmatically", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input value='#b33f33'></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input value='#b33f33'></calcite-color-picker-hex-input>");
 
     const input = await page.find("calcite-color-picker-hex-input");
     const spy = await input.spyOnEvent("calciteColorPickerHexInputChange");
@@ -171,9 +164,8 @@ describe("calcite-color-picker-hex-input", () => {
   });
 
   it("prevents entering chars if invalid hex chars or it exceeds max hex length", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-hex-input value='#b33f33'></calcite-color-picker-hex-input>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-hex-input value='#b33f33'></calcite-color-picker-hex-input>");
     const input = await page.find("calcite-color-picker-hex-input");
     const selectAllText = async (): Promise<void> => await input.click({ clickCount: 3 });
 
@@ -256,9 +248,10 @@ describe("calcite-color-picker-hex-input", () => {
     let input: E2EElement;
 
     beforeEach(async () => {
-      page = await newE2EPage({
-        html: `<calcite-color-picker-hex-input value=${startingHex}></calcite-color-picker-hex-input>`
-      });
+      page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-color-picker-hex-input value=${startingHex}></calcite-color-picker-hex-input>`
+      );
 
       input = await page.find("calcite-color-picker-hex-input");
     });

--- a/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
+++ b/src/components/color-picker-swatch/color-picker-swatch.e2e.ts
@@ -34,9 +34,8 @@ describe("calcite-color-picker-swatch", () => {
 
   describe("accepts CSS color strings", () => {
     it("supports rgb", async () => {
-      const page = await newE2EPage({
-        html: "<calcite-color-picker-swatch color='rgb(255, 255, 255)'></calcite-color-picker-swatch>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker-swatch color='rgb(255, 255, 255)'></calcite-color-picker-swatch>");
       const swatch = await page.find(`calcite-color-picker-swatch >>> .${CSS.swatch} rect`);
       const style = await swatch.getComputedStyle();
 
@@ -44,9 +43,8 @@ describe("calcite-color-picker-swatch", () => {
     });
 
     it("supports keywords", async () => {
-      const page = await newE2EPage({
-        html: "<calcite-color-picker-swatch color='chartreuse'></calcite-color-picker-swatch>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker-swatch color='chartreuse'></calcite-color-picker-swatch>");
       const swatch = await page.find(`calcite-color-picker-swatch >>> .${CSS.swatch} rect`);
       const style = await swatch.getComputedStyle();
 
@@ -54,9 +52,8 @@ describe("calcite-color-picker-swatch", () => {
     });
 
     it("supports hsl", async () => {
-      const page = await newE2EPage({
-        html: "<calcite-color-picker-swatch color='hsl(120, 100%, 97%)'></calcite-color-picker-swatch>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker-swatch color='hsl(120, 100%, 97%)'></calcite-color-picker-swatch>");
       const swatch = await page.find(`calcite-color-picker-swatch >>> .${CSS.swatch} rect`);
       const style = await swatch.getComputedStyle();
 
@@ -64,9 +61,8 @@ describe("calcite-color-picker-swatch", () => {
     });
 
     it("supports hex", async () => {
-      const page = await newE2EPage({
-        html: "<calcite-color-picker-swatch color='#ff8200'></calcite-color-picker-swatch>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker-swatch color='#ff8200'></calcite-color-picker-swatch>");
       const swatch = await page.find(`calcite-color-picker-swatch >>> .${CSS.swatch} rect`);
 
       const style = await swatch.getComputedStyle();
@@ -78,9 +74,8 @@ describe("calcite-color-picker-swatch", () => {
   it("has an active state", async () => {
     // this is probably better suited for a screenshot test
 
-    const page = await newE2EPage({
-      html: "<calcite-color-picker-swatch color'#beefee'></calcite-color-picker-swatch>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker-swatch color'#beefee'></calcite-color-picker-swatch>");
     const swatchRect = await page.find(`calcite-color-picker-swatch >>> .${CSS.swatch} rect`);
 
     expect(swatchRect.getAttribute("rx")).toBe("0");

--- a/src/components/color-picker/color-picker.e2e.ts
+++ b/src/components/color-picker/color-picker.e2e.ts
@@ -4,6 +4,7 @@ import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing
 import { ColorValue } from "./interfaces";
 import SpyInstance = jest.SpyInstance;
 import { GlobalTestProps, selectText, getElementXY } from "../../tests/utils";
+import { html } from "../../../support/formatting";
 describe("calcite-color-picker", () => {
   let consoleSpy: SpyInstance;
 
@@ -80,9 +81,8 @@ describe("calcite-color-picker", () => {
   it("supports translations", () => t9n("<calcite-color-picker></calcite-color-picker>"));
 
   it(`should set all internal calcite-button types to 'button'`, async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
 
     const buttons = await page.findAll("calcite-color-picker >>> calcite-button");
 
@@ -189,7 +189,8 @@ describe("calcite-color-picker", () => {
 
   it("does not emit on initialization", async () => {
     // initialize page with calcite-color-picker to make it available in the evaluate callback below
-    const page = await newE2EPage({ html: "<calcite-color-picker></calcite-color-picker>" });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     await page.setContent("");
 
     const emitted = await page.evaluate(() => {
@@ -273,7 +274,9 @@ describe("calcite-color-picker", () => {
 
       it("initial value and format are both set if compatible", async () => {
         const initialValue = "rgb(255, 128, 255)";
-        await page.setContent(`<calcite-color-picker format='rgb-css' value='${initialValue}'></calcite-color-picker>`);
+        await page.setContent(
+          html`<calcite-color-picker format="rgb-css" value="${initialValue}"></calcite-color-picker>`
+        );
         const color = await page.find("calcite-color-picker");
 
         const initialValueIsRendered = await page.$eval(
@@ -299,9 +302,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("allows specifying the color value format", async () => {
-      const page = await newE2EPage({
-        html: "<calcite-color-picker></calcite-color-picker>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker></calcite-color-picker>");
 
       const color = await page.find("calcite-color-picker");
 
@@ -325,9 +327,10 @@ describe("calcite-color-picker", () => {
     });
 
     it("changing format updates value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker value=${supportedFormatToSampleValue["hex"]}></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-color-picker value=${supportedFormatToSampleValue["hex"]}></calcite-color-picker>`
+      );
       const color = await page.find("calcite-color-picker");
 
       for (const format in supportedFormatToSampleValue) {
@@ -340,9 +343,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("accepts multiple color value formats", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     const picker = await page.find("calcite-color-picker");
 
     const supportedStringFormats = [
@@ -466,9 +468,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("keeps tracking mouse movement when a thumb is actively dragged", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     const picker = await page.find(`calcite-color-picker`);
     const colorFieldAndSlider = await page.find(`calcite-color-picker >>> .${CSS.colorFieldAndSlider}`);
 
@@ -527,9 +528,8 @@ describe("calcite-color-picker", () => {
   it(`mouse movement tracking is not offset by the component's padding (mimics issue from #3041 when the component was placed within another component's shadow DOM)`, async () => {
     const colorFieldCenterValueHsv = { h: 127, s: 50, v: 50 };
 
-    const page = await newE2EPage({
-      html: `<calcite-color-picker style='padding: 10px;'></calcite-color-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-color-picker style="padding: 10px;"></calcite-color-picker>`);
     const colorPicker = await page.find("calcite-color-picker");
 
     colorPicker.setProperty("value", colorFieldCenterValueHsv);
@@ -579,9 +579,8 @@ describe("calcite-color-picker", () => {
     }
 
     beforeEach(async () => {
-      page = await newE2EPage({
-        html: "<calcite-color-picker></calcite-color-picker>"
-      });
+      page = await newE2EPage();
+      await page.setContent("<calcite-color-picker></calcite-color-picker>");
     });
 
     it("ignores unsupported value types", () => assertUnsupportedValue(page, "unsupported-color-format"));
@@ -590,9 +589,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("normalizes shorthand CSS hex", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     const picker = await page.find("calcite-color-picker");
 
     picker.setProperty("value", "#ABC");
@@ -602,9 +600,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("has backdoor color prop for advanced use cases", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-color-picker></calcite-color-picker>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-color-picker></calcite-color-picker>");
     const picker = await page.find("calcite-color-picker");
 
     expect(await picker.getProperty("color")).toBeTruthy();
@@ -620,18 +617,16 @@ describe("calcite-color-picker", () => {
     }
 
     it("value as attribute", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker value="${initialColor}"></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker value="${initialColor}"></calcite-color-picker>`);
 
       expect(await getInternalColorAsHex(page)).toBe(initialColor);
     });
 
     it("value as property", async () => {
       // initialize page with calcite-color-picker to make it available in the evaluate callback below
-      const page = await newE2EPage({
-        html: "<calcite-color-picker></calcite-color-picker>"
-      });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-color-picker></calcite-color-picker>");
       await page.setContent("");
 
       await page.evaluate(async (color) => {
@@ -652,9 +647,8 @@ describe("calcite-color-picker", () => {
       let picker: E2EElement;
 
       beforeEach(async () => {
-        page = await newE2EPage({
-          html: "<calcite-color-picker></calcite-color-picker>"
-        });
+        page = await newE2EPage();
+        await page.setContent("<calcite-color-picker></calcite-color-picker>");
         picker = await page.find("calcite-color-picker");
       });
 
@@ -794,9 +788,8 @@ describe("calcite-color-picker", () => {
     describe("color gets propagated to support inputs", () => {
       describe("valid color", () => {
         it("color gets propagated to hex, RGB & HSV inputs", async () => {
-          const page = await newE2EPage({
-            html: "<calcite-color-picker value='#fff000'></calcite-color-picker>"
-          });
+          const page = await newE2EPage();
+          await page.setContent("<calcite-color-picker value='#fff000'></calcite-color-picker>");
 
           const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
@@ -821,9 +814,8 @@ describe("calcite-color-picker", () => {
         });
 
         it("allows modifying color via hex, RGB, HSV inputs", async () => {
-          const page = await newE2EPage({
-            html: "<calcite-color-picker value='#fff'></calcite-color-picker>"
-          });
+          const page = await newE2EPage();
+          await page.setContent("<calcite-color-picker value='#fff'></calcite-color-picker>");
           const picker = await page.find("calcite-color-picker");
 
           const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
@@ -875,9 +867,8 @@ describe("calcite-color-picker", () => {
             expect(await calciteInput.getProperty("value")).toBe(currentValue);
           };
 
-          const page = await newE2EPage({
-            html: "<calcite-color-picker value='#408048'></calcite-color-picker>"
-          });
+          const page = await newE2EPage();
+          await page.setContent("<calcite-color-picker value='#408048'></calcite-color-picker>");
 
           const [rgbModeButton, hsvModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
           const [rInput, gInput, bInput, hInput, sInput, vInput] = await page.findAll(
@@ -900,9 +891,8 @@ describe("calcite-color-picker", () => {
 
       describe("when no-color", () => {
         it("color gets propagated to hex, RGB & HSV inputs", async () => {
-          const page = await newE2EPage({
-            html: "<calcite-color-picker allow-empty value=''></calcite-color-picker>"
-          });
+          const page = await newE2EPage();
+          await page.setContent("<calcite-color-picker allow-empty value=''></calcite-color-picker>");
 
           const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
@@ -928,9 +918,8 @@ describe("calcite-color-picker", () => {
 
         describe("clearing color via supporting inputs", () => {
           it("clears color via hex input", async () => {
-            const page = await newE2EPage({
-              html: "<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>"
-            });
+            const page = await newE2EPage();
+            await page.setContent("<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>");
             const picker = await page.find("calcite-color-picker");
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
@@ -940,9 +929,8 @@ describe("calcite-color-picker", () => {
           });
 
           it("clears color via RGB channel inputs", async () => {
-            const page = await newE2EPage({
-              html: "<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>"
-            });
+            const page = await newE2EPage();
+            await page.setContent("<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>");
             const picker = await page.find("calcite-color-picker");
 
             const [rgbModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
@@ -962,9 +950,8 @@ describe("calcite-color-picker", () => {
           });
 
           it("clears color via HSV channel inputs", async () => {
-            const page = await newE2EPage({
-              html: "<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>"
-            });
+            const page = await newE2EPage();
+            await page.setContent("<calcite-color-picker allow-empty value='#c0ff33'></calcite-color-picker>");
             const picker = await page.find("calcite-color-picker");
 
             const [, hsvModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
@@ -1022,9 +1009,10 @@ describe("calcite-color-picker", () => {
             expect(await calciteInput.getProperty("value")).toBe(consistentRgbHsvChannelValue);
           };
 
-          const page = await newE2EPage({
-            html: `<calcite-color-picker allow-empty value='${initialValue}'></calcite-color-picker>`
-          });
+          const page = await newE2EPage();
+          await page.setContent(
+            html`<calcite-color-picker allow-empty value="${initialValue}"></calcite-color-picker>`
+          );
 
           const [rgbModeButton, hsvModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
           const [rInput, gInput, bInput, hInput, sInput, vInput] = await page.findAll(
@@ -1045,9 +1033,8 @@ describe("calcite-color-picker", () => {
         });
 
         it("changes the value to the specified format after being empty", async () => {
-          const page = await newE2EPage({
-            html: "<calcite-color-picker allow-empty value='' format='rgb'></calcite-color-picker>"
-          });
+          const page = await newE2EPage();
+          await page.setContent("<calcite-color-picker allow-empty value='' format='rgb'></calcite-color-picker>");
           const color = await page.find("calcite-color-picker");
 
           const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
@@ -1066,9 +1053,8 @@ describe("calcite-color-picker", () => {
 
     async function clearStorage(): Promise<void> {
       const storageKey = `${DEFAULT_STORAGE_KEY_PREFIX}${storageId}`;
-      const page = await newE2EPage({
-        html: `<calcite-color-picker></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker></calcite-color-picker>`);
       await page.evaluate((storageKey) => localStorage.removeItem(storageKey), [storageKey]);
     }
 
@@ -1076,9 +1062,8 @@ describe("calcite-color-picker", () => {
     afterAll(clearStorage);
 
     it("allows saving unique colors", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`);
 
       const picker = await page.find("calcite-color-picker");
       const saveColor = await page.find(`calcite-color-picker >>> .${CSS.saveColor}`);
@@ -1107,9 +1092,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("loads saved colors", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`);
 
       const savedColors = await page.findAll(
         `calcite-color-picker >>> .${CSS.savedColors} calcite-color-picker-swatch`
@@ -1118,9 +1102,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("allows removing stored colors", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker storage-id=${storageId}></calcite-color-picker>`);
 
       const picker = await page.find("calcite-color-picker");
       const saveColor = await page.find(`calcite-color-picker >>> .${CSS.saveColor}`);
@@ -1152,9 +1135,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("does not allow saving/removing when no-color is set", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
 
       const saveColor = await page.find(`calcite-color-picker >>> .${CSS.saveColor}`);
       const removeColor = await page.find(`calcite-color-picker >>> .${CSS.deleteColor}`);
@@ -1165,9 +1147,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("allows setting no-color", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-color-picker allow-empty></calcite-color-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-color-picker allow-empty></calcite-color-picker>`);
 
     const color = await page.find("calcite-color-picker");
 
@@ -1184,9 +1165,8 @@ describe("calcite-color-picker", () => {
   });
 
   it("allows hiding sections", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-color-picker></calcite-color-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-color-picker></calcite-color-picker>`);
 
     type HiddenSection = "hex" | "channels" | "saved";
 
@@ -1242,9 +1222,8 @@ describe("calcite-color-picker", () => {
 
   describe("scope keyboard interaction", () => {
     it("allows editing color field via keyboard", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
 
       const picker = await page.find("calcite-color-picker");
       const scope = await page.find(`calcite-color-picker >>> .${CSS.scope}`);
@@ -1266,9 +1245,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("allows nudging color's saturation even if it does not change RGB value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker value="#000"></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker value="#000"></calcite-color-picker>`);
       const scope = await page.find(`calcite-color-picker >>> .${CSS.colorFieldScope}`);
 
       const initialStyle = await scope.getComputedStyle();
@@ -1287,9 +1265,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("allows nudging color's hue even if it does not change RGB value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker value="#000"></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker value="#000"></calcite-color-picker>`);
       const scope = await page.find(`calcite-color-picker >>> .${CSS.hueScope}`);
 
       const nudgeAThirdOfSlider = async () => {
@@ -1324,9 +1301,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("allows editing hue slider via keyboard", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker allow-empty value=""></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
 
       const picker = await page.find("calcite-color-picker");
       const scopes = await page.findAll(`calcite-color-picker >>> .${CSS.scope}`);
@@ -1347,9 +1323,8 @@ describe("calcite-color-picker", () => {
     });
 
     it("positions the scope correctly when the color is 000", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-color-picker value="#000"></calcite-color-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-color-picker value="#000"></calcite-color-picker>`);
 
       const [, hueSliderScope] = await page.findAll(`calcite-color-picker >>> .${CSS.scope}`);
 

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -66,16 +66,13 @@ describe("calcite-combobox", () => {
   it("can be disabled", () => disabled("calcite-combobox"));
 
   it("filtering does not match property with value of undefined", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-combobox id="myCombobox">
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
-        </calcite-combobox>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-combobox id="myCombobox">
+      <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
+      <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
+      <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
+      <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+    </calcite-combobox>`);
 
     const combobox = await page.find("calcite-combobox");
     const input = await page.find("calcite-combobox >>> input");
@@ -93,16 +90,13 @@ describe("calcite-combobox", () => {
   });
 
   it("should filter the items in listbox when typing into the input", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-combobox id="myCombobox">
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
-        </calcite-combobox>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-combobox id="myCombobox">
+      <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
+      <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
+      <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
+      <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
+    </calcite-combobox>`);
 
     const combobox = await page.find("calcite-combobox");
     const input = await page.find("calcite-combobox >>> input");
@@ -154,7 +148,7 @@ describe("calcite-combobox", () => {
 
     const maxItems = 7;
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-combobox max-items="${maxItems}">
         <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
           <calcite-combobox-item id="item-1" value="item-1" text-label="item-1"></calcite-combobox-item>
@@ -189,7 +183,7 @@ describe("calcite-combobox", () => {
 
     const maxItems = 8;
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-combobox max-items="${maxItems}">
         <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
           <calcite-combobox-item id="item-1" value="item-1" text-label="item-1"></calcite-combobox-item>
@@ -224,29 +218,29 @@ describe("calcite-combobox", () => {
 
     const maxItems = 6;
 
-    await page.setContent(`
-    <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
-      <calcite-combobox-item value="Trees" text-label="Trees" selected>
-        <calcite-combobox-item value="Pine" text-label="Pine">
-          <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+    await page.setContent(html`
+      <calcite-combobox label="custom values" allow-custom-values placeholder="placeholder" max-items="6">
+        <calcite-combobox-item value="Trees" text-label="Trees" selected>
+          <calcite-combobox-item value="Pine" text-label="Pine">
+            <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+          </calcite-combobox-item>
+          <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+          <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
         </calcite-combobox-item>
-        <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
-        <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Flowers" text-label="Flowers">
-        <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-        <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
-        <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Animals" text-label="Animals">
-        <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
-        <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
-        <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
-      </calcite-combobox-item>
-      <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
-      <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
-      <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
-    </calcite-combobox>
+        <calcite-combobox-item value="Flowers" text-label="Flowers">
+          <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+          <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+          <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Animals" text-label="Animals">
+          <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+          <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+          <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+        </calcite-combobox-item>
+        <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+        <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+        <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+      </calcite-combobox>
     `);
     await page.waitForChanges();
 
@@ -426,11 +420,10 @@ describe("calcite-combobox", () => {
     });
 
     it("should honor calciteComboboxChipClose", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-combobox>
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-combobox>
         <calcite-combobox-item value="one" selected text-label="one"></calcite-combobox-item>
-      </calcite-combobox>`
-      });
+      </calcite-combobox>`);
 
       const eventSpy = await page.spyOnEvent("calciteComboboxChipClose", "window");
 
@@ -1128,10 +1121,10 @@ describe("calcite-combobox", () => {
 
   it("respects the filterDisabled item property", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-combobox selection-mode="single">
         <calcite-combobox-item id="one" value="one" text-label="One"></calcite-combobox-item>
-        <calcite-combobox-item id="two" value="two" text-label="Two" ></calcite-combobox-item>
+        <calcite-combobox-item id="two" value="two" text-label="Two"></calcite-combobox-item>
         <calcite-combobox-item id="three" value="three" text-label="Three" filter-disabled></calcite-combobox-item>
       </calcite-combobox>
     `);
@@ -1151,7 +1144,7 @@ describe("calcite-combobox", () => {
 
   it("works correctly inside a shadowRoot", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <div></div>
       <template>
         <calcite-combobox selection-mode="single">

--- a/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
+++ b/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { renders } from "../../tests/commonTests";
+import { newProgrammaticE2EPage } from "../../tests/utils";
 
 describe("calcite-date-picker-month-header", () => {
   describe("renders", () => {
@@ -38,11 +39,7 @@ describe("calcite-date-picker-month-header", () => {
   };
 
   it("displays next/previous options", async () => {
-    const page = await newE2EPage({
-      // intentionally using calcite-date-picker to wire up supporting components to be used in `evaluate` fn below
-      html: "<calcite-date-picker></calcite-date-picker>"
-    });
-    await page.waitForChanges();
+    const page = await newProgrammaticE2EPage();
 
     await page.evaluate((localeData) => {
       const dateMonthHeader = document.createElement(

--- a/src/components/date-picker/date-picker.e2e.ts
+++ b/src/components/date-picker/date-picker.e2e.ts
@@ -49,7 +49,7 @@ describe("calcite-date-picker", () => {
 
   it("updates the calendar immediately as a new year is typed but doesn't change the year", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-date-picker value="2015-02-28" active></calcite-date-picker>`);
+    await page.setContent(html`<calcite-date-picker value="2015-02-28" active></calcite-date-picker>`);
     const datePicker = await page.find("calcite-date-picker");
     await page.waitForTimeout(animationDurationInMs);
 
@@ -245,8 +245,7 @@ describe("calcite-date-picker", () => {
 
   it("fires calciteDatePickerRangeChange event on user change", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-date-picker range></calcite-date-picker>`);
-    await page.waitForChanges();
+    await page.setContent(html`<calcite-date-picker range></calcite-date-picker>`);
     const date = await page.find("calcite-date-picker");
     date.setProperty("value", ["2020-09-08", "2020-09-23"]);
 
@@ -277,10 +276,8 @@ describe("calcite-date-picker", () => {
 
   describe("when the lang is set to Slovak calendar", () => {
     it("should start the week on Monday", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-date-picker scale="m" lang="sk" value="2000-11-27"></calcite-date-picker>`
-      });
-      await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-date-picker scale="m" lang="sk" value="2000-11-27"></calcite-date-picker>`);
       const text: string = await page.evaluate(
         () =>
           document

--- a/src/components/dropdown-item/dropdown-item.e2e.ts
+++ b/src/components/dropdown-item/dropdown-item.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { focusable, renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-dropdown-item", () => {
   describe("renders", () => {
@@ -12,7 +13,7 @@ describe("calcite-dropdown-item", () => {
 
   it("should emit calciteDropdownItemSelect", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>`);
+    await page.setContent(html`<calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>`);
 
     const element = await page.find("calcite-dropdown-item");
     const itemChangeSpy = await element.spyOnEvent("calciteDropdownItemSelect");

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -2,7 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import dedent from "dedent";
 import { html } from "../../../support/formatting";
 import { focusable, accessible, defaults, disabled, floatingUIOwner, hidden, renders } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
+import { GlobalTestProps, newProgrammaticE2EPage } from "../../tests/utils";
 import { CSS } from "./resources";
 
 const simpleDropdownHTML = html`<calcite-dropdown>
@@ -467,17 +467,16 @@ describe("calcite-dropdown", () => {
   });
 
   it("should focus the first item on open when there is no selected item", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-dropdown>
-        <calcite-button slot="trigger">Open Dropdown</calcite-button>
-        <calcite-dropdown-group>
-          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-dropdown>
+      <calcite-button slot="trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group>
+        <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>`);
 
     const element = await page.find("calcite-dropdown");
     const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
@@ -487,17 +486,16 @@ describe("calcite-dropdown", () => {
   });
 
   it("should focus the first selected item on open", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-dropdown>
-        <calcite-button slot="trigger">Open Dropdown</calcite-button>
-        <calcite-dropdown-group>
-          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-3" selected>3</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-dropdown>
+      <calcite-button slot="trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group>
+        <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-3" selected>3</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>`);
 
     const element = await page.find("calcite-dropdown");
     const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
@@ -508,17 +506,16 @@ describe("calcite-dropdown", () => {
   });
 
   it("should focus the first selected item on open (multi)", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-dropdown>
-        <calcite-button slot="trigger">Open Dropdown</calcite-button>
-        <calcite-dropdown-group selection-mode="multiple">
-          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2" selected>2</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-4" selected>4</calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-dropdown>
+      <calcite-button slot="trigger">Open Dropdown</calcite-button>
+      <calcite-dropdown-group selection-mode="multiple">
+        <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-2" selected>2</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-4" selected>4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-dropdown>`);
 
     const element = await page.find("calcite-dropdown");
     const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
@@ -593,25 +590,24 @@ describe("calcite-dropdown", () => {
 
     it("control max items displayed", async () => {
       const maxItems = 7;
-      const page = await newE2EPage({
-        html: html`<calcite-dropdown max-items="${maxItems}">
-          <calcite-button slot="trigger">Open Dropdown</calcite-button>
-          <calcite-dropdown-group group-title="First group">
-            <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
-          </calcite-dropdown-group>
-          <calcite-dropdown-group group-title="Second group">
-            <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
-          </calcite-dropdown-group>
-        </calcite-dropdown>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-dropdown max-items="${maxItems}">
+        <calcite-button slot="trigger">Open Dropdown</calcite-button>
+        <calcite-dropdown-group group-title="First group">
+          <calcite-dropdown-item id="item-1">1</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-2">2</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-3">3</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-4">4</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-5">5</calcite-dropdown-item>
+        </calcite-dropdown-group>
+        <calcite-dropdown-group group-title="Second group">
+          <calcite-dropdown-item id="item-6">6</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-7">7</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-8">8</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-9">9</calcite-dropdown-item>
+          <calcite-dropdown-item id="item-10">10</calcite-dropdown-item>
+        </calcite-dropdown-group>
+      </calcite-dropdown>`);
 
       const element = await page.find("calcite-dropdown");
       const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");
@@ -907,7 +903,6 @@ describe("calcite-dropdown", () => {
   it("correct role and aria properties are applied based on selection type", async () => {
     const page = await newE2EPage();
     await page.setContent(dedent`${dropdownSelectionModeContent}`);
-    await page.waitForChanges();
 
     const element = await page.find("calcite-dropdown");
     const group1 = await element.find("calcite-dropdown-group[id='group-1']");
@@ -959,13 +954,7 @@ describe("calcite-dropdown", () => {
       </calcite-dropdown>
     `;
 
-    const page = await newE2EPage({
-      // load page with the dropdown template,
-      // so they're available in the browser-evaluated fn below
-      html: wrappedDropdownTemplateHTML
-    });
-    await page.waitForChanges();
-
+    const page = await newProgrammaticE2EPage();
     const wrapperName = "dropdown-wrapping-component";
 
     await page.evaluate(
@@ -1003,22 +992,21 @@ describe("calcite-dropdown", () => {
   });
 
   it.skip("dropdown should not overflow when wrapped inside a tab #3007", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-tabs>
-        <calcite-tab-nav slot="title-group">
-          <calcite-tab-title is-active>First tab</calcite-tab-title>
-        </calcite-tab-nav>
-        <calcite-tab is-active>
-          <calcite-dropdown>
-            <calcite-button slot="trigger" class="dropdown">Dropdown</calcite-button>
-            <calcite-dropdown-group group-title="Select one">
-              <calcite-dropdown-item>First</calcite-dropdown-item>
-              <calcite-dropdown-item>Second</calcite-dropdown-item>
-            </calcite-dropdown-group>
-          </calcite-dropdown>
-        </calcite-tab>
-      </calcite-tabs>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tabs>
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title is-active>First tab</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab is-active>
+        <calcite-dropdown>
+          <calcite-button slot="trigger" class="dropdown">Dropdown</calcite-button>
+          <calcite-dropdown-group group-title="Select one">
+            <calcite-dropdown-item>First</calcite-dropdown-item>
+            <calcite-dropdown-item>Second</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+      </calcite-tab>
+    </calcite-tabs>`);
     await page.waitForChanges();
 
     const button = await page.find("calcite-button");
@@ -1036,21 +1024,20 @@ describe("calcite-dropdown", () => {
   });
 
   it("dropdown wrapper should have height when filter results empty and combined with a PickList in Panel  #3048", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-panel heading="Issue #3048">
-        <calcite-pick-list filter-enabled>
-          <calcite-dropdown slot="menu-actions" placement="bottom-end" type="click">
-            <calcite-action slot="trigger" title="Sort" icon="sort-descending"> </calcite-action>
-            <calcite-dropdown-group selection-mode="single">
-              <calcite-dropdown-item>Display name</calcite-dropdown-item>
-              <calcite-dropdown-item>Type</calcite-dropdown-item>
-            </calcite-dropdown-group>
-          </calcite-dropdown>
-          <calcite-pick-list-item label="calcite" description="calcite!"> </calcite-pick-list-item>
-          <calcite-pick-list-item label="calcite" description="calcite"> </calcite-pick-list-item>
-        </calcite-pick-list>
-      </calcite-panel>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-panel heading="Issue #3048">
+      <calcite-pick-list filter-enabled>
+        <calcite-dropdown slot="menu-actions" placement="bottom-end" type="click">
+          <calcite-action slot="trigger" title="Sort" icon="sort-descending"> </calcite-action>
+          <calcite-dropdown-group selection-mode="single">
+            <calcite-dropdown-item>Display name</calcite-dropdown-item>
+            <calcite-dropdown-item>Type</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <calcite-pick-list-item label="calcite" description="calcite!"> </calcite-pick-list-item>
+        <calcite-pick-list-item label="calcite" description="calcite"> </calcite-pick-list-item>
+      </calcite-pick-list>
+    </calcite-panel>`);
     await page.waitForChanges();
 
     const dropdownContentHeight = await (

--- a/src/components/dropdown/dropdown.e2e.ts
+++ b/src/components/dropdown/dropdown.e2e.ts
@@ -988,7 +988,7 @@ describe("calcite-dropdown", () => {
       return wrapper.shadowRoot.querySelector("calcite-dropdown-item[selected]").id;
     }, wrapperName);
 
-    await expect(finalSelectedItem).toBe("item-3");
+    expect(finalSelectedItem).toBe("item-3");
   });
 
   it.skip("dropdown should not overflow when wrapped inside a tab #3007", async () => {

--- a/src/components/fab/fab.e2e.ts
+++ b/src/components/fab/fab.e2e.ts
@@ -2,6 +2,7 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, disabled, hidden, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
 import { defaults } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-fab", () => {
   describe("renders", () => {
@@ -25,9 +26,8 @@ describe("calcite-fab", () => {
   it("can be disabled", () => disabled("calcite-fab"));
 
   it(`should set all internal calcite-button types to 'button'`, async () => {
-    const page = await newE2EPage({
-      html: "<calcite-fab></calcite-fab>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-fab></calcite-fab>");
 
     const buttons = await page.findAll("calcite-fab >>> calcite-button");
 
@@ -40,7 +40,7 @@ describe("calcite-fab", () => {
 
   it("should have visible text when text is enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world" text-enabled></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world" text-enabled></calcite-fab>`);
 
     const button = await page.find(`calcite-fab >>> .${CSS.button}`);
     const text = button.textContent;
@@ -50,7 +50,7 @@ describe("calcite-fab", () => {
 
   it("should not have a tooltip when text-enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world" text-enabled></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world" text-enabled></calcite-fab>`);
 
     const button = await page.find(`calcite-fab >>> .${CSS.button}`);
     expect(button.getAttribute("title")).toBe(null);
@@ -58,7 +58,7 @@ describe("calcite-fab", () => {
 
   it("should have a tooltip when not text-enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world"></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world"></calcite-fab>`);
     const button = await page.find(`calcite-fab >>> .${CSS.button}`);
     expect(button.getAttribute("title")).toBe("hello world");
 
@@ -71,7 +71,7 @@ describe("calcite-fab", () => {
 
   it("should not have visible text when text is not enabled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world"></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world"></calcite-fab>`);
 
     const button = await page.find(`calcite-fab >>> .${CSS.button}`);
     const text = button.textContent;
@@ -81,7 +81,7 @@ describe("calcite-fab", () => {
 
   it("should have label", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world" label="hi"></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world" label="hi"></calcite-fab>`);
 
     const calciteButton = await page.find(`calcite-fab >>> .${CSS.button}`);
     expect(calciteButton.getAttribute("title")).toBe("hi");
@@ -90,7 +90,7 @@ describe("calcite-fab", () => {
 
   it("should have appearance=solid", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab text="hello world"></calcite-fab>`);
+    await page.setContent(html`<calcite-fab text="hello world"></calcite-fab>`);
 
     const fab = await page.find(`calcite-fab >>> .${CSS.button}`);
     expect(fab.getAttribute("appearance")).toBe("solid");
@@ -98,7 +98,7 @@ describe("calcite-fab", () => {
 
   it("should have appearance=outline-fill", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-fab appearance="outline-fill" text="hello world"></calcite-fab>`);
+    await page.setContent(html`<calcite-fab appearance="outline-fill" text="hello world"></calcite-fab>`);
 
     const fab = await page.find(`calcite-fab >>> .${CSS.button}`);
     expect(fab.getAttribute("appearance")).toBe("outline-fill");
@@ -112,15 +112,8 @@ describe("calcite-fab", () => {
   describe("when invalid appearance values are passed", () => {
     describe("when value is 'transparent'", () => {
       it("should render with default 'outline-fill' appearance", async () => {
-        const page = await newE2EPage({
-          html: `
-          <calcite-fab
-            text="FAB"
-            text-enabled
-            appearance="transparent"
-          ></calcite-fab>
-          `
-        });
+        const page = await newE2EPage();
+        await page.setContent(html` <calcite-fab text="FAB" text-enabled appearance="transparent"></calcite-fab> `);
         const fab = await page.find(`calcite-fab >>> .${CSS.button}`);
         expect(fab.getAttribute("appearance")).toBe("outline-fill");
       });
@@ -128,15 +121,8 @@ describe("calcite-fab", () => {
 
     describe("when value is 'clear'", () => {
       it("should render with default 'outline-fill' appearance", async () => {
-        const page = await newE2EPage({
-          html: `
-          <calcite-fab
-            text="FAB"
-            text-enabled
-            appearance="outline"
-          ></calcite-fab>
-          `
-        });
+        const page = await newE2EPage();
+        await page.setContent(html` <calcite-fab text="FAB" text-enabled appearance="outline"></calcite-fab> `);
         const fab = await page.find(`calcite-fab >>> .${CSS.button}`);
         expect(fab.getAttribute("appearance")).toBe("outline-fill");
       });

--- a/src/components/filter/filter.e2e.ts
+++ b/src/components/filter/filter.e2e.ts
@@ -2,6 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";
 import { DEBOUNCE_TIMEOUT } from "./resources";
 import { CSS as INPUT_CSS } from "../input/resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-filter", () => {
   describe("renders", () => {
@@ -49,7 +50,7 @@ describe("calcite-filter", () => {
   it("sets scale on the input", async () => {
     const scale = "s";
     const page = await newE2EPage();
-    await page.setContent(`<calcite-filter scale="${scale}"></calcite-filter>`);
+    await page.setContent(html`<calcite-filter scale="${scale}"></calcite-filter>`);
 
     const input = await page.find(`calcite-filter >>> calcite-input`);
     expect(await input.getProperty("scale")).toBe(scale);
@@ -59,7 +60,7 @@ describe("calcite-filter", () => {
     it("should update the filter placeholder when a string is provided", async () => {
       const page = await newE2EPage();
       const placeholderText = "placeholder";
-      await page.setContent(`<calcite-filter placeholder="${placeholderText}"></calcite-filter>`);
+      await page.setContent(html`<calcite-filter placeholder="${placeholderText}"></calcite-filter>`);
 
       const input = await page.find(`calcite-filter >>> calcite-input`);
       expect(await input.getProperty("placeholder")).toBe(placeholderText);
@@ -239,7 +240,7 @@ describe("calcite-filter", () => {
 
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`<calcite-filter value="harry"></calcite-filter>`);
+      await page.setContent(html`<calcite-filter value="harry"></calcite-filter>`);
       await page.evaluate(() => {
         const filter = document.querySelector("calcite-filter");
         filter.items = [

--- a/src/components/flow-item/flow-item.e2e.ts
+++ b/src/components/flow-item/flow-item.e2e.ts
@@ -146,9 +146,8 @@ describe("calcite-flow-item", () => {
   });
 
   it("honors calciteFlowItemScroll event", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-flow-item>test</calcite-flow-item>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-flow-item>test</calcite-flow-item>");
 
     const scrollSpy = await page.spyOnEvent("calciteFlowItemScroll");
 

--- a/src/components/flow/flow.e2e.ts
+++ b/src/components/flow/flow.e2e.ts
@@ -28,7 +28,7 @@ describe("calcite-flow", () => {
     it("back() method should remove item", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
+      await page.setContent(html`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
 
       const flow = await page.find("calcite-flow");
 
@@ -64,7 +64,7 @@ describe("calcite-flow", () => {
       const mockCallBack = jest.fn().mockReturnValue(Promise.resolve());
       await page.exposeFunction("beforeBack", mockCallBack);
 
-      await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
+      await page.setContent(html`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
 
       await page.$eval(
         "calcite-flow-item",
@@ -83,7 +83,7 @@ describe("calcite-flow", () => {
     it("frame advancing should add animation class", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
+      await page.setContent(html`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
 
       const items = await page.findAll("calcite-flow-item");
 
@@ -107,7 +107,7 @@ describe("calcite-flow", () => {
     it("frame advancing should add animation class when subtree is modified", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-flow><calcite-flow-item>flow1</calcite-flow-item></calcite-flow>`);
+      await page.setContent(html`<calcite-flow><calcite-flow-item>flow1</calcite-flow-item></calcite-flow>`);
 
       const element = await page.find("calcite-flow");
 

--- a/src/components/graph/graph.e2e.ts
+++ b/src/components/graph/graph.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage, E2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-graph", () => {
   describe("renders", () => {
@@ -44,7 +45,7 @@ describe("calcite-graph", () => {
   it("draws an area graph", async () => {
     const dimensionsStyle = `style="height:100px; width:300px;"`;
     const page = await newE2EPage();
-    await page.setContent(`<calcite-graph ${dimensionsStyle}></calcite-graph>`);
+    await page.setContent(html`<calcite-graph ${dimensionsStyle}></calcite-graph>`);
     await page.$eval("calcite-graph", (elm: any) => {
       elm.data = [
         [0, 4],
@@ -63,7 +64,7 @@ describe("calcite-graph", () => {
 
   it("uses color-stops when provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-graph></calcite-graph>`);
+    await page.setContent(html`<calcite-graph></calcite-graph>`);
     await page.$eval("calcite-graph", (elm: any) => {
       elm.data = [
         [0, 4],

--- a/src/components/icon/icon.e2e.ts
+++ b/src/components/icon/icon.e2e.ts
@@ -2,6 +2,7 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, reflects, renders } from "../../tests/commonTests";
 import { CSS } from "./resources";
 import { scaleToPx } from "./utils";
+import { html } from "../../../support/formatting";
 
 describe("calcite-icon", () => {
   it("honors hidden attribute", async () => hidden("calcite-icon"));
@@ -24,7 +25,7 @@ describe("calcite-icon", () => {
 
   it("flips icon when enabled and in RTL", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-icon icon="a-z"></calcite-icon>`);
+    await page.setContent(html`<calcite-icon icon="a-z"></calcite-icon>`);
     const icon = await page.find(`calcite-icon`);
     const flipRtlIconSelector = `calcite-icon >>> .${CSS.flipRtl}`;
 
@@ -44,8 +45,7 @@ describe("calcite-icon", () => {
 
     it("uses path data to render icon", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-icon icon="a-z"></calcite-icon>`);
-      await page.waitForChanges();
+      await page.setContent(html`<calcite-icon icon="a-z"></calcite-icon>`);
       const path = await page.find(`calcite-icon >>> path`);
 
       expect(path.getAttribute("d")).toBeTruthy();
@@ -53,8 +53,7 @@ describe("calcite-icon", () => {
 
     it("supports both camelcase and kebab case for icon name", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-icon icon="a-z"></calcite-icon>`);
-      await page.waitForChanges();
+      await page.setContent(html`<calcite-icon icon="a-z"></calcite-icon>`);
       const icon = await page.find(`calcite-icon`);
       const path = await page.find(`calcite-icon >>> path`);
       const iconPathData = path.getAttribute("d");
@@ -67,9 +66,7 @@ describe("calcite-icon", () => {
 
     it.skip("loads icon when it's close to viewport", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-icon icon="a-z" style="margin-top: 1000px"></calcite-icon>`);
-      await page.waitForChanges();
-
+      await page.setContent(html`<calcite-icon icon="a-z" style="margin-top: 1000px"></calcite-icon>`);
       const icon = await page.find(`calcite-icon`);
       const path = await page.find(`calcite-icon >>> path`);
 
@@ -87,7 +84,7 @@ describe("calcite-icon", () => {
       scales.forEach((scale) =>
         it(`${scale} scale`, async () => {
           const page = await newE2EPage();
-          await page.setContent(`<calcite-icon icon="a-z" scale="${scale}"></calcite-icon>`);
+          await page.setContent(html`<calcite-icon icon="a-z" scale="${scale}"></calcite-icon>`);
           const calciteIcon = await page.find(`calcite-icon`);
           const calciteIconComputedStyle = await calciteIcon.getComputedStyle();
           const svg = await page.find(`calcite-icon >>> svg`);

--- a/src/components/inline-editable/inline-editable.e2e.ts
+++ b/src/components/inline-editable/inline-editable.e2e.ts
@@ -32,10 +32,10 @@ describe("calcite-inline-editable", () => {
     let page: E2EPage;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`
-      <calcite-inline-editable>
-        <calcite-input/>
-      </calcite-inline-editable>
+      await page.setContent(html`
+        <calcite-inline-editable>
+          <calcite-input />
+        </calcite-inline-editable>
       `);
     });
 
@@ -48,11 +48,10 @@ describe("calcite-inline-editable", () => {
     });
 
     it(`should set all internal calcite-button types to 'button'`, async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-inline-editable controls editing-enabled>
-          <calcite-input />
-        </calcite-inline-editable>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-inline-editable controls editing-enabled>
+        <calcite-input />
+      </calcite-inline-editable>`);
 
       const buttons = await page.findAll("calcite-inline-editable >>> calcite-button");
 
@@ -65,12 +64,12 @@ describe("calcite-inline-editable", () => {
 
     it("uses a child input's scale when none are provided", async () => {
       page = await newE2EPage();
-      await page.setContent(`
-      <calcite-label>
-        <calcite-inline-editable>
-          <calcite-input scale="l"/>
-        </calcite-inline-editable>
-      </calcite-label>
+      await page.setContent(html`
+        <calcite-label>
+          <calcite-inline-editable>
+            <calcite-input scale="l" />
+          </calcite-inline-editable>
+        </calcite-label>
       `);
       await page.waitForChanges();
       const element = await page.find("calcite-inline-editable");
@@ -79,10 +78,10 @@ describe("calcite-inline-editable", () => {
 
     it("renders requested props when valid props are provided", async () => {
       page = await newE2EPage();
-      await page.setContent(`
-      <calcite-inline-editable controls editing-enabled loading disabled scale="l" >
-        <calcite-input/>
-      </calcite-inline-editable>
+      await page.setContent(html`
+        <calcite-inline-editable controls editing-enabled loading disabled scale="l">
+          <calcite-input />
+        </calcite-inline-editable>
       `);
       await page.waitForChanges();
       const element = await page.find("calcite-inline-editable");
@@ -98,10 +97,10 @@ describe("calcite-inline-editable", () => {
     let page: E2EPage;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`
-      <calcite-inline-editable>
-        <calcite-input value="John Doe"/>
-      </calcite-inline-editable>
+      await page.setContent(html`
+        <calcite-inline-editable>
+          <calcite-input value="John Doe" />
+        </calcite-inline-editable>
       `);
     });
 
@@ -162,10 +161,10 @@ describe("calcite-inline-editable", () => {
     let page: E2EPage;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`
-      <calcite-inline-editable controls>
-        <calcite-input value="John Doe"/>
-      </calcite-inline-editable>
+      await page.setContent(html`
+        <calcite-inline-editable controls>
+          <calcite-input value="John Doe" />
+        </calcite-inline-editable>
       `);
     });
 

--- a/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -100,7 +100,7 @@ describe("calcite-input-date-picker", () => {
 
     it("doesn't emit when cleared programmatically for single date", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker value="2023-03-07"></calcite-input-date-picker>`);
+      await page.setContent(html`<calcite-input-date-picker value="2023-03-07"></calcite-input-date-picker>`);
       const element = await page.find("calcite-input-date-picker");
       element.setProperty("value", "");
       await page.waitForChanges();
@@ -113,7 +113,7 @@ describe("calcite-input-date-picker", () => {
 
     it("doesn't emit when cleared programmatically for date range", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker range></calcite-input-date-picker>`);
+      await page.setContent(html`<calcite-input-date-picker range></calcite-input-date-picker>`);
       const element = await page.find("calcite-input-date-picker");
       const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
       element.setProperty("value", ["2023-03-07", "2023-03-08"]);
@@ -207,7 +207,7 @@ describe("calcite-input-date-picker", () => {
 
   it("should clear active date properly when deleted and committed via keyboard", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-date-picker value="2021-12-08"></calcite-input-date-picker>`);
+    await page.setContent(html`<calcite-input-date-picker value="2021-12-08"></calcite-input-date-picker>`);
     const input = (
       await page.waitForFunction(() =>
         document
@@ -376,7 +376,7 @@ describe("calcite-input-date-picker", () => {
 
   it("allows clicking a date in the calendar popup", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-date-picker value="2023-01-31"></calcite-input-date-picker>`);
+    await page.setContent(html`<calcite-input-date-picker value="2023-01-31"></calcite-input-date-picker>`);
     const inputDatePicker = await page.find("calcite-input-date-picker");
 
     await inputDatePicker.click();
@@ -434,7 +434,7 @@ describe("calcite-input-date-picker", () => {
 
   it("when set to readOnly, element still focusable but won't display the controls or allow for changing the value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-date-picker read-only id="canReadOnly"></calcite-input-date-picker>`);
+    await page.setContent(html`<calcite-input-date-picker read-only id="canReadOnly"></calcite-input-date-picker>`);
 
     const component = await page.find("#canReadOnly");
     const input = await page.find("#canReadOnly >>> calcite-input");

--- a/src/components/input-message/input-message.e2e.ts
+++ b/src/components/input-message/input-message.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, hidden, renders } from "../../tests/commonTests";
 import { StatusIconDefaults } from "./interfaces";
 
@@ -20,9 +21,7 @@ describe("calcite-input-message", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-message></calcite-input-message>
-    `);
+    await page.setContent(html` <calcite-input-message></calcite-input-message> `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "idle");
@@ -30,9 +29,7 @@ describe("calcite-input-message", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-message status="valid">Text</calcite-input-message>
-    `);
+    await page.setContent(html` <calcite-input-message status="valid">Text</calcite-input-message> `);
 
     const element = await page.find("calcite-input-message");
     expect(element).toEqualAttribute("status", "valid");
@@ -40,9 +37,7 @@ describe("calcite-input-message", () => {
 
   it("does not render an icon if not requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-message>Text</calcite-input-message>
-    `);
+    await page.setContent(html` <calcite-input-message>Text</calcite-input-message> `);
 
     const icon = await page.find("calcite-input-message >>> .calcite-input-message-icon");
     expect(icon).toBeNull();
@@ -61,9 +56,7 @@ describe("calcite-input-message", () => {
     describe("when it's a boolean type", () => {
       describe("when value is true", () => {
         it("should render the default status icon", async () => {
-          await page.setContent(`
-          <calcite-input-message icon>Text</calcite-input-message>
-          `);
+          await page.setContent(html` <calcite-input-message icon>Text</calcite-input-message> `);
           iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
           requestedIcon = await iconEl.getAttribute("icon");
           expect(requestedIcon).toEqual(StatusIconDefaults.idle);
@@ -72,7 +65,7 @@ describe("calcite-input-message", () => {
 
         describe("when element status is changed", () => {
           it("should render icon based on new status", async () => {
-            await page.setContent(`
+            await page.setContent(html`
               <calcite-input-message icon status="invalid">An example with icon</calcite-input-message>
             `);
             element = await page.find("calcite-input-message");
@@ -95,9 +88,7 @@ describe("calcite-input-message", () => {
       describe("when value is false", () => {
         it("should render no icon", async () => {
           const page = await newE2EPage();
-          await page.setContent(`
-          <calcite-input-message !icon>Text</calcite-input-message>
-          `);
+          await page.setContent(html` <calcite-input-message !icon>Text</calcite-input-message> `);
           iconEl = await page.find("calcite-input-message >>> .calcite-input-message-icon");
           expect(iconEl).toBeNull();
         });

--- a/src/components/input-number/input-number.e2e.ts
+++ b/src/components/input-number/input-number.e2e.ts
@@ -1342,9 +1342,7 @@ describe("calcite-input-number", () => {
 
   it("input event fires when number ends with a decimal", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-number value="1.2"></calcite-input-number>
-    `);
+    await page.setContent(html` <calcite-input-number value="1.2"></calcite-input-number> `);
 
     const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
     const element = await page.find("calcite-input-number");
@@ -1359,9 +1357,7 @@ describe("calcite-input-number", () => {
 
   it("sanitize leading zeros from value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input-number></calcite-input-number>
-    `);
+    await page.setContent(html` <calcite-input-number></calcite-input-number> `);
 
     const element = await page.find("calcite-input-number");
     await element.callMethod("setFocus");
@@ -1380,7 +1376,7 @@ describe("calcite-input-number", () => {
 
   it("sanitize extra dashes from value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-number></calcite-input-number>`);
+    await page.setContent(html`<calcite-input-number></calcite-input-number>`);
 
     const element = await page.find("calcite-input-number");
     await element.callMethod("setFocus");
@@ -1413,7 +1409,7 @@ describe("calcite-input-number", () => {
     });
 
     it("should not work, but increment instead", async () => {
-      await page.setContent(`<calcite-input-number></calcite-input-number>`);
+      await page.setContent(html`<calcite-input-number></calcite-input-number>`);
       const element = await page.find("calcite-input-number");
 
       await element.callMethod("setFocus");

--- a/src/components/input-text/input-text.e2e.ts
+++ b/src/components/input-text/input-text.e2e.ts
@@ -82,7 +82,8 @@ describe("calcite-input-text", () => {
     }));
 
   it("does not fire any input or change events when a focused input is blurred after its value is set directly", async () => {
-    const page = await newE2EPage({ html: "<calcite-input-text></calcite-input-text>" });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-input-text></calcite-input-text>");
     const input = await page.find("calcite-input-text");
     const inputEventSpy = await input.spyOnEvent("calciteInputTextInput");
     const changeEventSpy = await input.spyOnEvent("calciteInputTextChange");
@@ -350,7 +351,7 @@ describe("calcite-input-text", () => {
     };
 
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-text></calcite-input-text>`);
+    await page.setContent(html`<calcite-input-text></calcite-input-text>`);
     const element = await page.find("calcite-input-text");
 
     await element.callMethod("setFocus");

--- a/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -89,9 +89,10 @@ describe("calcite-input-time-picker", () => {
     const locale = "fr";
     const numberingSystem = "latn";
 
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker lang="${locale}" numbering-system="${numberingSystem}" step="1"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker lang="${locale}" numbering-system="${numberingSystem}" step="1"></calcite-input-time-picker>`
+    );
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const input = await page.find("calcite-input-time-picker >>> calcite-input");
@@ -155,9 +156,10 @@ describe("calcite-input-time-picker", () => {
     const locale = "ar";
     const numberingSystem = "arab";
 
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker lang="${locale}" numbering-system="${numberingSystem}" step="1"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker lang="${locale}" numbering-system="${numberingSystem}" step="1"></calcite-input-time-picker>`
+    );
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const input = await page.find("calcite-input-time-picker >>> calcite-input");
@@ -185,9 +187,10 @@ describe("calcite-input-time-picker", () => {
     const locale = "en";
     const numberingSystem = "latn";
 
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker step="1" lang="${locale}" numbering-system="${numberingSystem}" value="11:00:00"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker step="1" lang="${locale}" numbering-system="${numberingSystem}" value="11:00:00"></calcite-input-time-picker>`
+    );
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const input = await page.find("calcite-input-time-picker >>> calcite-input");
@@ -219,9 +222,10 @@ describe("calcite-input-time-picker", () => {
     const numberingSystem = "thai";
     const initialValue = "11:00:00";
 
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker step="1" lang="${locale}" numbering-system="${numberingSystem}" value=${initialValue}></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker step="1" lang="${locale}" numbering-system="${numberingSystem}" value=${initialValue}></calcite-input-time-picker>`
+    );
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const input = await page.find("calcite-input-time-picker >>> calcite-input");
@@ -255,9 +259,10 @@ describe("calcite-input-time-picker", () => {
     const time = "11:59";
     const numberingSystem = "latn";
 
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker lang="${lang}" numbering-system="${numberingSystem}" value="${time}"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-input-time-picker lang="${lang}" numbering-system="${numberingSystem}" value="${time}"></calcite-input-time-picker>`
+    );
     const inputTimePicker = await page.find("calcite-input-time-picker");
 
     const getLocalizedTime = async () =>
@@ -283,7 +288,7 @@ describe("calcite-input-time-picker", () => {
 
   it("appropriately triggers calciteInputTimePickerChange event when the user types a value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-time-picker step="1"></calcite-input-time-picker>`);
+    await page.setContent(html`<calcite-input-time-picker step="1"></calcite-input-time-picker>`);
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const changeEvent = await inputTimePicker.spyOnEvent("calciteInputTimePickerChange");
@@ -309,7 +314,7 @@ describe("calcite-input-time-picker", () => {
 
   it("formats valid typed time value appropriately on blur", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input-time-picker step="1"></calcite-input-time-picker><input>`);
+    await page.setContent(html`<calcite-input-time-picker step="1"></calcite-input-time-picker><input />`);
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
 
@@ -322,9 +327,8 @@ describe("calcite-input-time-picker", () => {
   });
 
   it("resets to previous value when default event behavior is prevented", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker value="14:59"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-time-picker value="14:59"></calcite-input-time-picker>`);
     const inputTimePicker = await page.find("calcite-input-time-picker");
 
     await page.evaluate(() => {
@@ -345,9 +349,8 @@ describe("calcite-input-time-picker", () => {
   });
 
   it("sets initial value to undefined when it is not a valid time value", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker value="invalid"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-time-picker value="invalid"></calcite-input-time-picker>`);
     const inputTimePicker = await page.find("calcite-input-time-picker");
 
     expect(await inputTimePicker.getProperty("value")).toBeUndefined();
@@ -358,9 +361,8 @@ describe("calcite-input-time-picker", () => {
   });
 
   it("toggles seconds display when step is < 60", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-input-time-picker value="11:00:00"></calcite-input-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-time-picker value="11:00:00"></calcite-input-time-picker>`);
 
     const inputTimePicker = await page.find("calcite-input-time-picker");
     const input = await page.find("calcite-input-time-picker >>> calcite-input");

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -678,7 +678,8 @@ describe("calcite-input", () => {
     });
 
     it("does not fire any input or change events when a focused input is blurred after its value is set directly", async () => {
-      const page = await newE2EPage({ html: "<calcite-input></calcite-input>" });
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input></calcite-input>");
       const input = await page.find("calcite-input");
       const inputEventSpy = await input.spyOnEvent("calciteInputInput");
       const changeEventSpy = await input.spyOnEvent("calciteInputChange");
@@ -1520,9 +1521,7 @@ describe("calcite-input", () => {
 
   it("input event fires when number ends with a decimal", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input type="number" value="1.2"></calcite-input>
-    `);
+    await page.setContent(html` <calcite-input type="number" value="1.2"></calcite-input> `);
 
     const calciteInputInput = await page.spyOnEvent("calciteInputInput");
     const element = await page.find("calcite-input");
@@ -1537,9 +1536,7 @@ describe("calcite-input", () => {
 
   it("sanitize leading zeros from number input value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-input type="number"></calcite-input>
-    `);
+    await page.setContent(html` <calcite-input type="number"></calcite-input> `);
 
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
@@ -1558,7 +1555,7 @@ describe("calcite-input", () => {
 
   it("sanitize extra dashes from number input value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-input type="number"></calcite-input>`);
+    await page.setContent(html`<calcite-input type="number"></calcite-input>`);
 
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
@@ -1598,7 +1595,7 @@ describe("calcite-input", () => {
     });
 
     it("works for type textarea", async () => {
-      await page.setContent(`<calcite-input type="textarea"></calcite-input>`);
+      await page.setContent(html`<calcite-input type="textarea"></calcite-input>`);
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");
@@ -1617,7 +1614,7 @@ describe("calcite-input", () => {
     });
 
     it("works for type text", async () => {
-      await page.setContent(`<calcite-input type="text"></calcite-input>`);
+      await page.setContent(html`<calcite-input type="text"></calcite-input>`);
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");
@@ -1636,7 +1633,7 @@ describe("calcite-input", () => {
     });
 
     it("should not work for type number, but increment instead", async () => {
-      await page.setContent(`<calcite-input type="number"></calcite-input>`);
+      await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");

--- a/src/components/label/label.e2e.ts
+++ b/src/components/label/label.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { renders, hidden } from "../../tests/commonTests";
 
 describe("calcite-label", () => {
@@ -8,11 +9,11 @@ describe("calcite-label", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-label>
-    Label text
-    <calcite-input></calcite-input>
-    </calcite-label>
+    await page.setContent(html`
+      <calcite-label>
+        Label text
+        <calcite-input></calcite-input>
+      </calcite-label>
     `);
 
     const element = await page.find("calcite-label");
@@ -21,11 +22,11 @@ describe("calcite-label", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-label layout="inline-space-between">
-    Label text
-    <calcite-input></calcite-input>
-    </calcite-label>
+    await page.setContent(html`
+      <calcite-label layout="inline-space-between">
+        Label text
+        <calcite-input></calcite-input>
+      </calcite-label>
     `);
 
     const element = await page.find("calcite-label");
@@ -41,11 +42,11 @@ describe("calcite-label", () => {
 
     describe("default behavior", () => {
       it("should render with 'start' alignment", async () => {
-        page = await newE2EPage({
-          html: `<calcite-label>Label text
+        page = await newE2EPage();
+        await page.setContent(html`<calcite-label
+          >Label text
           <calcite-input></calcite-input>
-          </calcite-label>`
-        });
+        </calcite-label>`);
         element = await page.find("calcite-label");
         expect(await element.getProperty("alignment")).toEqual("start");
       });
@@ -53,13 +54,13 @@ describe("calcite-label", () => {
       describe("when in a center-aligned container", () => {
         describe("when direction is left-to-right", () => {
           it("should render text left-aligned", async () => {
-            page = await newE2EPage({
-              html: `<div style="text-align: center;">
-              <calcite-label dir="ltr">Label text
-              <calcite-input></calcite-input>
+            page = await newE2EPage();
+            await page.setContent(html`<div style="text-align: center;">
+              <calcite-label dir="ltr"
+                >Label text
+                <calcite-input></calcite-input>
               </calcite-label>
-              </div>`
-            });
+            </div>`);
             element = await page.find("calcite-label >>> .container");
             style = await element.getComputedStyle();
             expect(style["textAlign"]).toEqual("start");
@@ -68,13 +69,13 @@ describe("calcite-label", () => {
 
         describe("when direction is right-to-left", () => {
           it("should render text right-aligned", async () => {
-            page = await newE2EPage({
-              html: `<div style="text-align: center;">
-              <calcite-label dir="rtl">Label text
-              <calcite-input></calcite-input>
+            page = await newE2EPage();
+            await page.setContent(html`<div style="text-align: center;">
+              <calcite-label dir="rtl"
+                >Label text
+                <calcite-input></calcite-input>
               </calcite-label>
-              </div>`
-            });
+            </div>`);
             element = await page.find("calcite-label >>> .container");
             style = await element.getComputedStyle();
             expect(style["textAlign"]).toEqual("start");
@@ -86,11 +87,11 @@ describe("calcite-label", () => {
     describe("when alignment prop is provided", () => {
       describe("'center' alignment", () => {
         it("should render text center-aligned", async () => {
-          page = await newE2EPage({
-            html: `<calcite-label alignment="center">Label text
+          page = await newE2EPage();
+          await page.setContent(html`<calcite-label alignment="center"
+            >Label text
             <calcite-input></calcite-input>
-            </calcite-label>`
-          });
+          </calcite-label>`);
           element = await page.find("calcite-label >>> .container");
           style = await element.getComputedStyle();
           expect(style["textAlign"]).toEqual("center");
@@ -100,11 +101,11 @@ describe("calcite-label", () => {
       describe("'end' alignment", () => {
         describe("when direction is left-to-right", () => {
           it("should render text right-aligned", async () => {
-            page = await newE2EPage({
-              html: `<calcite-label alignment="end" dir="ltr">Label text
+            page = await newE2EPage();
+            await page.setContent(html`<calcite-label alignment="end" dir="ltr"
+              >Label text
               <calcite-input></calcite-input>
-              </calcite-label>`
-            });
+            </calcite-label>`);
             element = await page.find("calcite-label >>> .container");
             style = await element.getComputedStyle();
             expect(style["textAlign"]).toEqual("end");
@@ -113,11 +114,11 @@ describe("calcite-label", () => {
 
         describe("when direction is right-to-left", () => {
           it("should render text left-aligned", async () => {
-            page = await newE2EPage({
-              html: `<calcite-label alignment="end" dir="rtl">Label text
+            page = await newE2EPage();
+            await page.setContent(html`<calcite-label alignment="end" dir="rtl"
+              >Label text
               <calcite-input></calcite-input>
-              </calcite-label>`
-            });
+            </calcite-label>`);
             element = await page.find("calcite-label >>> .container");
             style = await element.getComputedStyle();
             expect(style["textAlign"]).toEqual("end");
@@ -129,11 +130,11 @@ describe("calcite-label", () => {
 
   it("does not pass id to child label element", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-label id="dont-duplicate-me" layout="inline-space-between">
-    Label text
-    <calcite-input></calcite-input>
-    </calcite-label>
+    await page.setContent(html`
+      <calcite-label id="dont-duplicate-me" layout="inline-space-between">
+        Label text
+        <calcite-input></calcite-input>
+      </calcite-label>
     `);
 
     const element = await page.find("calcite-label");

--- a/src/components/link/link.e2e.ts
+++ b/src/components/link/link.e2e.ts
@@ -1,4 +1,5 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, defaults, disabled, hidden, renders } from "../../tests/commonTests";
 
 describe("calcite-link", () => {
@@ -26,7 +27,7 @@ describe("calcite-link", () => {
 
   it("sets download attribute on internal anchor", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link href="file.jpg">Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link href="file.jpg">Continue</calcite-link>`);
 
     const elementAsLink = await page.find("calcite-link >>> a");
 
@@ -59,7 +60,7 @@ describe("calcite-link", () => {
 
   it("renders as a span with default props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link>Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link>Continue</calcite-link>`);
 
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
@@ -75,7 +76,8 @@ describe("calcite-link", () => {
   });
 
   it("should update childElType when href changes", async () => {
-    const page = await newE2EPage({ html: `<calcite-link>Continue</calcite-link>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-link>Continue</calcite-link>`);
     const link = await page.find("calcite-link");
     let elementAsLink: E2EElement;
     let elementAsSpan: E2EElement;
@@ -96,7 +98,7 @@ describe("calcite-link", () => {
 
   it("renders as a link with default props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link href="/">Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link href="/">Continue</calcite-link>`);
     const element = await page.find("calcite-link");
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
@@ -112,7 +114,7 @@ describe("calcite-link", () => {
 
   it("renders as a span with requested props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link>Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link>Continue</calcite-link>`);
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const iconStart = await page.find("calcite-link >>> .calcite-link--icon.icon-start");
@@ -126,7 +128,7 @@ describe("calcite-link", () => {
 
   it("renders as a link with requested props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link href="/">Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link href="/">Continue</calcite-link>`);
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const iconStart = await page.find("calcite-link >>> .calcite-link--icon.icon-start");
@@ -160,7 +162,7 @@ describe("calcite-link", () => {
 
   it("renders with an icon-start", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link icon-start='plus'>Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link icon-start="plus">Continue</calcite-link>`);
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const iconStart = await page.find("calcite-link >>> .calcite-link--icon.icon-start");
@@ -173,7 +175,7 @@ describe("calcite-link", () => {
 
   it("renders with an icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link icon-end='plus'>Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link icon-end="plus">Continue</calcite-link>`);
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const iconStart = await page.find("calcite-link >>> .calcite-link--icon.icon-start");
@@ -186,7 +188,7 @@ describe("calcite-link", () => {
 
   it("renders with an icon-start and icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-link icon-start='plus' icon-end='plus'>Continue</calcite-link>`);
+    await page.setContent(html`<calcite-link icon-start="plus" icon-end="plus">Continue</calcite-link>`);
     const elementAsSpan = await page.find("calcite-link >>> span");
     const elementAsLink = await page.find("calcite-link >>> a");
     const iconStart = await page.find("calcite-link >>> .calcite-link--icon.icon-start");
@@ -205,9 +207,8 @@ describe("calcite-link", () => {
     let targetUrl: string;
 
     beforeEach(async () => {
-      page = await newE2EPage({
-        html: `<calcite-link href="/${targetPage}">link</calcite-link>`
-      });
+      page = await newE2EPage();
+      await page.setContent(html`<calcite-link href="/${targetPage}">link</calcite-link>`);
 
       pageUrl = page.url();
       targetUrl = `${pageUrl}${targetPage}`;
@@ -259,7 +260,8 @@ describe("calcite-link", () => {
     let linkUnderlineStyle;
 
     it("should have defined CSS custom properties", async () => {
-      page = await newE2EPage({ html: linkHtml });
+      page = await newE2EPage();
+      await page.setContent(linkHtml);
       linkUnderlineStyle = await page.evaluate(() => {
         link = document.querySelector("calcite-link");
         link.style.setProperty("--calcite-link-blue-underline", "red");
@@ -270,7 +272,8 @@ describe("calcite-link", () => {
 
     describe("when mode attribute is not provided", () => {
       it("should render link background with default value tied to mode", async () => {
-        page = await newE2EPage({ html: linkHtml });
+        page = await newE2EPage();
+        await page.setContent(linkHtml);
         link = await page.find("calcite-link >>> a");
         linkStyles = await link.getComputedStyle();
         linkUnderlineStyle = await linkStyles.getPropertyValue("background-image");
@@ -282,9 +285,8 @@ describe("calcite-link", () => {
 
     describe("when mode attribute is dark", () => {
       it("should render link background with value tied to dark mode", async () => {
-        page = await newE2EPage({
-          html: `<article class="calcite-mode-dark">${linkHtml}</article>`
-        });
+        page = await newE2EPage();
+        await page.setContent(html`<article class="calcite-mode-dark">${linkHtml}</article>`);
         link = await page.find("calcite-link >>> a");
         linkStyles = await link.getComputedStyle();
         linkUnderlineStyle = await linkStyles.getPropertyValue("background-image");
@@ -296,16 +298,15 @@ describe("calcite-link", () => {
 
     it("should allow the CSS custom property to be overridden", async () => {
       const overrideStyle = "rgba(255, 244, 40, 0.5)";
-      page = await newE2EPage({
-        html: `
+      page = await newE2EPage();
+      await page.setContent(html`
         <style>
           :root {
             --calcite-link-blue-underline: ${overrideStyle};
           }
         </style>
         ${linkHtml}
-        `
-      });
+      `);
       link = await page.find("calcite-link >>> a");
       linkStyles = await link.getComputedStyle();
       linkUnderlineStyle = await linkStyles.getPropertyValue("background-image");

--- a/src/components/list-item/list-item.e2e.ts
+++ b/src/components/list-item/list-item.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { defaults, disabled, focusable, hidden, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
@@ -47,7 +48,8 @@ describe("calcite-list-item", () => {
   it("can be disabled", () => disabled(`<calcite-list-item label="test" active></calcite-list-item>`));
 
   it("renders content node when label is provided", async () => {
-    const page = await newE2EPage({ html: `<calcite-list-item label="test"></calcite-list-item>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list-item label="test"></calcite-list-item>`);
 
     const contentNode = await page.find(`calcite-list-item >>> .${CSS.content}`);
 
@@ -55,7 +57,8 @@ describe("calcite-list-item", () => {
   });
 
   it("renders content node when description is provided", async () => {
-    const page = await newE2EPage({ html: `<calcite-list-item description="test"></calcite-list-item>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list-item description="test"></calcite-list-item>`);
 
     const contentNode = await page.find(`calcite-list-item >>> .${CSS.content}`);
 
@@ -63,7 +66,8 @@ describe("calcite-list-item", () => {
   });
 
   it("does not render content node when description and label is not provided", async () => {
-    const page = await newE2EPage({ html: `<calcite-list-item></calcite-list-item>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list-item></calcite-list-item>`);
 
     const contentNode = await page.find(`calcite-list-item >>> .${CSS.content}`);
 
@@ -71,9 +75,10 @@ describe("calcite-list-item", () => {
   });
 
   it("renders custom content in place of label and description", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-list-item label="test" description="test"><div slot="content">My custom content</div></calcite-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-list-item label="test" description="test"><div slot="content">My custom content</div></calcite-list-item>`
+    );
 
     await page.waitForChanges();
 
@@ -87,11 +92,8 @@ describe("calcite-list-item", () => {
   });
 
   it("emits calciteListItemSelect on click", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-list-item label="hello" description="world"></calcite-list-item>`
-    });
-
-    await page.waitForChanges();
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list-item label="hello" description="world"></calcite-list-item>`);
 
     const contentContainer = await page.find(`calcite-list-item >>> .${CSS.contentContainer}`);
 
@@ -103,9 +105,10 @@ describe("calcite-list-item", () => {
   });
 
   it("emits calciteInternalListItemActive on click", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-list-item selection-mode="none" label="hello" description="world"></calcite-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-list-item selection-mode="none" label="hello" description="world"></calcite-list-item>`
+    );
 
     await page.waitForChanges();
 
@@ -140,7 +143,8 @@ describe("calcite-list-item", () => {
   });
 
   it("should fire close event when closed", async () => {
-    const page = await newE2EPage({ html: "<calcite-list-item closable>test</calcite-list-item>" });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-list-item closable>test</calcite-list-item>");
 
     const calciteListItemClose = await page.spyOnEvent("calciteListItemClose", "window");
 

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -100,14 +100,11 @@ describe("calcite-list", () => {
     ));
 
   it("navigating items after filtering", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-list filter-enabled>
-          <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
-          <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
-        </calcite-list>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list filter-enabled>
+      <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
+      <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
+    </calcite-list>`);
     await page.waitForChanges();
     const list = await page.find("calcite-list");
     const filter = await page.find(`calcite-list >>> calcite-filter`);
@@ -151,36 +148,13 @@ describe("calcite-list", () => {
   });
 
   it("filters initially", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-list filter-enabled filter-text="match">
-          <calcite-list-item
-            id="label-match"
-            label="match"
-            description="description-1"
-            value="value-1"
-          ></calcite-list-item>
-          <calcite-list-item
-            id="description-match"
-            label="label-2"
-            description="match"
-            value="value-1"
-          ></calcite-list-item>
-          <calcite-list-item
-            id="value-match"
-            label="label-3"
-            description="description-3"
-            value="match"
-          ></calcite-list-item>
-          <calcite-list-item
-            id="no-match"
-            label="label-4"
-            description="description-4"
-            value="value-4"
-          ></calcite-list-item>
-        </calcite-list>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list filter-enabled filter-text="match">
+      <calcite-list-item id="label-match" label="match" description="description-1" value="value-1"></calcite-list-item>
+      <calcite-list-item id="description-match" label="label-2" description="match" value="value-1"></calcite-list-item>
+      <calcite-list-item id="value-match" label="label-3" description="description-3" value="match"></calcite-list-item>
+      <calcite-list-item id="no-match" label="label-4" description="description-4" value="value-4"></calcite-list-item>
+    </calcite-list>`);
 
     const list = await page.find("calcite-list");
     await page.waitForTimeout(listDebounceTimeout);
@@ -195,13 +169,12 @@ describe("calcite-list", () => {
   });
 
   it("should update active item on init and click", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-list selection-mode="none">
-        <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
-        <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
-        <calcite-list-item id="item-3" label="hello 3" description="world 3"></calcite-list-item>
-      </calcite-list>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list selection-mode="none">
+      <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
+      <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
+      <calcite-list-item id="item-3" label="hello 3" description="world 3"></calcite-list-item>
+    </calcite-list>`);
 
     await page.waitForTimeout(listDebounceTimeout);
     await page.waitForChanges();
@@ -226,13 +199,12 @@ describe("calcite-list", () => {
   });
 
   it("should prevent de-selection of selected item in single-persist mode", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-list selection-mode="single-persist">
-        <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
-        <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
-        <calcite-list-item id="item-3" selected label="hello 3" description="world 3"></calcite-list-item>
-      </calcite-list>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list selection-mode="single-persist">
+      <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
+      <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
+      <calcite-list-item id="item-3" selected label="hello 3" description="world 3"></calcite-list-item>
+    </calcite-list>`);
 
     await page.waitForTimeout(listDebounceTimeout);
     await page.waitForChanges();
@@ -257,13 +229,12 @@ describe("calcite-list", () => {
   });
 
   it("should correctly allow de-selection and change of selected item in single mode", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-list selection-mode="single">
-        <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
-        <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
-        <calcite-list-item id="item-3" selected label="hello 3" description="world 3"></calcite-list-item>
-      </calcite-list>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list selection-mode="single">
+      <calcite-list-item id="item-1" label="hello" description="world"></calcite-list-item>
+      <calcite-list-item id="item-2" label="hello 2" description="world 2"></calcite-list-item>
+      <calcite-list-item id="item-3" selected label="hello 3" description="world 3"></calcite-list-item>
+    </calcite-list>`);
 
     await page.waitForTimeout(listDebounceTimeout);
     await page.waitForChanges();
@@ -298,14 +269,11 @@ describe("calcite-list", () => {
   });
 
   it("should emit calciteListChange on selection change", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-list selection-mode="single">
-          <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
-          <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
-        </calcite-list>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list selection-mode="single">
+      <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
+      <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
+    </calcite-list>`);
     await page.waitForChanges();
     const list = await page.find("calcite-list");
     const listItemOne = await page.find(`calcite-list-item[value=one]`);

--- a/src/components/list/list.e2e.ts
+++ b/src/components/list/list.e2e.ts
@@ -106,7 +106,6 @@ describe("calcite-list", () => {
       <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
       <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
     </calcite-list>`);
-    await page.waitForChanges();
     const list = await page.find("calcite-list");
     const filter = await page.find(`calcite-list >>> calcite-filter`);
     expect(await list.getProperty("filteredItems")).toHaveLength(2);

--- a/src/components/loader/loader.e2e.ts
+++ b/src/components/loader/loader.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { hidden, renders } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-loader", () => {
   describe("renders", () => {
@@ -11,14 +12,14 @@ describe("calcite-loader", () => {
 
   it("displays label from text prop", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader text="testing"></calcite-loader>`);
+    await page.setContent(html`<calcite-loader text="testing"></calcite-loader>`);
     const elm = await page.find("calcite-loader >>> .loader__text");
     expect(elm).toEqualText("testing");
   });
 
   it("sets aria attributes properly for indeterminate loader", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader></calcite-loader>`);
+    await page.setContent(html`<calcite-loader></calcite-loader>`);
     const loader = await page.find("calcite-loader");
     expect(loader).toEqualAttribute("role", "progressbar");
     expect(loader).not.toHaveAttribute("aria-valuemin");
@@ -28,7 +29,7 @@ describe("calcite-loader", () => {
 
   it("sets aria attributes properly for determinate loader", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader type="determinate"></calcite-loader>`);
+    await page.setContent(html`<calcite-loader type="determinate"></calcite-loader>`);
     const loader = await page.find("calcite-loader");
     expect(loader).toHaveAttribute("aria-valuenow");
     expect(loader).toEqualAttribute("aria-valuenow", 0);
@@ -41,14 +42,14 @@ describe("calcite-loader", () => {
 
   it("displays inline with text from inline prop", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader inline></calcite-loader>`);
+    await page.setContent(html`<calcite-loader inline></calcite-loader>`);
     const rect = await page.find("calcite-loader >>> circle");
     expect(rect).toEqualAttribute("r", "7.2");
   });
 
   it("sets a default id when none is provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-loader></calcite-loader>`);
+    await page.setContent(html`<calcite-loader></calcite-loader>`);
     const loader = await page.find("calcite-loader");
     expect(loader).toHaveAttribute("id");
     expect(loader.getAttribute("id").length).toEqual(36);

--- a/src/components/modal/modal.e2e.ts
+++ b/src/components/modal/modal.e2e.ts
@@ -27,7 +27,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     // set large page to ensure test modal isn't becoming fullscreen
     await page.setViewport({ width: 1440, height: 1440 });
-    await page.setContent(`<calcite-modal style="--calcite-modal-width:600px;"></calcite-modal>`);
+    await page.setContent(html`<calcite-modal style="--calcite-modal-width:600px;"></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -42,7 +42,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     // set large page to ensure test modal isn't becoming fullscreen
     await page.setViewport({ width: 1440, height: 1440 });
-    await page.setContent(`<calcite-modal style="--calcite-modal-height:600px;" open></calcite-modal>`);
+    await page.setContent(html`<calcite-modal style="--calcite-modal-height:600px;" open></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -57,7 +57,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     // set large page to ensure test modal isn't becoming fullscreen
     await page.setViewport({ width: 1440, height: 1440 });
-    await page.setContent(`<calcite-modal style="--calcite-modal-width:600px;" fullscreen open></calcite-modal>`);
+    await page.setContent(html`<calcite-modal style="--calcite-modal-width:600px;" fullscreen open></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -72,7 +72,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     // set large page to ensure test modal isn't becoming fullscreen
     await page.setViewport({ width: 1440, height: 1440 });
-    await page.setContent(`<calcite-modal style="--calcite-modal-height:600px;" fullscreen open></calcite-modal>`);
+    await page.setContent(html`<calcite-modal style="--calcite-modal-height:600px;" fullscreen open></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -109,9 +109,7 @@ describe("calcite-modal properties", () => {
     const page = await newE2EPage();
     const mockCallBack = jest.fn();
     await page.exposeFunction("beforeClose", mockCallBack);
-    await page.setContent(`
-      <calcite-modal open></calcite-modal>
-    `);
+    await page.setContent(html` <calcite-modal open></calcite-modal> `);
     const modal = await page.find("calcite-modal");
     await page.$eval(
       "calcite-modal",
@@ -414,7 +412,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("has correct aria role/attribute", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     expect(modal).toEqualAttribute("role", "dialog");
     expect(modal).toEqualAttribute("aria-modal", "true");
@@ -422,7 +420,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("closes and allows re-opening when Escape key is pressed", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal ></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     await skipAnimations(page);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
@@ -439,7 +437,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("closes when Escape key is pressed and modal is open on page load", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal  open></calcite-modal>`);
+    await page.setContent(html`<calcite-modal open></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await page.waitForChanges();
     expect(modal).toHaveAttribute("open");
@@ -456,7 +454,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("closes and allows re-opening when Close button is clicked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal ></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     await skipAnimations(page);
     const modal = await page.find("calcite-modal");
     modal.setProperty("open", true);
@@ -474,7 +472,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("should close when the scrim is clicked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal ></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     modal.setProperty("open", true);
     await page.waitForChanges();
@@ -486,7 +484,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("should not close when the scrim is clicked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal outside-close-disabled ></calcite-modal>`);
+    await page.setContent(html`<calcite-modal outside-close-disabled></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     modal.setProperty("open", true);
     await page.waitForChanges();
@@ -498,7 +496,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("does not close when Escape is pressed and escape-disabled is set", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal escape-disabled></calcite-modal>`);
+    await page.setContent(html`<calcite-modal escape-disabled></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -510,7 +508,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("correctly adds overflow class on document when open", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -522,7 +520,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("correctly does not add overflow class on document when open and slotted in shell modals slot", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-shell><calcite-modal slot="modals"></calcite-modal></calcite-shell>`);
+    await page.setContent(html`<calcite-shell><calcite-modal slot="modals"></calcite-modal></calcite-shell>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -534,7 +532,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("correctly removes overflow class on document once closed", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-modal></calcite-modal>`);
+    await page.setContent(html`<calcite-modal></calcite-modal>`);
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
@@ -548,7 +546,7 @@ describe("calcite-modal accessibility checks", () => {
 
   it("renders correctly with no footer", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-modal>
         <calcite-button slot="primary">TEST</calcite-button>
       </calcite-modal>
@@ -562,8 +560,8 @@ describe("calcite-modal accessibility checks", () => {
   });
 
   it("should render calcite-scrim with default background color", async () => {
-    const page = await newE2EPage({
-      html: `
+    const page = await newE2EPage();
+    await page.setContent(html`
       <calcite-modal aria-labelledby="modal-title" open>
         <h3 slot="header" id="modal-title">Title of the modal</h3>
         <div slot="content">The actual content of the modal</div>
@@ -573,8 +571,7 @@ describe("calcite-modal accessibility checks", () => {
         <calcite-button slot="secondary" width="full" appearance="outline"> Cancel </calcite-button>
         <calcite-button slot="primary" width="full"> Save </calcite-button>
       </calcite-modal>
-      `
-    });
+    `);
     const scrimStyles = await page.evaluate(() => {
       const scrim = document.querySelector("calcite-modal").shadowRoot.querySelector(".scrim");
       return window.getComputedStyle(scrim).getPropertyValue("--calcite-scrim-background");
@@ -584,8 +581,8 @@ describe("calcite-modal accessibility checks", () => {
 
   it("when modal css override set, scrim should adhere to requested color", async () => {
     const overrideStyle = "rgba(160, 20, 10, 0.5)";
-    const page = await newE2EPage({
-      html: `
+    const page = await newE2EPage();
+    await page.setContent(html`
       <calcite-modal aria-labelledby="modal-title" open style="--calcite-modal-scrim-background:${overrideStyle}">
         <h3 slot="header" id="modal-title">Title of the modal</h3>
         <div slot="content">The actual content of the modal</div>
@@ -595,8 +592,7 @@ describe("calcite-modal accessibility checks", () => {
         <calcite-button slot="secondary" width="full" appearance="outline"> Cancel </calcite-button>
         <calcite-button slot="primary" width="full"> Save </calcite-button>
       </calcite-modal>
-      `
-    });
+    `);
     const scrimStyles = await page.evaluate(() => {
       const scrim = document.querySelector("calcite-modal").shadowRoot.querySelector(".scrim");
       return window.getComputedStyle(scrim).getPropertyValue("--calcite-scrim-background");

--- a/src/components/notice/notice.e2e.ts
+++ b/src/components/notice/notice.e2e.ts
@@ -36,11 +36,10 @@ describe("calcite-notice", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-notice>
-    <div slot="title">Title Text</div>
-    <div slot="message">Message Text</div>
-    <calcite-link slot="link" href="">Action</calcite-link>
+    await page.setContent(html` <calcite-notice>
+      <div slot="title">Title Text</div>
+      <div slot="message">Message Text</div>
+      <calcite-link slot="link" href="">Action</calcite-link>
     </calcite-notice>`);
     const element = await page.find("calcite-notice");
     const close = await page.find(`calcite-notice >>> .${CSS.close}`);
@@ -52,10 +51,7 @@ describe("calcite-notice", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-notice kind="warning" closable>
-    ${noticeContent}
-    </calcite-notice>`);
+    await page.setContent(html` <calcite-notice kind="warning" closable> ${noticeContent} </calcite-notice>`);
 
     const element = await page.find("calcite-notice");
     const close = await page.find(`calcite-notice >>> .${CSS.close}`);
@@ -68,10 +64,7 @@ describe("calcite-notice", () => {
 
   it("renders an icon and close button when requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-notice icon closable>
-    ${noticeContent}
-    </calcite-notice>`);
+    await page.setContent(html` <calcite-notice icon closable> ${noticeContent} </calcite-notice>`);
 
     const close = await page.find(`calcite-notice >>> .${CSS.close}`);
     const icon = await page.find(`calcite-notice >>> .${CSS.icon}`);
@@ -81,11 +74,7 @@ describe("calcite-notice", () => {
 
   it("successfully closes a closable notice", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-notice id="notice-1" open closable>
-    ${noticeContent}
-    </calcite-notice>
-    `);
+    await page.setContent(html` <calcite-notice id="notice-1" open closable> ${noticeContent} </calcite-notice> `);
 
     const notice1 = await page.find("#notice-1 >>> .container");
     const noticeclose1 = await page.find(`#notice-1 >>> .${CSS.close}`);

--- a/src/components/option-group/option-group.e2e.ts
+++ b/src/components/option-group/option-group.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-option-group", () => {
   describe("renders", () => {
@@ -29,9 +30,8 @@ describe("calcite-option-group", () => {
     ]));
 
   it("has a label", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-option-group label="test-group"></calcite-option-group>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-option-group label="test-group"></calcite-option-group>`);
 
     const group = await page.find("calcite-option-group");
     expect(group.shadowRoot.textContent).toBe("test-group");

--- a/src/components/option/option.e2e.ts
+++ b/src/components/option/option.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-option", () => {
   describe("renders", () => {
@@ -34,9 +35,8 @@ describe("calcite-option", () => {
 
   it("falls back to the text content when value/label is not specified", async () => {
     const optionText = "one";
-    const page = await newE2EPage({
-      html: `<calcite-option>${optionText}</calcite-option>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-option>${optionText}</calcite-option>`);
     const option = await page.find("calcite-option");
 
     expect(await option.getProperty("label")).toBe(optionText);

--- a/src/components/pagination/pagination.e2e.ts
+++ b/src/components/pagination/pagination.e2e.ts
@@ -29,7 +29,7 @@ describe("calcite-pagination", () => {
   describe("page links", () => {
     it("should render only one page when totalItems is less than pageSize", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination total-items="10" page-size="11"></calcite-pagination>`);
+      await page.setContent(html`<calcite-pagination total-items="10" page-size="11"></calcite-pagination>`);
       const links = await page.findAll(`calcite-pagination >>> .${CSS.page}`);
       expect(links.length).toBe(1);
     });
@@ -38,7 +38,7 @@ describe("calcite-pagination", () => {
   describe("ellipsis rendering", () => {
     it("should not render either ellipsis when total pages is less than or equal to 5", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination total-items="80"></calcite-pagination>`);
+      await page.setContent(html`<calcite-pagination total-items="80"></calcite-pagination>`);
 
       const startEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisStart}`);
       const endEllipsis = await page.find(`calcite-pagination >>> .${CSS.ellipsis}.${CSS.ellipsisEnd}`);
@@ -132,7 +132,9 @@ describe("calcite-pagination", () => {
   describe("page buttons", () => {
     it("should switch selected page to the page that's clicked", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start-item="1" total-items="36" page-size="10"></calcite-pagination>`);
+      await page.setContent(
+        html`<calcite-pagination start-item="1" total-items="36" page-size="10"></calcite-pagination>`
+      );
       const toggleSpy = await page.spyOnEvent("calcitePaginationChange");
       const pages = await page.findAll("calcite-pagination >>> .page");
       await pages[1].click();
@@ -155,7 +157,9 @@ describe("calcite-pagination", () => {
     let pagination: E2EElement;
     beforeEach(async () => {
       page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start-item="1" total-items="5" page-size="1"></calcite-pagination>`);
+      await page.setContent(
+        html`<calcite-pagination start-item="1" total-items="5" page-size="1"></calcite-pagination>`
+      );
       pagination = await page.find("calcite-pagination");
     });
     it("should show the first page", async () => {

--- a/src/components/panel/panel.e2e.ts
+++ b/src/components/panel/panel.e2e.ts
@@ -59,7 +59,8 @@ describe("calcite-panel", () => {
   });
 
   it("close event should fire when closed", async () => {
-    const page = await newE2EPage({ html: "<calcite-panel closable>test</calcite-panel>" });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-panel closable>test</calcite-panel>");
 
     const calcitePanelClose = await page.spyOnEvent("calcitePanelClose", "window");
 
@@ -101,9 +102,8 @@ describe("calcite-panel", () => {
     }));
 
   it("honors calcitePanelScroll event", async () => {
-    const page = await newE2EPage({
-      html: "<calcite-panel>test</calcite-panel>"
-    });
+    const page = await newE2EPage();
+    await page.setContent("<calcite-panel>test</calcite-panel>");
 
     const scrollSpy = await page.spyOnEvent("calcitePanelScroll");
 

--- a/src/components/pick-list-group/pick-list-group.e2e.ts
+++ b/src/components/pick-list-group/pick-list-group.e2e.ts
@@ -36,7 +36,7 @@ describe("calcite-pick-list-group", () => {
   it("should render", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-pick-list-group></calcite-pick-list-group>`);
+    await page.setContent(html`<calcite-pick-list-group></calcite-pick-list-group>`);
     const pickList = await page.find("calcite-pick-list-group");
     expect(pickList).not.toBeNull();
     const isVisible = await pickList.isVisible();
@@ -47,7 +47,7 @@ describe("calcite-pick-list-group", () => {
     const page = await newE2EPage();
     const headingText = "testing";
 
-    await page.setContent(`<calcite-pick-list-group group-title=${headingText}></calcite-pick-list-group>`);
+    await page.setContent(html`<calcite-pick-list-group group-title=${headingText}></calcite-pick-list-group>`);
     const heading = await page.find(`calcite-pick-list-group >>> .${CSS.heading}`);
     const isVisible = await heading.isVisible();
     expect(isVisible).toBe(true);
@@ -56,7 +56,7 @@ describe("calcite-pick-list-group", () => {
 
   it("should indent children if a parent slot is passed", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-pick-list filter-enabled>
+    await page.setContent(html`<calcite-pick-list filter-enabled>
       <calcite-pick-list-group>
         <calcite-pick-list-item slot="parent-item" value="nums" label="Numbers"></calcite-pick-list-item>
         <calcite-pick-list-item value="1" label="One" description="uno"></calcite-pick-list-item>

--- a/src/components/pick-list-item/pick-list-item.e2e.ts
+++ b/src/components/pick-list-item/pick-list-item.e2e.ts
@@ -38,7 +38,8 @@ describe("calcite-pick-list-item", () => {
   it("supports translations", () => t9n("calcite-pick-list-item"));
 
   it("should toggle selected attribute when clicked", async () => {
-    const page = await newE2EPage({ html: `<calcite-pick-list-item label="test"></calcite-pick-list-item>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-pick-list-item label="test"></calcite-pick-list-item>`);
 
     const item = await page.find("calcite-pick-list-item");
     expect(await item.getProperty("selected")).toBe(false);
@@ -51,9 +52,8 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("should toggle selected attribute when icon is clicked", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" icon="circle"></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-pick-list-item label="test" icon="circle"></calcite-pick-list-item>`);
 
     const item = await page.find("calcite-pick-list-item");
     expect(await item.getProperty("selected")).toBe(false);
@@ -67,9 +67,8 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("should fire event calciteListItemChange when item is clicked", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" value="example"></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-pick-list-item label="test" value="example"></calcite-pick-list-item>`);
     const item = await page.find("calcite-pick-list-item");
     await page.evaluate(() => {
       document.addEventListener("calciteListItemChange", (event: CustomEvent): void => {
@@ -89,9 +88,10 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("prevents deselection when deselectDisabled is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" value="example" deselect-disabled selected></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-pick-list-item label="test" value="example" deselect-disabled selected></calcite-pick-list-item>`
+    );
     const item = await page.find("calcite-pick-list-item");
 
     await item.click();
@@ -100,9 +100,10 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("prevents selection when nonInteractive is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" value="example" non-interactive></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-pick-list-item label="test" value="example" non-interactive></calcite-pick-list-item>`
+    );
     const item = await page.find("calcite-pick-list-item");
 
     await item.click();
@@ -111,9 +112,10 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("prevents deselection when nonInteractive is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" value="example" non-interactive selected></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-pick-list-item label="test" value="example" non-interactive selected></calcite-pick-list-item>`
+    );
     const item = await page.find("calcite-pick-list-item");
 
     await item.click();
@@ -122,9 +124,10 @@ describe("calcite-pick-list-item", () => {
   });
 
   it("allows for easy removal", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list-item label="test" value="example" removable></calcite-pick-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-pick-list-item label="test" value="example" removable></calcite-pick-list-item>`
+    );
 
     const removeButton = await page.find(`calcite-pick-list-item >>> .${CSS.remove}`);
 

--- a/src/components/pick-list/pick-list.e2e.ts
+++ b/src/components/pick-list/pick-list.e2e.ts
@@ -52,7 +52,7 @@ describe("calcite-pick-list", () => {
   describe("icon logic", () => {
     it("should be 'circle' when multi-select is disabled", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pick-list>
+      await page.setContent(html`<calcite-pick-list>
         <calcite-pick-list-item value="one"></calcite-pick-list-item>
       </calcite-pick-list>`);
 
@@ -63,7 +63,7 @@ describe("calcite-pick-list", () => {
 
     it("should be 'square' when multi-select is enabled", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-pick-list multiple>
+      await page.setContent(html`<calcite-pick-list multiple>
         <calcite-pick-list-item value="one"></calcite-pick-list-item>
       </calcite-pick-list>`);
 
@@ -107,14 +107,13 @@ describe("calcite-pick-list", () => {
 
     describe("filtering with groups", () => {
       beforeEach(async () => {
-        page = await newE2EPage({
-          html: `<calcite-pick-list filter-enabled>
+        page = await newE2EPage();
+        await page.setContent(html`<calcite-pick-list filter-enabled>
           <calcite-pick-list-group group-title="Numbers">
             <calcite-pick-list-item value="1" label="One" description="uno"></calcite-pick-list-item>
             <calcite-pick-list-item value="2" label="Two" description="dos"></calcite-pick-list-item>
           </calcite-pick-list-group>
-        </calcite-pick-list>`
-        });
+        </calcite-pick-list>`);
 
         groupOrParentItem = await page.find(`calcite-pick-list-group`);
         item1 = await page.find(`calcite-pick-list-item[value="1"]`);
@@ -140,15 +139,14 @@ describe("calcite-pick-list", () => {
 
     describe("filtering with groups (nested)", () => {
       beforeEach(async () => {
-        page = await newE2EPage({
-          html: `<calcite-pick-list filter-enabled>
+        page = await newE2EPage();
+        await page.setContent(html`<calcite-pick-list filter-enabled>
           <calcite-pick-list-group>
             <calcite-pick-list-item slot="parent-item" value="nums" label="Numbers"></calcite-pick-list-item>
             <calcite-pick-list-item value="1" label="One" description="uno"></calcite-pick-list-item>
             <calcite-pick-list-item value="2" label="Two" description="dos"></calcite-pick-list-item>
           </calcite-pick-list-group>
-        </calcite-pick-list>`
-        });
+        </calcite-pick-list>`);
 
         groupOrParentItem = await page.find(`calcite-pick-list-item[slot="parent-item"]`);
         item1 = await page.find(`calcite-pick-list-item[value="1"]`);
@@ -201,14 +199,13 @@ describe("calcite-pick-list", () => {
   });
 
   it("should set headingLevel of tip", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-pick-list heading-level="1">
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-pick-list heading-level="1">
       <calcite-pick-list-group group-title="test">
         <calcite-pick-list-item value="1" label="One" description="uno"></calcite-pick-list-item>
         <calcite-pick-list-item value="2" label="Two" description="dos"></calcite-pick-list-item>
       </calcite-pick-list-group>
-    </calcite-pick-list>`
-    });
+    </calcite-pick-list>`);
 
     await page.waitForChanges();
 

--- a/src/components/pick-list/shared-list-tests.ts
+++ b/src/components/pick-list/shared-list-tests.ts
@@ -21,16 +21,15 @@ export function keyboardNavigation(listType: ListType): void {
 
   describe("multi selection", () => {
     it("keyboard interaction", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-${listType}-list multiple>
           <calcite-${listType}-list-item disabled value="zero" label="Zero (disabled)"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item disabled value="three" label="Three (disabled)"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
-      `
-      });
+      `);
       const list = await page.find(`calcite-${listType}-list`);
       await list.callMethod("setFocus");
 
@@ -71,14 +70,13 @@ export function keyboardNavigation(listType: ListType): void {
   describe("single selection", () => {
     describe("with selected item", () => {
       it("keyboard interaction", async () => {
-        const page = await newE2EPage({
-          html: `
+        const page = await newE2EPage();
+        await page.setContent(html`
         <calcite-${listType}-list>
           <calcite-${listType}-list-item id="one" value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item id="two" value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
-      `
-        });
+      `);
         const list = await page.find(`calcite-${listType}-list`);
         const firstItem = await page.find("#one");
         const secondItem = await page.find("#two");
@@ -127,14 +125,13 @@ export function keyboardNavigation(listType: ListType): void {
       });
 
       it("keyboard interaction + selectionFollowsFocus", async () => {
-        const page = await newE2EPage({
-          html: `
+        const page = await newE2EPage();
+        await page.setContent(html`
         <calcite-${listType}-list selection-follows-focus>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
-      `
-        });
+      `);
         const list = await page.find(`calcite-${listType}-list`);
 
         expect(await getFocusedItemValue(page)).toBeNull();
@@ -169,14 +166,13 @@ export function keyboardNavigation(listType: ListType): void {
     });
 
     it.skip("should honor filterText", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-${listType}-list filter-enabled filter-text="one">
           <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
-      `
-      });
+      `);
       const list = await page.find(`calcite-${listType}-list`);
       expect(await list.getProperty("filteredItems")).toHaveLength(1);
       expect(await list.getProperty("filteredData")).toHaveLength(1);
@@ -184,14 +180,13 @@ export function keyboardNavigation(listType: ListType): void {
     });
 
     it.skip("navigating items after filtering", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-${listType}-list filter-enabled>
           <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>
-      `
-      });
+      `);
       const list = await page.find(`calcite-${listType}-list`);
       expect(await list.getProperty("filteredItems")).toHaveLength(2);
       expect(await list.getProperty("filteredData")).toHaveLength(2);
@@ -268,7 +263,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("when multiple is false and an item is clicked", () => {
     it("should emit an event with the last selected item data", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list>
+      await page.setContent(html`<calcite-${listType}-list>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
@@ -287,7 +282,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("when multiple is true and a item is clicked", () => {
     it("should emit an event with each selected item's data", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list multiple>
+      await page.setContent(html`<calcite-${listType}-list multiple>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
@@ -307,7 +302,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("preselected items", () => {
     it("should be included in the list of selected items", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list multiple>
+      await page.setContent(html`<calcite-${listType}-list multiple>
           <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
@@ -325,7 +320,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("shift click behavior", () => {
     it("should multi-select", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list multiple>
+      await page.setContent(html`<calcite-${listType}-list multiple>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="three" label="Three"></calcite-${listType}-list-item>
@@ -350,7 +345,7 @@ export function selectionAndDeselection(listType: ListType): void {
 
     it("should multi de-select", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list multiple>
+      await page.setContent(html`<calcite-${listType}-list multiple>
           <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="three" label="Three" selected></calcite-${listType}-list-item>
@@ -377,7 +372,7 @@ export function selectionAndDeselection(listType: ListType): void {
     it("should fire event when a selection changed", async () => {
       const page = await newE2EPage();
 
-      await page.setContent(`<calcite-${listType}-list>
+      await page.setContent(html`<calcite-${listType}-list>
           <calcite-${listType}-list-item label="test" value="example"></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
       const item = await page.find(`calcite-${listType}-list-item`);
@@ -408,7 +403,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("when an item is selected and then gets removed", () => {
     it("should deselect the removed item from the selectedValues map", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list multiple>
+      await page.setContent(html`<calcite-${listType}-list multiple>
           <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
           <calcite-${listType}-list-item id="item2" value="two" label="Two" selected></calcite-${listType}-list-item>
         </calcite-${listType}-list>`);
@@ -426,7 +421,7 @@ export function selectionAndDeselection(listType: ListType): void {
   describe("value changes after item is selected", () => {
     it("should update the value in selectedValues map", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-${listType}-list>
+      await page.setContent(html`<calcite-${listType}-list>
           <calcite-${listType}-list-item value="one" label="One" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="two" label="Two" selected></calcite-${listType}-list-item>
           <calcite-${listType}-list-item value="three" label="Three" selected></calcite-${listType}-list-item>
@@ -470,7 +465,7 @@ export function filterBehavior(listType: ListType): void {
 
   beforeEach(async () => {
     page = await newE2EPage();
-    await page.setContent(`<calcite-${listType}-list filter-enabled>
+    await page.setContent(html`<calcite-${listType}-list filter-enabled>
         <calcite-${listType}-list-item value="1" label="One" description="uno"></calcite-${listType}-list-item>
         <calcite-${listType}-list-item value="2" label="Two [regex chars]" description="dos (regex chars)"></calcite-${listType}-list-item>
       </calcite-${listType}-list>`);
@@ -540,7 +535,7 @@ export function filterBehavior(listType: ListType): void {
 export function loadingState(listType: ListType): void {
   it("loading", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-${listType}-list loading>
+    await page.setContent(html`<calcite-${listType}-list loading>
         <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
       </calcite-${listType}-list>`);
 
@@ -570,14 +565,11 @@ export function itemRemoval(listType: ListType): void {
     </calcite-pick-list-group>`;
 
   it("handles removing items", async () => {
-    const page = await newE2EPage({
-      html: html`
-      <calcite-${listType}-list>
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-${listType}-list>
         ${listType === "value" ? "" : pickListGroupHtml}
         <calcite-${listType}-list-item value="remove-me" label="Remove me!" removable></calcite-${listType}-list-item>
-      </calcite-${listType}-list>
-    `
-    });
+      </calcite-${listType}-list>`);
     const list = await page.find(`calcite-${listType}-list`);
     const removeItemSpy = await list.spyOnEvent("calciteListItemRemove");
     const listChangeSpy = await list.spyOnEvent("calciteListChange");

--- a/src/components/popover/popover.e2e.ts
+++ b/src/components/popover/popover.e2e.ts
@@ -114,7 +114,10 @@ describe("calcite-popover", () => {
   it("open popover should be visible", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-popover placement="auto"></calcite-popover><div>referenceElement</div>`);
+    await page.setContent(
+      html`<calcite-popover placement="auto"></calcite-popover>
+        <div>referenceElement</div>`
+    );
 
     const element = await page.find("calcite-popover");
 
@@ -162,7 +165,7 @@ describe("calcite-popover", () => {
   it("should accept referenceElement as a virtual element", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-popover placement="auto" open>content</calcite-popover>`);
+    await page.setContent(html`<calcite-popover placement="auto" open>content</calcite-popover>`);
 
     await page.$eval("calcite-popover", (popover: HTMLCalcitePopoverElement) => {
       const virtualElement = {

--- a/src/components/radio-button/radio-button.e2e.ts
+++ b/src/components/radio-button/radio-button.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import {
   accessible,
   defaults,
@@ -40,7 +41,7 @@ describe("calcite-radio-button", () => {
 
   it("focusing skips over hidden radio-buttons", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="hidden" value="first"></calcite-radio-button>
       <calcite-radio-button name="hidden" value="second" hidden></calcite-radio-button>
       <calcite-radio-button name="hidden" value="third"></calcite-radio-button>
@@ -75,7 +76,7 @@ describe("calcite-radio-button", () => {
 
   it("does not require an item to be checked", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="none-checked" value="1"></calcite-radio-button>
       <calcite-radio-button name="none-checked" value="2"></calcite-radio-button>
       <calcite-radio-button name="none-checked" value="3"></calcite-radio-button>
@@ -89,7 +90,7 @@ describe("calcite-radio-button", () => {
 
   it("when multiple items are checked, last one wins", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="multiple-checked" value="1" checked></calcite-radio-button>
       <calcite-radio-button name="multiple-checked" value="2" checked></calcite-radio-button>
       <calcite-radio-button name="multiple-checked" value="3" checked></calcite-radio-button>
@@ -103,7 +104,7 @@ describe("calcite-radio-button", () => {
 
   it("selects item with left and arrow keys", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="keyboard" value="1" checked></calcite-radio-button>
       <calcite-radio-button name="keyboard" value="2"></calcite-radio-button>
       <calcite-radio-button name="keyboard" value="3"></calcite-radio-button>
@@ -142,7 +143,7 @@ describe("calcite-radio-button", () => {
 
   it("selects item with up and down keys", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="up-down-keys" value="1" checked></calcite-radio-button>
       <calcite-radio-button name="up-down-keys" value="2"></calcite-radio-button>
       <calcite-radio-button name="up-down-keys" value="3"></calcite-radio-button>
@@ -179,7 +180,7 @@ describe("calcite-radio-button", () => {
 
   it("clicking a radio updates its checked status", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="radio" value="one" checked></calcite-radio-button>
       <calcite-radio-button name="radio" value="two"></calcite-radio-button>
     `);
@@ -215,7 +216,7 @@ describe("calcite-radio-button", () => {
 
   it("programmatically checking a radio button updates the group's state correctly", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="radio" value="one" checked></calcite-radio-button>
       <calcite-radio-button name="radio" value="two"></calcite-radio-button>
       <calcite-radio-button name="radio" value="three"></calcite-radio-button>
@@ -235,7 +236,7 @@ describe("calcite-radio-button", () => {
 
   it("programmatically un-checking a radio button updates the group's state correctly", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-radio-button name="radio" value="one" checked></calcite-radio-button>
       <calcite-radio-button name="radio" value="two"></calcite-radio-button>
       <calcite-radio-button name="radio" value="three"></calcite-radio-button>
@@ -252,7 +253,7 @@ describe("calcite-radio-button", () => {
 
   it("appropriately triggers the custom change event", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-radio-button></calcite-radio-button>`);
+    await page.setContent(html`<calcite-radio-button></calcite-radio-button>`);
 
     const radio = await page.find("calcite-radio-button");
 
@@ -378,7 +379,7 @@ describe("calcite-radio-button", () => {
 
   it("resets to initial value when form reset event is triggered", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <form id="form">
         <calcite-radio-button id="unchecked" name="reset" value="unchecked"></calcite-radio-button>
         <calcite-radio-button id="checked" name="reset" value="checked" checked></calcite-radio-button>
@@ -408,7 +409,7 @@ describe("calcite-radio-button", () => {
 
   it("works correctly inside a shadowRoot", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <div></div>
       <template>
         <calcite-radio-button name="in-shadow" value="one"></calcite-radio-button>

--- a/src/components/scrim/scrim.e2e.ts
+++ b/src/components/scrim/scrim.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";
 import { CSS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-scrim", () => {
   describe("renders", () => {
@@ -50,7 +51,7 @@ describe("calcite-scrim", () => {
   it("does not allow clicks in underlying nodes", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-panel>
         <calcite-button>Test</calcite-button>
         <calcite-scrim></calcite-scrim>
@@ -67,7 +68,7 @@ describe("calcite-scrim", () => {
   it("does allow clicks inside default node", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-scrim>
         <calcite-button>Test</calcite-button>
       </calcite-scrim>
@@ -85,7 +86,7 @@ describe("calcite-scrim", () => {
   it("does not render content if the default slot if it is empty", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-scrim></calcite-scrim>`);
+    await page.setContent(html`<calcite-scrim></calcite-scrim>`);
 
     const contentNode = await page.find(`calcite-scrim >>> .${CSS.content}`);
 
@@ -95,7 +96,7 @@ describe("calcite-scrim", () => {
   it("renders conent in the default slot has content", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-scrim>This is a test.</calcite-scrim>`);
+    await page.setContent(html`<calcite-scrim>This is a test.</calcite-scrim>`);
 
     const contentNode = await page.find(`calcite-scrim >>> .${CSS.content}`);
 
@@ -117,7 +118,8 @@ describe("calcite-scrim", () => {
     let scrimBgStyle;
 
     it("should have defined CSS custom properties", async () => {
-      page = await newE2EPage({ html: scrimSnippet });
+      page = await newE2EPage();
+      await page.setContent(scrimSnippet);
       scrimBgStyle = await page.evaluate(() => {
         scrim = document.querySelector("calcite-scrim");
         scrim.style.setProperty("--calcite-scrim-background", "green");
@@ -128,7 +130,8 @@ describe("calcite-scrim", () => {
 
     describe("when mode attribute is not provided", () => {
       it("should render scrim background with default value tied to mode", async () => {
-        page = await newE2EPage({ html: scrimSnippet });
+        page = await newE2EPage();
+        await page.setContent(scrimSnippet);
         scrim = await page.find("calcite-scrim >>> .scrim");
         scrimStyles = await scrim.getComputedStyle();
         scrimBgStyle = await scrimStyles.getPropertyValue("background-color");
@@ -138,9 +141,8 @@ describe("calcite-scrim", () => {
 
     describe("when mode attribute is dark", () => {
       it("should render scrim background with value tied to dark mode", async () => {
-        page = await newE2EPage({
-          html: `<div class="calcite-mode-dark">${scrimSnippet}</div>`
-        });
+        page = await newE2EPage();
+        await page.setContent(html`<div class="calcite-mode-dark">${scrimSnippet}</div>`);
         scrim = await page.find("calcite-scrim >>> .scrim");
         scrimStyles = await scrim.getComputedStyle();
         scrimBgStyle = await scrimStyles.getPropertyValue("background-color");
@@ -150,16 +152,15 @@ describe("calcite-scrim", () => {
 
     it("should allow the CSS custom property to be overridden when applied to :root", async () => {
       const overrideStyle = "rgb(128, 0, 128)";
-      page = await newE2EPage({
-        html: `
+      page = await newE2EPage();
+      await page.setContent(html`
         <style>
           :root {
             --calcite-scrim-background: ${overrideStyle};
           }
         </style>
         ${scrimSnippet}
-        `
-      });
+      `);
       scrim = await page.find("calcite-scrim >>> .scrim");
       scrimStyles = await scrim.getComputedStyle();
       scrimBgStyle = await scrimStyles.getPropertyValue("background-color");
@@ -168,16 +169,15 @@ describe("calcite-scrim", () => {
 
     it("should allow the CSS custom property to be overridden when applied to element", async () => {
       const overrideStyle = "rgb(128, 0, 128)";
-      page = await newE2EPage({
-        html: `
+      page = await newE2EPage();
+      await page.setContent(html`
         <style>
           calcite-scrim {
             --calcite-scrim-background: ${overrideStyle};
           }
         </style>
         ${scrimSnippet}
-        `
-      });
+      `);
       scrim = await page.find("calcite-scrim >>> .scrim");
       scrimStyles = await scrim.getComputedStyle();
       scrimBgStyle = await scrimStyles.getPropertyValue("background-color");

--- a/src/components/segmented-control-item/segmented-control-item.e2e.ts
+++ b/src/components/segmented-control-item/segmented-control-item.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-segmented-control-item", () => {
   describe("renders", () => {
@@ -45,7 +46,7 @@ describe("calcite-segmented-control-item", () => {
 
   it("renders icon at start if requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
     <calcite-segmented-control-item icon-start="car">Content</calcite-accordion-item>`);
     const icon = await page.find("calcite-segmented-control-item >>> .segmented-control-item-icon");
     expect(icon).not.toBe(null);
@@ -53,7 +54,7 @@ describe("calcite-segmented-control-item", () => {
 
   it("does not render icon if not requested", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
     <calcite-segmented-control-item>Content</calcite-accordion-item>`);
     const icon = await page.find("calcite-segmented-control-item >>> .segmented-control-item-icon");
     expect(icon).toBe(null);

--- a/src/components/select/select.e2e.ts
+++ b/src/components/select/select.e2e.ts
@@ -60,15 +60,12 @@ describe("calcite-select", () => {
 
   describe("flat options", () => {
     it("allows selecting items", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option>uno</calcite-option>
-            <calcite-option>dos</calcite-option>
-            <calcite-option>tres</calcite-option>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>tres</calcite-option>
+      </calcite-select>`);
       const select = await page.find("calcite-select");
       const spy = await select.spyOnEvent("calciteSelectChange");
 
@@ -99,15 +96,12 @@ describe("calcite-select", () => {
     });
 
     it("selects the last selected option when multiple are selected", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option selected>uno</calcite-option>
-            <calcite-option selected>dos</calcite-option>
-            <calcite-option selected>tres</calcite-option>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option selected>uno</calcite-option>
+        <calcite-option selected>dos</calcite-option>
+        <calcite-option selected>tres</calcite-option>
+      </calcite-select>`);
       const selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
@@ -116,15 +110,12 @@ describe("calcite-select", () => {
     });
 
     it("selects the first available option when none are selected", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option>uno</calcite-option>
-            <calcite-option>dos</calcite-option>
-            <calcite-option>tres</calcite-option>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>tres</calcite-option>
+      </calcite-select>`);
       const selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
@@ -133,15 +124,12 @@ describe("calcite-select", () => {
     });
 
     it("internally maps children to native elements", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option>uno</calcite-option>
-            <calcite-option>dos</calcite-option>
-            <calcite-option>tres</calcite-option>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option>uno</calcite-option>
+        <calcite-option>dos</calcite-option>
+        <calcite-option>tres</calcite-option>
+      </calcite-select>`);
       const internalSelect = await page.find(`calcite-select >>> .${CSS.select}`);
 
       expect(await internalSelect.findAll("option")).toHaveLength(3);
@@ -167,23 +155,20 @@ describe("calcite-select", () => {
 
   describe("grouped options", () => {
     it("allows selecting items", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option-group label="letters">
-              <calcite-option>a</calcite-option>
-              <calcite-option>b</calcite-option>
-              <calcite-option>c</calcite-option>
-              <calcite-option disabled>d (disabled)</calcite-option>
-            </calcite-option-group>
-            <calcite-option-group label="numbers">
-              <calcite-option label="one">1</calcite-option>
-              <calcite-option label="two" selected>2</calcite-option>
-              <calcite-option label="three">3</calcite-option>
-            </calcite-option-group>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option-group label="letters">
+          <calcite-option>a</calcite-option>
+          <calcite-option>b</calcite-option>
+          <calcite-option>c</calcite-option>
+          <calcite-option disabled>d (disabled)</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="numbers">
+          <calcite-option label="one">1</calcite-option>
+          <calcite-option label="two" selected>2</calcite-option>
+          <calcite-option label="three">3</calcite-option>
+        </calcite-option-group>
+      </calcite-select>`);
       const select = await page.find("calcite-select");
       const spy = await select.spyOnEvent("calciteSelectChange");
 
@@ -214,22 +199,19 @@ describe("calcite-select", () => {
     });
 
     it("selects the last selected option when multiple are selected", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option-group label="letters">
-              <calcite-option selected>a</calcite-option>
-              <calcite-option selected>b</calcite-option>
-              <calcite-option selected>c</calcite-option>
-            </calcite-option-group>
-            <calcite-option-group label="numbers">
-              <calcite-option selected>1</calcite-option>
-              <calcite-option selected>2</calcite-option>
-              <calcite-option selected>3</calcite-option>
-            </calcite-option-group>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option-group label="letters">
+          <calcite-option selected>a</calcite-option>
+          <calcite-option selected>b</calcite-option>
+          <calcite-option selected>c</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="numbers">
+          <calcite-option selected>1</calcite-option>
+          <calcite-option selected>2</calcite-option>
+          <calcite-option selected>3</calcite-option>
+        </calcite-option-group>
+      </calcite-select>`);
       const selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
@@ -238,22 +220,19 @@ describe("calcite-select", () => {
     });
 
     it("selects the first available option when none are selected", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option-group label="letters">
-              <calcite-option>a</calcite-option>
-              <calcite-option>b</calcite-option>
-              <calcite-option>c</calcite-option>
-            </calcite-option-group>
-            <calcite-option-group label="numbers">
-              <calcite-option>1</calcite-option>
-              <calcite-option>2</calcite-option>
-              <calcite-option>3</calcite-option>
-            </calcite-option-group>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option-group label="letters">
+          <calcite-option>a</calcite-option>
+          <calcite-option>b</calcite-option>
+          <calcite-option>c</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="numbers">
+          <calcite-option>1</calcite-option>
+          <calcite-option>2</calcite-option>
+          <calcite-option>3</calcite-option>
+        </calcite-option-group>
+      </calcite-select>`);
       const selected = await page.findAll("calcite-option[selected]");
 
       await assertSelectedOption(page, selected[0]);
@@ -262,20 +241,17 @@ describe("calcite-select", () => {
     });
 
     it("internally maps children to native elements", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <calcite-select>
-            <calcite-option-group label="letters">
-              <calcite-option>a</calcite-option>
-              <calcite-option>b</calcite-option>
-            </calcite-option-group>
-            <calcite-option-group label="numbers">
-              <calcite-option label="one">1</calcite-option>
-            </calcite-option-group>
-            <calcite-option-group label="empty"></calcite-option-group>
-          </calcite-select>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-select>
+        <calcite-option-group label="letters">
+          <calcite-option>a</calcite-option>
+          <calcite-option>b</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="numbers">
+          <calcite-option label="one">1</calcite-option>
+        </calcite-option-group>
+        <calcite-option-group label="empty"></calcite-option-group>
+      </calcite-select>`);
       const internalSelect = await page.find(`calcite-select >>> .${CSS.select}`);
 
       expect(await internalSelect.findAll("option")).toHaveLength(3);
@@ -311,15 +287,12 @@ describe("calcite-select", () => {
   });
 
   it("item is selected before change event", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-select>
-          <calcite-option id="1">uno</calcite-option>
-          <calcite-option id="2">dos</calcite-option>
-          <calcite-option id="3">tres</calcite-option>
-        </calcite-select>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-select>
+      <calcite-option id="1">uno</calcite-option>
+      <calcite-option id="2">dos</calcite-option>
+      <calcite-option id="3">tres</calcite-option>
+    </calcite-select>`);
 
     type TestWindow = typeof window & { selectedOptionId: string };
 

--- a/src/components/shell-panel/shell-panel.e2e.ts
+++ b/src/components/shell-panel/shell-panel.e2e.ts
@@ -1,4 +1,5 @@
 import { E2EElement, newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 
 import { accessible, defaults, hidden, renders, slots, t9n } from "../../tests/commonTests";
 import { getElementXY } from "../../tests/utils";
@@ -151,19 +152,11 @@ describe("calcite-shell-panel", () => {
 
   it("should update width based on the requested CSS variable override", async () => {
     const override = "678px";
-
     const page = await newE2EPage();
-
-    await page.setContent(`
-      <calcite-shell-panel>
-        test
-      </calcite-shell-panel>
-    `);
-
-    await page.waitForChanges();
+    await page.setContent(html` <calcite-shell-panel> test </calcite-shell-panel> `);
 
     const page2 = await newE2EPage();
-    await page2.setContent(`
+    await page2.setContent(html`
       <style>
         :root {
           --calcite-shell-panel-min-width: ${override};
@@ -171,12 +164,8 @@ describe("calcite-shell-panel", () => {
           --calcite-shell-panel-width: ${override};
         }
       </style>
-      <calcite-shell-panel>
-        test multiplied
-      </calcite-shell-panel>
+      <calcite-shell-panel> test multiplied </calcite-shell-panel>
     `);
-
-    await page2.waitForChanges();
 
     const content2 = await page2.find(`calcite-shell-panel >>> .${CSS.content}`);
     const style2 = await content2.getComputedStyle();
@@ -189,14 +178,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-start">
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>
@@ -219,14 +206,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-start">
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>
@@ -258,14 +243,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-start" resizable>
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>
@@ -334,14 +317,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-top" resizable layout="horizontal">
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>
@@ -410,14 +391,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-start" resizable>
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>
@@ -448,14 +427,12 @@ describe("calcite-shell-panel", () => {
     const page = await newE2EPage();
 
     await page.setViewport({ width: 1600, height: 1200 });
-    await page.setContent(`
+    await page.setContent(html`
       <div style="width: 100%; height: 100%;">
         <calcite-shell>
           <calcite-shell-panel slot="panel-top" resizable layout="horizontal">
             <calcite-button slot="headder">Header test</calcite-button>
-            <calcite-panel>
-              Content test
-            </calcite-panel>
+            <calcite-panel> Content test </calcite-panel>
           </calcite-shell-panel>
         </calcite-shell>
       </div>

--- a/src/components/shell/shell.e2e.ts
+++ b/src/components/shell/shell.e2e.ts
@@ -15,7 +15,7 @@ describe("calcite-shell", () => {
   it("content node should always be present", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-shell></calcite-shell>`);
+    await page.setContent(html`<calcite-shell></calcite-shell>`);
 
     const content = await page.find(`calcite-shell >>> .${CSS.content}`);
 

--- a/src/components/slider/slider.e2e.ts
+++ b/src/components/slider/slider.e2e.ts
@@ -63,14 +63,8 @@ describe("calcite-slider", () => {
 
   it("sets aria attributes properly for single value", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        value="23"
-        min="0"
-        max="100"
-        min-label="Yeah! Slider!"
-      >
-      </calcite-slider>
+    await page.setContent(html`
+      <calcite-slider value="23" min="0" max="100" min-label="Yeah! Slider!"> </calcite-slider>
     `);
     const button = await page.find("calcite-slider >>> .thumb");
     expect(button).toEqualAttribute("role", "slider");
@@ -83,15 +77,8 @@ describe("calcite-slider", () => {
 
   it("sets aria attributes properly for range values", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        min-value="23"
-        max-value="47"
-        min="0"
-        max="100"
-        min-label="Min Label"
-        max-label="Max Label"
-      >
+    await page.setContent(html`
+      <calcite-slider min-value="23" max-value="47" min="0" max="100" min-label="Min Label" max-label="Max Label">
       </calcite-slider>
     `);
     const maxButton = await page.find("calcite-slider >>> .thumb--value");
@@ -112,15 +99,8 @@ describe("calcite-slider", () => {
 
   it("can be controlled via keyboard", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        value="30"
-        min="0"
-        max="100"
-        step="1"
-        page-step="10"
-      >
-      </calcite-slider>
+    await page.setContent(html`
+      <calcite-slider value="30" min="0" max="100" step="1" page-step="10"> </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
     const handle = await page.find("calcite-slider >>> .thumb");
@@ -191,16 +171,7 @@ describe("calcite-slider", () => {
 
   it("only selects values on step interval when snap prop is passed", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        value="23"
-        min="0"
-        max="100"
-        step="10"
-        snap
-      >
-      </calcite-slider>
-    `);
+    await page.setContent(html` <calcite-slider value="23" min="0" max="100" step="10" snap> </calcite-slider> `);
     const slider = await page.find("calcite-slider");
     const handle = await page.find("calcite-slider >>> .thumb--value");
     await page.waitForChanges();
@@ -213,32 +184,15 @@ describe("calcite-slider", () => {
 
   it("displays tick marks when ticks prop is passed", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        value="23"
-        min="0"
-        max="100"
-        step="1"
-        ticks="10"
-      >
-      </calcite-slider>
-    `);
+    await page.setContent(html` <calcite-slider value="23" min="0" max="100" step="1" ticks="10"> </calcite-slider> `);
     const ticks = await page.findAll("calcite-slider >>> .tick");
     expect(ticks.length).toBe(11);
   });
 
   it("should cap the rendered last tick label to the slider's provided max", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-      min="5"
-      max="100"
-      step="10"
-      ticks="10"
-      label-handles
-      label-ticks
-      >
-      </calcite-slider>
+    await page.setContent(html`
+      <calcite-slider min="5" max="100" step="10" ticks="10" label-handles label-ticks> </calcite-slider>
     `);
     const slider = await page.find("calcite-slider");
     const maxTickLabel = await page.find("calcite-slider >>> .tick:nth-of-type(11)");
@@ -247,16 +201,7 @@ describe("calcite-slider", () => {
 
   it("key press should change the value and emit input and change events", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-slider
-        value="23"
-        min="0"
-        max="100"
-        step="1"
-        ticks="10"
-      >
-      </calcite-slider>
-    `);
+    await page.setContent(html` <calcite-slider value="23" min="0" max="100" step="1" ticks="10"> </calcite-slider> `);
     const slider = await page.find("calcite-slider");
     const handle = await page.find("calcite-slider >>> .thumb");
     const inputEvent = await slider.spyOnEvent("calciteSliderInput");
@@ -337,10 +282,8 @@ describe("calcite-slider", () => {
     ></calcite-slider>`;
 
     it("should focus the min thumb when clicked on track close to minValue", async () => {
-      const page = await newE2EPage({
-        html: `${sliderForThumbFocusTests}`
-      });
-      await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`${sliderForThumbFocusTests}`);
       const slider = await page.find("calcite-slider");
       const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
@@ -359,10 +302,8 @@ describe("calcite-slider", () => {
     });
 
     it("should focus the max thumb when clicked on track close to maxValue", async () => {
-      const page = await newE2EPage({
-        html: `${sliderForThumbFocusTests}`
-      });
-      await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`${sliderForThumbFocusTests}`);
       const slider = await page.find("calcite-slider");
       const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
@@ -381,10 +322,8 @@ describe("calcite-slider", () => {
     });
 
     it("should focus the max thumb when clicked on middle of the track", async () => {
-      const page = await newE2EPage({
-        html: `${sliderForThumbFocusTests}`
-      });
-      await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`${sliderForThumbFocusTests}`);
       const slider = await page.find("calcite-slider");
       const [trackX, trackY] = await getElementXY(page, "calcite-slider", ".track");
 
@@ -405,9 +344,10 @@ describe("calcite-slider", () => {
 
   describe("mouse interaction", () => {
     it("single handle: clicking the track changes value on mousedown, emits on mouseup", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");
       const changeEvent = await slider.spyOnEvent("calciteSliderChange");
@@ -427,9 +367,10 @@ describe("calcite-slider", () => {
     });
 
     it("single handle: clicking and dragging the track changes and emits the value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");
       const inputEvent = await slider.spyOnEvent("calciteSliderInput");
@@ -453,9 +394,10 @@ describe("calcite-slider", () => {
     });
 
     it("range: clicking the track to the left of the min handle changes minValue on mousedown, emits on mouseup", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider min-value="50" max-value="75" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider min-value="50" max-value="75" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
 
       const slider = await page.find("calcite-slider");
@@ -482,9 +424,10 @@ describe("calcite-slider", () => {
     });
 
     it("range: clicking and dragging the track to the left of the min handle changes minValue and emits", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider min-value="50" max-value="75" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider min-value="50" max-value="75" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
 
       const slider = await page.find("calcite-slider");
@@ -511,9 +454,10 @@ describe("calcite-slider", () => {
     });
 
     it("range: clicking the track to the right of the max handle changes maxValue on mousedown, emits on mouseup", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider min-value="25" max-value="50" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider min-value="25" max-value="50" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
 
       const slider = await page.find("calcite-slider");
@@ -537,9 +481,10 @@ describe("calcite-slider", () => {
     });
 
     it("range: clicking and dragging the track to the right of the max handle changes maxValue on mousedown, emits on mouseup", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider min-value="25" max-value="50" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-slider min-value="25" max-value="50" snap style="width:${sliderWidthFor1To1PixelValueTrack}"></calcite-slider>`
+      );
       await page.waitForChanges();
       const slider = await page.find("calcite-slider");
       const inputEvent = await slider.spyOnEvent("calciteSliderInput");
@@ -599,7 +544,8 @@ describe("calcite-slider", () => {
 
   describe("histogram", () => {
     it("creates calcite-graph with color stops", async () => {
-      const page = await newE2EPage({ html: `<calcite-slider></calcite-slider>` });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-slider></calcite-slider>`);
 
       const props = {
         histogram: [
@@ -657,10 +603,8 @@ describe("calcite-slider", () => {
       style="width:${sliderWidthFor1To1PixelValueTrack}"`;
 
     it("click/tap should grab the max value thumb", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider ${commonSliderAttrs}></calcite-slider>`
-      });
-      await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-slider ${commonSliderAttrs}></calcite-slider>`);
       const element = await page.find("calcite-slider");
       const changeEvent = await element.spyOnEvent("calciteSliderChange");
       const inputEvent = await element.spyOnEvent("calciteSliderInput");
@@ -683,9 +627,8 @@ describe("calcite-slider", () => {
     });
 
     it("mirrored: click/tap should grab the max value thumb", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-slider ${commonSliderAttrs} mirrored></calcite-slider>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-slider ${commonSliderAttrs} mirrored></calcite-slider>`);
       const element = await page.find("calcite-slider");
       const changeEvent = await element.spyOnEvent("calciteSliderChange");
       const inputEvent = await element.spyOnEvent("calciteSliderInput");
@@ -718,7 +661,8 @@ describe("calcite-slider", () => {
     const mirroredSlider = `<div style="width: 300px; margin: 1rem;">${slider} mirrored></calcite-slider></div>`;
 
     it("should position the minValue thumb beside the maxValue thumb", async () => {
-      const page = await newE2EPage({ html: nonMirroredSlider });
+      const page = await newE2EPage();
+      await page.setContent(nonMirroredSlider);
       const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
       const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
       const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
@@ -728,7 +672,8 @@ describe("calcite-slider", () => {
     });
 
     it("should position the minValue thumb beside the maxValue thumb when mirrored", async () => {
-      const page = await newE2EPage({ html: mirroredSlider });
+      const page = await newE2EPage();
+      await page.setContent(mirroredSlider);
       const minValueThumb = await page.find("calcite-slider >>> .thumb--minValue");
       const maxValueThumb = await page.find("calcite-slider >>> .thumb--value");
       const minHandleLeft = await (await minValueThumb.getComputedStyle()).left;
@@ -738,7 +683,8 @@ describe("calcite-slider", () => {
     });
 
     it("should position the minValue thumb beside the maxValue thumb when it's a histogram range", async () => {
-      const page = await newE2EPage({ html: nonMirroredSlider });
+      const page = await newE2EPage();
+      await page.setContent(nonMirroredSlider);
       await page.$eval("calcite-slider", (slider: HTMLCalciteSliderElement) => {
         slider.histogram = [
           [0, 0],

--- a/src/components/sortable-list/sortable-list.e2e.ts
+++ b/src/components/sortable-list/sortable-list.e2e.ts
@@ -45,13 +45,12 @@ describe("calcite-sortable-list", () => {
   describe("drag and drop", () => {
     let page: E2EPage;
     beforeEach(async () => {
-      page = await newE2EPage({
-        html: `<calcite-sortable-list>
+      page = await newE2EPage();
+      await page.setContent(html`<calcite-sortable-list>
         <div id="one"><calcite-handle></calcite-handle>1</div>
         <div id="two"><calcite-handle></calcite-handle>2</div>
         <div id="three"><calcite-handle></calcite-handle>3</div>
-      </calcite-sortable-list>`
-      });
+      </calcite-sortable-list>`);
     });
 
     it("works using a mouse", () => worksUsingMouse(page));
@@ -62,13 +61,12 @@ describe("calcite-sortable-list", () => {
   describe("drag and drop with dragSelector", () => {
     let page: E2EPage;
     beforeEach(async () => {
-      page = await newE2EPage({
-        html: `<calcite-sortable-list drag-selector=".calcite-sortable">
+      page = await newE2EPage();
+      await page.setContent(html`<calcite-sortable-list drag-selector=".calcite-sortable">
         <div class="calcite-sortable" id="one"><calcite-handle></calcite-handle>1</div>
         <div class="calcite-sortable" id="two"><calcite-handle></calcite-handle>2</div>
         <div class="calcite-sortable" id="three"><calcite-handle></calcite-handle>3</div>
-      </calcite-sortable-list>`
-      });
+      </calcite-sortable-list>`);
     });
 
     it("works using a mouse", () => worksUsingMouse(page));

--- a/src/components/split-button/split-button.e2e.ts
+++ b/src/components/split-button/split-button.e2e.ts
@@ -72,9 +72,7 @@ describe("calcite-split-button", () => {
 
   it("renders default props when none are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button>
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button> </calcite-split-button>`);
     const element = await page.find("calcite-split-button");
     expect(element).toEqualAttribute("scale", "m");
     expect(element).toEqualAttribute("kind", "brand");
@@ -83,9 +81,8 @@ describe("calcite-split-button", () => {
   });
 
   it(`should set all internal calcite-button types to 'button'`, async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-split-button primary-text="primary action"></calcite-split-button>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-split-button primary-text="primary action"></calcite-split-button>`);
 
     const buttons = await page.findAll("calcite-split-button >>> calcite-button");
 
@@ -98,17 +95,17 @@ describe("calcite-split-button", () => {
 
   it("renders requested props when valid props are provided", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button
-          scale="s"
-          kind="danger"
-          dropdown-icon-type="caret"
-          loading
-          disabled
-          width="half"
-          dropdown-label="more actions"
-          primary-label="primary action">
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button
+      scale="s"
+      kind="danger"
+      dropdown-icon-type="caret"
+      loading
+      disabled
+      width="half"
+      dropdown-label="more actions"
+      primary-label="primary action"
+    >
+    </calcite-split-button>`);
     const element = await page.find("calcite-split-button");
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
     const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
@@ -124,9 +121,7 @@ describe("calcite-split-button", () => {
 
   it("renders primaryText without icons as inner content of primary button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button primary-text="primary action">
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button primary-text="primary action"> </calcite-split-button>`);
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
 
     expect(primaryButton).toEqualText("primary action");
@@ -136,9 +131,8 @@ describe("calcite-split-button", () => {
 
   it("renders primaryText + primary-icon-start as inner content of primary button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button primary-text="primary action" primary-icon-start="save">
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button primary-text="primary action" primary-icon-start="save">
+    </calcite-split-button>`);
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
 
     expect(primaryButton).toEqualText("primary action");
@@ -148,9 +142,8 @@ describe("calcite-split-button", () => {
 
   it("renders primaryText + primary-icon-end as inner content of primary button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button primary-text="primary action" primary-icon-end="save">
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button primary-text="primary action" primary-icon-end="save">
+    </calcite-split-button>`);
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
     expect(primaryButton).toEqualText("primary action");
     expect(primaryButton).not.toHaveAttribute("icon-start");
@@ -158,9 +151,12 @@ describe("calcite-split-button", () => {
   });
   it("renders primaryText + primary-icon-end and primary-icon-start as inner content of primary button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button primary-text="primary action" primary-icon-start="save" primary-icon-end="save">
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button
+      primary-text="primary action"
+      primary-icon-start="save"
+      primary-icon-end="save"
+    >
+    </calcite-split-button>`);
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
     expect(primaryButton).toEqualText("primary action");
     expect(primaryButton).toEqualAttribute("icon-start", "save");
@@ -179,9 +175,7 @@ describe("calcite-split-button", () => {
       l: "l"
     };
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button>
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button> </calcite-split-button>`);
     const element = await page.find("calcite-split-button");
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
     const dropdown = await page.find("calcite-split-button >>> calcite-dropdown");
@@ -197,9 +191,7 @@ describe("calcite-split-button", () => {
 
   it("adds split-child attributes to child button components", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-split-button>
-      </calcite-split-button>`);
+    await page.setContent(html` <calcite-split-button> </calcite-split-button>`);
     const primaryButton = await page.find("calcite-split-button >>> calcite-button");
     const dropdownButton = await page.find("calcite-split-button >>> calcite-dropdown calcite-button");
     expect(primaryButton).toEqualAttribute("split-child", "primary");
@@ -208,7 +200,7 @@ describe("calcite-split-button", () => {
 
   it("adds the relevant CSS class based on the width attribute", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-split-button width="auto"></calcite-split-button>`);
+    await page.setContent(html`<calcite-split-button width="auto"></calcite-split-button>`);
 
     const element = await page.find(`calcite-split-button`);
     const container = await page.find(`calcite-split-button >>> .${CSS.widthAuto}`);
@@ -226,13 +218,13 @@ describe("calcite-split-button", () => {
 
   it("should support dropdown item keyboard navigation", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-split-button scale="s" primary-text="Button">
-    <calcite-dropdown-group selection-mode="none">
-      <calcite-dropdown-item id="item-1">Option 2</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-2">Option 3</calcite-dropdown-item>
-      <calcite-dropdown-item id="item-3">Option 4</calcite-dropdown-item>
-    </calcite-dropdown-group>
-  </calcite-split-button>`);
+    await page.setContent(html`<calcite-split-button scale="s" primary-text="Button">
+      <calcite-dropdown-group selection-mode="none">
+        <calcite-dropdown-item id="item-1">Option 2</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-2">Option 3</calcite-dropdown-item>
+        <calcite-dropdown-item id="item-3">Option 4</calcite-dropdown-item>
+      </calcite-dropdown-group>
+    </calcite-split-button>`);
     const group = await page.find("calcite-dropdown-group");
     const secondary = await page.find(`calcite-split-button >>> calcite-button[split-child="secondary"]`);
     const dropdownOpenEvent = page.waitForEvent("calciteDropdownOpen");

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -392,8 +392,7 @@ describe("calcite-stepper", () => {
         <calcite-button id="next">Next Step</calcite-button>
       `;
 
-      const page = await newE2EPage({ html: templateHTML });
-
+      const page = await newE2EPage();
       await page.waitForChanges();
 
       const finalSelectedItem = await page.evaluate(

--- a/src/components/stepper/stepper.e2e.ts
+++ b/src/components/stepper/stepper.e2e.ts
@@ -2,6 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { renders, hidden } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { NumberStringFormatOptions } from "../../utils/locale";
+import { newProgrammaticE2EPage } from "../../tests/utils";
 
 // todo test the automatic setting of first item to selected
 describe("calcite-stepper", () => {
@@ -392,8 +393,7 @@ describe("calcite-stepper", () => {
         <calcite-button id="next">Next Step</calcite-button>
       `;
 
-      const page = await newE2EPage();
-      await page.waitForChanges();
+      const page = await newProgrammaticE2EPage();
 
       const finalSelectedItem = await page.evaluate(
         async (templateHTML: string): Promise<string> => {
@@ -428,6 +428,7 @@ describe("calcite-stepper", () => {
         },
         [templateHTML]
       );
+      await page.waitForChanges();
 
       expect(finalSelectedItem).toBe("item-3");
     });

--- a/src/components/switch/switch.e2e.ts
+++ b/src/components/switch/switch.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, disabled, formAssociated, hidden, HYDRATED_ATTR, labelable } from "../../tests/commonTests";
 
 describe("calcite-switch", () => {
@@ -67,7 +68,7 @@ describe("calcite-switch", () => {
 
   it("appropriately triggers the custom change event", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-switch></calcite-switch>`);
+    await page.setContent(html`<calcite-switch></calcite-switch>`);
 
     const calciteSwitch = await page.find("calcite-switch");
 
@@ -95,7 +96,7 @@ describe("calcite-switch", () => {
 
   it("toggles the checked attributes when the checkbox is toggled", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-switch></calcite-switch>`);
+    await page.setContent(html`<calcite-switch></calcite-switch>`);
 
     const calciteSwitch = await page.find("calcite-switch");
 
@@ -109,7 +110,7 @@ describe("calcite-switch", () => {
 
   it("renders requested props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-switch scale="l" ></calcite-switch>`);
+    await page.setContent(html`<calcite-switch scale="l"></calcite-switch>`);
     const element = await page.find("calcite-switch");
 
     expect(element).toEqualAttribute("scale", "l");
@@ -117,10 +118,7 @@ describe("calcite-switch", () => {
 
   it("renders default props", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-    <calcite-switch></calcite-switch>`);
-
-    await page.waitForChanges();
+    await page.setContent(html` <calcite-switch></calcite-switch>`);
 
     const element = await page.find("calcite-switch");
     expect(element).toEqualAttribute("scale", "m");

--- a/src/components/tab-nav/tab-nav.e2e.ts
+++ b/src/components/tab-nav/tab-nav.e2e.ts
@@ -44,7 +44,7 @@ describe("calcite-tab-nav", () => {
 
     it("has its active indicator positioned from left if LTR", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-tab-nav>${tabTitles}</calcite-tab-nav>`);
+      await page.setContent(html`<calcite-tab-nav>${tabTitles}</calcite-tab-nav>`);
       const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
       const style = await element.getComputedStyle();
       expect(style["left"]).toBe("0px");
@@ -54,7 +54,7 @@ describe("calcite-tab-nav", () => {
 
     it("has its active indicator positioned from right if RTL", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-tab-nav dir='rtl'>${tabTitles}</calcite-tab-nav>`);
+      await page.setContent(html`<calcite-tab-nav dir="rtl">${tabTitles}</calcite-tab-nav>`);
       const element = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
       const style = await element.getComputedStyle();
       expect(style["right"]).toBe("0px");
@@ -64,7 +64,7 @@ describe("calcite-tab-nav", () => {
 
     it("updates position when made visible", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-tab-nav hidden>${tabTitles}</calcite-tab-nav>`);
+      await page.setContent(html`<calcite-tab-nav hidden>${tabTitles}</calcite-tab-nav>`);
       const tabNav = await page.find("calcite-tab-nav");
       const indicator = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator");
 
@@ -79,9 +79,8 @@ describe("calcite-tab-nav", () => {
   describe("scale property", () => {
     describe("default", () => {
       it("should render without scale", async () => {
-        const page = await newE2EPage({
-          html: `${tabNavHtml}`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`${tabNavHtml}`);
         const element = await page.find("calcite-tab-nav");
         expect(element).not.toHaveAttribute("scale");
       });
@@ -89,14 +88,13 @@ describe("calcite-tab-nav", () => {
 
     describe("when scale is small", () => {
       it("should render with small scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale='s'>
-            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="s">
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-nav");
         expect(await (await element.getComputedStyle())["minHeight"]).toEqual("24px");
         expect(element).toEqualAttribute("scale", "s");
@@ -105,14 +103,13 @@ describe("calcite-tab-nav", () => {
 
     describe("when scale is medium", () => {
       it("should render with medium scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale='m'>
-            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="m">
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-nav");
         expect(await (await element.getComputedStyle())["minHeight"]).toEqual("32px");
         expect(element).toEqualAttribute("scale", "m");
@@ -121,14 +118,13 @@ describe("calcite-tab-nav", () => {
 
     describe("when scale is large", () => {
       it("should render with medium scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale='l'>
-            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="l">
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 4 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-nav");
         expect(await (await element.getComputedStyle())["minHeight"]).toEqual("44px");
         expect(element).toEqualAttribute("scale", "l");
@@ -137,18 +133,16 @@ describe("calcite-tab-nav", () => {
 
     describe("when nested within tabs parent", () => {
       it("should render with default medium scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs>${tabNavHtml}</calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs>${tabNavHtml}</calcite-tabs>`);
         const element = await page.find("calcite-tab-nav");
         expect(element).toEqualAttribute("scale", "m");
       });
 
       describe("when tabs scale is small", () => {
         it("should render with small scale", async () => {
-          const page = await newE2EPage({
-            html: `<calcite-tabs scale="s">${tabNavHtml}</calcite-tabs>`
-          });
+          const page = await newE2EPage();
+          await page.setContent(html`<calcite-tabs scale="s">${tabNavHtml}</calcite-tabs>`);
           const element = await page.find("calcite-tab-nav");
           expect(element).toEqualAttribute("scale", "s");
         });
@@ -156,9 +150,8 @@ describe("calcite-tab-nav", () => {
 
       describe("when tabs scale is large", () => {
         it("should render with large scale", async () => {
-          const page = await newE2EPage({
-            html: `<calcite-tabs scale="l">${tabNavHtml}</calcite-tabs>`
-          });
+          const page = await newE2EPage();
+          await page.setContent(html`<calcite-tabs scale="l">${tabNavHtml}</calcite-tabs>`);
           const element = await page.find("calcite-tab-nav");
           expect(element).toEqualAttribute("scale", "l");
         });

--- a/src/components/tab-title/tab-title.e2e.ts
+++ b/src/components/tab-title/tab-title.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { disabled, HYDRATED_ATTR, renders, hidden } from "../../tests/commonTests";
 import { CSS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-tab-title", () => {
   const tabTitleHtml = "<calcite-tab-title></calcite-tab-title>";
@@ -17,7 +18,7 @@ describe("calcite-tab-title", () => {
 
   it("renders with an icon-start", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-tab-title icon-start='plus'>Text</calcite-tab-title>`);
+    await page.setContent(html`<calcite-tab-title icon-start="plus">Text</calcite-tab-title>`);
     const element = await page.find("calcite-tab-title");
     const iconStart = await page.find(iconStartHtml);
     const iconEnd = await page.find(iconEndHtml);
@@ -28,7 +29,7 @@ describe("calcite-tab-title", () => {
 
   it("renders with an icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-tab-title icon-end='plus'>Text</calcite-tab-title>`);
+    await page.setContent(html`<calcite-tab-title icon-end="plus">Text</calcite-tab-title>`);
     const element = await page.find("calcite-tab-title");
     const iconStart = await page.find(iconStartHtml);
     const iconEnd = await page.find(iconEndHtml);
@@ -39,7 +40,7 @@ describe("calcite-tab-title", () => {
 
   it("renders with an icon-start and icon-end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-tab-title icon-start='plus' icon-end='plus'>Text</calcite-tab-title>`);
+    await page.setContent(html`<calcite-tab-title icon-start="plus" icon-end="plus">Text</calcite-tab-title>`);
     const element = await page.find("calcite-tab-title");
     const iconStart = await page.find(iconStartHtml);
     const iconEnd = await page.find(iconEndHtml);
@@ -50,7 +51,7 @@ describe("calcite-tab-title", () => {
 
   it.skip("emits active event on user interaction only", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-tab-title>Title</calcite-tab-title>`);
+    await page.setContent(html`<calcite-tab-title>Title</calcite-tab-title>`);
     const activeEventSpy = await page.spyOnEvent("calciteTabsActivate");
     const title = await page.find("calcite-tab-title");
 
@@ -68,13 +69,12 @@ describe("calcite-tab-title", () => {
   describe("when parent element is tab-nav", () => {
     describe("when position is top, default", () => {
       it("should render with bottom border on hover", async () => {
-        const page = await newE2EPage({
-          html: `
+        const page = await newE2EPage();
+        await page.setContent(html`
           <calcite-tab-nav>
             <calcite-tab-title id="for-hover">Tab 1 title</calcite-tab-title>
           </calcite-tab-nav>
-          `
-        });
+        `);
         const element = await page.find("#for-hover");
         await element.hover();
 
@@ -87,14 +87,13 @@ describe("calcite-tab-title", () => {
 
     describe("when position is bottom", () => {
       it("should render with top border on hover", async () => {
-        const page = await newE2EPage({
-          html: `
+        const page = await newE2EPage();
+        await page.setContent(html`
           <calcite-tab-nav position="bottom">
             <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
             <calcite-tab-title id="for-hover">Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>
-          `
-        });
+        `);
         const element = await page.find("#for-hover");
         await element.hover();
 
@@ -107,12 +106,11 @@ describe("calcite-tab-title", () => {
 
     describe("scale property", () => {
       it("should inherit small scale from tab-nav", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale="s">
-            <calcite-tab-title selected>Tab Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="s">
+          <calcite-tab-title selected>Tab Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-title");
         const container = await page.find("calcite-tab-title >>> .container");
         const containerStyles = await container.getComputedStyle();
@@ -122,12 +120,11 @@ describe("calcite-tab-title", () => {
       });
 
       it("should inherit medium scale from tab-nav", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale="m">
-            <calcite-tab-title selected>Tab Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="m">
+          <calcite-tab-title selected>Tab Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-title");
         const container = await page.find("calcite-tab-title >>> .container");
         const containerStyles = await container.getComputedStyle();
@@ -137,12 +134,11 @@ describe("calcite-tab-title", () => {
       });
 
       it("should inherit large scale from tab-nav", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tab-nav scale="l">
-            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tab-nav>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tab-nav scale="l">
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tab-nav>`);
         const element = await page.find("calcite-tab-title");
         const container = await page.find("calcite-tab-title >>> .container");
         const containerStyles = await container.getComputedStyle();
@@ -156,34 +152,31 @@ describe("calcite-tab-title", () => {
   describe("when parent element is tabs", () => {
     describe("scale property", () => {
       it("should inherit default m scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs>
-            <calcite-tab-title selected>Tab Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs>
+          <calcite-tab-title selected>Tab Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tabs>`);
         const element = await page.find("calcite-tab-title");
         expect(element).toEqualAttribute("scale", "m");
       });
 
       it("should inherit small scale from tabs", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs scale="s">
-            <calcite-tab-title selected>Tab Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs scale="s">
+          <calcite-tab-title selected>Tab Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tabs>`);
         const element = await page.find("calcite-tab-title");
         expect(element).toEqualAttribute("scale", "s");
       });
 
       it("should inherit large scale from tabs", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs scale="l">
-            <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-          </calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs scale="l">
+          <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
+          <calcite-tab-title>Tab 2 Title</calcite-tab-title>
+        </calcite-tabs>`);
         const element = await page.find("calcite-tab-title");
         expect(element).toEqualAttribute("scale", "l");
       });
@@ -192,8 +185,8 @@ describe("calcite-tab-title", () => {
 
   describe("when the active tab-title changes", () => {
     it("should move the active tab nav indicator", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-tabs>
           <calcite-tab-nav slot="title-group">
             <calcite-tab-title class="title-1">Tab 1 Title</calcite-tab-title>
@@ -206,8 +199,7 @@ describe("calcite-tab-title", () => {
           <calcite-tab>Tab 3 Content</calcite-tab>
           <calcite-tab>Tab 4 Content</calcite-tab>
         </calcite-tabs>
-        `
-      });
+      `);
       const tabTitle1 = await page.find(".title-1");
       const tabTitle2 = await page.find(".title-2");
 

--- a/src/components/tab/tab.e2e.ts
+++ b/src/components/tab/tab.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { defaults, renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-tab", () => {
   const tabHtml = "<calcite-tab>A tab</calcite-tab>";
@@ -20,9 +21,8 @@ describe("calcite-tab", () => {
 
   describe("when nested within calcite-tabs component", () => {
     it("should render with medium scale", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs>${tabHtml}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs>${tabHtml}</calcite-tabs>`);
       const element = await page.find("calcite-tab");
       expect(element).toEqualAttribute("scale", "m");
       expect(await (await element.getComputedStyle())["font-size"]).toEqual("14px");
@@ -31,9 +31,8 @@ describe("calcite-tab", () => {
 
     describe("when tabs scale is small", () => {
       it("should render with small scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs scale="s">${tabHtml}</calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs scale="s">${tabHtml}</calcite-tabs>`);
         const element = await page.find("calcite-tab");
         expect(element).toEqualAttribute("scale", "s");
         expect(await (await element.getComputedStyle())["font-size"]).toEqual("12px");
@@ -43,9 +42,8 @@ describe("calcite-tab", () => {
 
     describe("when tabs scale is large", () => {
       it("should render with large scale", async () => {
-        const page = await newE2EPage({
-          html: `<calcite-tabs scale="l">${tabHtml}</calcite-tabs>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tabs scale="l">${tabHtml}</calcite-tabs>`);
         const element = await page.find("calcite-tab");
         expect(element).toEqualAttribute("scale", "l");
         expect(await (await element.getComputedStyle())["font-size"]).toEqual("16px");

--- a/src/components/tabs/tabs.e2e.ts
+++ b/src/components/tabs/tabs.e2e.ts
@@ -220,7 +220,6 @@ describe("calcite-tabs", () => {
     `;
 
     const page = await newProgrammaticE2EPage();
-    await page.waitForChanges();
 
     const finalSelectedItem = await page.evaluate(
       async (templateHTML: string): Promise<{ titleTab: string; contentTab: string }> => {
@@ -252,6 +251,7 @@ describe("calcite-tabs", () => {
       },
       [wrappedTabTemplateHTML]
     );
+    await page.waitForChanges();
     expect(finalSelectedItem.titleTab).toBe("title-2");
     expect(finalSelectedItem.contentTab).toBe("tab-2");
   });

--- a/src/components/tabs/tabs.e2e.ts
+++ b/src/components/tabs/tabs.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
+import { newProgrammaticE2EPage } from "../../tests/utils";
 
 describe("calcite-tabs", () => {
   const tabsContent = `
@@ -37,13 +38,13 @@ describe("calcite-tabs", () => {
   it("sets up basic aria attributes", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-tabs>
         <calcite-tab-nav slot="title-group">
           <calcite-tab-title id="title-1" selected>Tab 1 Title</calcite-tab-title>
-          <calcite-tab-title id="title-2" >Tab 2 Title</calcite-tab-title>
-          <calcite-tab-title id="title-3" >Tab 3 Title</calcite-tab-title>
-          <calcite-tab-title id="title-4" >Tab 4 Title</calcite-tab-title>
+          <calcite-tab-title id="title-2">Tab 2 Title</calcite-tab-title>
+          <calcite-tab-title id="title-3">Tab 3 Title</calcite-tab-title>
+          <calcite-tab-title id="title-4">Tab 4 Title</calcite-tab-title>
         </calcite-tab-nav>
 
         <calcite-tab id="tab-1" selected>Tab 1 Content</calcite-tab>
@@ -74,7 +75,7 @@ describe("calcite-tabs", () => {
   it("keeps aria attributes in sync across DOM mutations", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-tabs>
         <calcite-tab-nav slot="title-group">
           <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
@@ -115,9 +116,8 @@ describe("calcite-tabs", () => {
 
   describe("when no scale is provided", () => {
     it("should render itself and child tab elements with default medium scale", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs>${tabsContent}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs>${tabsContent}</calcite-tabs>`);
       expect(await page.find("calcite-tabs")).toEqualAttribute("scale", "m");
       expect(await page.find("calcite-tab-nav")).toEqualAttribute("scale", "m");
       expect(await page.find("calcite-tab-title")).toEqualAttribute("scale", "m");
@@ -127,9 +127,8 @@ describe("calcite-tabs", () => {
 
   describe("when scale is provided", () => {
     it("should render itself and child tab elements with corresponding scale (small)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs scale="s">${tabsContent}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs scale="s">${tabsContent}</calcite-tabs>`);
       expect(await page.find("calcite-tabs")).toEqualAttribute("scale", "s");
       expect(await page.find("calcite-tab-nav")).toEqualAttribute("scale", "s");
       expect(await page.find("calcite-tab-title")).toEqualAttribute("scale", "s");
@@ -137,9 +136,8 @@ describe("calcite-tabs", () => {
     });
 
     it("should render itself and child tab elements with corresponding scale (medium)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs scale="m">${tabsContent}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs scale="m">${tabsContent}</calcite-tabs>`);
       expect(await page.find("calcite-tabs")).toEqualAttribute("scale", "m");
       expect(await page.find("calcite-tab-nav")).toEqualAttribute("scale", "m");
       expect(await page.find("calcite-tab-title")).toEqualAttribute("scale", "m");
@@ -147,9 +145,8 @@ describe("calcite-tabs", () => {
     });
 
     it("should render itself and child tab elements with corresponding scale (large)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs scale="l">${tabsContent}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs scale="l">${tabsContent}</calcite-tabs>`);
       expect(await page.find("calcite-tabs")).toEqualAttribute("scale", "l");
       expect(await page.find("calcite-tab-nav")).toEqualAttribute("scale", "l");
       expect(await page.find("calcite-tab-title")).toEqualAttribute("scale", "l");
@@ -159,9 +156,8 @@ describe("calcite-tabs", () => {
 
   describe("when layout is inline and bordered is true", () => {
     it("should render tabs, tab-nav, and tab-title with bordered attribute", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tabs bordered>${tabsContent}</calcite-tabs>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tabs bordered>${tabsContent}</calcite-tabs>`);
       expect(await page.find("calcite-tabs")).toEqualAttribute("bordered", "");
       expect(await page.find("calcite-tab-nav")).toEqualAttribute("bordered", "");
       expect(await page.find("calcite-tab-title")).toEqualAttribute("bordered", "");
@@ -169,18 +165,17 @@ describe("calcite-tabs", () => {
     });
 
     it("should render tab-nav's blue active indicator on top", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-tabs bordered>
           <calcite-tab-nav slot="title-group">
             <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" >Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>
           <calcite-tab>Tab 1 Content</calcite-tab>
           <calcite-tab>Tab 2 Content</calcite-tab>
         </calcite-tabs>
-        `
-      });
+      `);
       const indicator = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator-container");
       const indicatorStyles = await indicator.getComputedStyle();
       expect(indicatorStyles.top).toEqual("0px");
@@ -188,18 +183,17 @@ describe("calcite-tabs", () => {
     });
 
     it("should render tab-nav's blue active indicator on bottom when position is bottom", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-tabs bordered position="bottom">
           <calcite-tab-nav slot="title-group">
             <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 1 Title</calcite-tab-title>
-            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right" >Tab 2 Title</calcite-tab-title>
+            <calcite-tab-title icon-start="arrow-left" icon-end="arrow-right">Tab 2 Title</calcite-tab-title>
           </calcite-tab-nav>
           <calcite-tab>Tab 1 Content</calcite-tab>
           <calcite-tab>Tab 2 Content</calcite-tab>
         </calcite-tabs>
-        `
-      });
+      `);
       const indicator = await page.find("calcite-tab-nav >>> .tab-nav-active-indicator-container");
       const indicatorStyles = await indicator.getComputedStyle();
       expect(indicatorStyles.bottom).toEqual("0px");
@@ -208,9 +202,8 @@ describe("calcite-tabs", () => {
   });
 
   it("should not ignore bordered attribute when layout is center", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-tabs layout="center" bordered>${tabsContent}</calcite-tabs>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tabs layout="center" bordered>${tabsContent}</calcite-tabs>`);
     expect(await page.find("calcite-tabs")).toHaveAttribute("bordered");
   });
 
@@ -226,12 +219,7 @@ describe("calcite-tabs", () => {
       </calcite-tabs>
     `;
 
-    const page = await newE2EPage({
-      // load page with the tab template,
-      // so they're available in the browser-evaluated fn below
-      html: wrappedTabTemplateHTML
-    });
-
+    const page = await newProgrammaticE2EPage();
     await page.waitForChanges();
 
     const finalSelectedItem = await page.evaluate(
@@ -269,29 +257,26 @@ describe("calcite-tabs", () => {
   });
 
   it("item selection should work with nested tabs", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-tabs id="parentTabs">
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tabs id="parentTabs">
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title id="parentA">Parent 1</calcite-tab-title>
+        <calcite-tab-title>Parent 2</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab id="parentTabA">
+        <calcite-tabs>
           <calcite-tab-nav slot="title-group">
-            <calcite-tab-title id="parentA">Parent 1</calcite-tab-title>
-            <calcite-tab-title>Parent 2</calcite-tab-title>
+            <calcite-tab-title>Child 1</calcite-tab-title>
+            <calcite-tab-title id="kidB">Child 2</calcite-tab-title>
+            <calcite-tab-title>Child 3</calcite-tab-title>
           </calcite-tab-nav>
-          <calcite-tab id="parentTabA">
-            <calcite-tabs>
-              <calcite-tab-nav slot="title-group">
-                <calcite-tab-title>Child 1</calcite-tab-title>
-                <calcite-tab-title id="kidB">Child 2</calcite-tab-title>
-                <calcite-tab-title>Child 3</calcite-tab-title>
-              </calcite-tab-nav>
-              <calcite-tab>child content 1</calcite-tab>
-              <calcite-tab id="kidBTab">child content 2</calcite-tab>
-              <calcite-tab>child content 3</calcite-tab>
-            </calcite-tabs>
-          </calcite-tab>
-          <calcite-tab>Parent content 2</calcite-tab>
+          <calcite-tab>child content 1</calcite-tab>
+          <calcite-tab id="kidBTab">child content 2</calcite-tab>
+          <calcite-tab>child content 3</calcite-tab>
         </calcite-tabs>
-      `
-    });
+      </calcite-tab>
+      <calcite-tab>Parent content 2</calcite-tab>
+    </calcite-tabs>`);
 
     await page.waitForChanges();
 

--- a/src/components/text-area/text-area.e2e.ts
+++ b/src/components/text-area/text-area.e2e.ts
@@ -131,9 +131,10 @@ describe("calcite-text-area", () => {
 
   it("should have footer--slotted class when slotted at both start and end", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-text-area>
-    <calcite-button slot="footer-start">CLEAR</calcite-button>
-    <calcite-button slot="footer-end">RESET</calcite-button></calcite-text-area>`);
+    await page.setContent(html`<calcite-text-area>
+      <calcite-button slot="footer-start">CLEAR</calcite-button>
+      <calcite-button slot="footer-end">RESET</calcite-button></calcite-text-area
+    >`);
 
     const element = await page.find("calcite-text-area >>> textarea");
     await page.waitForChanges();
@@ -146,7 +147,7 @@ describe("calcite-text-area", () => {
   describe("resize", () => {
     it("should set CSS resize property to horizontal", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-text-area resize="horizontal"></calcite-text-area>`);
+      await page.setContent(html`<calcite-text-area resize="horizontal"></calcite-text-area>`);
 
       const element = await page.find("calcite-text-area >>> textarea");
       await page.waitForChanges();
@@ -156,7 +157,7 @@ describe("calcite-text-area", () => {
 
     it("should set CSS resize property to vertical", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-text-area resize="vertical"></calcite-text-area>`);
+      await page.setContent(html`<calcite-text-area resize="vertical"></calcite-text-area>`);
 
       const element = await page.find("calcite-text-area >>> textarea");
       await page.waitForChanges();

--- a/src/components/tile-select/tile-select.e2e.ts
+++ b/src/components/tile-select/tile-select.e2e.ts
@@ -77,9 +77,7 @@ describe("calcite-tile-select", () => {
 
   it("removing a tile-select also removes its corresponding calcite-radio-button", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
-      <calcite-tile-select name="radio" value="first"></calcite-tile-select>
-    `);
+    await page.setContent(html` <calcite-tile-select name="radio" value="first"></calcite-tile-select> `);
 
     let firstRadioButton = await page.find("calcite-radio-button");
     expect(await firstRadioButton.getProperty("name")).toBe("radio");
@@ -97,7 +95,7 @@ describe("calcite-tile-select", () => {
 
   it("removing a tile-select also removes its corresponding calcite-checkbox", async () => {
     const page = await newE2EPage();
-    await page.setContent(`
+    await page.setContent(html`
       <calcite-tile-select name="checky" value="first" type="checkbox"></calcite-tile-select>
     `);
 
@@ -126,9 +124,8 @@ describe("calcite-tile-select", () => {
     }));
 
   it("emits change event on checkbox toggle and suppresses internal checkbox change event", async () => {
-    const page = await newE2EPage({
-      html: html`<calcite-tile-select type="checkbox" input-enabled></calcite-tile-select>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tile-select type="checkbox" input-enabled></calcite-tile-select>`);
 
     const tileSelectSpy = await page.spyOnEvent("calciteTileSelectChange");
     const checkboxSpy = await page.spyOnEvent("calciteCheckboxChange");
@@ -150,12 +147,14 @@ describe("calcite-tile-select", () => {
   });
 
   it("emits change event on radio check and suppresses internal radio change event", async () => {
-    const page = await newE2EPage({
-      html: html`
-        <calcite-tile-select name="change" type="radio" input-enabled value="one"></calcite-tile-select>
-        <calcite-tile-select name="change" type="radio" input-enabled value="two"></calcite-tile-select>
-      `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tile-select
+        name="change"
+        type="radio"
+        input-enabled
+        value="one"
+      ></calcite-tile-select>
+      <calcite-tile-select name="change" type="radio" input-enabled value="two"></calcite-tile-select>`);
 
     const tileSelectSpy = await page.spyOnEvent("calciteTileSelectChange");
     const radioButtonSpy = await page.spyOnEvent("calciteRadioButtonChange");

--- a/src/components/time-picker/time-picker.e2e.ts
+++ b/src/components/time-picker/time-picker.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests";
 import { formatTimePart } from "../../utils/time";
 import { CSS } from "./resources";
@@ -68,9 +69,8 @@ describe("calcite-time-picker", () => {
   it("value displays correctly when value is programmatically changed", async () => {
     const originalValue = "11:00:00";
     const newValue = "14:30:40";
-    const page = await newE2EPage({
-      html: `<calcite-time-picker step="1" value="${originalValue}"></calcite-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-time-picker step="1" value="${originalValue}"></calcite-time-picker>`);
 
     const timePicker = await page.find("calcite-time-picker");
     const hourEl = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
@@ -96,9 +96,8 @@ describe("calcite-time-picker", () => {
 
   describe("keyboard accessibility", () => {
     it("tabbing focuses each input in the correct sequence", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
 
       await page.keyboard.press("Tab");
       await page.waitForChanges();
@@ -146,9 +145,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("pressing right and left arrow keys focuses each input in the correct sequence", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
 
       await page.keyboard.press("Tab");
       await page.waitForChanges();
@@ -229,9 +227,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowUp key increments hour property and display hour correctly for fr lang (24-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -250,9 +247,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowDown key decrements hour property and display hour correctly for fr lang (24-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -267,9 +263,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowUp key increments hour property and display hour correctly for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -285,9 +280,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowDown key decrements hour property and display hour correctly for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -302,9 +296,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowUp key increments minute property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
 
       await minute.click();
@@ -316,9 +309,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowDown key decrements minute property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
 
       await minute.click();
@@ -330,9 +322,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowUp key increments second property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
 
       await second.click();
@@ -344,9 +335,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowDown key decrements second property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
 
       await second.click();
@@ -358,9 +348,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowUp key increments meridiem property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
 
       await meridiem.click();
@@ -386,9 +375,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("ArrowDown key decrements meridiem property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
 
       await meridiem.click();
@@ -414,9 +402,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("typing letter keys changes nothing for hour, minute and second in 24-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -444,9 +431,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("typing letter keys changes nothing for hour, minute and second in 12-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -474,9 +460,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("allows typing single digit values for hour, minute and second and pads the value and display with a leading zero for 24-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -516,9 +501,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("allows typing single digit values for hour, minute and second and pads the value and display with a leading zero for 12-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -558,9 +542,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("restricts typing to valid hour values for 12-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -587,9 +570,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("restricts typing to valid hour values for 24-hour format", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr" step="1"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
 
       await hour.click();
@@ -616,9 +598,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("restricts typing to valid minute values", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
 
       await minute.click();
@@ -645,9 +626,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("restricts typing to valid second values", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
 
       await second.click();
@@ -674,9 +654,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("allows typing AM and PM for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
 
       await meridiem.click();
@@ -692,9 +671,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("typing am and pm multiple times when they are already set doesn't affect the hour", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker value="00:00"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker value="00:00"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
 
@@ -717,9 +695,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("Pressing delete when hour is focused clears the whole value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`);
       const timePicker = await page.find("calcite-time-picker");
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
@@ -744,9 +721,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("Pressing delete when minute is focused clears the whole value", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -768,9 +744,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("Pressing delete when second is focused just clears seconds", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1" value="00:00:00"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
@@ -794,9 +769,8 @@ describe("calcite-time-picker", () => {
 
   describe("time behavior", () => {
     it("hour, display hour and AM/PM set correctly as hour changes for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker value="00:00:00"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker value="00:00:00"></calcite-time-picker>`);
 
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
@@ -818,9 +792,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("changing AM/PM updates value property correctly for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker value="00:00:00" step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker value="00:00:00" step="1"></calcite-time-picker>`);
 
       const timePicker = await page.find(`calcite-time-picker`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
@@ -845,9 +818,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("hour-up button increments hour property and display hour correctly for fr lang (24-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const hourUp = await page.find(`calcite-time-picker >>> .${CSS.buttonHourUp}`);
 
@@ -865,9 +837,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("hour-down button decrements hour property and display hour correctly for fr lang (24-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="fr"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="fr"></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const hourdown = await page.find(`calcite-time-picker >>> .${CSS.buttonHourDown}`);
 
@@ -885,9 +856,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("hour-up button increments hour property and display hour correctly for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const hourup = await page.find(`calcite-time-picker >>> .${CSS.buttonHourUp}`);
 
@@ -900,9 +870,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("hour-down button decrements hour property and display hour correctly for en lang (12-hour)", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const hour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
       const hourdown = await page.find(`calcite-time-picker >>> .${CSS.buttonHourDown}`);
 
@@ -920,9 +889,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("minute-up button increments minute property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const minuteup = await page.find(`calcite-time-picker >>> .${CSS.buttonMinuteUp}`);
 
@@ -940,9 +908,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("minute-down button decrements minute property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const minute = await page.find(`calcite-time-picker >>> .${CSS.minute}`);
       const minutedown = await page.find(`calcite-time-picker >>> .${CSS.buttonMinuteDown}`);
 
@@ -960,9 +927,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("second-up button increments second property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
       const secondup = await page.find(`calcite-time-picker >>> .${CSS.buttonSecondUp}`);
 
@@ -980,9 +946,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("second-down button decrements second property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker step="1"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker step="1"></calcite-time-picker>`);
       const second = await page.find(`calcite-time-picker >>> .${CSS.second}`);
       const seconddown = await page.find(`calcite-time-picker >>> .${CSS.buttonSecondDown}`);
 
@@ -1000,9 +965,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("meridiem-up button increments meridiem property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
       const meridiemup = await page.find(`calcite-time-picker >>> .${CSS.buttonMeridiemUp}`);
 
@@ -1023,9 +987,8 @@ describe("calcite-time-picker", () => {
     });
 
     it("meridiem-down button decrements meridiem property correctly", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
       const meridiem = await page.find(`calcite-time-picker >>> .${CSS.meridiem}`);
       const meridiemdown = await page.find(`calcite-time-picker >>> .${CSS.buttonMeridiemDown}`);
 
@@ -1046,18 +1009,16 @@ describe("calcite-time-picker", () => {
     });
 
     it("time picker container direction is ltr when set to rtl on host", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker dir="rtl" ></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker dir="rtl"></calcite-time-picker>`);
       const timePicker = await page.find(`calcite-time-picker >>> .${CSS.timePicker}`);
       const timePickerDir = await timePicker.getAttribute("dir");
       expect(timePickerDir).toBe("ltr");
     });
 
     it("meridiem is at the start of the time for arabic locale", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-time-picker lang="ar" dir="rtl"></calcite-time-picker>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-time-picker lang="ar" dir="rtl"></calcite-time-picker>`);
 
       const meridiemStart = await page.find(`calcite-time-picker >>> .${CSS.meridiemStart}`);
       expect(meridiemStart).toBeTruthy();
@@ -1067,9 +1028,8 @@ describe("calcite-time-picker", () => {
   it("suuports translation", () => t9n("<calcite-time-picker></calcite-time-picker>"));
 
   it("toggles seconds display when step is < 60", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-time-picker value="11:00:00"></calcite-time-picker>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-time-picker value="11:00:00"></calcite-time-picker>`);
     const timePicker = await page.find("calcite-time-picker");
 
     expect(await page.find(`calcite-time-picker >>> .${CSS.second}`)).toBeNull();

--- a/src/components/tip-manager/tip-manager.e2e.ts
+++ b/src/components/tip-manager/tip-manager.e2e.ts
@@ -59,9 +59,10 @@ describe("calcite-tip-manager", () => {
   });
   describe("close button", () => {
     it("should be hidden after the close button is clicked", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tip-manager><calcite-tip><p>Close behavior</p></calcite-tip></calcite-tip-manager>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-tip-manager><calcite-tip><p>Close behavior</p></calcite-tip></calcite-tip-manager>`
+      );
 
       const tipManager = await page.find("calcite-tip-manager");
 
@@ -89,12 +90,11 @@ describe("calcite-tip-manager", () => {
   });
   describe("pagination", () => {
     it("should select the first tip by default and change the selectedIndex when the previous or next buttons are clicked", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tip-manager>
-      <calcite-tip id="one"><p>first tip default selected</p></calcite-tip>
-      <calcite-tip id="two"><p>next/prev behavior</p></calcite-tip>
-    </calcite-tip-manager>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tip-manager>
+        <calcite-tip id="one"><p>first tip default selected</p></calcite-tip>
+        <calcite-tip id="two"><p>next/prev behavior</p></calcite-tip>
+      </calcite-tip-manager>`);
 
       await page.waitForChanges();
 
@@ -132,18 +132,17 @@ describe("calcite-tip-manager", () => {
       const sharedTitle = "group1";
       const title2 = "group2";
 
-      const page = await newE2EPage({
-        html: `<calcite-tip-manager>
-      <calcite-tip-group group-title=${sharedTitle}>
-        <calcite-tip><p>group title behavior</p></calcite-tip>
-        <calcite-tip><p>same title as first one</p></calcite-tip>
-      </calcite-tip-group>
-      <calcite-tip-group group-title=${title2}>
-        <calcite-tip ><p>different title</p></calcite-tip>
-      </calcite-tip-group>
-      <calcite-tip><p>default title</p></calcite-tip>
-    </calcite-tip-manager>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tip-manager>
+        <calcite-tip-group group-title=${sharedTitle}>
+          <calcite-tip><p>group title behavior</p></calcite-tip>
+          <calcite-tip><p>same title as first one</p></calcite-tip>
+        </calcite-tip-group>
+        <calcite-tip-group group-title=${title2}>
+          <calcite-tip><p>different title</p></calcite-tip>
+        </calcite-tip-group>
+        <calcite-tip><p>default title</p></calcite-tip>
+      </calcite-tip-manager>`);
 
       await page.waitForChanges();
 
@@ -178,11 +177,10 @@ describe("calcite-tip-manager", () => {
   });
   describe("handling dom updates after initial render", () => {
     it("should update if tips are added after intial load", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-tip-manager>
-      <calcite-tip><p>dynamically adding/removing tips</p></calcite-tip>
-    </calcite-tip-manager>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tip-manager>
+        <calcite-tip><p>dynamically adding/removing tips</p></calcite-tip>
+      </calcite-tip-manager>`);
 
       const tipManager = await page.find("calcite-tip-manager");
       const newTipId = "newTip";

--- a/src/components/tip/tip.e2e.ts
+++ b/src/components/tip/tip.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
+import { html } from "../../../support/formatting";
 import { accessible, hidden, renders, defaults, slots, t9n } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
@@ -26,14 +27,15 @@ describe("calcite-tip", () => {
   it("should remove the closeButton if closeDisabled prop is true", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tip close-disabled><p>not dismissible</p></calcite-tip>`);
+    await page.setContent(html`<calcite-tip close-disabled><p>not dismissible</p></calcite-tip>`);
 
     const closeButton = await page.find(`calcite-tip >>> .${CSS.close}`);
     expect(closeButton).toBeNull();
   });
 
   it("should be hidden after the close button is clicked", async () => {
-    const page = await newE2EPage({ html: `<calcite-tip><p>testing close button</p></calcite-tip>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-tip><p>testing close button</p></calcite-tip>`);
 
     const eventSpy = await page.spyOnEvent("calciteTipDismiss", "window");
 
@@ -52,7 +54,7 @@ describe("calcite-tip", () => {
 
   it("header should only be visible if has a heading", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-tip><p>testing</p></calcite-tip>`);
+    await page.setContent(html`<calcite-tip><p>testing</p></calcite-tip>`);
 
     let header = await page.find(`calcite-tip >>> .${CSS.header}`);
 

--- a/src/components/tooltip/tooltip.e2e.ts
+++ b/src/components/tooltip/tooltip.e2e.ts
@@ -120,7 +120,10 @@ describe("calcite-tooltip", () => {
   it("open tooltip should be visible", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tooltip></calcite-tooltip><div>referenceElement</div>`);
+    await page.setContent(
+      html`<calcite-tooltip></calcite-tooltip>
+        <div>referenceElement</div>`
+    );
 
     const element = await page.find("calcite-tooltip");
 
@@ -168,7 +171,7 @@ describe("calcite-tooltip", () => {
   it("should accept referenceElement as virtual element", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tooltip open>content</calcite-tooltip>`);
+    await page.setContent(html`<calcite-tooltip open>content</calcite-tooltip>`);
 
     await page.$eval("calcite-tooltip", (tooltip: HTMLCalciteTooltipElement) => {
       const virtualElement = {

--- a/src/components/tree-item/tree-item.e2e.ts
+++ b/src/components/tree-item/tree-item.e2e.ts
@@ -97,7 +97,7 @@ describe("calcite-tree-item", () => {
   it("should allow starting expanded", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tree lines id="parentTree">
+    await page.setContent(html`<calcite-tree lines id="parentTree">
       <calcite-tree-item id="firstItem" expanded>
         <a href="#">Child 2</a>
 
@@ -117,7 +117,7 @@ describe("calcite-tree-item", () => {
   it("should navigate when the link inside the tree item is clicked", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tree lines id="parentTree">
+    await page.setContent(html`<calcite-tree lines id="parentTree">
       <calcite-tree-item id="firstItem">
         <a href="#">Child 1</a>
       </calcite-tree-item>
@@ -133,7 +133,7 @@ describe("calcite-tree-item", () => {
   it("should navigate to the link url when the item but not the link is clicked", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tree lines id="parentTree">
+    await page.setContent(html`<calcite-tree lines id="parentTree">
       <calcite-tree-item id="firstItem">
         <a href="#">Child 1</a>
       </calcite-tree-item>
@@ -149,7 +149,7 @@ describe("calcite-tree-item", () => {
   it("should navigate to the inner link when a child item is clicked and not the outer link", async () => {
     const page = await newE2EPage();
 
-    await page.setContent(`<calcite-tree lines id="parentTree">
+    await page.setContent(html`<calcite-tree lines id="parentTree">
       <calcite-tree-item expanded>
         <a href="#outer">Child 2</a>
 
@@ -199,7 +199,6 @@ describe("calcite-tree-item", () => {
       `;
       const page = await newE2EPage();
       await page.setContent(tree);
-      await page.waitForChanges();
       const ancestors = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
 
       for (const node of ancestors) {
@@ -234,7 +233,6 @@ describe("calcite-tree-item", () => {
       `;
       const page = await newE2EPage();
       await page.setContent(tree);
-      await page.waitForChanges();
       const [indeterminateAncestor, selectedAncestor] = await page.findAll(`calcite-tree-item[data-id="ancestor"]`);
 
       expect(await indeterminateAncestor.getProperty("indeterminate")).toBe(true);
@@ -248,11 +246,12 @@ describe("calcite-tree-item", () => {
   describe("when a parent tree-item is expanded and a new item is appended into it", () => {
     it("should render the visible, keyboard navigable item", async () => {
       const page = await newE2EPage();
-      await page.setContent(`<calcite-panel>
-        <calcite-button id='add-item-btn'>Add item to tree</calcite-button>
+      await page.setContent(html`<calcite-panel>
+        <calcite-button id="add-item-btn">Add item to tree</calcite-button>
         <calcite-tree>
-          <calcite-tree-item expanded><span>Element 1</span>
-            <calcite-tree slot='children' id='target-tree'>
+          <calcite-tree-item expanded
+            ><span>Element 1</span>
+            <calcite-tree slot="children" id="target-tree">
               <calcite-tree-item>Child 1</calcite-tree-item>
             </calcite-tree>
           </calcite-tree-item>
@@ -351,19 +350,18 @@ describe("calcite-tree-item", () => {
   });
 
   it("right arrow key expands subtree and left arrow collapses it", async () => {
-    const page = await newE2EPage({
-      html: `
-        <calcite-tree>
-          <calcite-tree-item id="cables">
-            Cables
-            <calcite-tree slot="children">
-              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
-              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-        </calcite-tree>
-    `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-tree>
+        <calcite-tree-item id="cables">
+          Cables
+          <calcite-tree slot="children">
+            <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
+            <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    `);
 
     await page.keyboard.press("Tab");
 
@@ -382,19 +380,18 @@ describe("calcite-tree-item", () => {
   });
 
   it("right arrow key focuses first item in expanded subtree", async () => {
-    const page = await newE2EPage({
-      html: `
-        <calcite-tree>
-          <calcite-tree-item id="cables" expanded>
-            Cables
-            <calcite-tree slot="children">
-              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
-              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-        </calcite-tree>
-    `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-tree>
+        <calcite-tree-item id="cables" expanded>
+          Cables
+          <calcite-tree slot="children">
+            <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
+            <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    `);
 
     await page.keyboard.press("Tab");
 

--- a/src/components/tree/tree.e2e.ts
+++ b/src/components/tree/tree.e2e.ts
@@ -33,13 +33,12 @@ describe("calcite-tree", () => {
 
   describe("it forwards focus", () => {
     it("to first selected item", async () => {
-      const page = await newE2EPage({
-        html: html` <calcite-tree>
-          <calcite-tree-item id="one">1</calcite-tree-item>
-          <calcite-tree-item id="two" selected>2</calcite-tree-item>
-          <calcite-tree-item id="three">3</calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree>
+        <calcite-tree-item id="one">1</calcite-tree-item>
+        <calcite-tree-item id="two" selected>2</calcite-tree-item>
+        <calcite-tree-item id="three">3</calcite-tree-item>
+      </calcite-tree>`);
 
       await page.keyboard.press("Tab");
 
@@ -47,13 +46,12 @@ describe("calcite-tree", () => {
     });
 
     it("to first item if none selected", async () => {
-      const page = await newE2EPage({
-        html: html` <calcite-tree>
-          <calcite-tree-item id="one">1</calcite-tree-item>
-          <calcite-tree-item id="two">2</calcite-tree-item>
-          <calcite-tree-item id="three">3</calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree>
+        <calcite-tree-item id="one">1</calcite-tree-item>
+        <calcite-tree-item id="two">2</calcite-tree-item>
+        <calcite-tree-item id="three">3</calcite-tree-item>
+      </calcite-tree>`);
 
       await page.keyboard.press("Tab");
 
@@ -66,11 +64,10 @@ describe("calcite-tree", () => {
     });
 
     it("doesn't trap focus", async () => {
-      const page = await newE2EPage({
-        html: html` <calcite-tree>
-          <calcite-tree-item id="one">1</calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree>
+        <calcite-tree-item id="one">1</calcite-tree-item>
+      </calcite-tree>`);
 
       await page.keyboard.press("Tab");
 
@@ -203,25 +200,24 @@ describe("calcite-tree", () => {
 
   describe("item selection", () => {
     it("allows selecting items", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-tree selection-mode="ancestors">
-          <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
-          <calcite-tree-item id="two">
-            <span>Two</span>
-            <calcite-tree slot="children">
-              <calcite-tree-item id="child-one">
-                <span>Child 1</span>
-                <calcite-tree slot="children">
-                  <calcite-tree-item id="grandchild-one">
-                    <span>Grandchild 1</span>
-                  </calcite-tree-item>
-                </calcite-tree>
-              </calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-          <calcite-tree-item disabled id="three"><span>Three</span></calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree selection-mode="ancestors">
+        <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
+        <calcite-tree-item id="two">
+          <span>Two</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item id="child-one">
+              <span>Child 1</span>
+              <calcite-tree slot="children">
+                <calcite-tree-item id="grandchild-one">
+                  <span>Grandchild 1</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+        <calcite-tree-item disabled id="three"><span>Three</span></calcite-tree-item>
+      </calcite-tree>`);
 
       const tree = await page.find("calcite-tree");
       const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
@@ -244,24 +240,23 @@ describe("calcite-tree", () => {
     });
 
     it("should only emit one event on grandchildren click", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-tree selection-mode="single">
-          <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
-          <calcite-tree-item id="two" expanded>
-            <span>Two</span>
-            <calcite-tree slot="children">
-              <calcite-tree-item id="child-one" expanded>
-                <span>Child 1</span>
-                <calcite-tree slot="children">
-                  <calcite-tree-item id="grandchild-one" expanded>
-                    <span>Grandchild 1</span>
-                  </calcite-tree-item>
-                </calcite-tree>
-              </calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree selection-mode="single">
+        <calcite-tree-item id="one"><span>One</span></calcite-tree-item>
+        <calcite-tree-item id="two" expanded>
+          <span>Two</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item id="child-one" expanded>
+              <span>Child 1</span>
+              <calcite-tree slot="children">
+                <calcite-tree-item id="grandchild-one" expanded>
+                  <span>Grandchild 1</span>
+                </calcite-tree-item>
+              </calcite-tree>
+            </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>`);
 
       await page.waitForChanges();
       const tree = await page.find("calcite-tree");
@@ -295,12 +290,11 @@ describe("calcite-tree", () => {
 
     describe("has selected items in the selection event payload", () => {
       it("contains current selection when selection=multiple", async () => {
-        const page = await newE2EPage({
-          html: html` <calcite-tree selection-mode="multiple">
-            <calcite-tree-item id="1">1</calcite-tree-item>
-            <calcite-tree-item id="2">2</calcite-tree-item>
-          </calcite-tree>`
-        });
+        const page = await newE2EPage();
+        await page.setContent(html`<calcite-tree selection-mode="multiple">
+          <calcite-tree-item id="1">1</calcite-tree-item>
+          <calcite-tree-item id="2">2</calcite-tree-item>
+        </calcite-tree>`);
 
         const tree = await page.find("calcite-tree");
 
@@ -361,11 +355,10 @@ describe("calcite-tree", () => {
     });
 
     it("emits once when the tree item checkbox label is clicked", async () => {
-      const page = await newE2EPage({
-        html: html`<calcite-tree selection-mode="ancestors">
-          <calcite-tree-item>1</calcite-tree-item>
-        </calcite-tree>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-tree selection-mode="ancestors">
+        <calcite-tree-item>1</calcite-tree-item>
+      </calcite-tree>`);
 
       const tree = await page.find("calcite-tree");
       const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
@@ -380,14 +373,13 @@ describe("calcite-tree", () => {
 
     describe(`when tree-item selection-mode is "ancestors"`, () => {
       it("should render checkbox inputs", async () => {
-        const page = await newE2EPage({
-          html: `
+        const page = await newE2EPage();
+        await page.setContent(html`
           <calcite-tree selection-mode="ancestors">
             <calcite-tree-item>1</calcite-tree-item>
             <calcite-tree-item>2</calcite-tree-item>
           </calcite-tree>
-          `
-        });
+        `);
         const checkbox = await page.find(
           `calcite-tree-item >>> .${CSS.nodeContainer} .${CSS.checkboxLabel} .${CSS.checkbox}`
         );
@@ -424,25 +416,24 @@ describe("calcite-tree", () => {
 
   describe("keyboard support", () => {
     it("should allow spacebar keydown events to propagate outside the root tree", async () => {
-      const page = await newE2EPage({
-        html: html`<div id="container">
-          <calcite-tree id="root">
-            <calcite-tree-item id="one" expanded>
-              <span>One</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id="child-one" expanded>
-                  <span>Child 1</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item id="grandchild-one">
-                      <span>Grandchild 1</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree id="root">
+          <calcite-tree-item id="one" expanded>
+            <span>One</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id="child-one" expanded>
+                <span>Child 1</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id="grandchild-one">
+                    <span>Grandchild 1</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
 
       const container = await page.find("#container");
       const grandchild = await page.find("#grandchild-one");
@@ -457,25 +448,24 @@ describe("calcite-tree", () => {
     });
 
     it("should allow enter keydown events to propagate outside the root tree", async () => {
-      const page = await newE2EPage({
-        html: html`<div id="container">
-          <calcite-tree id="root">
-            <calcite-tree-item id="one" expanded>
-              <span>One</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id="child-one" expanded>
-                  <span>Child 1</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item id="grandchild-one">
-                      <span>Grandchild 1</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree id="root">
+          <calcite-tree-item id="one" expanded>
+            <span>One</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id="child-one" expanded>
+                <span>Child 1</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id="grandchild-one">
+                    <span>Grandchild 1</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
 
       const container = await page.find("#container");
       const grandchild = await page.find("#grandchild-one");
@@ -490,25 +480,24 @@ describe("calcite-tree", () => {
     });
 
     it.skip("should allow ArrowRight and ArrowLeft keydown events to propagate outside the root tree", async () => {
-      const page = await newE2EPage({
-        html: html`<div id="container">
-          <calcite-tree id="root">
-            <calcite-tree-item id="one">
-              <span>One</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id="child-one">
-                  <span>Child 1</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item id="grandchild-one">
-                      <span>Grandchild 1</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree id="root">
+          <calcite-tree-item id="one">
+            <span>One</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id="child-one">
+                <span>Child 1</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id="grandchild-one">
+                    <span>Grandchild 1</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
 
       const container = await page.find("#container");
       const one = await page.find("#one");
@@ -551,25 +540,24 @@ describe("calcite-tree", () => {
       const child = "child";
       const grandchild = "grandchild";
 
-      const page = await newE2EPage({
-        html: html`<div id="container">
-          <calcite-tree id="root">
-            <calcite-tree-item id=${parent}>
-              <span>Parent</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id=${child}>
-                  <span>Child</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item id=${grandchild}>
-                      <span>Grandchild</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree id="root">
+          <calcite-tree-item id=${parent}>
+            <span>Parent</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id=${child}>
+                <span>Child</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id=${grandchild}>
+                    <span>Grandchild</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
 
       const parentEl = await page.find(`#${parent}`);
       const childEl = await page.find(`#${child}`);
@@ -650,40 +638,39 @@ describe("calcite-tree", () => {
     });
 
     it("ArrowUp and ArrowDown keys move focus between adjacent tree items at all 3 levels of depth and allow keydown events to propagate outside the tree root", async () => {
-      const page = await newE2EPage({
-        html: html`<div id="container">
-          <calcite-tree id="root">
-            <calcite-tree-item id="root-item-1">
-              <span>Root Item 1</span>
-            </calcite-tree-item>
-            <calcite-tree-item id="parent" expanded>
-              <span>Parent</span>
-              <calcite-tree slot="children">
-                <calcite-tree-item id="child">
-                  <span>Child</span>
-                </calcite-tree-item>
-                <calcite-tree-item id="child2" expanded>
-                  <span>Child 2</span>
-                  <calcite-tree slot="children">
-                    <calcite-tree-item id="grandchild">
-                      <span>Grandchild</span>
-                    </calcite-tree-item>
-                    <calcite-tree-item id="grandchild2">
-                      <span>Grandchild 2</span>
-                    </calcite-tree-item>
-                  </calcite-tree>
-                </calcite-tree-item>
-                <calcite-tree-item id="child3">
-                  <span>Child 3</span>
-                </calcite-tree-item>
-              </calcite-tree>
-            </calcite-tree-item>
-            <calcite-tree-item id="root-item-3">
-              <span>Root Item 3</span>
-            </calcite-tree-item>
-          </calcite-tree>
-        </div>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<div id="container">
+        <calcite-tree id="root">
+          <calcite-tree-item id="root-item-1">
+            <span>Root Item 1</span>
+          </calcite-tree-item>
+          <calcite-tree-item id="parent" expanded>
+            <span>Parent</span>
+            <calcite-tree slot="children">
+              <calcite-tree-item id="child">
+                <span>Child</span>
+              </calcite-tree-item>
+              <calcite-tree-item id="child2" expanded>
+                <span>Child 2</span>
+                <calcite-tree slot="children">
+                  <calcite-tree-item id="grandchild">
+                    <span>Grandchild</span>
+                  </calcite-tree-item>
+                  <calcite-tree-item id="grandchild2">
+                    <span>Grandchild 2</span>
+                  </calcite-tree-item>
+                </calcite-tree>
+              </calcite-tree-item>
+              <calcite-tree-item id="child3">
+                <span>Child 3</span>
+              </calcite-tree-item>
+            </calcite-tree>
+          </calcite-tree-item>
+          <calcite-tree-item id="root-item-3">
+            <span>Root Item 3</span>
+          </calcite-tree-item>
+        </calcite-tree>
+      </div>`);
 
       const container = await page.find("#container");
       const root = await page.find("#root");

--- a/src/components/value-list-item/value-list-item.e2e.ts
+++ b/src/components/value-list-item/value-list-item.e2e.ts
@@ -32,7 +32,8 @@ describe("calcite-value-list-item", () => {
   it("can be disabled", async () => disabled("calcite-value-list-item"));
 
   it("should toggle selected attribute when clicked", async () => {
-    const page = await newE2EPage({ html: `<calcite-value-list-item label="test"></calcite-value-list-item>` });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-value-list-item label="test"></calcite-value-list-item>`);
 
     const item = await page.find("calcite-value-list-item");
     expect(await item.getProperty("selected")).toBe(false);
@@ -45,9 +46,8 @@ describe("calcite-value-list-item", () => {
   });
 
   it("should fire event calciteListItemChange when item is clicked", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-value-list-item label="test" value="example"></calcite-value-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-value-list-item label="test" value="example"></calcite-value-list-item>`);
     const item = await page.find("calcite-value-list-item");
     await page.evaluate(() =>
       document.addEventListener("calciteListItemChange", (event: CustomEvent): void => {
@@ -67,9 +67,10 @@ describe("calcite-value-list-item", () => {
   });
 
   it("prevents deselection when deselectDisabled is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-value-list-item label="test" value="example" deselect-disabled selected></calcite-value-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-value-list-item label="test" value="example" deselect-disabled selected></calcite-value-list-item>`
+    );
     const item = await page.find("calcite-value-list-item");
 
     await item.click();
@@ -78,9 +79,10 @@ describe("calcite-value-list-item", () => {
   });
 
   it("prevents selection when nonInteractive is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-value-list-item label="test" value="example" non-interactive></calcite-value-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-value-list-item label="test" value="example" non-interactive></calcite-value-list-item>`
+    );
     const item = await page.find("calcite-value-list-item");
 
     await item.click();
@@ -89,9 +91,10 @@ describe("calcite-value-list-item", () => {
   });
 
   it("prevents deselection when nonInteractive is true", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-value-list-item label="test" value="example" non-interactive selected></calcite-value-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      `<calcite-value-list-item label="test" value="example" non-interactive selected></calcite-value-list-item>`
+    );
     const item = await page.find("calcite-value-list-item");
 
     await item.click();
@@ -117,9 +120,10 @@ describe("calcite-value-list-item", () => {
   }
 
   it("allows for easy removal", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-value-list-item label="test" value="example" removable></calcite-value-list-item>`
-    });
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-value-list-item label="test" value="example" removable></calcite-value-list-item>`
+    );
 
     const item = await page.find("calcite-value-list-item");
     const removeEventSpy = await item.spyOnEvent("calciteListItemRemove");

--- a/src/components/value-list/value-list.e2e.ts
+++ b/src/components/value-list/value-list.e2e.ts
@@ -32,10 +32,9 @@ describe("calcite-value-list", () => {
   it("supports translations", () => t9n("calcite-value-list"));
 
   it("should not display screen reader only text when drag-enabled", async () => {
-    const page = await newE2EPage({});
-    await page.setContent(`<calcite-value-list drag-enabled>
-      <calcite-value-list-item label="Lakes" description="Summary lorem ipsum" value="lakes">
-      </calcite-value-list-item>
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-value-list drag-enabled>
+      <calcite-value-list-item label="Lakes" description="Summary lorem ipsum" value="lakes"> </calcite-value-list-item>
     </calcite-value-list>`);
 
     const srOnlyElement = await page.find("calcite-value-list >>> span");
@@ -64,22 +63,20 @@ describe("calcite-value-list", () => {
 
   describe("icon logic", () => {
     it("should be 'grip' when in `configuration` mode drag and drop is enabled", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-value-list drag-enabled>
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-value-list drag-enabled>
         <calcite-value-list-item value="one"></calcite-value-list-item>
-      </calcite-value-list>`
-      });
+      </calcite-value-list>`);
 
       const item = await page.find("calcite-value-list-item");
       const icon = await item.getProperty("icon");
       expect(icon).toBe(ICON_TYPES.grip);
     });
     it("should be null when drag and drop is disabled", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-value-list>
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-value-list>
         <calcite-value-list-item value="one"></calcite-value-list-item>
-      </calcite-value-list>`
-      });
+      </calcite-value-list>`);
 
       const item = await page.find("calcite-value-list-item");
       const icon = await item.getProperty("icon");
@@ -105,13 +102,16 @@ describe("calcite-value-list", () => {
 
   describe("drag and drop", () => {
     async function createSimpleValueList(): Promise<E2EPage> {
-      return newE2EPage({
-        html: `<calcite-value-list drag-enabled>
-        <calcite-value-list-item value="one" label="One"></calcite-value-list-item>
-        <calcite-value-list-item value="two" label="Two"></calcite-value-list-item>
-        <calcite-value-list-item value="three" label="Three"></calcite-value-list-item>
-      </calcite-value-list>`
-      });
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-value-list drag-enabled>
+          <calcite-value-list-item value="one" label="One"></calcite-value-list-item>
+          <calcite-value-list-item value="two" label="Two"></calcite-value-list-item>
+          <calcite-value-list-item value="three" label="Three"></calcite-value-list-item>
+        </calcite-value-list>`
+      );
+
+      return page;
     }
 
     it("works using a mouse", async () => {
@@ -171,8 +171,8 @@ describe("calcite-value-list", () => {
     });
 
     it("supports dragging items between lists", async () => {
-      const page = await newE2EPage({
-        html: `
+      const page = await newE2EPage();
+      await page.setContent(html`
         <calcite-value-list id="first-letters" drag-enabled group="letters">
           <calcite-value-list-item value="a" label="A"></calcite-value-list-item>
           <calcite-value-list-item value="b" label="B"></calcite-value-list-item>
@@ -193,8 +193,7 @@ describe("calcite-value-list", () => {
           <calcite-value-list-item value="e" label="E"></calcite-value-list-item>
           <calcite-value-list-item value="f" label="F"></calcite-value-list-item>
         </calcite-value-list>
-        `
-      });
+      `);
 
       await dragAndDrop(
         page,

--- a/src/tests/commonTests.ts
+++ b/src/tests/commonTests.ts
@@ -38,6 +38,7 @@ function getTag(tagOrHTML: string): ComponentTag {
 
 async function simplePageSetup(componentTagOrHTML: TagOrHTML): Promise<E2EPage> {
   const componentTag = getTag(componentTagOrHTML);
+  // eslint-disable-next-line no-restricted-syntax -- basic test page requires additional options
   const page = await newE2EPage({
     html: isHTML(componentTagOrHTML) ? componentTagOrHTML : `<${componentTag}></${componentTag}>`,
     failOnConsoleError: true
@@ -386,8 +387,8 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
   }
 
   const wrappedHtml = html`<calcite-label> ${labelTitle} ${componentHtml}</calcite-label>`;
-  const wrappedPage: E2EPage = await newE2EPage({ html: wrappedHtml });
-  await wrappedPage.waitForChanges();
+  const wrappedPage: E2EPage = await newE2EPage();
+  await wrappedPage.setContent(wrappedHtml);
 
   await assertLabelable({
     page: wrappedPage,
@@ -401,8 +402,8 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
     <calcite-label for="${id}">${labelTitle}</calcite-label>
     ${componentHtml}
   `;
-  const siblingPage: E2EPage = await newE2EPage({ html: siblingHtml });
-  await siblingPage.waitForChanges();
+  const siblingPage: E2EPage = await newE2EPage();
+  await siblingPage.setContent(siblingHtml);
 
   await assertLabelable({
     page: siblingPage,
@@ -413,8 +414,7 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
   });
 
   const labelFirstSiblingPage: E2EPage = await newE2EPage();
-  await labelFirstSiblingPage.setContent(`<calcite-label for="${id}"></calcite-label>`);
-  await labelFirstSiblingPage.waitForChanges();
+  await labelFirstSiblingPage.setContent(html`<calcite-label for="${id}"></calcite-label>`);
   await labelFirstSiblingPage.evaluate((componentHtml: string) => {
     const template = document.createElement("template");
     template.innerHTML = `${componentHtml}`.trim();
@@ -432,8 +432,7 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
   });
 
   const labelFirstWrappedPage: E2EPage = await newE2EPage();
-  await labelFirstWrappedPage.setContent(`<calcite-label for="${id}"></calcite-label>`);
-  await labelFirstWrappedPage.waitForChanges();
+  await labelFirstWrappedPage.setContent(html`<calcite-label for="${id}"></calcite-label>`);
   await labelFirstWrappedPage.evaluate((componentHtml: string) => {
     const template = document.createElement("template");
     template.innerHTML = `${componentHtml}`.trim();
@@ -451,8 +450,8 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
     shadowFocusTargetSelector
   });
 
-  const componentFirstSiblingPage: E2EPage = await newE2EPage({ html: componentHtml });
-  await componentFirstSiblingPage.waitForChanges();
+  const componentFirstSiblingPage: E2EPage = await newE2EPage();
+  await componentFirstSiblingPage.setContent(componentHtml);
   await componentFirstSiblingPage.evaluate((id: string) => {
     const label = document.createElement("calcite-label");
     label.setAttribute("for", `${id}`);
@@ -469,8 +468,7 @@ export async function labelable(componentTagOrHtml: TagOrHTML, options?: Labelab
   });
 
   const componentFirstWrappedPage: E2EPage = await newE2EPage();
-  await componentFirstWrappedPage.setContent(`${componentHtml}`);
-  await componentFirstWrappedPage.waitForChanges();
+  await componentFirstWrappedPage.setContent(html`${componentHtml}`);
   await componentFirstWrappedPage.evaluate((id: string) => {
     const componentEl = document.querySelector(`[id='${id}']`);
     const labelEl = document.createElement("calcite-label");
@@ -534,16 +532,15 @@ export function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssoc
       componentTag
     );
 
-    const page = await newE2EPage({
-      html: html`<form>
-        ${componentHtml}
-        <!--
+    const page = await newE2EPage();
+    await page.setContent(html`<form>
+      ${componentHtml}
+      <!--
           keeping things simple by using submit-type input
           this should cover button and calcite-button submit cases
           -->
-        <input id="submitter" type="submit" />
-      </form>`
-    });
+      <input id="submitter" type="submit" />
+    </form>`);
     await page.waitForChanges();
     const component = await page.find(componentTag);
 
@@ -563,15 +560,14 @@ export function formAssociated(componentTagOrHtml: TagOrHTML, options: FormAssoc
       componentTag
     );
 
-    const page = await newE2EPage({
-      html: html`<form id="test-form"></form>
-        ${componentHtml}
-        <!--
+    const page = await newE2EPage();
+    await page.setContent(html`<form id="test-form"></form>
+      ${componentHtml}
+      <!--
         keeping things simple by using submit-type input
         this should cover button and calcite-button submit cases
         -->
-        <input id="submitter" form="test-form" type="submit" />`
-    });
+      <input id="submitter" form="test-form" type="submit" />`);
     await page.waitForChanges();
     const component = await page.find(componentTag);
 

--- a/src/tests/globalStyles.e2e.ts
+++ b/src/tests/globalStyles.e2e.ts
@@ -18,7 +18,8 @@ describe("global styles", () => {
 
     globalClasses.forEach((className) => {
       it(`should support rendering component with ${className} animation`, async () => {
-        const page = await newE2EPage({ html: snippet });
+        const page = await newE2EPage();
+        await page.setContent(snippet);
         const element = await page.find("calcite-notice");
         await element.setProperty("active", true);
         await element.classList.add(className);
@@ -42,20 +43,17 @@ describe("global styles", () => {
     });
 
     it("should set animation duration to 0ms when --calcite-duration-factor set to zero", async () => {
-      const page = await newE2EPage({
-        html: html`
-          <html>
-            <style>
-              html {
-                --calcite-duration-factor: 0;
-              }
-            </style>
-            <body>
-              <div style="transition: all var(--calcite-animation-timing) linear;"></div>
-            </body>
-          </html>
-        `
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<html>
+        <style>
+          html {
+            --calcite-duration-factor: 0;
+          }
+        </style>
+        <body>
+          <div style="transition: all var(--calcite-animation-timing) linear;"></div>
+        </body>
+      </html>`);
       await page.waitForChanges();
       const eleTransitionDuration = await page.evaluate(() => {
         const ele = document.querySelector("div");
@@ -66,10 +64,8 @@ describe("global styles", () => {
   });
 
   it("should not be able to disable animations with --calcite-duration-factor at component level", async () => {
-    const page = await newE2EPage({
-      html: html` <div style="transition: all var(--calcite-animation-timing) linear;"></div> `
-    });
-    await page.waitForChanges();
+    const page = await newE2EPage();
+    await page.setContent(html`<div style="transition: all var(--calcite-animation-timing) linear;"></div>`);
     await page.$eval("div", (element: any) => {
       element.style.setProperty("--calcite-duration-factor", 0);
     });
@@ -81,9 +77,8 @@ describe("global styles", () => {
   });
 
   it("should set animation duration to default value 150ms", async () => {
-    const page = await newE2EPage({
-      html: html` <div style="transition: all var(--calcite-animation-timing) linear;"></div> `
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<div style="transition: all var(--calcite-animation-timing) linear;"></div>`);
     const eleTransitionDuration = await page.evaluate(() => {
       const ele = document.querySelector("div");
       return ele ? window.getComputedStyle(ele).transitionDuration : null;

--- a/src/utils/dom.e2e.ts
+++ b/src/utils/dom.e2e.ts
@@ -36,9 +36,8 @@ describe("queries", () => {
   let page: E2EPage;
 
   beforeEach(async () => {
-    page = await newE2EPage({
-      html: outsideHostHTML
-    });
+    page = await newE2EPage();
+    await page.setContent(outsideHostHTML);
 
     function setUpTestComponent({ insideHostHTML, componentTag, insideShadowHTML }: SetUpTestComponentOptions) {
       class TestComponent extends HTMLElement {

--- a/support/formatting.ts
+++ b/support/formatting.ts
@@ -8,15 +8,14 @@ import dedent from "dedent";
  *
  * ```ts
  * // select.e2e.ts
- * const page = await newE2EPage({
- *   html: html`
- *     <calcite-select>
- *       <calcite-option id="1">uno</calcite-option>
- *       <calcite-option id="2">dos</calcite-option>
- *       <calcite-option id="3">tres</calcite-option>
- *     </calcite-select>
- *   `
- * });
+ * const page = await newE2EPage();
+ * await page.setContent(html`
+ *   <calcite-select>
+ *     <calcite-option id="1">uno</calcite-option>
+ *     <calcite-option id="2">dos</calcite-option>
+ *     <calcite-option id="3">tres</calcite-option>
+ *   </calcite-select>
+ * `});
  * ```
  *
  * ```ts


### PR DESCRIPTION
Related Issue: #4844

## Summary

This PR uses `no-restricted-syntax` rule to enforce a single way of initializing tests for both consistency and test stability.

Additionally, this also updates tests to be consistent and also uses the `html` tagged template for consistent formatting.