### PR TITLE
ci(deploy-latest): hardcode node version to prevent errors

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: 16
+          node-version: 16
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: package.json
+          node-version-file: 16
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## Summary

The `deploy-latest` action is [throwing an error](https://github.com/Esri/calcite-design-system/actions/runs/5814180775/job/15763323592#step:4:9) saying it can't find the Node version from Volta in `package.json`. 

Interestingly, the `deploy-next` action [checks for the node version](https://github.com/Esri/calcite-design-system/blob/main/.github/workflows/deploy-next.yml#L20) in the exact same way and its run [succeeds](https://github.com/Esri/calcite-design-system/actions/runs/5814180776/job/15763326002#step:3:11) on the same commit.

`¯\_(ツ)_/¯`