### PR TITLE
fix(tooltip): avoid extra before open/close event emitting

### DIFF
--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -208,6 +208,7 @@ export default class TooltipManager {
   }
 
   private openHoveredTooltip = (tooltip: HTMLCalciteTooltipElement): void => {
+    this.clearHoverOpenTimeout();
     this.hoverOpenTimeout = window.setTimeout(
       () => {
         if (this.hoverOpenTimeout === null) {
@@ -215,6 +216,11 @@ export default class TooltipManager {
         }
 
         this.clearHoverCloseTimeout();
+
+        if (this.activeTooltip === this.hoveredTooltip) {
+          return;
+        }
+
         this.closeActiveTooltip();
 
         if (tooltip !== this.hoveredTooltip) {
@@ -228,6 +234,7 @@ export default class TooltipManager {
   };
 
   private closeHoveredTooltip = (): void => {
+    this.clearHoverCloseTimeout();
     this.hoverCloseTimeout = window.setTimeout(() => {
       if (this.hoverCloseTimeout === null) {
         return;

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -208,7 +208,6 @@ export default class TooltipManager {
   }
 
   private openHoveredTooltip = (tooltip: HTMLCalciteTooltipElement): void => {
-    this.clearHoverOpenTimeout();
     this.hoverOpenTimeout = window.setTimeout(
       () => {
         if (this.hoverOpenTimeout === null) {
@@ -234,7 +233,6 @@ export default class TooltipManager {
   };
 
   private closeHoveredTooltip = (): void => {
-    this.clearHoverCloseTimeout();
     this.hoverCloseTimeout = window.setTimeout(() => {
       if (this.hoverCloseTimeout === null) {
         return;

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -2,7 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { TOOLTIP_OPEN_DELAY_MS, TOOLTIP_CLOSE_DELAY_MS } from "../tooltip/resources";
 import { accessible, defaults, hidden, floatingUIOwner, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { GlobalTestProps } from "../../tests/utils";
+import { getElementXY, GlobalTestProps } from "../../tests/utils";
 
 interface PointerMoveOptions {
   delay: number;
@@ -677,59 +677,112 @@ describe("calcite-tooltip", () => {
     expect(await tooltip.isVisible()).toBe(true);
   });
 
-  it("should emit open and beforeOpen events", async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-tooltip placement="auto" reference-element="ref">content</calcite-tooltip><div id="ref">referenceElement</div>`
-    );
-    const tooltip = await page.find("calcite-tooltip");
+  describe("beforeOpen, open, beforeClose, close event emitting", () => {
+    it("emits via prop", async () => {
+      await assertEventEmitting({
+        openTooltip: async (page) => {
+          const tooltipBeforeOpenEvent = page.waitForEvent("calciteTooltipBeforeOpen");
+          const tooltipOpenEvent = page.waitForEvent("calciteTooltipOpen");
+          const tooltip = await page.find("calcite-tooltip");
 
-    const openEvent = await tooltip.spyOnEvent("calciteTooltipOpen");
-    const beforeOpenEvent = await tooltip.spyOnEvent("calciteTooltipBeforeOpen");
+          tooltip.setProperty("open", true);
+          await page.waitForChanges();
 
-    expect(openEvent).toHaveReceivedEventTimes(0);
-    expect(beforeOpenEvent).toHaveReceivedEventTimes(0);
+          await tooltipBeforeOpenEvent;
+          await tooltipOpenEvent;
+        },
+        closeTooltip: async (page) => {
+          const tooltipBeforeCloseEvent = page.waitForEvent("calciteTooltipBeforeClose");
+          const tooltipCloseEvent = page.waitForEvent("calciteTooltipClose");
+          const tooltip = await page.find("calcite-tooltip");
 
-    const tooltipOpenEvent = page.waitForEvent("calciteTooltipOpen");
-    const tooltipBeforeOpenEvent = page.waitForEvent("calciteTooltipBeforeOpen");
+          tooltip.setProperty("open", false);
+          await page.waitForChanges();
 
-    tooltip.setProperty("open", true);
-    await page.waitForChanges();
-
-    await tooltipOpenEvent;
-    await tooltipBeforeOpenEvent;
-
-    expect(openEvent).toHaveReceivedEventTimes(1);
-    expect(beforeOpenEvent).toHaveReceivedEventTimes(1);
-  });
-
-  it("should emit close and beforeClose events", async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      `<calcite-tooltip placement="auto" reference-element="ref" open>content</calcite-tooltip><div id="ref">referenceElement</div>`
-    );
-
-    const tooltip = await page.find("calcite-tooltip");
-
-    const closeEvent = await tooltip.spyOnEvent("calciteTooltipClose");
-    const beforeCloseEvent = await tooltip.spyOnEvent("calciteTooltipBeforeClose");
-
-    expect(closeEvent).toHaveReceivedEventTimes(0);
-    expect(beforeCloseEvent).toHaveReceivedEventTimes(0);
-
-    const tooltipCloseEvent = page.waitForEvent("calciteTooltipClose");
-    const tooltipBeforeCloseEvent = page.waitForEvent("calciteTooltipBeforeClose");
-
-    await page.evaluate(() => {
-      const tooltip = document.querySelector("calcite-tooltip");
-      tooltip.open = false;
+          await tooltipBeforeCloseEvent;
+          await tooltipCloseEvent;
+        },
+      });
     });
 
-    await tooltipBeforeCloseEvent;
-    await tooltipCloseEvent;
+    it("emits via mouse", async () => {
+      const moveOptions = { steps: 10 };
+      const totalDelayFromMoveSteps = TOOLTIP_OPEN_DELAY_MS * moveOptions.steps;
+      const xMoveOffset = 25;
 
-    expect(closeEvent).toHaveReceivedEventTimes(1);
-    expect(beforeCloseEvent).toHaveReceivedEventTimes(1);
+      await assertEventEmitting({
+        openTooltip: async (page: E2EPage) => {
+          const [refElementX, refElementY] = await getElementXY(page, "#ref");
+
+          await page.mouse.move(0, 0, moveOptions);
+          await page.mouse.move(refElementX, refElementY, moveOptions);
+          await page.mouse.move(refElementX + xMoveOffset, refElementY, moveOptions);
+          await page.waitForChanges();
+
+          await page.waitForTimeout(totalDelayFromMoveSteps);
+        },
+        closeTooltip: async (page: E2EPage) => {
+          const [refElementX, refElementY] = await getElementXY(page, "#ref");
+
+          await page.mouse.move(refElementX + xMoveOffset, refElementY, moveOptions);
+          await page.mouse.move(refElementX, refElementY, moveOptions);
+          await page.mouse.move(0, 0, moveOptions);
+          await page.waitForChanges();
+
+          await page.waitForTimeout(totalDelayFromMoveSteps);
+        },
+      });
+    });
+
+    it("emits via keyboard", async () => {
+      await assertEventEmitting({
+        openTooltip: async (page) => {
+          await page.keyboard.press("Tab");
+          await page.waitForChanges();
+        },
+        closeTooltip: async (page) => {
+          await page.keyboard.press("Tab");
+          await page.waitForChanges();
+        },
+      });
+    });
+
+    async function assertEventEmitting(params: {
+      openTooltip: (page: E2EPage) => Promise<void>;
+      closeTooltip: (page: E2EPage) => Promise<void>;
+    }): Promise<void> {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-tooltip placement="auto" reference-element="ref">content</calcite-tooltip><button id="ref">referenceElement</button>`
+      );
+      const tooltip = await page.find("calcite-tooltip");
+
+      const beforeOpenEvent = await tooltip.spyOnEvent("calciteTooltipBeforeOpen");
+      const openEvent = await tooltip.spyOnEvent("calciteTooltipOpen");
+      const beforeCloseEvent = await tooltip.spyOnEvent("calciteTooltipBeforeClose");
+      const closeEvent = await tooltip.spyOnEvent("calciteTooltipClose");
+
+      expect(beforeOpenEvent).toHaveReceivedEventTimes(0);
+      expect(openEvent).toHaveReceivedEventTimes(0);
+      expect(beforeCloseEvent).toHaveReceivedEventTimes(0);
+      expect(closeEvent).toHaveReceivedEventTimes(0);
+
+      await params.openTooltip(page);
+      await page.waitForChanges();
+
+      expect(beforeOpenEvent).toHaveReceivedEventTimes(1);
+      expect(openEvent).toHaveReceivedEventTimes(1);
+      expect(beforeCloseEvent).toHaveReceivedEventTimes(0);
+      expect(closeEvent).toHaveReceivedEventTimes(0);
+
+      await params.closeTooltip(page);
+      await page.waitForChanges();
+
+      expect(beforeOpenEvent).toHaveReceivedEventTimes(1);
+      expect(openEvent).toHaveReceivedEventTimes(1);
+      expect(beforeCloseEvent).toHaveReceivedEventTimes(1);
+      expect(closeEvent).toHaveReceivedEventTimes(1);
+    }
   });
 
   it.skip("should open hovered tooltip while pointer is moving", async () => {


### PR DESCRIPTION
**Related Issue:** #7396

## Summary

Updates `TooltipManager` logic to avoid toggling hovered tooltips if they are the active ones.