### PR TITLE
refactor(alert, dropdown): `onToggleOpenCloseComponent` replaces connect logic

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -31,11 +31,7 @@ import {
   NumberingSystem,
   numberStringFormatter,
 } from "../../utils/locale";
-import {
-  connectOpenCloseComponent,
-  disconnectOpenCloseComponent,
-  OpenCloseComponent,
-} from "../../utils/openCloseComponent";
+import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import {
   connectMessages,
   disconnectMessages,
@@ -87,6 +83,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   @Watch("open")
   openHandler(): void {
+    onToggleOpenCloseComponent(this);
     if (this.open && !this.queued) {
       this.calciteInternalAlertRegister.emit();
     }
@@ -189,13 +186,15 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
       this.openHandler();
       this.calciteInternalAlertRegister.emit();
     }
-    connectOpenCloseComponent(this);
   }
 
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
     this.requestedIcon = setRequestedIcon(KindIcons, this.icon, this.kind);
     await setUpMessages(this);
+    if (open) {
+      onToggleOpenCloseComponent(this);
+    }
   }
 
   componentDidLoad(): void {
@@ -210,7 +209,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     );
     window.clearTimeout(this.autoCloseTimeoutId);
     window.clearTimeout(this.queueTimeout);
-    disconnectOpenCloseComponent(this);
     disconnectLocalized(this);
     disconnectMessages(this);
     this.slottedInShell = false;
@@ -450,7 +448,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   private setTransitionEl = (el): void => {
     this.transitionEl = el;
-    connectOpenCloseComponent(this);
   };
 
   /** determine which alert is active */

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -83,9 +83,9 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   @Watch("open")
   openHandler(): void {
+    onToggleOpenCloseComponent(this);
     if (this.open && !this.queued) {
       this.calciteInternalAlertRegister.emit();
-      onToggleOpenCloseComponent(this);
     }
     if (!this.open) {
       this.queue = this.queue.filter((el) => el !== this.el);

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -83,9 +83,9 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   @Watch("open")
   openHandler(): void {
-    onToggleOpenCloseComponent(this);
     if (this.open && !this.queued) {
       this.calciteInternalAlertRegister.emit();
+      onToggleOpenCloseComponent(this);
     }
     if (!this.open) {
       this.queue = this.queue.filter((el) => el !== this.el);
@@ -185,6 +185,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     if (open && !this.queued) {
       this.openHandler();
       this.calciteInternalAlertRegister.emit();
+      onToggleOpenCloseComponent(this);
     }
   }
 
@@ -192,9 +193,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     setUpLoadableComponent(this);
     this.requestedIcon = setRequestedIcon(KindIcons, this.icon, this.kind);
     await setUpMessages(this);
-    if (open) {
-      onToggleOpenCloseComponent(this);
-    }
   }
 
   componentDidLoad(): void {

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -46,11 +46,7 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { createObserver } from "../../utils/observers";
-import {
-  connectOpenCloseComponent,
-  disconnectOpenCloseComponent,
-  OpenCloseComponent,
-} from "../../utils/openCloseComponent";
+import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { RequestedItem } from "../dropdown-group/interfaces";
 import { Scale } from "../interfaces";
 import { SLOTS } from "./resources";
@@ -94,6 +90,7 @@ export class Dropdown
       if (value) {
         this.reposition(true);
       }
+      onToggleOpenCloseComponent(this);
       return;
     }
 
@@ -216,9 +213,9 @@ export class Dropdown
     this.reposition(true);
     if (this.open) {
       this.openHandler(this.open);
+      onToggleOpenCloseComponent(this);
     }
     connectInteractive(this);
-    connectOpenCloseComponent(this);
   }
 
   componentWillLoad(): void {
@@ -239,7 +236,6 @@ export class Dropdown
     this.resizeObserver?.disconnect();
     disconnectInteractive(this);
     disconnectFloatingUI(this, this.referenceEl, this.floatingEl);
-    disconnectOpenCloseComponent(this);
   }
 
   render(): VNode {
@@ -550,7 +546,6 @@ export class Dropdown
     this.scrollerEl = el;
 
     this.transitionEl = el;
-    connectOpenCloseComponent(this);
   };
 
   onBeforeOpen(): void {


### PR DESCRIPTION
**Related Issue:** #6018

## Summary
Use the new `onToggleOpenCloseComponent` pattern to replace both `connectOpenCloseComponent` and `disconnectOpenCloseComponent` on `alert` and `dropdown`. This new pattern is intended to simplify the overall eventing logic.
