### PR TITLE
docs(storybook): add list dragEnabled knob and modify stories

### DIFF
--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -27,7 +27,7 @@ const knobsHTML = (): string => html`selection-mode="${select(
 )}"
 selection-appearance="${select("selection-appearance", ["icon", "border"], "icon")}" ${boolean("loading", false)}
 ${boolean("closable", false)} ${boolean("closed", false)} ${boolean("filter-enabled", false)}
-${boolean("disabled", false)} ${text("label", "My List")}`;
+${boolean("drag-enabled", false)} ${boolean("disabled", false)} ${text("label", "My List")}`;
 
 export const simple = (): string => html`
   <calcite-list ${knobsHTML()}>
@@ -200,7 +200,7 @@ export const startAndEndContentSlots = (): string => html`<calcite-list ${knobsH
 export const richContent = (): string => html`
   <calcite-list ${knobsHTML()}>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Princess Bubblegum website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="effects" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -208,7 +208,7 @@ export const richContent = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Finn Mertens" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Finn Mertens website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="running" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -216,7 +216,7 @@ export const richContent = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Jake T. Dog" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Jake T. Dog website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="walking" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon
@@ -233,7 +233,7 @@ export const richContent = (): string => html`
 export const richContentFilterEnabled = (): string => html`
   <calcite-list filter-enabled>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Princess Bubblegum website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="effects" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -241,7 +241,7 @@ export const richContentFilterEnabled = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Finn Mertens" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Finn Mertens website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="running" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -249,7 +249,7 @@ export const richContentFilterEnabled = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Jake T. Dog" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Jake T. Dog website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="walking" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon
@@ -267,7 +267,7 @@ export const richContentFilterEnabled = (): string => html`
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-list class="calcite-mode-dark" dir="rtl" ${knobsHTML()}>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Princess Bubblegum website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="effects" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -275,7 +275,7 @@ export const darkModeRTL_TestOnly = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Finn Mertens" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Finn Mertens website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="running" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon scale="s" icon="check" slot="content-end" style="color: var(--calcite-ui-success)"></calcite-icon>
@@ -283,7 +283,7 @@ export const darkModeRTL_TestOnly = (): string => html`
       <calcite-action icon="x" label="remove" slot="actions-end"></calcite-action>
     </calcite-list-item>
     <calcite-list-item label="Jake T. Dog" description="Part owner of the Tree House">
-      <calcite-action icon="drag" label="drag" scale="s" slot="actions-start"></calcite-action>
+      <calcite-action icon="web" label="Jake T. Dog website" scale="s" slot="actions-start"></calcite-action>
       <calcite-icon scale="l" icon="walking" slot="content-start"></calcite-icon>
       <calcite-avatar scale="l" slot="content-start" thumbnail="${thumbnailImage}"></calcite-avatar>
       <calcite-icon


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
- Adds `dragEnabled` to the `list` knobs
- Modifies the stories with the `"drag"` icon to a different icon, in the event testing is conducted with `dragEnabled`