### PR TITLE
refactor(popover): renames private method

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -111,7 +111,7 @@ export class Popover
   @Prop({ reflect: true }) focusTrapDisabled = false;
 
   @Watch("focusTrapDisabled")
-  handlefocusTrapDisabled(focusTrapDisabled: boolean): void {
+  handleFocusTrapDisabled(focusTrapDisabled: boolean): void {
     if (!this.open) {
       return;
     }


### PR DESCRIPTION
**Related Issue:** None

## Summary

- renames private method from `handlefocusTrapDisabled` to `handleFocusTrapDisabled`