### PR TITLE
test(modal): skip unstable test

### DIFF
--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -267,7 +267,7 @@ describe("opening and closing behavior", () => {
     expect(openSpy).toHaveReceivedEventTimes(1);
   });
 
-  it("emits when duration is set to 0", async () => {
+  it.skip("emits when duration is set to 0", async () => {
     const page = await newProgrammaticE2EPage();
     await skipAnimations(page);
 


### PR DESCRIPTION
**Related Issue:** #7273

## Summary

Skip unstable test.

Might be related to awaiting something that isn't a promise.

<img width="730" alt="image" src="https://github.com/Esri/calcite-design-system/assets/1231455/9e6a902d-d443-4509-a6c1-1462f16a4cc2">
