### PR TITLE
fix(action-bar, action-pad): Add native tooltip to expand action

### DIFF
--- a/packages/calcite-components/src/components/functional/ExpandToggle.tsx
+++ b/packages/calcite-components/src/components/functional/ExpandToggle.tsx
@@ -93,6 +93,7 @@ export const ExpandToggle: FunctionalComponent<ExpandToggleProps> = ({
       scale={scale}
       text={text}
       textEnabled={expanded}
+      title={!expanded && !tooltip ? text : null}
       // eslint-disable-next-line react/jsx-sort-props
       ref={(referenceElement): HTMLCalciteActionElement =>
         setTooltipReference({ tooltip, referenceElement, expanded, ref })


### PR DESCRIPTION
**Related Issue:** #7451

## Summary

- Add native tooltip to expand action when no tooltip is slotted.