### PR TITLE
fix(list): fix keyboard navigation when filterEnabled is true

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -369,23 +369,23 @@ describe("calcite-list", () => {
       await list.callMethod("setFocus");
       await page.waitForChanges();
 
-      await isElementFocused(page, "#one");
+      expect(await isElementFocused(page, "#one")).toBe(true);
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#two");
+      expect(await isElementFocused(page, "#two")).toBe(true);
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#two");
+      expect(await isElementFocused(page, "#two")).toBe(true);
 
       await list.press("ArrowUp");
 
-      await isElementFocused(page, "#one");
+      expect(await isElementFocused(page, "#one")).toBe(true);
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#two");
+      expect(await isElementFocused(page, "#two")).toBe(true);
 
       const listItemThree = await page.find("#three");
       listItemThree.setProperty("disabled", false);
@@ -394,7 +394,7 @@ describe("calcite-list", () => {
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#three");
+      expect(await isElementFocused(page, "#three")).toBe(true);
 
       const listItemFour = await page.find("#four");
       listItemFour.setProperty("closed", false);
@@ -403,15 +403,15 @@ describe("calcite-list", () => {
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#four");
+      expect(await isElementFocused(page, "#four")).toBe(true);
 
       await list.press("Home");
 
-      await isElementFocused(page, "#one");
+      expect(await isElementFocused(page, "#one")).toBe(true);
 
       await list.press("End");
 
-      await isElementFocused(page, "#four");
+      expect(await isElementFocused(page, "#four")).toBe(true);
     });
 
     it("should navigate via ArrowUp, ArrowDown with filtered items", async () => {
@@ -428,26 +428,27 @@ describe("calcite-list", () => {
       `);
       await page.waitForChanges();
       const list = await page.find("calcite-list");
+      await page.waitForTimeout(listDebounceTimeout);
       await list.callMethod("setFocus");
       await page.waitForChanges();
 
-      await isElementFocused(page, "calcite-filter");
+      expect(await isElementFocused(page, "calcite-filter", { shadowed: true })).toBe(true);
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#four");
+      expect(await isElementFocused(page, "#four")).toBe(true);
 
       await list.press("ArrowDown");
 
-      await isElementFocused(page, "#five");
+      expect(await isElementFocused(page, "#five")).toBe(true);
 
       await list.press("ArrowUp");
 
-      await isElementFocused(page, "#four");
+      expect(await isElementFocused(page, "#four")).toBe(true);
 
       await list.press("ArrowUp");
 
-      await isElementFocused(page, "calcite-filter");
+      expect(await isElementFocused(page, "calcite-filter", { shadowed: true })).toBe(true);
     });
   });
 });

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -413,5 +413,41 @@ describe("calcite-list", () => {
 
       await isElementFocused(page, "#four");
     });
+
+    it("should navigate via ArrowUp, ArrowDown with filtered items", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled filter-text="water">
+          <calcite-list-item id="one" value="fire" label="fire" description="fire"></calcite-list-item>
+          <calcite-list-item id="two" value="fire" label="fire" description="fire"></calcite-list-item>
+          <calcite-list-item id="three" value="fire" label="fire" description="fire"></calcite-list-item>
+          <calcite-list-item id="four" value="water" label="water" description="water"></calcite-list-item>
+          <calcite-list-item id="five" value="water" label="water" description="water"></calcite-list-item>
+          <calcite-list-item id="six" value="water" label="water" description="water"></calcite-list-item>
+        </calcite-list>
+      `);
+      await page.waitForChanges();
+      const list = await page.find("calcite-list");
+      await list.callMethod("setFocus");
+      await page.waitForChanges();
+
+      await isElementFocused(page, "calcite-filter");
+
+      await list.press("ArrowDown");
+
+      await isElementFocused(page, "#four");
+
+      await list.press("ArrowDown");
+
+      await isElementFocused(page, "#five");
+
+      await list.press("ArrowUp");
+
+      await isElementFocused(page, "#four");
+
+      await list.press("ArrowUp");
+
+      await isElementFocused(page, "calcite-filter");
+    });
   });
 });

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -493,7 +493,7 @@ export class List implements InteractiveComponent, LoadableComponent {
       }
     }
     this.updateFilteredItems(emit);
