### PR TITLE
fix(tooltip): ensure --calcite-app-z-index-tooltip is applied

### DIFF
--- a/packages/calcite-components/calcite-preset.ts
+++ b/packages/calcite-components/calcite-preset.ts
@@ -240,7 +240,7 @@ export default {
         overlay: "var(--calcite-app-z-index-overlay)",
         modal: "var(--calcite-app-z-index-modal)",
         popover: "var(--calcite-app-z-index-popup)",
-        tooltip: "901",
+        tooltip: "var(--calcite-app-z-index-tooltip)",
       },
     },
   },


### PR DESCRIPTION
**Related Issue:** #7344 

## Summary

This updates the tooltip z-index layer to use the corresponding design token CSS var.
