### PR TITLE
feat(switch): updates focus outline to be rounded

### DIFF
--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -129,3 +129,4 @@
 }
 
 @include hidden-form-input();
+@include base-component();

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -52,6 +52,11 @@
   @apply focus-base w-auto;
 }
 
+.container {
+  @apply rounded-full
+  border;
+}
+
 .track {
   @apply bg-foreground-2
     border-color-2
@@ -125,4 +130,3 @@
 }
 
 @include hidden-form-input();
-@include base-component();

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -53,8 +53,7 @@
 }
 
 .container {
-  @apply rounded-full
-  border;
+  @apply rounded-full;
 }
 
 .track {

--- a/packages/calcite-components/src/components/switch/switch.stories.ts
+++ b/packages/calcite-components/src/components/switch/switch.stories.ts
@@ -35,3 +35,14 @@ export const darkModeRTL_TestOnly = (): string => html`
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
 
 export const disabled_TestOnly = (): string => html`<calcite-switch disabled checked></calcite-switch>`;
+
+export const Focus_TestOnly = (): string =>
+  html` <div>
+    <calcite-switch> </calcite-switch>
+    <script>
+      (async () => {
+        await customElements.whenDefined("calcite-date-picker");
+        await document.querySelector("calcite-switch").focus();
+      })();
+    </script>
+  </div>`;

--- a/packages/calcite-components/src/components/switch/switch.stories.ts
+++ b/packages/calcite-components/src/components/switch/switch.stories.ts
@@ -37,12 +37,12 @@ darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
 export const disabled_TestOnly = (): string => html`<calcite-switch disabled checked></calcite-switch>`;
 
 export const Focus_TestOnly = (): string =>
-  html` <div>
+  html`
     <calcite-switch> </calcite-switch>
     <script>
       (async () => {
-        await customElements.whenDefined("calcite-date-picker");
+        await customElements.whenDefined("calcite-switch");
         await document.querySelector("calcite-switch").focus();
       })();
     </script>
-  </div>`;
+  `;

--- a/packages/calcite-components/src/components/switch/switch.stories.ts
+++ b/packages/calcite-components/src/components/switch/switch.stories.ts
@@ -46,3 +46,7 @@ export const Focus_TestOnly = (): string =>
       })();
     </script>
   `;
+
+Focus_TestOnly.parameters = {
+  chromatic: { delay: 1000 },
+};

--- a/packages/calcite-components/src/components/switch/switch.stories.ts
+++ b/packages/calcite-components/src/components/switch/switch.stories.ts
@@ -42,7 +42,7 @@ export const Focus_TestOnly = (): string =>
     <script>
       (async () => {
         await customElements.whenDefined("calcite-switch");
-        await document.querySelector("calcite-switch").focus();
+        await document.querySelector("calcite-switch").setFocus();
       })();
     </script>
   `;

--- a/packages/calcite-components/src/components/switch/switch.stories.ts
+++ b/packages/calcite-components/src/components/switch/switch.stories.ts
@@ -38,7 +38,9 @@ export const disabled_TestOnly = (): string => html`<calcite-switch disabled che
 
 export const Focus_TestOnly = (): string =>
   html`
-    <calcite-switch> </calcite-switch>
+    <div style="width:300px;height:300px; padding: 20px">
+      <calcite-switch> </calcite-switch>
+    </div>
     <script>
       (async () => {
         await customElements.whenDefined("calcite-switch");


### PR DESCRIPTION
**Related Issue:** #4633 

## Summary

This PR will replace the block focus outline of `calcite-switch` with a rounded one.

Before the change:

![25C47646-4B10-45A7-94E3-3CD884D35370_4_5005_c](https://github.com/Esri/calcite-design-system/assets/88453586/02313b88-8c2e-4f51-9b45-7b9631dff59f)


After the change:

![92B6D3BC-5B7E-4041-B424-BAB2F89E3C32_4_5005_c](https://github.com/Esri/calcite-design-system/assets/88453586/4d47a41f-dd8d-43f2-8390-1b89a9120440)
