### PR TITLE
chore(storybook): hide warning and show TestOnly stories in local builds

### DIFF
--- a/packages/calcite-components/.storybook/helpers.ts
+++ b/packages/calcite-components/.storybook/helpers.ts
@@ -44,6 +44,10 @@ export function storyFilters(): {
   excludeStories: RegExp | string[];
 } {
   return {
-    excludeStories: process.env.STORYBOOK_SCREENSHOT_TEST_BUILD ? /.*_NoTest$/ : /.*_TestOnly$/,
+    excludeStories: process.env.STORYBOOK_SCREENSHOT_TEST_BUILD
+      ? /.*_NoTest$/
+      : process.env.STORYBOOK_SCREENSHOT_LOCAL_BUILD
+      ? []
+      : /.*_TestOnly$/,
   };
 }

--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -37,7 +37,7 @@ module.exports = {
     }
   `,
   managerHead: (head: string): string => {
-    if (process.env.STORYBOOK_SCREENSHOT_TEST_BUILD) {
+    if (process.env.STORYBOOK_SCREENSHOT_TEST_BUILD || process.env.STORYBOOK_SCREENSHOT_LOCAL_BUILD) {
       return head;
     }
 

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -26,7 +26,7 @@
     "clean": "npm run util:clean-js-files && rimraf node_modules dist www hydrate docs .turbo src/components.d.ts",
     "deps:update": "updtr --exclude chalk cheerio typescript @types/jest jest jest-cli ts-jest puppeteer @whitespace/storybook-addon-html && npm audit fix",
     "docs": "build-storybook",
-    "docs:preview": "npm run util:build-docs && start-storybook",
+    "docs:preview": "npm run util:build-docs && STORYBOOK_SCREENSHOT_LOCAL_BUILD=true start-storybook",
     "lint": "concurrently npm:lint:*",
     "lint:html": "prettier --write \"**/*.html\" >/dev/null",
     "lint:json": "prettier --write \"**/*.json\" >/dev/null",


### PR DESCRIPTION
**Related Issue:** #7338

## Summary

Creates a `STORYBOOK_SNAPSHOT_LOCAL_BUILD` environment variable and automatically sets it in the `docs:preview` npm script. When the environment variable is truthy, the storybook build:

- Hides the warning banner
- Displays both TestOnly and NoTest stories