### PR TITLE
fix(panel): Add native tooltip to close button.

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -411,6 +411,7 @@ export class Panel
         icon={ICONS.close}
         onClick={close}
         text={text}
+        title={text}
         // eslint-disable-next-line react/jsx-sort-props
         ref={this.setCloseRef}
       />


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

fix(panel): Add native tooltip to close button.

- Modal uses a native tooltip for its close button
- Using a calcite-tooltip would be too much visual noise