### PR TITLE
fix(accordion): restore accordion-items working with accordion across shadow DOM

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -119,15 +119,10 @@ export class AccordionItem implements ConditionalSlotComponent {
 
   connectedCallback(): void {
     connectConditionalSlotComponent(this);
-    document.addEventListener("calciteInternalAccordionItemsSync", this.updateAccordionChildSync);
   }
 
   disconnectedCallback(): void {
     disconnectConditionalSlotComponent(this);
-    document.removeEventListener(
-      "calciteInternalAccordionItemsSync",
-      this.updateAccordionChildSync
-    );
   }
 
   // --------------------------------------------------------------------------
@@ -260,10 +255,18 @@ export class AccordionItem implements ConditionalSlotComponent {
     event.stopPropagation();
   }
 
-  private updateAccordionChildSync = (event: CustomEvent): void => {
+  @Listen("calciteInternalAccordionItemsSync", { target: "document" })
+  updateAccordionChildSync(event: CustomEvent): void {
     const [accordion] = event.composedPath();
+    const accordionItem = this.el;
+
+    const willBeSyncedByDirectParent = accordionItem.parentElement === accordion;
+    if (willBeSyncedByDirectParent) {
+      return;
+    }
+
     const closestAccordionParent = closestElementCrossShadowBoundary<HTMLCalciteAccordionElement>(
-      this.el,
+      accordionItem,
       "calcite-accordion"
     );
 
@@ -271,11 +274,11 @@ export class AccordionItem implements ConditionalSlotComponent {
       return;
     }
 
-    this.el.iconPosition = closestAccordionParent.iconPosition;
-    this.el.iconType = closestAccordionParent.iconType;
-    this.el.scale = closestAccordionParent.scale;
+    accordionItem.iconPosition = closestAccordionParent.iconPosition;
+    accordionItem.iconType = closestAccordionParent.iconType;
+    accordionItem.scale = closestAccordionParent.scale;
     event.stopPropagation();
-  };
+  }
 
   //--------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -119,10 +119,15 @@ export class AccordionItem implements ConditionalSlotComponent {
 
   connectedCallback(): void {
     connectConditionalSlotComponent(this);
+    document.addEventListener("calciteInternalAccordionItemsSync", this.updateAccordionChildSync);
   }
 
   disconnectedCallback(): void {
     disconnectConditionalSlotComponent(this);
+    document.removeEventListener(
+      "calciteInternalAccordionItemsSync",
+      this.updateAccordionChildSync
+    );
   }
 
   // --------------------------------------------------------------------------
@@ -255,8 +260,7 @@ export class AccordionItem implements ConditionalSlotComponent {
     event.stopPropagation();
   }
 
-  @Listen("calciteInternalAccordionItemsSync", { target: "document" })
-  updateAccordionChildSync(event: CustomEvent): void {
+  private updateAccordionChildSync = (event: CustomEvent): void => {
     const [accordion] = event.composedPath();
     const closestAccordionParent = closestElementCrossShadowBoundary<HTMLCalciteAccordionElement>(
       this.el,
@@ -271,7 +275,7 @@ export class AccordionItem implements ConditionalSlotComponent {
     this.el.iconType = closestAccordionParent.iconType;
     this.el.scale = closestAccordionParent.scale;
     event.stopPropagation();
-  }
+  };
 
   //--------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/accordion/accordion.tsx
+++ b/packages/calcite-components/src/components/accordion/accordion.tsx
@@ -133,6 +133,13 @@ export class Accordion {
   //--------------------------------------------------------------------------
 
   private updateAccordionItems(): void {
+    this.el.querySelectorAll("calcite-accordion-item").forEach((item) => {
+      item.iconPosition = this.iconPosition;
+      item.iconType = this.iconType;
+      item.scale = this.scale;
+    });
+
+    // sync props on items across shadow DOM
     document.dispatchEvent(new CustomEvent("calciteInternalAccordionItemsSync"));
   }
 }

--- a/packages/calcite-components/src/components/accordion/accordion.tsx
+++ b/packages/calcite-components/src/components/accordion/accordion.tsx
@@ -35,9 +35,6 @@ export class Accordion {
   //
   //--------------------------------------------------------------------------
 
-  /** Specifies the parent of the component. */
-  @Prop({ reflect: true }) accordionParent: HTMLCalciteAccordionElement;
-
   /** Specifies the appearance of the component. */
   @Prop({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> = "solid";
 
@@ -76,7 +73,7 @@ export class Accordion {
   /**
    * @internal
    */
-  @Event({ cancelable: false }) calciteInternalAccordionChange: EventEmitter<RequestedItem>;
+  @Event({ cancelable: false }) private calciteInternalAccordionChange: EventEmitter<RequestedItem>;
 
   //--------------------------------------------------------------------------
   //
@@ -115,9 +112,8 @@ export class Accordion {
 
   @Listen("calciteInternalAccordionItemSelect")
   updateActiveItemOnChange(event: CustomEvent): void {
-    this.requestedAccordionItem = event.detail.requestedAccordionItem;
     this.calciteInternalAccordionChange.emit({
-      requestedAccordionItem: this.requestedAccordionItem,
+      requestedAccordionItem: event.detail.requestedAccordionItem,
     });
     event.stopPropagation();
   }
@@ -130,9 +126,6 @@ export class Accordion {
 
   mutationObserver = createObserver("mutation", () => this.updateAccordionItems());
 
-  /** keep track of the requested item for multi mode */
-  private requestedAccordionItem: HTMLCalciteAccordionItemElement;
-
   //--------------------------------------------------------------------------
   //
   //  Private Methods
@@ -140,12 +133,6 @@ export class Accordion {
   //--------------------------------------------------------------------------
 
   private updateAccordionItems(): void {
-    this.el.querySelectorAll("calcite-accordion-item").forEach((item) => {
-      item.iconPosition = this.iconPosition;
-      item.iconType = this.iconType;
-      item.selectionMode = this.selectionMode;
-      item.scale = this.scale;
-      item.accordionParent = this.el;
-    });
+    document.dispatchEvent(new CustomEvent("calciteInternalAccordionItemsSync"));
   }
 }


### PR DESCRIPTION
**Related Issue:** #7448 

## Summary

This updates accordion to sync its children's properties across shadow boundaries via events.