### PR TITLE
fix(input): fix clearable from throwing an error when value is undefined

### DIFF
--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -419,7 +419,7 @@ export class Input
   private childNumberEl?: HTMLInputElement;
 
   get isClearable(): boolean {
-    return !this.isTextarea && (this.clearable || this.type === "search") && this.value.length > 0;
+    return !this.isTextarea && (this.clearable || this.type === "search") && this.value?.length > 0;
   }
 
   get isTextarea(): boolean {


### PR DESCRIPTION
**Related Issue:** #7475

## Summary

- Makes sure `value` is defined before trying to get its length.