### PR TITLE
fix(flow): Set tooltip placement to "bottom" by default.

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -345,7 +345,7 @@ export class FlowItem
             closeOnClick={true}
             label={label}
             overlayPositioning="fixed"
-            placement="top"
+            placement="bottom"
             referenceElement={backButtonEl}
           >
             {label}


### PR DESCRIPTION
**Related Issue:** #7433

## Summary

- Set tooltip placement to "bottom" by default.