### PR TITLE
fix(chip-group): Add existence checks

### DIFF
--- a/packages/calcite-components/src/components/chip-group/chip-group.tsx
+++ b/packages/calcite-components/src/components/chip-group/chip-group.tsx
@@ -197,10 +197,10 @@ export class ChipGroup implements InteractiveComponent {
   private updateItems = (event?: Event): void => {
     const target = event ? (event.target as HTMLSlotElement) : this.slotRefEl;
     this.items = target
-      .assignedElements({ flatten: true })
+      ?.assignedElements({ flatten: true })
       .filter((el) => el?.matches("calcite-chip")) as HTMLCalciteChipElement[];
 
-    this.items.forEach((el) => {
+    this.items?.forEach((el) => {
       el.interactive = true;
       el.scale = this.scale;
       el.selectionMode = this.selectionMode;


### PR DESCRIPTION
## Summary
Running into some error using Chip Group / Chip in React environment with programmatically populated Chips...

![Screenshot 2023-08-08 at 10 45 44 AM](https://github.com/Esri/calcite-design-system/assets/4733155/b8f1a301-b317-4d22-92f2-e4fd269d30a9)
![Screenshot 2023-08-08 at 10 33 17 AM](https://github.com/Esri/calcite-design-system/assets/4733155/b3c2e3dd-2253-4c43-8130-b8ca73bf0a1f)

Adds check for existence of unfound element.