### PR TITLE
docs: Add implementation example to `visualizeMouseCursor` util

### DIFF
--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -155,6 +155,15 @@ export async function getElementXY(
  * Note that this util should only be used for test debugging purposes and not be included in a test.
  * Based on https://github.com/puppeteer/puppeteer/issues/4378#issuecomment-499726973
  *
+ * @example
+ * import { visualizeMouseCursor } from "../../tests/utils";
+ *
+ * const page = await newE2EPage();
+ * await page.setContent(`<calcite-tooltip>Content</calcite-tooltip>`);
+ *
+ * await visualizeMouseCursor(page);
+ * await page.waitForChanges();
+ *
  * @param {E2EPage} page - the e2e page
  */
 export async function visualizeMouseCursor(page: E2EPage): Promise<void> {


### PR DESCRIPTION
**Related Issue:** #N/A

## Summary

Refactor to add implementation example to `visualizeMouseCursor` util doc.