### PR TITLE
fix(slider): prevent excessive tick rendering

### DIFF
--- a/packages/calcite-components/src/components/slider/resources.ts
+++ b/packages/calcite-components/src/components/slider/resources.ts
@@ -5,3 +5,5 @@ export const CSS = {
   tickMin: "tick__label--min",
   tickMax: "tick__label--max",
 };
+
+export const maxTickElementThreshold = 250;

--- a/packages/calcite-components/src/components/slider/slider.stories.ts
+++ b/packages/calcite-components/src/components/slider/slider.stories.ts
@@ -395,6 +395,12 @@ export const WithLargeFontSize_TestOnly = (): string => html`<html lang="en">
 </html>`;
 
 export const maxTickRendering_TestOnly = (): string => html`
+  <style>
+    calcite-slider {
+      width: 60vw;
+    }
+  </style>
+
   <calcite-slider min="-100" max="100" ticks="1"></calcite-slider>
   <calcite-slider min="-100" max="100" ticks="5"></calcite-slider>
   <calcite-slider min="-100" max="100" ticks="10"></calcite-slider>

--- a/packages/calcite-components/src/components/slider/slider.stories.ts
+++ b/packages/calcite-components/src/components/slider/slider.stories.ts
@@ -393,3 +393,18 @@ export const WithLargeFontSize_TestOnly = (): string => html`<html lang="en">
     </div>
   </body>
 </html>`;
+
+export const maxTickRendering_TestOnly = (): string => html`
+  <calcite-slider min="-100" max="100" ticks="1"></calcite-slider>
+  <calcite-slider min="-100" max="100" ticks="5"></calcite-slider>
+  <calcite-slider min="-100" max="100" ticks="10"></calcite-slider>
+  <calcite-slider min="-250" max="250" ticks="1"></calcite-slider>
+  <calcite-slider min="-250" max="250" ticks="5"></calcite-slider>
+  <calcite-slider min="-250" max="250" ticks="10"></calcite-slider>
+  <calcite-slider min="-500" max="500" ticks="1"></calcite-slider>
+  <calcite-slider min="-500" max="500" ticks="5"></calcite-slider>
+  <calcite-slider min="-500" max="500" ticks="10"></calcite-slider>
+  <calcite-slider min="-1000" max="1000" ticks="1"></calcite-slider>
+  <calcite-slider min="-1000" max="1000" ticks="5"></calcite-slider>
+  <calcite-slider min="-1000" max="1000" ticks="10"></calcite-slider>
+`;

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -29,7 +29,7 @@ import {
   updateHostInteraction,
 } from "../../utils/interactive";
 import { isActivationKey } from "../../utils/key";
-import { connectLabel, disconnectLabel, LabelableComponent, getLabelText } from "../../utils/label";
+import { connectLabel, disconnectLabel, getLabelText, LabelableComponent } from "../../utils/label";
 import {
   componentFocusable,
   LoadableComponent,
@@ -46,7 +46,7 @@ import {
 import { clamp, decimalPlaces } from "../../utils/math";
 import { ColorStop, DataSeries } from "../graph/interfaces";
 import { Scale } from "../interfaces";
-import { CSS } from "./resources";
+import { CSS, maxTickElementThreshold } from "./resources";
 
 type ActiveSliderProperty = "minValue" | "maxValue" | "value" | "minMaxValue";
 type SetValueProperty = Exclude<ActiveSliderProperty, "minMaxValue">;
@@ -1031,13 +1031,22 @@ export class Slider
     );
   }
 
+  private getTickRatio(): number {
+    const totalTicks = (this.max - this.min) / this.ticks;
+    return totalTicks / maxTickElementThreshold;
+  }
+
   private generateTickValues(): number[] {
     const ticks = [];
-    let current = this.min;
-    while (this.ticks && current < this.max + this.ticks) {
+    const ratio = this.getTickRatio();
+    const effectiveRatio = ratio < 1 ? 1 : ratio;
+    let current = this.min * effectiveRatio;
+
+    while (this.ticks > 0 && current < this.max + this.ticks) {
       ticks.push(Math.min(current, this.max));
-      current = current + this.ticks;
+      current += this.ticks * effectiveRatio;
     }
+
     return ticks;
   }
 

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -1037,14 +1037,25 @@ export class Slider
   }
 
   private generateTickValues(): number[] {
-    const ticks = [];
+    const tickInterval = this.ticks ?? 0;
+
+    if (tickInterval <= 0) {
+      return [];
+    }
+
+    const ticks: number[] = [this.min];
     const ratio = this.getTickRatio();
     const effectiveRatio = ratio < 1 ? 1 : ratio;
-    let current = this.min * effectiveRatio;
+    let current = this.min;
+    const tickOffset = tickInterval * effectiveRatio;
 
-    while (this.ticks > 0 && current < this.max + this.ticks) {
+    while (current < this.max) {
+      current += tickOffset;
       ticks.push(Math.min(current, this.max));
-      current += this.ticks * effectiveRatio;
+    }
+
+    if (!ticks.includes(this.max)) {
+      ticks.push(this.max);
     }
 
     return ticks;

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -1031,9 +1031,10 @@ export class Slider
     );
   }
 
-  private getTickRatio(): number {
-    const totalTicks = (this.max - this.min) / this.ticks;
-    return totalTicks / maxTickElementThreshold;
+  private getTickDensity(): number {
+    const density = (this.max - this.min) / this.ticks / maxTickElementThreshold;
+
+    return density < 1 ? 1 : density;
   }
 
   private generateTickValues(): number[] {
@@ -1044,10 +1045,9 @@ export class Slider
     }
 
     const ticks: number[] = [this.min];
-    const ratio = this.getTickRatio();
-    const effectiveRatio = ratio < 1 ? 1 : ratio;
+    const density = this.getTickDensity();
+    const tickOffset = tickInterval * density;
     let current = this.min;
-    const tickOffset = tickInterval * effectiveRatio;
 
     while (current < this.max) {
       current += tickOffset;


### PR DESCRIPTION
**Related Issue:** #7242

## Summary

This caps the amount of ticks that get rendered at a time (max 250).

**Note**: The current max was determined heuristically to strike a balance between amount of ticks displayed and avoiding cluttering.