### PR TITLE
refactor(modal): use inline style to set overflow instead of a class

### DIFF
--- a/packages/calcite-components/src/assets/styles/global.scss
+++ b/packages/calcite-components/src/assets/styles/global.scss
@@ -73,7 +73,3 @@
     @include calcite-mode-light-extended();
   }
 }
-
-.overflow-hidden {
-  overflow: hidden;
-}

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -520,10 +520,10 @@ describe("calcite-modal accessibility checks", () => {
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
-    const documentClass = await page.evaluate(() => {
-      return document.documentElement.classList.contains("overflow-hidden");
+    const isOverflowHIdden = await page.evaluate(() => {
+      return document.documentElement.style.overflow === "hidden";
     });
-    expect(documentClass).toEqual(true);
+    expect(isOverflowHIdden).toEqual(true);
   });
 
   it("correctly does not add overflow class on document when open and slotted in shell modals slot", async () => {
@@ -532,10 +532,10 @@ describe("calcite-modal accessibility checks", () => {
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
-    const documentClass = await page.evaluate(() => {
-      return document.documentElement.classList.contains("overflow-hidden");
+    const isOverflowHIdden = await page.evaluate(() => {
+      return document.documentElement.style.overflow === "hidden";
     });
-    expect(documentClass).toEqual(false);
+    expect(isOverflowHIdden).toEqual(false);
   });
 
   it("correctly removes overflow class on document once closed", async () => {

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -520,10 +520,10 @@ describe("calcite-modal accessibility checks", () => {
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
-    const isOverflowHIdden = await page.evaluate(() => {
+    const isOverflowHidden = await page.evaluate(() => {
       return document.documentElement.style.overflow === "hidden";
     });
-    expect(isOverflowHIdden).toEqual(true);
+    expect(isOverflowHidden).toEqual(true);
   });
 
   it("correctly does not add overflow class on document when open and slotted in shell modals slot", async () => {
@@ -532,10 +532,10 @@ describe("calcite-modal accessibility checks", () => {
     const modal = await page.find("calcite-modal");
     await modal.setProperty("open", true);
     await page.waitForChanges();
-    const isOverflowHIdden = await page.evaluate(() => {
+    const isOverflowHidden = await page.evaluate(() => {
       return document.documentElement.style.overflow === "hidden";
     });
-    expect(isOverflowHIdden).toEqual(false);
+    expect(isOverflowHidden).toEqual(false);
   });
 
   it("correctly removes overflow class on document once closed", async () => {

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -532,7 +532,7 @@ export class Modal
     this.contentId = ensureId(contentEl);
 
     if (!this.slottedInShell) {
-      document.documentElement.classList.add(CSS.overflowHidden);
+      document.documentElement.style.setProperty("overflow", "hidden");
     }
   }
 
@@ -554,7 +554,7 @@ export class Modal
   };
 
   private removeOverflowHiddenClass(): void {
-    document.documentElement.classList.remove(CSS.overflowHidden);
+    document.documentElement.style.removeProperty("overflow");
   }
 
   private handleMutationObserver = (): void => {

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -352,6 +352,8 @@ export class Modal
 
   modalContent: HTMLDivElement;
 
+  initialOverflowCSS: string;
+
   private mutationObserver: MutationObserver = createObserver("mutation", () =>
     this.handleMutationObserver()
   );
@@ -532,6 +534,8 @@ export class Modal
     this.contentId = ensureId(contentEl);
 
     if (!this.slottedInShell) {
+      this.initialOverflowCSS = document.documentElement.style.overflow;
+      // use an inline style instead of a utility class to avoid global class declarations.
       document.documentElement.style.setProperty("overflow", "hidden");
     }
   }
@@ -554,7 +558,7 @@ export class Modal
   };
 
   private removeOverflowHiddenClass(): void {
-    document.documentElement.style.removeProperty("overflow");
+    document.documentElement.style.setProperty("overflow", this.initialOverflowCSS);
   }
 
   private handleMutationObserver = (): void => {

--- a/packages/calcite-components/src/components/modal/resources.ts
+++ b/packages/calcite-components/src/components/modal/resources.ts
@@ -8,7 +8,6 @@ export const CSS = {
   close: "close",
   secondary: "secondary",
   primary: "primary",
-  overflowHidden: "overflow-hidden",
   container: "container",
   containerOpen: "container--open",
   content: "content",


### PR DESCRIPTION
**Related Issue:** #7325

## Summary

- refactor(modal): use inline style to set overflow instead of a class
- We don't want to expose css utility classes this way.
