### PR TITLE
fix: fix SSR build error caused by browser-sniffing util

### DIFF
--- a/packages/calcite-components/src/utils/browser.ts
+++ b/packages/calcite-components/src/utils/browser.ts
@@ -1,3 +1,5 @@
+import { Build } from "@stencil/core";
+
 interface NavigatorUAData {
   brands: Array<{ brand: string; version: string }>;
   mobile: boolean;
@@ -9,6 +11,10 @@ function getUserAgentData(): NavigatorUAData | undefined {
 }
 
 export function getUserAgentString(): string {
+  if (!Build.isBrowser) {
+    return "";
+  }
+
   const uaData = getUserAgentData();
 
   return uaData?.brands


### PR DESCRIPTION
**Related Issue:** #7459 

## Summary

This checks the build context to make sure `navigator` is available. The prerendering test wasn't catching this because Stencil will mock it.