### PR TITLE
fix(combobox): prevents navigation list with Space key

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -897,7 +897,7 @@ describe("calcite-combobox", () => {
       expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
     });
 
-    it(`Space opens dropdown and puts focus on first item`, async () => {
+    it(`Space opens dropdown and puts focus on first item and subsequent Space do not change the focus`, async () => {
       const inputEl = await page.find(`#myCombobox >>> input`);
       await inputEl.focus();
       await page.waitForChanges();
@@ -910,6 +910,12 @@ describe("calcite-combobox", () => {
 
       const visible = await firstFocusedGroupItem.isVisible();
       expect(visible).toBe(true);
+
+      await page.keyboard.press("Space");
+      await page.waitForChanges();
+      await page.keyboard.press("Space");
+      await page.waitForChanges();
+      expect(firstFocusedGroupItem).toBeTruthy();
     });
 
     it("when the combobox is focused & closed, Page up/down (fn arrow up/down) scrolls up and down the page", async () => {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -605,8 +605,10 @@ export class Combobox
       case " ":
         if (!this.textInput.value) {
           event.preventDefault();
-          this.open = true;
-          this.shiftActiveItemIndex(1);
+          if (!this.open) {
+            this.open = true;
+            this.shiftActiveItemIndex(1);
+          }
         }
         break;
       case "Home":

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -603,11 +603,13 @@ export class Combobox
         }
         break;
       case " ":
-        if (!this.open) {
-          this.open = true;
-          this.shiftActiveItemIndex(1);
+        if (!this.textInput.value) {
+          if (!this.open) {
+            this.open = true;
+            this.shiftActiveItemIndex(1);
+          }
+          event.preventDefault();
         }
-        event.preventDefault();
         break;
       case "Home":
         if (!this.open) {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -603,13 +603,11 @@ export class Combobox
         }
         break;
       case " ":
-        if (!this.textInput.value) {
-          event.preventDefault();
-          if (!this.open) {
-            this.open = true;
-            this.shiftActiveItemIndex(1);
-          }
+        if (!this.open) {
+          this.open = true;
+          this.shiftActiveItemIndex(1);
         }
+        event.preventDefault();
         break;
       case "Home":
         if (!this.open) {
@@ -644,6 +642,7 @@ export class Combobox
       case "Enter":
         if (this.activeItemIndex > -1) {
           this.toggleSelection(this.filteredItems[this.activeItemIndex]);
+          console.log("after enter", this.filteredItems[this.activeItemIndex]);
           event.preventDefault();
         } else if (this.activeChipIndex > -1) {
           this.removeActiveChip();
@@ -903,6 +902,7 @@ export class Combobox
       this.emitComboboxChange();
       if (this.textInput) {
         this.textInput.value = item.textLabel;
+        console.log("toggle selection", item.textLabel);
       }
       this.open = false;
       this.updateActiveItemIndex(-1);

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -901,7 +901,6 @@ export class Combobox
       this.emitComboboxChange();
       if (this.textInput) {
         this.textInput.value = item.textLabel;
-        console.log("toggle selection", item.textLabel);
       }
       this.open = false;
       this.updateActiveItemIndex(-1);

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -642,7 +642,6 @@ export class Combobox
       case "Enter":
         if (this.activeItemIndex > -1) {
           this.toggleSelection(this.filteredItems[this.activeItemIndex]);
-          console.log("after enter", this.filteredItems[this.activeItemIndex]);
           event.preventDefault();
         } else if (this.activeChipIndex > -1) {
           this.removeActiveChip();


### PR DESCRIPTION
**Related Issue:** #6387 

## Summary

This prevents `Space` key navigating combobox list when opened. 