### PR TITLE
docs: add warning notice to internal storybook

### DIFF
--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -35,7 +35,7 @@ module.exports = {
 
       <template id="internalStorybookNotice">
         <calcite-notice open icon="exclamation-mark-triangle" closable kind="warning" scale="l" style="font-family: var(--calcite-sans-family)">
-          <div slot="title">This storybook is meant for internal, testing purposes only (using @next)</div>
+          <div slot="title">This storybook is on the current @next version and is meant for internal, testing purposes only.</div>
           <div slot="link">
             Please refer to the
             <calcite-link

--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -23,4 +23,42 @@ module.exports = {
       ],
     };
   },
+  managerHead: (head: string): string => {
+    if (process.env.STORYBOOK_SCREENSHOT_TEST_BUILD) {
+      return head;
+    }
+
+    return `
+      <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
+      <link rel="stylesheet" href="./build/calcite.css" />
+      <script type="module" src="./build/calcite.esm.js"></script>
+
+      <template id="internalStorybookNotice">
+        <calcite-notice open icon="exclamation-mark-triangle" closable kind="warning" scale="l" style="font-family: var(--calcite-sans-family)">
+          <div slot="title">This storybook is meant for internal, testing purposes only (using @next)</div>
+          <div slot="link">
+            Please refer to the
+            <calcite-link
+              slot="link"
+              title="my action"
+              href="https://developers.arcgis.com/calcite-design-system/components/"
+            >
+              Calcite Components documentation site
+            </calcite-link>
+            to browse and interact with components.
+          </div>
+        </calcite-notice>
+      </template>
+
+      <script>
+        window.addEventListener(
+          "load",
+          () => document.body.prepend(document.getElementById("internalStorybookNotice").content.cloneNode(true)),
+          { once: true }
+        );
+      </script>
+
+      ${head}
+    `;
+  },
 };


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This displays a notice for anyone that might still be looking at the storybook link, which has now been deprecated (as component doc) in favor of the official documentation site.

![Screenshot 2023-07-18 at 5 09 20 PM](https://github.com/Esri/calcite-design-system/assets/197440/b09aca56-59e4-469d-a1ad-23bf143499ee)

**Note**: this won't be displayed for Chromatic Storybook builds