-    this.enabledListItems = items.filter((item) => !item.disabled && !item.closed);
+    this.enabledListItems = this.filteredItems.filter((item) => !item.disabled && !item.closed);
     this.setActiveListItem();
     this.updateSelectedItems(emit);
   }, debounceTimeout);
@@ -533,7 +533,14 @@ export class List implements InteractiveComponent, LoadableComponent {
     const filteredItems = this.enabledListItems.filter((listItem) => this.isNavigable(listItem));
     const currentIndex = filteredItems.findIndex((listItem) => listItem.active);
 
-    if (key === "ArrowDown") {
+    if (key === "ArrowDown" && event.target === this.filterEl) {
+      event.preventDefault();
+      const nextIndex = 0;
+
+      if (filteredItems[nextIndex]) {
+        this.focusRow(filteredItems[nextIndex]);
+      }
+    } else if (key === "ArrowDown") {
       event.preventDefault();
       const nextIndex = currentIndex + 1;
 
@@ -546,6 +553,8 @@ export class List implements InteractiveComponent, LoadableComponent {
 
       if (filteredItems[prevIndex]) {
         this.focusRow(filteredItems[prevIndex]);
+      } else if (currentIndex === 0 && this.filterEnabled && this.filterEl) {
+        this.filterEl.setFocus();
       }
     } else if (key === "Home") {
       event.preventDefault();

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -269,6 +269,11 @@ export class List implements InteractiveComponent, LoadableComponent {
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);
+
+    if (this.filterEl && this.filterEnabled) {
+      return this.filterEl.setFocus();
+    }
+
     return this.enabledListItems.find((listItem) => listItem.active)?.setFocus();
   }
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -270,8 +270,8 @@ export class List implements InteractiveComponent, LoadableComponent {
   async setFocus(): Promise<void> {
     await componentFocusable(this);
 
-    if (this.filterEl && this.filterEnabled) {
-      return this.filterEl.setFocus();
+    if (this.filterEnabled) {
+      return this.filterEl?.setFocus();
     }
 
     return this.enabledListItems.find((listItem) => listItem.active)?.setFocus();
@@ -538,28 +538,25 @@ export class List implements InteractiveComponent, LoadableComponent {
     const filteredItems = this.enabledListItems.filter((listItem) => this.isNavigable(listItem));
     const currentIndex = filteredItems.findIndex((listItem) => listItem.active);
 
-    if (key === "ArrowDown" && event.target === this.filterEl) {
+    if (key === "ArrowDown") {
       event.preventDefault();
-      const nextIndex = 0;
-
-      if (filteredItems[nextIndex]) {
-        this.focusRow(filteredItems[nextIndex]);
-      }
-    } else if (key === "ArrowDown") {
-      event.preventDefault();
-      const nextIndex = currentIndex + 1;
+      const nextIndex = event.target === this.filterEl ? 0 : currentIndex + 1;
 
       if (filteredItems[nextIndex]) {
         this.focusRow(filteredItems[nextIndex]);
       }
     } else if (key === "ArrowUp") {
       event.preventDefault();
+
+      if (currentIndex === 0 && this.filterEnabled) {
+        this.filterEl?.setFocus();
+        return;
+      }
+
       const prevIndex = currentIndex - 1;
 
       if (filteredItems[prevIndex]) {
         this.focusRow(filteredItems[prevIndex]);
-      } else if (currentIndex === 0 && this.filterEnabled && this.filterEl) {
-        this.filterEl.setFocus();
       }
     } else if (key === "Home") {
       event.preventDefault();


### PR DESCRIPTION
**Related Issue:** #6736

## Summary

- Updates keyboard navigable items to account for filtered items.
- Updates setFocus method to account for filter being enabled.
- Updates keyboard to account for filter navigation.
- Fixes test
- Adds test
