### PR TITLE
refactor: rename remaining intl props from interface

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -353,10 +353,10 @@ export class ActionBar
 
     const expandToggleNode = !expandDisabled ? (
       <ExpandToggle
+        collapseText={messages.collapse}
         el={el}
+        expandText={messages.expand}
         expanded={expanded}
-        intlCollapse={messages.collapse}
-        intlExpand={messages.expand}
         position={position}
         scale={scale}
         toggle={toggleExpand}

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -246,10 +246,10 @@ export class ActionPad
 
     const expandToggleNode = !expandDisabled ? (
       <ExpandToggle
+        collapseText={messages.collapse}
         el={el}
+        expandText={messages.expand}
         expanded={expanded}
-        intlCollapse={messages.collapse}
-        intlExpand={messages.expand}
         position={position}
         scale={scale}
         toggle={toggleExpand}

--- a/packages/calcite-components/src/components/functional/ExpandToggle.tsx
+++ b/packages/calcite-components/src/components/functional/ExpandToggle.tsx
@@ -6,8 +6,8 @@ import { Position, Scale } from "../interfaces";
 
 interface ExpandToggleProps {
   expanded: boolean;
-  intlExpand: string;
-  intlCollapse: string;
+  expandText: string;
+  collapseText: string;
   el: HTMLElement;
   position: Position;
   tooltip?: HTMLCalciteTooltipElement;
@@ -64,8 +64,8 @@ const setTooltipReference = ({
 
 export const ExpandToggle: FunctionalComponent<ExpandToggleProps> = ({
   expanded,
-  intlExpand,
-  intlCollapse,
+  expandText,
+  collapseText,
   toggle,
   el,
   position,
@@ -75,7 +75,7 @@ export const ExpandToggle: FunctionalComponent<ExpandToggleProps> = ({
 }) => {
   const rtl = getElementDir(el) === "rtl";
 
-  const expandText = expanded ? intlCollapse : intlExpand;
+  const text = expanded ? collapseText : expandText;
   const icons = [ICONS.chevronsLeft, ICONS.chevronsRight];
 
   if (rtl) {
@@ -91,7 +91,7 @@ export const ExpandToggle: FunctionalComponent<ExpandToggleProps> = ({
       icon={expanded ? expandIcon : collapseIcon}
       onClick={toggle}
       scale={scale}
-      text={expandText}
+      text={text}
       textEnabled={expanded}
       // eslint-disable-next-line react/jsx-sort-props
       ref={(referenceElement): HTMLCalciteActionElement =>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Cleans up some remaining, internal `intlX` props.