### PR TITLE
fix(input-date-picker): provides placeholder text context for AT users

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/assets/input-date-picker/t9n/messages.json
+++ b/packages/calcite-components/src/components/input-date-picker/assets/input-date-picker/t9n/messages.json
@@ -1,3 +1,4 @@
 {
-  "chooseDate": "Choose date"
+  "chooseDate": "Choose date",
+  "dateFormat": "Date Format:"
 }

--- a/packages/calcite-components/src/components/input-date-picker/assets/input-date-picker/t9n/messages_en.json
+++ b/packages/calcite-components/src/components/input-date-picker/assets/input-date-picker/t9n/messages_en.json
@@ -1,3 +1,4 @@
 {
-  "chooseDate": "Choose date"
+  "chooseDate": "Choose date",
+  "dateFormat": "Date Format:"
 }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -153,3 +153,7 @@
 }
 
 @include hidden-form-input();
+
+.assistive-text {
+  @apply sr-only;
+}

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -528,6 +528,7 @@ export class InputDatePicker
               <calcite-input
                 aria-autocomplete="none"
                 aria-controls={this.dialogId}
+                aria-describedby={this.placeholderTextId}
                 aria-expanded={toAriaBoolean(this.open)}
                 aria-haspopup="dialog"
                 class={`input ${
@@ -550,6 +551,9 @@ export class InputDatePicker
                 ref={this.setStartInput}
               />
               {this.renderToggleIcon(this.open && this.focusedInput === "start")}
+              <span aria-hidden="true" class={CSS.assistiveText} id={this.placeholderTextId}>
+                Date Format: {this.localeData?.placeholder}
+              </span>
             </div>
             <div
               aria-hidden={toAriaBoolean(!this.open)}
@@ -728,6 +732,8 @@ export class InputDatePicker
   }
 
   private valueAsDateChangedExternally = false;
+
+  private placeholderTextId = `calcite-input-date-picker-placeholder-${guid()}`;
 
   //--------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/input-date-picker/resources.ts
+++ b/packages/calcite-components/src/components/input-date-picker/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
+  assistiveText: "assistive-text",
   menu: "menu-container",
   menuActive: "menu-container--active",
   toggleIcon: "toggle-icon"


### PR DESCRIPTION
**Related Issue:** #5581 

## Summary

This fix will provide placeholder text context for Assistive Technology users in `calcite-input-date-picker`.