### PR TITLE
test(block): disable loader animation in chromatic snapshots

### DIFF
--- a/packages/calcite-components/src/components/block/block.stories.ts
+++ b/packages/calcite-components/src/components/block/block.stories.ts
@@ -218,6 +218,11 @@ export const contentSpacing_TestOnly = (): string =>
 
 export const loadingWithSlottedIcon_TestOnly = (): string =>
   html`
+    <style>
+      :root {
+        --calcite-duration-factor: 0;
+      }
+    </style>
     <calcite-block collapsible open loading heading="Layer effects" description="Adjust blur">
       <calcite-icon scale="s" slot="icon" icon="effects"></calcite-icon>
       <calcite-notice open>
@@ -228,6 +233,11 @@ export const loadingWithSlottedIcon_TestOnly = (): string =>
 
 export const loadingWithNoStatusNorSlottedIcon_TestOnly = (): string =>
   html`
+    <style>
+      :root {
+        --calcite-duration-factor: 0;
+      }
+    </style>
     <calcite-block collapsible open loading heading="Layer effects" description="Adjust blur">
       <calcite-notice open>
         <div slot="message">Use layer effects sparingly</div>
@@ -237,6 +247,11 @@ export const loadingWithNoStatusNorSlottedIcon_TestOnly = (): string =>
 
 export const loadingWithStatusIcon_TestOnly = (): string =>
   html`
+    <style>
+      :root {
+        --calcite-duration-factor: 0;
+      }
+    </style>
     <calcite-block loading heading="Valid status" description="summary" collapsible status="valid">
       <calcite-input icon="form-field" placeholder="This is valid input field"></calcite-input>
     </calcite-block>


### PR DESCRIPTION
**Related Issue:** noticed the failing snapshots in #7327

For example: https://www.chromatic.com/test?appId=6266d45509d7eb004aa254fb&id=64b6d984dc6b56c885b8872f

## Summary

Sets the duration factor to 0 in chromatic snapshots to prevent failures due to loader animation