### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+    charset = utf-8
+    insert_final_newline = true
+    end_of_line = lf
+    quote_type = double
+    indent_style = space
+    indent_size = 2
+    max_line_length = 120
+    curly_bracket_next_line = false
+    spaces_around_brackets = true
+    spaces_around_operators = true
+    indent_brace_style = K&R
+
+[*.tsx]
+    max_line_length = 100
+
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,19 +1,4 @@
 {
-  "arrowParens": "always",
-  "bracketSameLine": false,
-  "bracketSpacing": true,
-  "printWidth": 120,
-  "semi": true,
-  "singleQuote": false,
-  "tabWidth": 2,
-  "trailingComma": "none",
-  "useTabs": false,
-  "overrides": [
-    {
-      "files": "*.tsx",
-      "options": {
-        "printWidth": 100
-      }
-    }
-  ]
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "trailingComma": "none"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/prettierrc",
-  "trailingComma": "none"
-}


### PR DESCRIPTION
## Summary

Adds [`.editorconfig`](https://editorconfig.org/#file-format-details) to ensure people's editors have the same settings as prettier. Prettier will get settings from editorconfig if there is one found. This PR also switches to the new Prettier 3x default of adding trailing commas. 

I linted and nothing else changed except for a few cleanups that also changed w/o the editorconfig. I'll make a separate PR for that.

ref: https://prettier.io/docs/en/configuration.html#editorconfig
options: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties