### PR TITLE
feat: Add a Calcite config for defining a focus trap stack

### DIFF
--- a/packages/calcite-components/src/core/config.ts
+++ b/packages/calcite-components/src/core/config.ts
@@ -1,0 +1,5 @@
+import type { FocusTrap } from "focus-trap";
+
+const config: { trapStack: FocusTrap[] } = { trapStack: [] };
+
+export default config;

--- a/packages/calcite-components/src/index.ts
+++ b/packages/calcite-components/src/index.ts
@@ -2,3 +2,4 @@
 // this file was added as a workaround to force the build to export `getAssetPath`,
 // which enables developers to check if the asset path has been set or not
 export { getAssetPath } from "@stencil/core";
+export * as config from "./core/config";

--- a/packages/calcite-components/src/utils/focusTrapComponent.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.ts
@@ -1,7 +1,7 @@
 import { createFocusTrap, FocusTrap as _FocusTrap, Options as FocusTrapOptions } from "focus-trap";
 import { FocusableElement, focusElement, tabbableOptions } from "./dom";
-
-const trapStack: _FocusTrap[] = [];
+import config from "../core/config";
+const { trapStack } = config;
 
 /**
  * Defines interface for components with a focus trap. Focusable content is required for components implementing focus trapping with this interface.


### PR DESCRIPTION
**Related Issue:** #6659

## Summary

- Adds a config for defining a focus trap stack.