### PR TITLE
ci: notify teams about calcite-components releases only

### DIFF
--- a/.github/workflows/notify-teams-release_calcite_components.yml
+++ b/.github/workflows/notify-teams-release_calcite_components.yml
@@ -1,0 +1,13 @@
+name: Release Notification
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification
+        if: contains(github.event.release.tag_name, '@esri/calcite-components@')
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d '{"@context": "http://schema.org/extensions", "@type": "MessageCard", "title": "${{ github.event.release.tag_name }}", "text": "🚀 <code>${{ github.event.release.tag_name }}</code> released! Check out the [changelog](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/CHANGELOG.md#changelog) for more info. 🚀"}' ${{ secrets.TEAMS_WEBHOOK_URI_RELEASE }}


### PR DESCRIPTION
**Original PRs:** #3771 #5512

## Summary

Adding back the Teams release notification action. I had to refactor it after the monorepo transition so it wouldn't spam the channel with release notifications for all of the packages. 

We can make additional steps for different packages that go to different channels at some point. For example,  a `design-tokens` release notification to "Get Help - Design and FIGMA"