### PR TITLE
ci(release-please): use default pull request title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "tag-separator": "@",
-  "group-pull-request-title-pattern": "chore: release latest",
   "include-v-in-tag": false,
   "packages": {
     "packages/calcite-components": {


### PR DESCRIPTION
## Summary

`release-please` was having problems finding it's own pull requests, which was causing issues with the post-merge deployments. The [logs say the problem is with the custom pull request title](https://github.com/Esri/calcite-design-system/actions/runs/5756030451/job/15604709660#step:2:28). Reverting the configuration to the default title seemed to fix the issues in my test repo.
