### PR TITLE
fix(block): defaults the status icon to `scale=s`

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -254,7 +254,7 @@ export class Block
             [CSS.invalid]: status == "invalid",
           }}
           icon={ICONS[status]}
-          scale="m"
+          scale="s"
         />
       </div>
     ) : hasSlottedIcon ? (


### PR DESCRIPTION
**Related Issue:** #6484 

## Summary

Defaults the scale of status icon to `s` 