### PR TITLE
test: stabilize tests using setFocus

### DIFF
--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
@@ -407,6 +407,7 @@ describe("calcite-color-picker-hex-input", () => {
             await input.setProperty("value", noColorValue);
             await page.waitForChanges();
             await input.callMethod("setFocus");
+            await page.waitForChanges();
 
             await page.keyboard.press("ArrowUp");
             await page.waitForChanges();
@@ -525,6 +526,7 @@ describe("calcite-color-picker-hex-input", () => {
             await input.setProperty("value", noColorValue);
             await page.waitForChanges();
             await input.callMethod("setFocus");
+            await page.waitForChanges();
 
             await page.keyboard.press("ArrowUp");
             await page.waitForChanges();

--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -281,6 +281,7 @@ describe("calcite-color-picker", () => {
     value: string
   ): Promise<void> => {
     await channelInputOrHexInput.callMethod("setFocus");
+    await page.waitForChanges();
     await selectText(channelInputOrHexInput);
     await channelInputOrHexInput.press("Backspace");
     await channelInputOrHexInput.type(value);
@@ -1051,6 +1052,7 @@ describe("calcite-color-picker", () => {
 
             const assertChannelValueNudge = async (page: E2EPage, calciteInput: E2EElement): Promise<void> => {
               await calciteInput.callMethod("setFocus");
+              await page.waitForChanges();
               const currentValue = await calciteInput.getProperty("value");
 
               await page.keyboard.press("ArrowUp");
@@ -1140,7 +1142,6 @@ describe("calcite-color-picker", () => {
             });
 
             const assertChannelValueNudge = async (page: E2EPage, calciteInput: E2EElement): Promise<void> => {
-              await calciteInput.callMethod("setFocus");
               await clearAndEnterHexOrChannelValue(page, calciteInput, "");
 
               // using page.waitForChanges as keyboard nudges occur in the next frame
@@ -1598,6 +1599,7 @@ describe("calcite-color-picker", () => {
 
           const assertChannelValueNudge = async (page: E2EPage, calciteInputOrSlider: E2EElement): Promise<void> => {
             await calciteInputOrSlider.callMethod("setFocus");
+            await page.waitForChanges();
             const currentValue = await calciteInputOrSlider.getProperty("value");
 
             function ensureValueType(value: string | number): number | string {
@@ -1717,6 +1719,7 @@ describe("calcite-color-picker", () => {
               }
 
               await calciteInputOrSlider.callMethod("setFocus");
+              await page.waitForChanges();
               await clearValue();
 
               // using page.waitForChanges as keyboard nudges occur in the next frame

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -783,6 +783,7 @@ describe("calcite-combobox", () => {
         }
       } else {
         await combobox.callMethod("setFocus");
+        await page.waitForChanges();
         await page.keyboard.press("Escape");
       }
 

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.e2e.ts
@@ -31,6 +31,7 @@ describe("calcite-dropdown-item", () => {
 
     calciteDropdownItemSelectEvent = page.waitForEvent("calciteDropdownItemSelect");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Enter");
     await calciteDropdownItemSelectEvent;
 
@@ -38,6 +39,7 @@ describe("calcite-dropdown-item", () => {
 
     calciteDropdownItemSelectEvent = page.waitForEvent("calciteDropdownItemSelect");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Space");
     await calciteDropdownItemSelectEvent;
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -754,6 +754,7 @@ describe("calcite-dropdown", () => {
       expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);
@@ -799,6 +800,7 @@ describe("calcite-dropdown", () => {
       expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(await dropdownWrapper.isVisible()).toBe(false);

--- a/packages/calcite-components/src/components/filter/filter.e2e.ts
+++ b/packages/calcite-components/src/components/filter/filter.e2e.ts
@@ -93,6 +93,7 @@ describe("calcite-filter", () => {
       it("should clear the value in the input when pressed", async () => {
         const filter = await page.find("calcite-filter");
         await filter.callMethod("setFocus");
+        await page.waitForChanges();
 
         await page.keyboard.type("developer");
         await page.waitForChanges();
@@ -118,6 +119,7 @@ describe("calcite-filter", () => {
       it("should clear the value in the input when the Escape key is pressed", async () => {
         const filter = await page.find("calcite-filter");
         await filter.callMethod("setFocus");
+        await page.waitForChanges();
 
         await page.keyboard.type("developer");
         await page.waitForChanges();
@@ -203,6 +205,7 @@ describe("calcite-filter", () => {
 
       const filterChangeEvent = page.waitForEvent("calciteFilterChange");
       await filter.callMethod("setFocus");
+      await page.waitForChanges();
       await filter.type("developer");
       await filterChangeEvent;
 
@@ -224,6 +227,7 @@ describe("calcite-filter", () => {
       const filter = await page.find("calcite-filter");
 
       await filter.callMethod("setFocus");
+      await page.waitForChanges();
       await filter.type("volt");
       await waitForEvent;
 
@@ -235,6 +239,7 @@ describe("calcite-filter", () => {
       const filter = await page.find("calcite-filter");
 
       await filter.callMethod("setFocus");
+      await page.waitForChanges();
       await filter.type("regex()");
       await waitForEvent;
 

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -522,6 +522,7 @@ describe("calcite-input-number", () => {
       const input = await page.find("calcite-input-number");
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
       await input.callMethod("setFocus");
+      await page.waitForChanges();
 
       await page.keyboard.down("ArrowUp");
       await page.waitForTimeout(delayFor2UpdatesInMs);
@@ -629,6 +630,7 @@ describe("calcite-input-number", () => {
       await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
       const element = await page.find("calcite-input-number");
       await element.callMethod("setFocus");
+      await page.waitForChanges();
 
       await Promise.all((["ArrowUp", "ArrowDown"] as const).map((key) => page.keyboard.press(key)));
       await page.waitForTimeout(delayFor2UpdatesInMs);
@@ -640,6 +642,7 @@ describe("calcite-input-number", () => {
       const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
       const element = await page.find("calcite-input-number");
       await element.callMethod("setFocus");
+      await page.waitForChanges();
 
       const arrowUpDown = page.keyboard.down("ArrowUp");
       const arrowUpUp = page.keyboard.up("ArrowUp");
@@ -654,6 +657,7 @@ describe("calcite-input-number", () => {
       await page.setContent(html`<calcite-input-number step="0.1"></calcite-input-number> `);
       const input = await page.find("calcite-input-number");
       await input.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("ArrowUp");
       await page.waitForChanges();
 
@@ -679,6 +683,7 @@ describe("calcite-input-number", () => {
       await page.setContent(html`<calcite-input-number step="5" value="1.008"></calcite-input-number>`);
       const input = await page.find("calcite-input-number");
       await input.callMethod("setFocus");
+      await page.waitForChanges();
 
       await page.keyboard.press("ArrowUp");
       await page.waitForChanges();
@@ -730,34 +735,40 @@ describe("calcite-input-number", () => {
 
       const inputFirstPart = "12345";
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, inputFirstPart);
       expect(await element.getProperty("value")).toBe(inputFirstPart);
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(0);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Enter");
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Enter");
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(5);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
 
       const textSecondPart = "67890";
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, textSecondPart);
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Tab");
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
       expect(await element.getProperty("value")).toBe(`${inputFirstPart}${textSecondPart}`);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Tab");
       expect(calciteInputNumberInput).toHaveReceivedEventTimes(10);
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
@@ -772,6 +783,7 @@ describe("calcite-input-number", () => {
       expect(calciteInputNumberChange).toHaveReceivedEventTimes(2);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await selectText(element);
       await page.keyboard.press("Backspace");
       await page.keyboard.press("Tab");
@@ -934,6 +946,7 @@ describe("calcite-input-number", () => {
     const calciteInput = await page.find("calcite-input-number");
     const input = await page.find("calcite-input-number >>> input");
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     const nonELetterKeys = letterKeys.filter((key) => key !== "e");
     for (let i = 0; i < nonELetterKeys.length; i++) {
       await page.keyboard.down("Shift");
@@ -950,6 +963,7 @@ describe("calcite-input-number", () => {
     const calciteInput = await page.find("calcite-input");
     const input = await page.find("calcite-input >>> input");
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     const numberKeysExcludingZero = numberKeys.slice(1);
 
     let result = "";
@@ -971,6 +985,7 @@ describe("calcite-input-number", () => {
     `);
     const calciteInput2 = await page.find("#input2");
     await calciteInput2.callMethod("setFocus");
+    await page.waitForChanges();
     expect(await page.evaluate(() => document.activeElement.getAttribute("label"))).toEqual("two");
     await page.keyboard.down("Shift");
     await page.keyboard.press("Tab");
@@ -984,6 +999,7 @@ describe("calcite-input-number", () => {
     const calciteInput = await page.find("calcite-input-number");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("0");
     await page.waitForChanges();
@@ -1003,6 +1019,7 @@ describe("calcite-input-number", () => {
     await page.setContent(html`<calcite-input-number></calcite-input-number>`);
     const input = await page.find("calcite-input-number");
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "1.005");
     await page.waitForChanges();
 
@@ -1019,6 +1036,7 @@ describe("calcite-input-number", () => {
     expect(await input.getProperty("value")).toBe("");
 
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "-123");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("-123");
@@ -1159,6 +1177,7 @@ describe("calcite-input-number", () => {
           const calciteInput = await page.find("calcite-input-number");
           const input = await page.find("calcite-input-number >>> input");
           await calciteInput.callMethod("setFocus");
+          await page.waitForChanges();
           await typeNumberValue(page, `0${decimalSeparator}0000`);
           await page.waitForChanges();
           expect(await input.getProperty("value")).toBe(`0${decimalSeparator}0000`);
@@ -1188,6 +1207,7 @@ describe("calcite-input-number", () => {
           const calciteInput = await page.find("calcite-input-number");
           const input = await page.find("calcite-input-number >>> input");
           await calciteInput.callMethod("setFocus");
+          await page.waitForChanges();
           await typeNumberValue(page, `0${decimalSeparator}01`);
           await page.waitForChanges();
           expect(await input.getProperty("value")).toBe(`0${decimalSeparator}01`);
@@ -1226,6 +1246,7 @@ describe("calcite-input-number", () => {
     await page.setContent(html`<calcite-input-number lang="ar"></calcite-input-number>`);
     const element = await page.find("calcite-input-number");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, value);
     await page.waitForChanges();
     await page.keyboard.press("Tab");
@@ -1240,6 +1261,7 @@ describe("calcite-input-number", () => {
     // overwrite initial value by selecting and typing
     await element.callMethod("selectText");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, value);
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe(value);
@@ -1304,6 +1326,7 @@ describe("calcite-input-number", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1332,6 +1355,7 @@ describe("calcite-input-number", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1359,6 +1383,7 @@ describe("calcite-input-number", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1393,6 +1418,7 @@ describe("calcite-input-number", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1409,6 +1435,7 @@ describe("calcite-input-number", () => {
     const element = await page.find("calcite-input-number");
     expect(await element.getProperty("value")).toBe("123");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("4");
     await page.waitForChanges();
@@ -1428,6 +1455,7 @@ describe("calcite-input-number", () => {
     const element = await page.find("calcite-input-number");
     expect(await element.getProperty("value")).toBe("5");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
@@ -1473,6 +1501,7 @@ describe("calcite-input-number", () => {
     const element = await page.find("calcite-input-number");
     expect(await element.getProperty("value")).toBe("1.2");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("Backspace");
     await page.waitForChanges();
@@ -1488,6 +1517,7 @@ describe("calcite-input-number", () => {
 
     const element = await page.find("calcite-input-number");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "0000000");
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("0");
@@ -1507,6 +1537,7 @@ describe("calcite-input-number", () => {
 
     const element = await page.find("calcite-input-number");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await typeNumberValue(page, "1--2---3");
     await page.waitForChanges();
@@ -1540,6 +1571,7 @@ describe("calcite-input-number", () => {
       const element = await page.find("calcite-input-number");
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("12345");
       await page.waitForChanges();
 
@@ -1592,6 +1624,7 @@ describe("calcite-input-number", () => {
     const button = await page.find("calcite-button");
 
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "1");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("1");
@@ -1610,6 +1643,7 @@ describe("calcite-input-number", () => {
     await input.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "3");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("13");
@@ -1619,6 +1653,7 @@ describe("calcite-input-number", () => {
     await button.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "4");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");
@@ -1628,6 +1663,7 @@ describe("calcite-input-number", () => {
     await input.setProperty("disabled", true);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");

--- a/packages/calcite-components/src/components/input-text/input-text.e2e.ts
+++ b/packages/calcite-components/src/components/input-text/input-text.e2e.ts
@@ -100,6 +100,7 @@ describe("calcite-input-text", () => {
     expect(changeEventSpy).not.toHaveReceivedEvent();
 
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await input.setProperty("value", "not a random value");
     await page.keyboard.press("Tab");
     await page.waitForChanges();
@@ -118,34 +119,40 @@ describe("calcite-input-text", () => {
 
     const inputFirstPart = "12345";
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type(inputFirstPart);
     expect(await element.getProperty("value")).toBe(inputFirstPart);
     expect(calciteInputTextInput).toHaveReceivedEventTimes(5);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(0);
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Enter");
     expect(calciteInputTextInput).toHaveReceivedEventTimes(5);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(1);
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Enter");
     expect(calciteInputTextInput).toHaveReceivedEventTimes(5);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(1);
 
     const textSecondPart = "67890";
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type(textSecondPart);
     expect(calciteInputTextInput).toHaveReceivedEventTimes(10);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(1);
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Tab");
     expect(calciteInputTextInput).toHaveReceivedEventTimes(10);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("value")).toBe(`${inputFirstPart}${textSecondPart}`);
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Tab");
     expect(calciteInputTextInput).toHaveReceivedEventTimes(10);
     expect(calciteInputTextChange).toHaveReceivedEventTimes(2);
@@ -160,6 +167,7 @@ describe("calcite-input-text", () => {
     expect(calciteInputTextChange).toHaveReceivedEventTimes(2);
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await selectText(element);
     await page.keyboard.press("Backspace");
     await page.keyboard.press("Tab");
@@ -199,6 +207,7 @@ describe("calcite-input-text", () => {
 
     const element = await page.find("calcite-input-text");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Escape");
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("");
@@ -237,6 +246,7 @@ describe("calcite-input-text", () => {
     const element = await page.find("calcite-input-text");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     expect(calciteInputTextInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -252,6 +262,7 @@ describe("calcite-input-text", () => {
     const element = await page.find("calcite-input-text");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     expect(calciteInputTextInput).not.toHaveReceivedEvent();
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -271,6 +282,7 @@ describe("calcite-input-text", () => {
 
     const input = await page.find("calcite-input-text");
     await input.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.type("1");
 
@@ -314,6 +326,7 @@ describe("calcite-input-text", () => {
     const element = await page.find("calcite-input-text");
     expect(await element.getProperty("value")).toBe("John Doe");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("a");
     await page.waitForChanges();
@@ -363,6 +376,7 @@ describe("calcite-input-text", () => {
     const element = await page.find("calcite-input-text");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("test");
     await page.waitForChanges();
 
@@ -387,6 +401,7 @@ describe("calcite-input-text", () => {
     const button = await page.find("calcite-button");
 
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("1");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("1");
@@ -405,6 +420,7 @@ describe("calcite-input-text", () => {
     await input.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("3");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("13");
@@ -414,6 +430,7 @@ describe("calcite-input-text", () => {
     await button.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("4");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");
@@ -423,6 +440,7 @@ describe("calcite-input-text", () => {
     await input.setProperty("disabled", true);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -265,6 +265,7 @@ describe("calcite-input-time-picker", () => {
     expect(changeEvent).toHaveReceivedEventTimes(0);
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5:4 PM");
     await page.waitForChanges();
 
@@ -293,6 +294,7 @@ describe("calcite-input-time-picker", () => {
     expect(changeEvent).toHaveReceivedEventTimes(0);
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5:4");
     await page.waitForChanges();
 
@@ -321,6 +323,7 @@ describe("calcite-input-time-picker", () => {
     expect(changeEvent).toHaveReceivedEventTimes(0);
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5:4:3 PM");
     await page.waitForChanges();
 
@@ -349,6 +352,7 @@ describe("calcite-input-time-picker", () => {
     expect(changeEvent).toHaveReceivedEventTimes(0);
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5:4:3");
     await page.waitForChanges();
 
@@ -559,6 +563,7 @@ describe("calcite-input-time-picker", () => {
     expect(await inputTimePicker.getProperty("value")).toBe("14:59");
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Backspace");
     await page.keyboard.press("5");
     await page.keyboard.press("Enter");
@@ -609,6 +614,7 @@ describe("calcite-input-time-picker", () => {
     const inputTimePicker = await page.find("calcite-input-time-picker");
 
     await inputTimePicker.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("ArrowLeft");
     await page.keyboard.press("ArrowRight");
     await page.keyboard.press("ArrowRight");
@@ -679,6 +685,7 @@ describe("calcite-input-time-picker", () => {
       const inputTimePicker = await page.find("calcite-input-time-picker");
 
       await inputTimePicker.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("0123456789");
 
       expect(await getInputValue(page)).toBe("٠١٢٣٤٥٦٧٨٩");
@@ -694,6 +701,7 @@ describe("calcite-input-time-picker", () => {
       const changeEvent = await inputTimePicker.spyOnEvent("calciteInputTimePickerChange");
 
       await inputTimePicker.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("2:45:30 م");
       await page.keyboard.press("Enter");
 
@@ -757,6 +765,7 @@ describe("calcite-input-time-picker", () => {
       const changeEvent = await inputTimePicker.spyOnEvent("calciteInputTimePickerChange");
 
       await inputTimePicker.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("1.2.3");
       await page.keyboard.press("Enter");
 
@@ -791,6 +800,7 @@ describe("calcite-input-time-picker", () => {
       const changeEvent = await inputTimePicker.spyOnEvent("calciteInputTimePickerChange");
 
       await inputTimePicker.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("2:3:5 am");
       await page.keyboard.press("Enter");
 

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -511,6 +511,7 @@ describe("calcite-input", () => {
       const input = await page.find("calcite-input");
       expect(calciteInputInput).toHaveReceivedEventTimes(0);
       await input.callMethod("setFocus");
+      await page.waitForChanges();
 
       await page.keyboard.down("ArrowUp");
       await page.waitForTimeout(delayFor2UpdatesInMs);
@@ -594,6 +595,7 @@ describe("calcite-input", () => {
       await page.setContent(html`<calcite-input type="number" value="0"></calcite-input>`);
       const element = await page.find("calcite-input");
       await element.callMethod("setFocus");
+      await page.waitForChanges();
 
       await Promise.all((["ArrowUp", "ArrowDown"] as const).map((key) => page.keyboard.press(key)));
       await page.waitForTimeout(delayFor2UpdatesInMs);
@@ -605,6 +607,7 @@ describe("calcite-input", () => {
       const calciteInputInput = await page.spyOnEvent("calciteInputInput");
       const element = await page.find("calcite-input");
       await element.callMethod("setFocus");
+      await page.waitForChanges();
 
       const arrowUpDown = page.keyboard.down("ArrowUp");
       const arrowUpUp = page.keyboard.up("ArrowUp");
@@ -619,6 +622,7 @@ describe("calcite-input", () => {
       await page.setContent(html`<calcite-input step="0.1" type="number"></calcite-input> `);
       const input = await page.find("calcite-input");
       await input.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("ArrowUp");
       await page.waitForChanges();
 
@@ -644,6 +648,7 @@ describe("calcite-input", () => {
       await page.setContent(html`<calcite-input step="5" type="number" value="1.008"></calcite-input>`);
       const input = await page.find("calcite-input");
       await input.callMethod("setFocus");
+      await page.waitForChanges();
 
       await page.keyboard.press("ArrowUp");
       await page.waitForChanges();
@@ -693,6 +698,7 @@ describe("calcite-input", () => {
       expect(changeEventSpy).not.toHaveReceivedEvent();
 
       await input.callMethod("setFocus");
+      await page.waitForChanges();
       await input.setProperty("value", "not a random value");
       await page.keyboard.press("Tab");
       await page.waitForChanges();
@@ -715,34 +721,40 @@ describe("calcite-input", () => {
 
       const inputFirstPart = "12345";
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, inputFirstPart);
       expect(await element.getProperty("value")).toBe(inputFirstPart);
       expect(calciteInputInput).toHaveReceivedEventTimes(5);
       expect(calciteInputChange).toHaveReceivedEventTimes(0);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Enter");
       expect(calciteInputInput).toHaveReceivedEventTimes(5);
       expect(calciteInputChange).toHaveReceivedEventTimes(1);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Enter");
       expect(calciteInputInput).toHaveReceivedEventTimes(5);
       expect(calciteInputChange).toHaveReceivedEventTimes(1);
 
       const textSecondPart = "67890";
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, textSecondPart);
       expect(calciteInputInput).toHaveReceivedEventTimes(10);
       expect(calciteInputChange).toHaveReceivedEventTimes(1);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Tab");
       expect(calciteInputInput).toHaveReceivedEventTimes(10);
       expect(calciteInputChange).toHaveReceivedEventTimes(2);
       expect(await element.getProperty("value")).toBe(`${inputFirstPart}${textSecondPart}`);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Tab");
       expect(calciteInputInput).toHaveReceivedEventTimes(10);
       expect(calciteInputChange).toHaveReceivedEventTimes(2);
@@ -757,6 +769,7 @@ describe("calcite-input", () => {
       expect(calciteInputChange).toHaveReceivedEventTimes(2);
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await selectText(element);
       await page.keyboard.press("Backspace");
       await page.keyboard.press("Tab");
@@ -801,6 +814,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.press("Escape");
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("");
@@ -839,6 +853,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -869,6 +884,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     expect(calciteInputInput).toHaveReceivedEventTimes(0);
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -884,6 +900,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
 
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     expect(calciteInputInput).not.toHaveReceivedEvent();
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -903,6 +920,7 @@ describe("calcite-input", () => {
 
     const input = await page.find("calcite-input");
     await input.callMethod("setFocus");
+    await page.waitForChanges();
 
     await typeNumberValue(page, "1");
 
@@ -1087,6 +1105,7 @@ describe("calcite-input", () => {
       const calciteInput = await page.find("calcite-input");
       const input = await page.find("calcite-input >>> input");
       await calciteInput.callMethod("setFocus");
+      await page.waitForChanges();
       const nonELetterKeys = letterKeys.filter((key) => key !== "e");
       for (let i = 0; i < nonELetterKeys.length; i++) {
         await page.keyboard.down("Shift");
@@ -1103,6 +1122,7 @@ describe("calcite-input", () => {
       const calciteInput = await page.find("calcite-input");
       const input = await page.find("calcite-input >>> input");
       await calciteInput.callMethod("setFocus");
+      await page.waitForChanges();
       const numberKeysExcludingZero = numberKeys.slice(1);
 
       let result = "";
@@ -1124,6 +1144,7 @@ describe("calcite-input", () => {
       `);
       const calciteInput2 = await page.find("#input2");
       await calciteInput2.callMethod("setFocus");
+      await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.getAttribute("label"))).toEqual("two");
       await page.keyboard.down("Shift");
       await page.keyboard.press("Tab");
@@ -1137,6 +1158,7 @@ describe("calcite-input", () => {
       const calciteInput = await page.find("calcite-input");
 
       await calciteInput.callMethod("setFocus");
+      await page.waitForChanges();
 
       await page.keyboard.press("0");
       await page.waitForChanges();
@@ -1156,6 +1178,7 @@ describe("calcite-input", () => {
       await page.setContent(html`<calcite-input type="number"></calcite-input>`);
       const input = await page.find("calcite-input");
       await input.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, "1.005");
       await page.waitForChanges();
 
@@ -1172,6 +1195,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe("");
 
       await input.callMethod("setFocus");
+      await page.waitForChanges();
       await typeNumberValue(page, "-123");
       await page.waitForChanges();
       expect(await input.getProperty("value")).toBe("-123");
@@ -1333,6 +1357,7 @@ describe("calcite-input", () => {
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("calcite-input >>> input");
           await calciteInput.callMethod("setFocus");
+          await page.waitForChanges();
           await typeNumberValue(page, `0${decimalSeparator}0000`);
           await page.waitForChanges();
           expect(await input.getProperty("value")).toBe(`0${decimalSeparator}0000`);
@@ -1362,6 +1387,7 @@ describe("calcite-input", () => {
           const calciteInput = await page.find("calcite-input");
           const input = await page.find("calcite-input >>> input");
           await calciteInput.callMethod("setFocus");
+          await page.waitForChanges();
           await typeNumberValue(page, `0${decimalSeparator}01`);
           await page.waitForChanges();
           expect(await input.getProperty("value")).toBe(`0${decimalSeparator}01`);
@@ -1400,6 +1426,7 @@ describe("calcite-input", () => {
     await page.setContent(html`<calcite-input lang="ar" type="number"></calcite-input>`);
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, value);
     await page.waitForChanges();
     await page.keyboard.press("Tab");
@@ -1414,6 +1441,7 @@ describe("calcite-input", () => {
     // overwrite initial value by selecting and typing
     await element.callMethod("selectText");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, value);
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe(value);
@@ -1478,6 +1506,7 @@ describe("calcite-input", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1506,6 +1535,7 @@ describe("calcite-input", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1533,6 +1563,7 @@ describe("calcite-input", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1568,6 +1599,7 @@ describe("calcite-input", () => {
     await page.keyboard.up("Meta");
 
     await calciteInput.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.down("Meta");
     await page.keyboard.press("v");
     await page.keyboard.up("Meta");
@@ -1584,6 +1616,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(await element.getProperty("value")).toBe("John Doe");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("a");
     await page.waitForChanges();
@@ -1603,6 +1636,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(await element.getProperty("value")).toBe("5");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
@@ -1648,6 +1682,7 @@ describe("calcite-input", () => {
     const element = await page.find("calcite-input");
     expect(await element.getProperty("value")).toBe("1.2");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await page.keyboard.press("Backspace");
     await page.waitForChanges();
@@ -1663,6 +1698,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
     await typeNumberValue(page, "0000000");
     await page.waitForChanges();
     expect(await element.getProperty("value")).toBe("0");
@@ -1682,6 +1718,7 @@ describe("calcite-input", () => {
 
     const element = await page.find("calcite-input");
     await element.callMethod("setFocus");
+    await page.waitForChanges();
 
     await typeNumberValue(page, "1--2---3");
     await page.waitForChanges();
@@ -1722,6 +1759,7 @@ describe("calcite-input", () => {
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("test");
       await page.waitForChanges();
 
@@ -1741,6 +1779,7 @@ describe("calcite-input", () => {
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("test");
       await page.waitForChanges();
 
@@ -1760,6 +1799,7 @@ describe("calcite-input", () => {
       const element = await page.find("calcite-input");
 
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.type("12345");
       await page.waitForChanges();
 
@@ -1812,6 +1852,7 @@ describe("calcite-input", () => {
     const button = await page.find("calcite-button");
 
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("1");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("1");
@@ -1830,6 +1871,7 @@ describe("calcite-input", () => {
     await input.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("3");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("13");
@@ -1839,6 +1881,7 @@ describe("calcite-input", () => {
     await button.setProperty("disabled", false);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("4");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");
@@ -1848,6 +1891,7 @@ describe("calcite-input", () => {
     await input.setProperty("disabled", true);
     await page.waitForChanges();
     await input.callMethod("setFocus");
+    await page.waitForChanges();
     await page.keyboard.type("5");
     await page.waitForChanges();
     expect(await input.getProperty("value")).toBe("134");

--- a/packages/calcite-components/src/components/link/link.e2e.ts
+++ b/packages/calcite-components/src/components/link/link.e2e.ts
@@ -221,6 +221,7 @@ describe("calcite-link", () => {
     it("keyboard", async () => {
       const element = await page.find("calcite-link");
       await element.callMethod("setFocus");
+      await page.waitForChanges();
       await page.keyboard.press("Enter");
       await page.waitForChanges();
 

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -123,6 +123,7 @@ describe("calcite-list", () => {
     expect(await list.getProperty("filterText")).toBeUndefined();
 
     await filter.callMethod("setFocus");
+    await page.waitForChanges();
 
     const calciteListFilterEvent = list.waitForEvent("calciteListFilter");
     await page.keyboard.type("one");


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Adds more `page.waitForChanges()` after `setFocus` calls. This is needed after https://github.com/Esri/calcite-design-system/pull/7277.