### PR TITLE
fix: remove style modifying all host components with hidden attribute

### DIFF
--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -15,10 +15,6 @@
   }
 }
 
-:host([hidden]) {
-  display: none;
-}
-
 @mixin word-break() {
   word-wrap: break-word;
   word-break: break-word;

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -71,6 +71,16 @@
   }
 }
 
+@mixin calciteComponentCommon() {
+  :host([hidden]) {
+    @apply hidden;
+  }
+
+  [hidden] {
+    @apply hidden;
+  }
+}
+
 @mixin xButton() {
   :host([scale="s"]) {
     .x-button {

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@mixin calciteComponentCommon() {
+@mixin baseComponent() {
   :host([hidden]) {
     @apply hidden;
   }

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@mixin baseComponent() {
+@mixin base-component() {
   :host([hidden]) {
     @apply hidden;
   }

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -28,8 +28,6 @@
   --calcite-accordion-item-active-icon-rotation-rtl: calc(theme("rotate.180") * -1);
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-3
     relative
@@ -215,3 +213,5 @@
     }
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -28,6 +28,8 @@
   --calcite-accordion-item-active-icon-rotation-rtl: calc(theme("rotate.180") * -1);
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-3
     relative

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -214,4 +214,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -214,4 +214,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/accordion/accordion.scss
+++ b/packages/calcite-components/src/components/accordion/accordion.scss
@@ -38,4 +38,4 @@
   @apply border border-solid border-color-2 border-b-0;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/accordion/accordion.scss
+++ b/packages/calcite-components/src/components/accordion/accordion.scss
@@ -20,8 +20,6 @@
   @apply text-0h;
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative
     block
@@ -39,3 +37,5 @@
 .accordion {
   @apply border border-solid border-color-2 border-b-0;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/accordion/accordion.scss
+++ b/packages/calcite-components/src/components/accordion/accordion.scss
@@ -20,6 +20,8 @@
   @apply text-0h;
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     block

--- a/packages/calcite-components/src/components/accordion/accordion.scss
+++ b/packages/calcite-components/src/components/accordion/accordion.scss
@@ -38,4 +38,4 @@
   @apply border border-solid border-color-2 border-b-0;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -62,4 +62,4 @@
   @apply justify-end;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -62,4 +62,4 @@
   @apply justify-end;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar when in "vertical" layout.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply pointer-events-auto

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar when in "vertical" layout.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply pointer-events-auto
@@ -63,3 +61,5 @@
 .action-group--bottom {
   @apply justify-end;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -53,4 +53,4 @@
   grid-template-columns: repeat(var(--calcite-action-group-columns), auto);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
 
@@ -54,3 +52,5 @@
 
   grid-template-columns: repeat(var(--calcite-action-group-columns), auto);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
 

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -53,4 +53,4 @@
   grid-template-columns: repeat(var(--calcite-action-group-columns), auto);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
   text-color-2
@@ -37,3 +35,5 @@
 .menu {
   @apply flex-col flex-nowrap outline-none;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -36,4 +36,4 @@
   @apply flex-col flex-nowrap outline-none;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -36,4 +36,4 @@
   @apply flex-col flex-nowrap outline-none;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
   text-color-2

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -56,4 +56,4 @@
   @apply border-b-0;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -56,4 +56,4 @@
   @apply border-b-0;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad when in "vertical" layout.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad when in "vertical" layout.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;
@@ -57,3 +55,5 @@
 ::slotted(calcite-action-group:last-child) {
   @apply border-b-0;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-action-indicator-color: Specifies the color of the component's indicator.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply flex bg-transparent;
@@ -241,3 +239,5 @@
 .indicator-text {
   @apply sr-only;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -240,4 +240,4 @@
   @apply sr-only;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -240,4 +240,4 @@
   @apply sr-only;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-action-indicator-color: Specifies the color of the component's indicator.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply flex bg-transparent;

--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -74,6 +74,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   --calcite-alert-edge-distance: theme("spacing.8");
   @apply block;
@@ -125,10 +127,6 @@
 }
 
 @include calciteHydratedHidden();
-
-[hidden] {
-  @apply hidden;
-}
 
 .container {
   @apply flex

--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -330,4 +330,4 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
   position: absolute;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -330,4 +330,4 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
   position: absolute;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -74,8 +74,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   --calcite-alert-edge-distance: theme("spacing.8");
   @apply block;
@@ -331,3 +329,5 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
 .container.slotted-in-shell {
   position: absolute;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/avatar/avatar.scss
+++ b/packages/calcite-components/src/components/avatar/avatar.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply rounded-half inline-block overflow-hidden;
 }

--- a/packages/calcite-components/src/components/avatar/avatar.scss
+++ b/packages/calcite-components/src/components/avatar/avatar.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply rounded-half inline-block overflow-hidden;
 }
@@ -31,3 +29,5 @@
 .thumbnail {
   @apply rounded-half h-full w-full;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/avatar/avatar.scss
+++ b/packages/calcite-components/src/components/avatar/avatar.scss
@@ -30,4 +30,4 @@
   @apply rounded-half h-full w-full;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/avatar/avatar.scss
+++ b/packages/calcite-components/src/components/avatar/avatar.scss
@@ -30,4 +30,4 @@
   @apply rounded-half h-full w-full;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -82,4 +82,4 @@
   color: theme("colors.danger");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -82,4 +82,4 @@
   color: theme("colors.danger");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
     text-color-2
@@ -83,3 +81,5 @@
 .status-icon.invalid {
   color: theme("colors.danger");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
     text-color-2

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @extend %component-spacing;

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @extend %component-spacing;
@@ -162,3 +160,5 @@ calcite-action-menu {
     @apply text-color-1;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -161,4 +161,4 @@ calcite-action-menu {
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -161,4 +161,4 @@ calcite-action-menu {
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-block w-auto align-middle;
 }

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -733,4 +733,4 @@
   --calcite-button-padding-x-internal: theme("padding.11");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -733,4 +733,4 @@
   --calcite-button-padding-x-internal: theme("padding.11");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-block w-auto align-middle;
 }
@@ -734,3 +732,5 @@
 :host([scale="l"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
   --calcite-button-padding-x-internal: theme("padding.11");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block max-w-full;
   & .calcite-card-container {

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -126,4 +126,4 @@ slot[name="footer-end"]::slotted(*) {
   @apply flex gap-1;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -126,4 +126,4 @@ slot[name="footer-end"]::slotted(*) {
   @apply flex gap-1;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block max-w-full;
   & .calcite-card-container {
@@ -127,3 +125,5 @@ slot[name="footer-start"]::slotted(*),
 slot[name="footer-end"]::slotted(*) {
   @apply flex gap-1;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -15,7 +15,6 @@
 :host([scale="l"]) {
   --calcite-checkbox-size: theme("spacing.4");
 }
-@include calciteComponentCommon();
 
 :host {
   @apply relative
@@ -70,3 +69,4 @@
 
 @include disabled();
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -15,6 +15,8 @@
 :host([scale="l"]) {
   --calcite-checkbox-size: theme("spacing.4");
 }
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     inline-flex

--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -69,4 +69,4 @@
 
 @include disabled();
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -69,4 +69,4 @@
 
 @include disabled();
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/chip-group/chip-group.scss
+++ b/packages/calcite-components/src/components/chip-group/chip-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   display: flex;
 }

--- a/packages/calcite-components/src/components/chip-group/chip-group.scss
+++ b/packages/calcite-components/src/components/chip-group/chip-group.scss
@@ -22,4 +22,4 @@
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/chip-group/chip-group.scss
+++ b/packages/calcite-components/src/components/chip-group/chip-group.scss
@@ -22,4 +22,4 @@
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/chip-group/chip-group.scss
+++ b/packages/calcite-components/src/components/chip-group/chip-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   display: flex;
 }
@@ -24,3 +22,4 @@
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -47,8 +47,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply inline-flex
     cursor-default
@@ -304,3 +302,4 @@ slot[name="image"]::slotted(*) {
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -302,4 +302,4 @@ slot[name="image"]::slotted(*) {
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -47,6 +47,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply inline-flex
     cursor-default

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -302,4 +302,4 @@ slot[name="image"]::slotted(*) {
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -32,4 +32,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -32,4 +32,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -33,3 +31,5 @@
     inline-size: 88px;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
@@ -2,8 +2,6 @@ $size-s: 20px;
 $size-m: 24px;
 $size-l: 28px;
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative inline-flex;
 }
@@ -43,3 +41,5 @@ $size-l: 28px;
 .checker {
   fill: #cacaca;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
@@ -2,6 +2,8 @@ $size-s: 20px;
 $size-m: 24px;
 $size-l: 28px;
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative inline-flex;
 }

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
@@ -42,4 +42,4 @@ $size-l: 28px;
   fill: #cacaca;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
@@ -42,4 +42,4 @@ $size-l: 28px;
   fill: #cacaca;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -190,4 +190,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-n2h inline-block font-normal;
 }
@@ -191,3 +189,5 @@
     outline-offset: 2px;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -190,4 +190,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-n2h inline-block font-normal;
 }

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -1,4 +1,4 @@
-@include calciteComponentCommon();
+@include baseComponent();
 
 .scale--s {
   @apply text-n2h;

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 .scale--s {
   @apply text-n2h;
   --calcite-combobox-item-spacing-unit-l: theme("spacing.2");

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -1,4 +1,4 @@
-@include baseComponent();
+@include base-component();
 
 .scale--s {
   @apply text-n2h;

--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -208,4 +208,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-combobox-input-height: Specifies the height of the component's input.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative block;
 }

--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -208,4 +208,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-combobox-input-height: Specifies the height of the component's input.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative block;
 }
@@ -210,3 +208,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-3 flex cursor-pointer;
 }

--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-3 flex cursor-pointer;
 }
@@ -490,3 +488,5 @@
     }
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
@@ -489,4 +489,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
@@ -489,4 +489,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -132,4 +132,4 @@
   inset-inline-start: 0;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -132,4 +132,4 @@
   inset-inline-start: 0;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }
@@ -126,7 +128,7 @@
 }
 
 .suffix {
-  @apply top-0 
+  @apply top-0
     whitespace-nowrap
     text-start;
   inset-inline-start: 0;

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -133,3 +131,5 @@
     text-start;
   inset-inline-start: 0;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
+++ b/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
@@ -1,4 +1,4 @@
-@include baseComponent();
+@include base-component();
 
 .calendar {
   @apply mb-1;

--- a/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
+++ b/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 .calendar {
   @apply mb-1;
 }

--- a/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
+++ b/packages/calcite-components/src/components/date-picker-month/date-picker-month.scss
@@ -1,4 +1,4 @@
-@include calciteComponentCommon();
+@include baseComponent();
 
 .calendar {
   @apply mb-1;

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -24,4 +24,4 @@
   max-inline-size: 398px;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -24,4 +24,4 @@
   max-inline-size: 398px;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply border-color-1
     bg-foreground-1

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply border-color-1
     bg-foreground-1
@@ -25,3 +23,5 @@
 :host([scale="l"]) {
   max-inline-size: 398px;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -46,4 +46,4 @@
   background-color: theme("borderColor.color.3");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -46,4 +46,4 @@
   background-color: theme("borderColor.color.3");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   // we make the host relative, so items can consistently compute their offsetTop based on the group
   @apply block relative;
@@ -47,3 +45,5 @@
   @apply block h-px;
   background-color: theme("borderColor.color.3");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   // we make the host relative, so items can consistently compute their offsetTop based on the group
   @apply block relative;

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -50,8 +50,6 @@
     ease-in-out;
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative
     flex
@@ -219,3 +217,5 @@
     margin-inline-start: theme("margin.4");
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -50,6 +50,8 @@
     ease-in-out;
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     flex

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -218,4 +218,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -218,4 +218,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/dropdown/dropdown.scss
+++ b/packages/calcite-components/src/components/dropdown/dropdown.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-dropdown-width: Specifies the width of the component's wrapper.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply inline-flex flex-initial;
 }
@@ -55,3 +53,5 @@
 :host([width="l"]) {
   --calcite-dropdown-width: theme("spacing.64");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/dropdown/dropdown.scss
+++ b/packages/calcite-components/src/components/dropdown/dropdown.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-dropdown-width: Specifies the width of the component's wrapper.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply inline-flex flex-initial;
 }

--- a/packages/calcite-components/src/components/dropdown/dropdown.scss
+++ b/packages/calcite-components/src/components/dropdown/dropdown.scss
@@ -54,4 +54,4 @@
   --calcite-dropdown-width: theme("spacing.64");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/dropdown/dropdown.scss
+++ b/packages/calcite-components/src/components/dropdown/dropdown.scss
@@ -54,4 +54,4 @@
   --calcite-dropdown-width: theme("spacing.64");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -14,4 +14,4 @@ calcite-button {
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -14,4 +14,4 @@ calcite-button {
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex bg-transparent;
 }
@@ -15,3 +13,5 @@ calcite-button {
     @apply shadow-2-sm;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex bg-transparent;
 }

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -70,4 +70,4 @@ input[type="text"]:focus {
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply flex w-full;
@@ -71,3 +69,5 @@ input[type="text"]:focus {
     @apply text-color-1;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -70,4 +70,4 @@ input[type="text"]:focus {
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply flex w-full;

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-flow-item-footer-padding: Specifies the padding of the component's footer.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply relative flex w-full flex-auto overflow-hidden;
@@ -26,3 +24,5 @@
 calcite-panel {
   --calcite-panel-footer-padding: var(--calcite-flow-item-footer-padding);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -25,4 +25,4 @@ calcite-panel {
   --calcite-panel-footer-padding: var(--calcite-flow-item-footer-padding);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-flow-item-footer-padding: Specifies the padding of the component's footer.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply relative flex w-full flex-auto overflow-hidden;

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -25,4 +25,4 @@ calcite-panel {
   --calcite-panel-footer-padding: var(--calcite-flow-item-footer-padding);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/flow/flow.scss
+++ b/packages/calcite-components/src/components/flow/flow.scss
@@ -61,4 +61,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/flow/flow.scss
+++ b/packages/calcite-components/src/components/flow/flow.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply relative

--- a/packages/calcite-components/src/components/flow/flow.scss
+++ b/packages/calcite-components/src/components/flow/flow.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply relative
@@ -62,3 +60,5 @@
     }
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/flow/flow.scss
+++ b/packages/calcite-components/src/components/flow/flow.scss
@@ -61,4 +61,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/graph/graph.scss
+++ b/packages/calcite-components/src/components/graph/graph.scss
@@ -14,4 +14,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/graph/graph.scss
+++ b/packages/calcite-components/src/components/graph/graph.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
   block-size: 100%;
@@ -15,3 +13,5 @@
     @apply opacity-50;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/graph/graph.scss
+++ b/packages/calcite-components/src/components/graph/graph.scss
@@ -14,4 +14,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/graph/graph.scss
+++ b/packages/calcite-components/src/components/graph/graph.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
   block-size: 100%;

--- a/packages/calcite-components/src/components/handle/handle.scss
+++ b/packages/calcite-components/src/components/handle/handle.scss
@@ -29,4 +29,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/handle/handle.scss
+++ b/packages/calcite-components/src/components/handle/handle.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
 }
@@ -30,3 +28,5 @@
     color: inherit;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/handle/handle.scss
+++ b/packages/calcite-components/src/components/handle/handle.scss
@@ -29,4 +29,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/handle/handle.scss
+++ b/packages/calcite-components/src/components/handle/handle.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
 }

--- a/packages/calcite-components/src/components/icon/icon.scss
+++ b/packages/calcite-components/src/components/icon/icon.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-ui-icon-color: The component's color. Defaults to `currentColor`.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-icon inline-flex;
 }

--- a/packages/calcite-components/src/components/icon/icon.scss
+++ b/packages/calcite-components/src/components/icon/icon.scss
@@ -36,4 +36,4 @@
   @apply block;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/icon/icon.scss
+++ b/packages/calcite-components/src/components/icon/icon.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-ui-icon-color: The component's color. Defaults to `currentColor`.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-icon inline-flex;
 }
@@ -37,3 +35,5 @@
 .svg {
   @apply block;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/icon/icon.scss
+++ b/packages/calcite-components/src/components/icon/icon.scss
@@ -36,4 +36,4 @@
   @apply block;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -50,4 +50,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -51,3 +49,5 @@
     @apply border-color-2;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -50,4 +50,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @extend %component-spacing;
   @include floatingUIElemAnim(".menu-container");
@@ -159,3 +157,5 @@
 .assistive-text {
   @apply sr-only;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -158,4 +158,4 @@
   @apply sr-only;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @extend %component-spacing;
   @include floatingUIElemAnim(".menu-container");

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -158,4 +158,4 @@
   @apply sr-only;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -65,4 +65,4 @@
   @apply text-n1h mt-1;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -11,8 +11,6 @@
   --calcite-input-message-spacing-value: theme("spacing.1");
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-1 transition-default invisible box-border flex h-0 w-full items-center font-medium opacity-0;
 }
@@ -66,3 +64,5 @@
 :host([status][scale="l"]) {
   @apply text-n1h mt-1;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -65,4 +65,4 @@
   @apply text-n1h mt-1;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -11,6 +11,8 @@
   --calcite-input-message-spacing-value: theme("spacing.1");
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-1 transition-default invisible box-border flex h-0 w-full items-center font-medium opacity-0;
 }

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -411,4 +411,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -411,4 +411,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -413,3 +411,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -299,4 +299,4 @@ input[type="text"]::-ms-reveal {
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -299,4 +299,4 @@ input[type="text"]::-ms-reveal {
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -301,3 +299,4 @@ input[type="text"]::-ms-reveal {
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -31,4 +31,4 @@
   padding-inline: var(--calcite-toggle-spacing);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -31,4 +31,4 @@
   padding-inline: var(--calcite-toggle-spacing);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-block
     select-none;
@@ -32,3 +30,5 @@
   inset-block: 0;
   padding-inline: var(--calcite-toggle-spacing);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-block
     select-none;

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -572,3 +570,4 @@ input[type="time"]::-webkit-clear-button {
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -570,4 +570,4 @@ input[type="time"]::-webkit-clear-button {
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -570,4 +570,4 @@ input[type="time"]::-webkit-clear-button {
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/label/label.scss
+++ b/packages/calcite-components/src/components/label/label.scss
@@ -88,4 +88,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/label/label.scss
+++ b/packages/calcite-components/src/components/label/label.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-label-margin-bottom: The spacing below the component.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
 }
@@ -89,3 +87,5 @@
     @apply bg-opacity-0;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/label/label.scss
+++ b/packages/calcite-components/src/components/label/label.scss
@@ -88,4 +88,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/label/label.scss
+++ b/packages/calcite-components/src/components/label/label.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-label-margin-bottom: The spacing below the component.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
 }

--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -86,4 +86,4 @@ calcite-icon {
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   display: inline;
 }

--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   display: inline;
 }
@@ -88,3 +86,4 @@ calcite-icon {
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -86,4 +86,4 @@ calcite-icon {
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.scss
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.scss
@@ -23,4 +23,4 @@
   @apply shadow-none;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.scss
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex flex-col bg-foreground-1;
   --calcite-list-item-spacing-indent: theme("spacing.4");
@@ -21,8 +23,4 @@
 
 ::slotted(calcite-list-item:last-child) {
   @apply shadow-none;
-}
-
-[hidden] {
-  display: none;
 }

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.scss
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.scss
@@ -23,4 +23,4 @@
   @apply shadow-none;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.scss
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex flex-col bg-foreground-1;
   --calcite-list-item-spacing-indent: theme("spacing.4");
@@ -24,3 +22,5 @@
 ::slotted(calcite-list-item:last-child) {
   @apply shadow-none;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex flex-col;
   --calcite-list-item-icon-color: theme("colors.brand");
@@ -140,8 +142,4 @@ td:focus {
 
 ::slotted(calcite-list-item) {
   @apply border-solid border-0 border-t border-color-3;
-}
-
-[hidden] {
-  display: none;
 }

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -142,4 +142,4 @@ td:focus {
   @apply border-solid border-0 border-t border-color-3;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex flex-col;
   --calcite-list-item-icon-color: theme("colors.brand");
@@ -143,3 +141,5 @@ td:focus {
 ::slotted(calcite-list-item) {
   @apply border-solid border-0 border-t border-color-3;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -142,4 +142,4 @@ td:focus {
   @apply border-solid border-0 border-t border-color-3;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -48,4 +48,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -49,3 +47,5 @@
     @apply p-0;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -48,4 +48,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -227,4 +227,4 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -21,8 +21,6 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative mx-auto hidden items-center justify-center opacity-100;
   min-block-size: var(--calcite-loader-size);
@@ -228,3 +226,5 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
     transform: rotate(360deg);
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -227,4 +227,4 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -21,6 +21,8 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative mx-auto hidden items-center justify-center opacity-100;
   min-block-size: var(--calcite-loader-size);

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -1,7 +1,9 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex
-  items-center 
-  relative 
+  items-center
+  relative
   box-border;
   flex-shrink: 0;
   & .container,
@@ -29,14 +31,14 @@
   items-center
   relative
   justify-center
-  cursor-pointer 
+  cursor-pointer
   outline-none
   text-0
-  text-color-2 
-  box-border 
+  text-color-2
+  box-border
   bg-foreground-1
-  px-4 
-  h-full 
+  px-4
+  h-full
   w-full;
   text-decoration: none;
   border-block-end: theme("spacing[0.5]") solid transparent;

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -172,4 +172,4 @@ calcite-action {
   @apply opacity-100 -end-1;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex
   items-center
@@ -173,3 +171,5 @@ calcite-action {
 .content:hover .hover-href-icon {
   @apply opacity-100 -end-1;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -172,4 +172,4 @@ calcite-action {
   @apply opacity-100 -end-1;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/menu/menu.scss
+++ b/packages/calcite-components/src/components/menu/menu.scss
@@ -10,4 +10,4 @@ ul {
   @apply flex flex-col w-full;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/menu/menu.scss
+++ b/packages/calcite-components/src/components/menu/menu.scss
@@ -10,4 +10,4 @@ ul {
   @apply flex flex-col w-full;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/menu/menu.scss
+++ b/packages/calcite-components/src/components/menu/menu.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
 }
@@ -11,3 +9,5 @@ ul {
 :host([layout="vertical"]) ul {
   @apply flex flex-col w-full;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/menu/menu.scss
+++ b/packages/calcite-components/src/components/menu/menu.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
 }

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -408,4 +408,4 @@ slot[name="primary"] {
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -11,8 +11,6 @@
  *
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply absolute flex inset-0 opacity-0 z-overlay;
   visibility: hidden !important;
@@ -409,3 +407,5 @@ slot[name="primary"] {
     position: absolute;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -11,6 +11,8 @@
  *
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply absolute flex inset-0 opacity-0 z-overlay;
   visibility: hidden !important;

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -408,4 +408,4 @@ slot[name="primary"] {
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -1,15 +1,17 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-flex outline-none;
 }
 
 .anchor {
-  @apply flex 
-    m-0 
-    items-center 
-    justify-center 
-    cursor-pointer 
-    transition-default 
-    focus-base 
+  @apply flex
+    m-0
+    items-center
+    justify-center
+    cursor-pointer
+    transition-default
+    focus-base
     no-underline
     text-0h;
   border-block-end: 2px solid transparent;
@@ -46,17 +48,17 @@
 }
 
 .container {
-  @apply flex 
-  flex-col 
-  truncate 
-  text-start 
-  px-4 
+  @apply flex
+  flex-col
+  truncate
+  text-start
+  px-4
   mt-0.5;
 }
 
 .heading {
-  @apply text-0 
-  ms-0 
+  @apply text-0
+  ms-0
   truncate
   text-color-1
   font-medium;

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -71,4 +71,4 @@
   font-size: var(--calcite-font-size--1);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -71,4 +71,4 @@
   font-size: var(--calcite-font-size--1);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-flex outline-none;
 }
@@ -72,3 +70,5 @@
   @apply text-color-2 truncate;
   font-size: var(--calcite-font-size--1);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -62,4 +62,4 @@ calcite-avatar ~ .text-container {
   font-size: var(--calcite-font-size--1);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -1,14 +1,16 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-flex outline-none;
   & .button {
     background-color: transparent;
     border: none;
-    @apply flex 
+    @apply flex
       m-0
-      items-center 
+      items-center
       justify-center
-      cursor-pointer 
-      transition-default 
+      cursor-pointer
+      transition-default
       focus-base
       font-sans
       text-0h;
@@ -43,16 +45,16 @@ calcite-avatar ~ .text-container {
 }
 
 .text-container {
-  @apply flex 
-  flex-col 
+  @apply flex
+  flex-col
   text-start
   px-4
   mt-0.5;
 }
 
 .full-name {
-  @apply text-0 
-  ms-0 
+  @apply text-0
+  ms-0
   text-color-1
   font-medium;
 }

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-flex outline-none;
   & .button {
@@ -63,3 +61,5 @@ calcite-avatar ~ .text-container {
   @apply text-color-2;
   font-size: var(--calcite-font-size--1);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -62,4 +62,4 @@ calcite-avatar ~ .text-container {
   font-size: var(--calcite-font-size--1);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -8,10 +8,12 @@
  * @prop --calcite-navigation-border-color: Specifies the border color of the component.
  */
 
+@include calciteComponentCommon();
+
 .container {
-  @apply flex 
+  @apply flex
   flex-col
-  mx-auto 
+  mx-auto
   w-full;
   margin-block: 0;
   margin-inline: auto;
@@ -46,9 +48,9 @@
 }
 
 .container-content {
-  @apply flex 
-  w-full 
-  h-full 
+  @apply flex
+  w-full
+  h-full
   mx-auto;
   margin-block: 0;
   inline-size: var(--calcite-navigation-width, 100%);

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -8,7 +8,7 @@
  * @prop --calcite-navigation-border-color: Specifies the border color of the component.
  */
 
-@include baseComponent();
+@include base-component();
 
 .container {
   @apply flex

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -8,7 +8,7 @@
  * @prop --calcite-navigation-border-color: Specifies the border color of the component.
  */
 
-@include calciteComponentCommon();
+@include baseComponent();
 
 .container {
   @apply flex

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -65,8 +65,6 @@
   --calcite-notice-width: theme("width.full");
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply mx-auto hidden max-w-full items-center;
   inline-size: var(--calcite-notice-width);
@@ -179,3 +177,5 @@ $noticeKinds: "brand" var(--calcite-ui-brand), "info" var(--calcite-ui-info), "d
     }
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -178,4 +178,4 @@ $noticeKinds: "brand" var(--calcite-ui-brand), "info" var(--calcite-ui-info), "d
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -65,6 +65,8 @@
   --calcite-notice-width: theme("width.full");
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply mx-auto hidden max-w-full items-center;
   inline-size: var(--calcite-notice-width);

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -178,4 +178,4 @@ $noticeKinds: "brand" var(--calcite-ui-brand), "info" var(--calcite-ui-info), "d
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/option-group/option-group.scss
+++ b/packages/calcite-components/src/components/option-group/option-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/option-group/option-group.scss
+++ b/packages/calcite-components/src/components/option-group/option-group.scss
@@ -2,4 +2,4 @@
   @apply block;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/option-group/option-group.scss
+++ b/packages/calcite-components/src/components/option-group/option-group.scss
@@ -2,4 +2,4 @@
   @apply block;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/option-group/option-group.scss
+++ b/packages/calcite-components/src/components/option-group/option-group.scss
@@ -1,5 +1,5 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/option/option.scss
+++ b/packages/calcite-components/src/components/option/option.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/option/option.scss
+++ b/packages/calcite-components/src/components/option/option.scss
@@ -2,4 +2,4 @@
   @apply block;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/option/option.scss
+++ b/packages/calcite-components/src/components/option/option.scss
@@ -2,4 +2,4 @@
   @apply block;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/option/option.scss
+++ b/packages/calcite-components/src/components/option/option.scss
@@ -1,5 +1,5 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -37,8 +37,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
   writing-mode: horizontal-tb;
@@ -104,3 +102,5 @@
 .ellipsis {
   @apply text-color-3 flex items-end;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -37,6 +37,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
   writing-mode: horizontal-tb;

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -103,4 +103,4 @@
   @apply text-color-3 flex items-end;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -103,4 +103,4 @@
   @apply text-color-3 flex items-end;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -132,4 +132,4 @@
   inline-size: fit-content;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-panel-footer-padding: Specifies the padding of the component's footer.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply relative flex w-full h-full flex-auto overflow-hidden;
@@ -130,8 +132,4 @@
   z-sticky;
   inset-inline: 0;
   inline-size: fit-content;
-}
-
-[hidden] {
-  display: none;
 }

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-panel-footer-padding: Specifies the padding of the component's footer.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply relative flex w-full h-full flex-auto overflow-hidden;
@@ -133,3 +131,5 @@
   inset-inline: 0;
   inline-size: fit-content;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -132,4 +132,4 @@
   inline-size: fit-content;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-2
     text-n1
@@ -29,3 +27,5 @@
 .container--indented {
   margin-inline-start: theme("margin.6");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
@@ -28,4 +28,4 @@
   margin-inline-start: theme("margin.6");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
@@ -28,4 +28,4 @@
   margin-inline-start: theme("margin.6");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-2
     text-n1

--- a/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
+++ b/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
     text-n1
@@ -101,3 +99,4 @@
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
+++ b/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
@@ -99,4 +99,4 @@
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
+++ b/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
@@ -99,4 +99,4 @@
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
+++ b/packages/calcite-components/src/components/pick-list-item/pick-list-item.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
     text-n1

--- a/packages/calcite-components/src/components/pick-list/pick-list.scss
+++ b/packages/calcite-components/src/components/pick-list/pick-list.scss
@@ -37,4 +37,4 @@ calcite-filter {
   min-block-size: 2rem;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/pick-list/pick-list.scss
+++ b/packages/calcite-components/src/components/pick-list/pick-list.scss
@@ -37,4 +37,4 @@ calcite-filter {
   min-block-size: 2rem;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/pick-list/pick-list.scss
+++ b/packages/calcite-components/src/components/pick-list/pick-list.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-2
     text-n1h
@@ -38,3 +36,5 @@ calcite-filter {
 :host([loading][disabled]) {
   min-block-size: 2rem;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/pick-list/pick-list.scss
+++ b/packages/calcite-components/src/components/pick-list/pick-list.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-2
     text-n1h

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-popover-z-index: Sets the z-index value for the component.
  */
 
-@include calciteComponentCommon();
-
 :host {
   --calcite-floating-ui-z-index: var(--calcite-popover-z-index, theme("zIndex.popover"));
 }
@@ -115,3 +113,5 @@
 ::slotted(calcite-flow) {
   @apply h-full;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -114,4 +114,4 @@
   @apply h-full;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -114,4 +114,4 @@
   @apply h-full;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-popover-z-index: Sets the z-index value for the component.
  */
 
+@include calciteComponentCommon();
+
 :host {
   --calcite-floating-ui-z-index: var(--calcite-popover-z-index, theme("zIndex.popover"));
 }

--- a/packages/calcite-components/src/components/progress/progress.scss
+++ b/packages/calcite-components/src/components/progress/progress.scss
@@ -54,4 +54,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/progress/progress.scss
+++ b/packages/calcite-components/src/components/progress/progress.scss
@@ -54,4 +54,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/progress/progress.scss
+++ b/packages/calcite-components/src/components/progress/progress.scss
@@ -1,5 +1,7 @@
 @import "../../assets/styles/animation";
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative block w-full;
 }

--- a/packages/calcite-components/src/components/progress/progress.scss
+++ b/packages/calcite-components/src/components/progress/progress.scss
@@ -1,7 +1,5 @@
 @import "../../assets/styles/animation";
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative block w-full;
 }
@@ -55,3 +53,5 @@
     transform: translate3d(600%, 0, 0);
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
@@ -18,4 +18,4 @@
   @apply flex-col;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
@@ -18,4 +18,4 @@
   @apply flex-col;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
   max-inline-size: 100vw;

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
   max-inline-size: 100vw;
@@ -19,3 +17,5 @@
 :host([layout="vertical"]) {
   @apply flex-col;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/radio-button/radio-button.scss
+++ b/packages/calcite-components/src/components/radio-button/radio-button.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block cursor-pointer;
   .container {
@@ -100,3 +98,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/radio-button/radio-button.scss
+++ b/packages/calcite-components/src/components/radio-button/radio-button.scss
@@ -98,4 +98,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/radio-button/radio-button.scss
+++ b/packages/calcite-components/src/components/radio-button/radio-button.scss
@@ -98,4 +98,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/radio-button/radio-button.scss
+++ b/packages/calcite-components/src/components/radio-button/radio-button.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block cursor-pointer;
   .container {

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -100,4 +100,4 @@ calcite-chip {
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating star.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative flex items-center;
   inline-size: fit-content;

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -100,4 +100,4 @@ calcite-chip {
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating star.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative flex items-center;
   inline-size: fit-content;
@@ -102,3 +100,4 @@ calcite-chip {
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/scrim/scrim.scss
+++ b/packages/calcite-components/src/components/scrim/scrim.scss
@@ -43,4 +43,4 @@
   @apply p-4;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/scrim/scrim.scss
+++ b/packages/calcite-components/src/components/scrim/scrim.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-scrim-background: Specifies the background color of the scrim.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply absolute
   inset-0

--- a/packages/calcite-components/src/components/scrim/scrim.scss
+++ b/packages/calcite-components/src/components/scrim/scrim.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-scrim-background: Specifies the background color of the scrim.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply absolute
   inset-0
@@ -44,3 +42,5 @@
 .content {
   @apply p-4;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/scrim/scrim.scss
+++ b/packages/calcite-components/src/components/scrim/scrim.scss
@@ -43,4 +43,4 @@
   @apply p-4;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex
     cursor-pointer

--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex
     cursor-pointer
@@ -120,3 +118,5 @@
 :host([icon-end]) .label--scale-l .segmented-control-item-icon {
   margin-inline-start: theme("margin.4");
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
@@ -119,4 +119,4 @@
   margin-inline-start: theme("margin.4");
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
@@ -119,4 +119,4 @@
   margin-inline-start: theme("margin.4");
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.scss
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.scss
@@ -30,4 +30,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.scss
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1 flex;
   inline-size: fit-content;

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.scss
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1 flex;
   inline-size: fit-content;
@@ -32,3 +30,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.scss
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.scss
@@ -30,4 +30,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/select/select.scss
+++ b/packages/calcite-components/src/components/select/select.scss
@@ -7,8 +7,6 @@
  * @prop --calcite-select-spacing: The padding around the selected option text.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-spacing;
 
@@ -112,3 +110,4 @@ select:disabled {
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/select/select.scss
+++ b/packages/calcite-components/src/components/select/select.scss
@@ -110,4 +110,4 @@ select:disabled {
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/select/select.scss
+++ b/packages/calcite-components/src/components/select/select.scss
@@ -7,6 +7,8 @@
  * @prop --calcite-select-spacing: The padding around the selected option text.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-spacing;
 

--- a/packages/calcite-components/src/components/select/select.scss
+++ b/packages/calcite-components/src/components/select/select.scss
@@ -110,4 +110,4 @@ select:disabled {
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
@@ -62,4 +62,4 @@
   @apply border-color-3;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply flex
@@ -63,3 +61,5 @@
   border-inline-end: theme("borderWidth.DEFAULT") solid;
   @apply border-color-3;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply flex

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.scss
@@ -62,4 +62,4 @@
   @apply border-color-3;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -316,4 +316,4 @@ slot[name="action-bar"]::slotted(calcite-action-bar),
   border-block-end: 0;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -316,4 +316,4 @@ slot[name="action-bar"]::slotted(calcite-action-bar),
   border-block-end: 0;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -14,8 +14,6 @@
  *
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative
     pointer-events-none
@@ -317,3 +315,5 @@ slot[name="action-bar"]::slotted(calcite-action-bar),
   border-inline: 0;
   border-block-end: 0;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -14,6 +14,8 @@
  *
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     pointer-events-none

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -121,4 +121,4 @@ slot[name="panel-top"]::slotted(calcite-shell-center-row) {
   inset: 0;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -121,4 +121,4 @@ slot[name="panel-top"]::slotted(calcite-shell-center-row) {
   inset: 0;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-shell-tip-spacing: The left and right spacing of the `calcite-tip-manager` when slotted in the component.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @extend %component-host;
   @apply absolute
@@ -122,3 +120,5 @@ slot[name="panel-top"]::slotted(calcite-shell-center-row) {
   pointer-events: none;
   inset: 0;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-shell-tip-spacing: The left and right spacing of the `calcite-tip-manager` when slotted in the component.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @extend %component-host;
   @apply absolute

--- a/packages/calcite-components/src/components/slider/slider.scss
+++ b/packages/calcite-components/src/components/slider/slider.scss
@@ -34,6 +34,8 @@
   font-size: var(--calcite-slider-container-font-size);
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/slider/slider.scss
+++ b/packages/calcite-components/src/components/slider/slider.scss
@@ -372,4 +372,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/slider/slider.scss
+++ b/packages/calcite-components/src/components/slider/slider.scss
@@ -372,4 +372,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/slider/slider.scss
+++ b/packages/calcite-components/src/components/slider/slider.scss
@@ -34,8 +34,6 @@
   font-size: var(--calcite-slider-container-font-size);
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -374,3 +372,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.scss
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.scss
@@ -16,4 +16,4 @@
   @apply flex-row;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.scss
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.scss
@@ -16,4 +16,4 @@
   @apply flex-row;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.scss
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex;
 }

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.scss
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex;
 }
@@ -17,3 +15,5 @@
 .container--horizontal {
   @apply flex-row;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -133,4 +133,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-block;
 }
@@ -134,3 +132,5 @@
     @apply pointer-events-none;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-block;
 }

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -133,4 +133,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/stack/stack.scss
+++ b/packages/calcite-components/src/components/stack/stack.scss
@@ -70,4 +70,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/stack/stack.scss
+++ b/packages/calcite-components/src/components/stack/stack.scss
@@ -70,4 +70,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/stack/stack.scss
+++ b/packages/calcite-components/src/components/stack/stack.scss
@@ -7,8 +7,6 @@
  * @prop --calcite-stack-padding-block: Specifies the block padding of the component's content.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply flex flex-col flex-1;
 }
@@ -71,3 +69,5 @@
     color: inherit;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/stack/stack.scss
+++ b/packages/calcite-components/src/components/stack/stack.scss
@@ -7,6 +7,8 @@
  * @prop --calcite-stack-padding-block: Specifies the block padding of the component's content.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply flex flex-col flex-1;
 }
@@ -68,8 +70,4 @@
 
     color: inherit;
   }
-}
-
-[hidden] {
-  display: none;
 }

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -348,4 +348,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -31,8 +31,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative
   flex
@@ -349,3 +347,5 @@
     border-color: highlight;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -348,4 +348,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -31,6 +31,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative
   flex

--- a/packages/calcite-components/src/components/stepper/stepper.scss
+++ b/packages/calcite-components/src/components/stepper/stepper.scss
@@ -22,4 +22,4 @@
     "content";
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/stepper/stepper.scss
+++ b/packages/calcite-components/src/components/stepper/stepper.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     flex

--- a/packages/calcite-components/src/components/stepper/stepper.scss
+++ b/packages/calcite-components/src/components/stepper/stepper.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply relative
     flex
@@ -23,3 +21,5 @@
     "items"
     "content";
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/stepper/stepper.scss
+++ b/packages/calcite-components/src/components/stepper/stepper.scss
@@ -22,4 +22,4 @@
     "content";
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -125,4 +125,4 @@
 }
 
 @include hidden-form-input();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -125,4 +125,4 @@
 }
 
 @include hidden-form-input();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -35,6 +35,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply relative
     inline-block

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -35,8 +35,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply relative
     inline-block
@@ -127,3 +125,4 @@
 }
 
 @include hidden-form-input();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -70,4 +70,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -70,4 +70,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply relative flex;
 }
@@ -71,3 +69,5 @@
     background-color: highlight;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply relative flex;
 }

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -299,4 +299,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block flex-initial outline-none;
   margin-inline-start: theme("margin.0");
@@ -300,3 +298,5 @@
     @apply z-default;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block flex-initial outline-none;
   margin-inline-start: theme("margin.0");

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -299,4 +299,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -31,4 +31,4 @@ section,
   padding-block: 13px;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -5,8 +5,6 @@
   }
 }
 
-@include calciteComponentCommon();
-
 :host {
   @apply hidden h-full w-full;
 }
@@ -32,3 +30,5 @@ section,
   @apply text-0h;
   padding-block: 13px;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -5,6 +5,8 @@
   }
 }
 
+@include calciteComponentCommon();
+
 :host {
   @apply hidden h-full w-full;
 }

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -31,4 +31,4 @@ section,
   padding-block: 13px;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex flex-col;
 }

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -66,4 +66,4 @@ section {
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -66,4 +66,4 @@ section {
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex flex-col;
 }
@@ -67,3 +65,5 @@ section {
       border-b-0;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/text-area/text-area.scss
+++ b/packages/calcite-components/src/components/text-area/text-area.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-block
   relative
@@ -181,3 +179,4 @@ textarea.block-size--full {
 
 @include hidden-form-input();
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/text-area/text-area.scss
+++ b/packages/calcite-components/src/components/text-area/text-area.scss
@@ -179,4 +179,4 @@ textarea.block-size--full {
 
 @include hidden-form-input();
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/text-area/text-area.scss
+++ b/packages/calcite-components/src/components/text-area/text-area.scss
@@ -179,4 +179,4 @@ textarea.block-size--full {
 
 @include hidden-form-input();
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/text-area/text-area.scss
+++ b/packages/calcite-components/src/components/text-area/text-area.scss
@@ -1,17 +1,19 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-block
   relative
-  w-full 
+  w-full
   h-full;
 }
 
 textarea {
-  @apply text-color-1 
-  relative 
+  @apply text-color-1
+  relative
   block
-  bg-foreground-1 
+  bg-foreground-1
   box-border
-  border-color-input  
+  border-color-input
   border
   font-sans
   w-full
@@ -25,9 +27,9 @@ textarea {
     @apply focus-inset;
   }
   &.text-area--invalid {
-    @apply border-color-danger 
-    border 
-    border-solid 
+    @apply border-color-danger
+    border
+    border-solid
     border-b;
     &:focus {
       @apply focus-inset-danger;
@@ -39,8 +41,8 @@ textarea {
 }
 
 .footer {
-  @apply flex 
-  bg-foreground-1 
+  @apply flex
+  bg-foreground-1
   box-border
   border-color-input
   border
@@ -50,16 +52,16 @@ textarea {
 }
 
 .character-limit {
-  @apply flex 
-  justify-end 
-  text-color-2 
+  @apply flex
+  justify-end
+  text-color-2
   items-center
-  font-normal 
+  font-normal
   whitespace-nowrap;
 }
 
 .character--over-limit {
-  @apply font-bold 
+  @apply font-bold
   text-danger;
 }
 
@@ -78,12 +80,12 @@ textarea {
 :host([scale="s"]) {
   @apply text-n2;
   .footer {
-    @apply py-1 
+    @apply py-1
     px-2;
     min-block-size: 1.75rem;
   }
   textarea {
-    @apply py-1 
+    @apply py-1
     px-2;
   }
 }
@@ -92,18 +94,18 @@ textarea {
   textarea,
   .footer,
   .character-limit {
-    @apply text-n2 
+    @apply text-n2
     pl-2;
   }
 }
 
 :host([scale="m"]) {
   textarea {
-    @apply py-2 
+    @apply py-2
     px-3;
   }
   .footer {
-    @apply py-2 
+    @apply py-2
     px-3;
     min-block-size: 2.25rem;
   }
@@ -113,7 +115,7 @@ textarea {
   textarea,
   .footer,
   .character-limit {
-    @apply text-n1 
+    @apply text-n1
     pl-3;
   }
 }
@@ -121,11 +123,11 @@ textarea {
 :host([scale="l"]) {
   @apply text-0;
   textarea {
-    @apply py-3 
+    @apply py-3
     px-4;
   }
   .footer {
-    @apply py-3 
+    @apply py-3
     px-4;
     min-block-size: 2.75rem;
   }
@@ -135,7 +137,7 @@ textarea {
   textarea,
   .footer,
   .character-limit {
-    @apply text-0 
+    @apply text-0
     pl-4;
   }
 }
@@ -168,7 +170,7 @@ textarea.block-size--full {
 }
 
 .container {
-  @apply flex 
+  @apply flex
   justify-between
   w-full;
 }

--- a/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
+++ b/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
@@ -11,4 +11,4 @@
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
+++ b/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
@@ -11,4 +11,4 @@
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
+++ b/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply flex flex-wrap;
   ::slotted(calcite-tile-select) {
@@ -13,3 +11,4 @@
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
+++ b/packages/calcite-components/src/components/tile-select-group/tile-select-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply flex flex-wrap;
   ::slotted(calcite-tile-select) {

--- a/packages/calcite-components/src/components/tile-select/tile-select.scss
+++ b/packages/calcite-components/src/components/tile-select/tile-select.scss
@@ -1,5 +1,7 @@
 $spacing: $baseline * 0.5;
 
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 

--- a/packages/calcite-components/src/components/tile-select/tile-select.scss
+++ b/packages/calcite-components/src/components/tile-select/tile-select.scss
@@ -129,4 +129,4 @@ $spacing: $baseline * 0.5;
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tile-select/tile-select.scss
+++ b/packages/calcite-components/src/components/tile-select/tile-select.scss
@@ -129,4 +129,4 @@ $spacing: $baseline * 0.5;
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tile-select/tile-select.scss
+++ b/packages/calcite-components/src/components/tile-select/tile-select.scss
@@ -1,7 +1,5 @@
 $spacing: $baseline * 0.5;
 
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 
@@ -131,3 +129,4 @@ $spacing: $baseline * 0.5;
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
     text-color-3
@@ -120,3 +118,5 @@
     @apply text-color-2;
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
     text-color-3

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -119,4 +119,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -119,4 +119,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply inline-block;
 }
@@ -119,3 +117,5 @@
     }
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -118,4 +118,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply inline-block;
 }

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -118,4 +118,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tip-group/tip-group.scss
+++ b/packages/calcite-components/src/components/tip-group/tip-group.scss
@@ -11,4 +11,4 @@
   max-inline-size: var(--calcite-tip-max-width);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tip-group/tip-group.scss
+++ b/packages/calcite-components/src/components/tip-group/tip-group.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
     text-color-2
@@ -12,3 +10,5 @@
   @apply m-0 border-none;
   max-inline-size: var(--calcite-tip-max-width);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tip-group/tip-group.scss
+++ b/packages/calcite-components/src/components/tip-group/tip-group.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
     text-color-2

--- a/packages/calcite-components/src/components/tip-group/tip-group.scss
+++ b/packages/calcite-components/src/components/tip-group/tip-group.scss
@@ -11,4 +11,4 @@
   max-inline-size: var(--calcite-tip-max-width);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -120,4 +120,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -7,6 +7,8 @@
  * @prop --calcite-tip-max-width: The maximum width of a slotted `calcite-tip` within the component.
  */
 
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
   text-color-2

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -120,4 +120,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -7,8 +7,6 @@
  * @prop --calcite-tip-max-width: The maximum width of a slotted `calcite-tip` within the component.
  */
 
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
   text-color-2
@@ -121,3 +119,5 @@
     transform: translate3d(0, 0, 0) scale(1);
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -78,4 +78,4 @@
   @apply max-w-full;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply border-color-2
     bg-foreground-1

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply border-color-2
     bg-foreground-1
@@ -79,3 +77,5 @@
 ::slotted(img) {
   @apply max-w-full;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -78,4 +78,4 @@
   @apply max-w-full;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -39,4 +39,4 @@
   outline: 1px solid var(--calcite-ui-border-3);
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-tooltip-z-index: Sets the z-index value for the component.
  */
 
+@include calciteComponentCommon();
+
 :host {
   --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, theme("zIndex.tooltip"));
 }

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -39,4 +39,4 @@
   outline: 1px solid var(--calcite-ui-border-3);
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -6,8 +6,6 @@
  * @prop --calcite-tooltip-z-index: Sets the z-index value for the component.
  */
 
-@include calciteComponentCommon();
-
 :host {
   --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, theme("zIndex.tooltip"));
 }
@@ -40,3 +38,5 @@
 .arrow::before {
   outline: 1px solid var(--calcite-ui-border-3);
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -1,12 +1,10 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-3
     block
     max-w-full
     cursor-pointer;
-}
-
-[hidden] {
-  @apply hidden;
 }
 
 .node-actions-container {

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-3
     block
@@ -254,3 +252,5 @@
     color: var(--calcite-ui-brand);
   }
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -253,4 +253,4 @@
   }
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -253,4 +253,4 @@
   }
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tree/tree.scss
+++ b/packages/calcite-components/src/components/tree/tree.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply block;
 }

--- a/packages/calcite-components/src/components/tree/tree.scss
+++ b/packages/calcite-components/src/components/tree/tree.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply block;
 }
@@ -7,3 +5,5 @@
 :host(:focus) {
   @apply outline-none;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/tree/tree.scss
+++ b/packages/calcite-components/src/components/tree/tree.scss
@@ -6,4 +6,4 @@
   @apply outline-none;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/tree/tree.scss
+++ b/packages/calcite-components/src/components/tree/tree.scss
@@ -6,4 +6,4 @@
   @apply outline-none;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/value-list-item/value-list-item.scss
+++ b/packages/calcite-components/src/components/value-list-item/value-list-item.scss
@@ -50,4 +50,4 @@ calcite-pick-list-item {
 }
 
 @include disabled();
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/value-list-item/value-list-item.scss
+++ b/packages/calcite-components/src/components/value-list-item/value-list-item.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply bg-foreground-1
     text-color-2
@@ -52,3 +50,4 @@ calcite-pick-list-item {
 }
 
 @include disabled();
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/value-list-item/value-list-item.scss
+++ b/packages/calcite-components/src/components/value-list-item/value-list-item.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply bg-foreground-1
     text-color-2

--- a/packages/calcite-components/src/components/value-list-item/value-list-item.scss
+++ b/packages/calcite-components/src/components/value-list-item/value-list-item.scss
@@ -50,4 +50,4 @@ calcite-pick-list-item {
 }
 
 @include disabled();
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/value-list/value-list.scss
+++ b/packages/calcite-components/src/components/value-list/value-list.scss
@@ -40,4 +40,4 @@ calcite-filter {
   @apply sr-only;
 }
 
-@include baseComponent();
+@include base-component();

--- a/packages/calcite-components/src/components/value-list/value-list.scss
+++ b/packages/calcite-components/src/components/value-list/value-list.scss
@@ -1,5 +1,3 @@
-@include calciteComponentCommon();
-
 :host {
   @apply text-color-2
     text-n1
@@ -41,3 +39,5 @@ calcite-filter {
 .assistive-text {
   @apply sr-only;
 }
+
+@include calciteComponentCommon();

--- a/packages/calcite-components/src/components/value-list/value-list.scss
+++ b/packages/calcite-components/src/components/value-list/value-list.scss
@@ -40,4 +40,4 @@ calcite-filter {
   @apply sr-only;
 }
 
-@include calciteComponentCommon();
+@include baseComponent();

--- a/packages/calcite-components/src/components/value-list/value-list.scss
+++ b/packages/calcite-components/src/components/value-list/value-list.scss
@@ -1,3 +1,5 @@
+@include calciteComponentCommon();
+
 :host {
   @apply text-color-2
     text-n1


### PR DESCRIPTION
**Related Issue:** #7325

## Summary

- Removes style modifying all host components with hidden attribute. This is modifying components outside of calcite and applying host styles outside of the host. Host styles should have no effect outside of a shadow DOM. https://developer.mozilla.org/en-US/docs/Web/CSS/:host
- Adds includes mixin for common component internal styles such as hidden attribute styling
- Includes mixin in every component file.