### PR TITLE
ci: ensure vscode-data is generated during every build

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -22,20 +22,19 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
           ref: main
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
-      - name: Build Packages
+      - name: Build Packages and Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm install
           npm run build
-      - name: Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
+          npm run publish:latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: npm run publish:latest

--- a/packages/calcite-components/support/stencilDoubleBuildTypesWorkaround.sh
+++ b/packages/calcite-components/support/stencilDoubleBuildTypesWorkaround.sh
@@ -13,5 +13,8 @@
 # https://github.com/lerna/lerna/blob/main/libs/commands/publish/README.md#lifecycle-scripts
 # https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts
 # https://github.com/Esri/calcite-design-system/pull/4303
+
+# The vscode data is not being generated if the file already exists
+rimraf dist/extras/vscode-data.json
 npm run build
 npm run util:test-types


### PR DESCRIPTION
**Related Issue:** #7397 

## Summary

The vscode-data Stencil output is not being generated if one already exists. It works on `next` because the components get built 3 times, once for tests, once for storybook deployment, and then a third time for the stencil types workaround. I'll try to find a way to remove one of those builds for `next` deployments.