### PR TITLE
fix(color-picker): draw slider thumbs within bounds

### DIFF
--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -515,12 +515,12 @@ describe("calcite-color-picker", () => {
     const expectedColorSamples = [
       "#ff0000",
       "#ffd900",
-      "#48ff00",
-      "#00ff91",
+      "#4cff00",
+      "#00ff8c",
       "#0095ff",
-      "#4800ff",
-      "#ff00dd",
-      "#ff0004",
+      "#4400ff",
+      "#ff00e1",
+      "#ff0008",
     ];
 
     for (let i = 0; i < expectedColorSamples.length; i++) {
@@ -672,7 +672,7 @@ describe("calcite-color-picker", () => {
 
     [hueScopeX, hueScopeY] = await getElementXY(page, "calcite-color-picker", `.${CSS.hueScope}`);
 
-    expect(hueScopeX).toBe(hueSliderX);
+    expect(hueScopeX).toBe(hueSliderX + DIMENSIONS.m.thumb.radius);
 
     await page.mouse.move(hueScopeX, hueScopeY);
     await page.mouse.down();
@@ -682,7 +682,7 @@ describe("calcite-color-picker", () => {
 
     [hueScopeX] = await getElementXY(page, "calcite-color-picker", `.${CSS.hueScope}`);
 
-    expect(hueScopeX).toBe(hueSliderX + DIMENSIONS.m.slider.width - 1);
+    expect(hueScopeX).toBe(hueSliderX + DIMENSIONS.m.slider.width - DIMENSIONS.m.thumb.radius);
   });
 
   describe("unsupported value handling", () => {
@@ -2187,25 +2187,27 @@ describe("calcite-color-picker", () => {
         }
       };
 
-      const getScopeLeftOffset = async () => parseFloat((await scope.getComputedStyle()).left);
+      const getScopeLeftOffset = async () =>
+        /* use int to simplify test */
+        parseInt((await scope.getComputedStyle()).left);
 
-      expect(await getScopeLeftOffset()).toBe(0);
+      expect(await getScopeLeftOffset()).toBe(0 + DIMENSIONS.m.thumb.radius);
 
       await nudgeAQuarterOfSlider();
-      expect(await getScopeLeftOffset()).toBe(68);
+      expect(await getScopeLeftOffset()).toBe(71);
 
       await nudgeAQuarterOfSlider();
-      expect(await getScopeLeftOffset()).toBe(136);
+      expect(await getScopeLeftOffset()).toBe(133);
 
       await nudgeAQuarterOfSlider();
       // hue wraps around, so we nudge it back to assert position at the edge
       await scope.press("ArrowLeft");
-      expect(await getScopeLeftOffset()).toBeLessThanOrEqual(204);
-      expect(await getScopeLeftOffset()).toBeGreaterThan(203);
+      expect(await getScopeLeftOffset()).toBeLessThanOrEqual(194);
+      expect(await getScopeLeftOffset()).toBeGreaterThan(193);
 
       // nudge it to wrap around
       await scope.press("ArrowRight");
-      expect(await getScopeLeftOffset()).toBe(0);
+      expect(await getScopeLeftOffset()).toBe(0 + DIMENSIONS.m.thumb.radius);
     });
 
     it("allows editing hue slider via keyboard", async () => {
@@ -2237,7 +2239,7 @@ describe("calcite-color-picker", () => {
 
       expect(await hueSliderScope.getComputedStyle()).toMatchObject({
         top: "10px",
-        left: "0px",
+        left: `${DIMENSIONS.m.thumb.radius}px`,
       });
     });
   });

--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -2200,16 +2200,16 @@ describe("calcite-color-picker", () => {
         expect(await getScopeLeftOffset()).toBeCloseTo(DIMENSIONS.m.thumb.radius - 0.5, 0);
 
         await nudgeAQuarterOfSlider();
-        expect(await getScopeLeftOffset()).toBeCloseTo(71, 0);
+        expect(await getScopeLeftOffset()).toBeCloseTo(67.5, 0);
 
         await nudgeAQuarterOfSlider();
-        expect(await getScopeLeftOffset()).toBeCloseTo(133, 0);
+        expect(await getScopeLeftOffset()).toBeCloseTo(135.5, 0);
 
         await nudgeAQuarterOfSlider();
         // hue wraps around, so we nudge it back to assert position at the edge
         await scope.press("ArrowLeft");
-        expect(await getScopeLeftOffset()).toBeLessThanOrEqual(194);
-        expect(await getScopeLeftOffset()).toBeGreaterThan(193);
+        expect(await getScopeLeftOffset()).toBeLessThanOrEqual(193.5);
+        expect(await getScopeLeftOffset()).toBeGreaterThan(189.5);
 
         // nudge it to wrap around
         await scope.press("ArrowRight");

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_STORAGE_KEY_PREFIX,
   DIMENSIONS,
   HSV_LIMITS,
+  HUE_LIMIT_CONSTRAINED,
   OPACITY_LIMITS,
   RGB_LIMITS,
   SCOPE_SIZE,
@@ -1095,7 +1096,7 @@ export class ColorPicker
         slider: { width },
       },
     } = this;
-    const hue = ((HSV_LIMITS.h - 1) / width) * x;
+    const hue = (HUE_LIMIT_CONSTRAINED / width) * x;
 
     this.internalColorSet(this.baseColorFieldColor.hue(hue), false);
   }
@@ -1416,7 +1417,7 @@ export class ColorPicker
       },
     } = this;
 
-    const x = hsvColor.hue() / ((HSV_LIMITS.h - 1) / width);
+    const x = hsvColor.hue() / (HUE_LIMIT_CONSTRAINED / width);
     const y = radius - height / 2 + height / 2;
     const sliderBoundX = remap(x, 0, width, radius, width - radius);
 

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -64,7 +64,7 @@ import {
   LocalizedComponent,
   NumberingSystem,
 } from "../../utils/locale";
-import { clamp, remap } from "../../utils/math";
+import { clamp, closeToRangeEdge, remap } from "../../utils/math";
 import {
   connectMessages,
   disconnectMessages,
@@ -1412,14 +1412,14 @@ export class ColorPicker
 
     const {
       dimensions: {
-        slider: { height, width },
+        slider: { width },
         thumb: { radius },
       },
     } = this;
 
     const x = hsvColor.hue() / (HUE_LIMIT_CONSTRAINED / width);
-    const y = radius - height / 2 + height / 2;
-    const sliderBoundX = remap(x, 0, width, radius, width - radius);
+    const y = radius;
+    const sliderBoundX = this.getSliderBoundX(x, width, radius);
 
     requestAnimationFrame(() => {
       this.hueScopeLeft = sliderBoundX;
@@ -1574,13 +1574,23 @@ export class ColorPicker
 
     const x = alphaToOpacity(hsvColor.alpha()) / (OPACITY_LIMITS.max / width);
     const y = radius;
-    const sliderBoundX = remap(x, 0, width, radius, width - radius);
+    const sliderBoundX = this.getSliderBoundX(x, width, radius);
 
     requestAnimationFrame(() => {
       this.opacityScopeLeft = sliderBoundX;
     });
 
     this.drawThumb(this.opacitySliderRenderingContext, radius, sliderBoundX, y, hsvColor);
+  }
+
+  private getSliderBoundX(x: number, width: number, radius: number): number {
+    const closeToEdge = closeToRangeEdge(x, width, radius);
+
+    return closeToEdge === 0
+      ? x
+      : closeToEdge === -1
+      ? remap(x, 0, width, radius, radius * 2)
+      : remap(x, 0, width, width - radius * 2, width - radius);
   }
 
   private storeOpacityScope = (node: HTMLDivElement): void => {

--- a/packages/calcite-components/src/components/color-picker/resources.ts
+++ b/packages/calcite-components/src/components/color-picker/resources.ts
@@ -48,6 +48,9 @@ export const HSV_LIMITS = {
   v: 100,
 };
 
+// 0 and 360 represent the same value, so we limit the hue to 359
+export const HUE_LIMIT_CONSTRAINED = HSV_LIMITS.h - 1;
+
 export const OPACITY_LIMITS = {
   min: 0,
   max: 100,

--- a/packages/calcite-components/src/utils/math.spec.ts
+++ b/packages/calcite-components/src/utils/math.spec.ts
@@ -1,4 +1,4 @@
-import { clamp, decimalPlaces } from "./math";
+import { clamp, decimalPlaces, remap } from "./math";
 
 describe("clamp", () => {
   it("clamps numbers within min/max", () => {
@@ -12,5 +12,13 @@ describe("decimalPlaces", () => {
   it("returns largest number", () => {
     expect(decimalPlaces(123)).toBe(0);
     expect(decimalPlaces(123.123)).toBe(3);
+  });
+});
+
+describe("remap", () => {
+  it("remaps numbers", () => {
+    expect(remap(5, 0, 10, 0, 100)).toBe(50);
+    expect(remap(0, -100, 100, 0, 100)).toBe(50);
+    expect(remap(0.5, 0, 1, 0, 100)).toBe(50);
   });
 });

--- a/packages/calcite-components/src/utils/math.spec.ts
+++ b/packages/calcite-components/src/utils/math.spec.ts
@@ -1,4 +1,4 @@
-import { clamp, decimalPlaces, remap } from "./math";
+import { clamp, closeToRangeEdge, decimalPlaces, remap } from "./math";
 
 describe("clamp", () => {
   it("clamps numbers within min/max", () => {
@@ -20,5 +20,21 @@ describe("remap", () => {
     expect(remap(5, 0, 10, 0, 100)).toBe(50);
     expect(remap(0, -100, 100, 0, 100)).toBe(50);
     expect(remap(0.5, 0, 1, 0, 100)).toBe(50);
+  });
+});
+
+describe("closeToRangeEdge", () => {
+  it("returns -1 if close to lower edge", () => {
+    expect(closeToRangeEdge(0, 100, 10)).toBe(-1);
+    expect(closeToRangeEdge(9, 100, 10)).toBe(-1);
+  });
+
+  it("returns 1 if close to upper edge", () => {
+    expect(closeToRangeEdge(100, 100, 10)).toBe(1);
+    expect(closeToRangeEdge(91, 100, 10)).toBe(1);
+  });
+
+  it("returns 0 if not close to edge", () => {
+    expect(closeToRangeEdge(50, 100, 10)).toBe(0);
   });
 });

--- a/packages/calcite-components/src/utils/math.ts
+++ b/packages/calcite-components/src/utils/math.ts
@@ -19,3 +19,15 @@ export const decimalPlaces = (value: number): number => {
 export function remap(value: number, fromMin: number, fromMax: number, toMin: number, toMax: number): number {
   return ((value - fromMin) * (toMax - toMin)) / (fromMax - fromMin) + toMin;
 }
+
+/**
+ * Helper to determine if a value is close to the edge of a range within a threshold.
+ *
+ * @param value
+ * @param range
+ * @param threshold
+ * @returns -1 if close to lower edge, 1 if close to upper edge, 0 otherwise.
+ */
+export function closeToRangeEdge(value: number, range: number, threshold: number): number {
+  return value < threshold ? -1 : value > range - threshold ? 1 : 0;
+}

--- a/packages/calcite-components/src/utils/math.ts
+++ b/packages/calcite-components/src/utils/math.ts
@@ -15,3 +15,7 @@ export const decimalPlaces = (value: number): number => {
       (match[2] ? +match[2] : 0)
   );
 };
+
+export function remap(value: number, fromMin: number, fromMax: number, toMin: number, toMax: number): number {
+  return ((value - fromMin) * (toMax - toMin)) / (fromMax - fromMin) + toMin;
+}


### PR DESCRIPTION
**Related Issue:** #7005

## Summary

This addresses slider thumbs appearing cut off.

![Screenshot 2023-07-31 at 2 44 23 PM](https://github.com/Esri/calcite-design-system/assets/197440/9570349e-54e6-4f90-9dc0-e5116aafa3b3)
![Screenshot 2023-07-31 at 2 44 07 PM](https://github.com/Esri/calcite-design-system/assets/197440/40b4a6de-2c68-4805-ba17-136a37c5854a)

This also ensures the max hue slider value doesn't overlap with 0 and adds a util to map a value between ranges.