### PR TITLE
fix(link): adds outline-offset to avoid overlapping with text.

### DIFF
--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -28,7 +28,7 @@
 :host span {
   @apply focus-base;
   &:focus {
-    @apply focus-inset;
+    @apply focus-outset;
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #6588 

## Summary
This PR will add back the `2px` outline-offset for `calcite-link`. 