### PR TITLE
fix(flow-item): Use a native tooltip for the back button

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -99,11 +99,6 @@ describe("calcite-flow-item", () => {
 
     expect(backButtonNew).not.toBeNull();
 
-    const backButtonTooltip = await page.find(`calcite-flow-item >>> calcite-tooltip`);
-
-    expect(backButtonTooltip).not.toBeNull();
-    expect(await backButtonTooltip.getProperty("closeOnClick")).toBe(true);
-
     expect(await backButtonNew.isVisible()).toBe(true);
 
     const calciteFlowItemBack = await page.spyOnEvent("calciteFlowItemBack", "window");

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -190,7 +190,6 @@ export class FlowItem
 
   containerEl: HTMLCalcitePanelElement;
 
-  @State()
   backButtonEl: HTMLCalciteActionElement;
 
   @State() defaultMessages: FlowItemMessages;
@@ -292,6 +291,7 @@ export class FlowItem
         scale="s"
         slot="header-actions-start"
         text={label}
+        title={label}
         // eslint-disable-next-line react/jsx-sort-props
         ref={this.setBackRef}
       />
@@ -309,9 +309,7 @@ export class FlowItem
       loading,
       menuOpen,
       messages,
-      backButtonEl,
     } = this;
-    const label = messages.back;
     return (
       <Host>
         <calcite-panel
@@ -340,17 +338,6 @@ export class FlowItem
           <slot name={SLOTS.footer} slot={PANEL_SLOTS.footer} />
           <slot />
         </calcite-panel>
-        {backButtonEl ? (
-          <calcite-tooltip
-            closeOnClick={true}
-            label={label}
-            overlayPositioning="fixed"
-            placement="top"
-            referenceElement={backButtonEl}
-          >
-            {label}
-          </calcite-tooltip>
-        ) : null}
       </Host>
     );
   }


### PR DESCRIPTION
**Related Issue:** #7436 #7433

## Summary

- Use a native tooltip for the back button. #7436
- This is the only component that uses a tooltip by default so it seems like we shouldn't do this
- A native tooltip probably makes more sense as the back icon is pretty recognizable