### PR TITLE
fix(tab-title): add full focus outline to closable tab button in high contrast mode

### DIFF
--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -292,4 +292,8 @@
   :host([bordered][position="bottom"][selected]) .container {
     border-block-start-style: none;
   }
+
+  .close-button {
+    @apply z-default;
+  }
 }

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -294,6 +294,7 @@
   }
 
   .close-button {
+    /* in high contrast the tab title outline covers the close button outline without a z-index */
     @apply z-default;
   }
 }


### PR DESCRIPTION
Effect is only noticable in high-contrast mode. Issue #6994

**Related Issue:** #6994

## Summary
Adds a simple z-index to show the high contrast focus outline over the tab title outline.