### PR TITLE
fix: prevent vitetest/ssr errors due to defining components on the server

### DIFF
--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -2,12 +2,15 @@
   "name": "@esri/calcite-components-react",
   "sideEffects": false,
   "version": "1.6.0-next.7",
+  "type": "module",
   "description": "A set of React components that wrap calcite components",
   "license": "SEE LICENSE.md",
   "scripts": {
     "build": "rimraf dist && npm run compile",
+    "prebuild": "npm run patch:ssr",
     "clean": "rimraf dist node_modules .turbo",
     "compile": "npm run tsc",
+    "patch:ssr": "ts-node --esm support/patchSSR.ts",
     "tsc": "tsc"
   },
   "main": "./dist/index.js",

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -2,7 +2,6 @@
   "name": "@esri/calcite-components-react",
   "sideEffects": false,
   "version": "1.6.0-next.7",
-  "type": "module",
   "description": "A set of React components that wrap calcite components",
   "license": "SEE LICENSE.md",
   "scripts": {
@@ -10,7 +9,7 @@
     "prebuild": "npm run patch:ssr",
     "clean": "rimraf dist node_modules .turbo",
     "compile": "npm run tsc",
-    "patch:ssr": "ts-node --esm support/patchSSR.ts",
+    "patch:ssr": "ts-node support/patchSSR.ts",
     "tsc": "tsc"
   },
   "main": "./dist/index.js",

--- a/packages/calcite-components-react/src/auto-define.ts
+++ b/packages/calcite-components-react/src/auto-define.ts
@@ -4,7 +4,7 @@ const isBrowser = (): boolean =>
   window.location === location &&
   window.document === document;
 
-export function autoDefine(component: string) {
+export function autoDefine(component: string): () => Promise<void> | undefined {
   if (isBrowser()) {
     return async () => (await import(`@esri/calcite-components/dist/components/${component}.js`)).defineCustomElement();
   }

--- a/packages/calcite-components-react/src/auto-define.ts
+++ b/packages/calcite-components-react/src/auto-define.ts
@@ -1,0 +1,12 @@
+const isBrowser = (): boolean =>
+  ![typeof window, typeof document, typeof location].includes("undefined") &&
+  [typeof process, typeof global].includes("undefined") &&
+  window.location === location &&
+  window.document === document;
+
+export function autoDefine(component: string) {
+  if (isBrowser()) {
+    return async () => (await import(`@esri/calcite-components/dist/components/${component}.js`)).defineCustomElement();
+  }
+  return undefined;
+}

--- a/packages/calcite-components-react/support/patchSSR.ts
+++ b/packages/calcite-components-react/support/patchSSR.ts
@@ -2,16 +2,14 @@
 // when using the includeImportCustomElements option
 // https://stenciljs.com/docs/react#includeimportcustomelements
 // https://github.com/Esri/calcite-design-system/issues/7486
-(async function () {
-  const {
-    promises: { readFile, writeFile },
-  } = await import("fs");
-  const { dirname, resolve } = await import("path");
-  const { fileURLToPath } = await import("url");
 
+const {
+  promises: { readFile, writeFile },
+} = require("fs");
+const { dirname, resolve } = require("path");
+
+(async () => {
   try {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
     const filePath = resolve(`${__dirname}/../src/components.ts`);
     const contents = await readFile(filePath, { encoding: "utf8" });
 

--- a/packages/calcite-components-react/support/patchSSR.ts
+++ b/packages/calcite-components-react/support/patchSSR.ts
@@ -1,0 +1,34 @@
+// patch needed due to Stencil executing client side code on the server
+// when using the includeImportCustomElements option
+// https://stenciljs.com/docs/react#includeimportcustomelements
+// https://github.com/Esri/calcite-design-system/issues/7486
+(async function () {
+  const {
+    promises: { readFile, writeFile },
+  } = await import("fs");
+  const { dirname, resolve } = await import("path");
+  const { fileURLToPath } = await import("url");
+
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const filePath = resolve(`${__dirname}/../src/components.ts`);
+    const contents = await readFile(filePath, { encoding: "utf8" });
+
+    const defineCustomElementImports = /import { defineCustomElement as defineCalcite.*(\r\n|\r|\n)/gm;
+    const reactWrapperExports = /createReactComponent<(.*)>.*\((['|\w|-]*)(.*)(defineCalcite\w*)\)/g;
+
+    const patchedContents = contents
+      .replace(
+        "import { createReactComponent } from './react-component-lib';",
+        "$&\nimport { autoDefine } from './auto-define';"
+      )
+      .replace(defineCustomElementImports, "")
+      .replace(reactWrapperExports, "createReactComponent<$1>($2$3autoDefine($2))");
+
+    await writeFile(filePath, patchedContents);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/packages/calcite-components-react/support/patchSSR.ts
+++ b/packages/calcite-components-react/support/patchSSR.ts
@@ -6,23 +6,42 @@
 const {
   promises: { readFile, writeFile },
 } = require("fs");
-const { dirname, resolve } = require("path");
+const { resolve } = require("path");
+
+// Matches imports of defineCustomElement from calcite-component's custom-elements output target.
+// Importing defineCustomElement on the server throws errors due to ESM/CJS conflicts and
+// attempting to use browser APIs, which don't exist on the server.
+const defineCustomElementImports = /import { defineCustomElement as defineCalcite.*(\r\n|\r|\n)/gm;
+
+// The removed imports are replaced with autoDefine, which is a wrapper around defineCustomElement
+// to make sure it's only called on the client.
+const autoDefineImport = "import { autoDefine } from './auto-define';";
+
+// Matches createReactComponent exports to add autoDefine instead of defineCustomElement.
+// The regex creates capture groups for the component name and other parts of the line
+// that shouldn't be replaced/removed.
+const reactWrapperExports = /createReactComponent<(.*)>.*\((['|\w|-]*)(.*)(defineCalcite\w*)\)/g;
+
+// The patched version of the createReactComponent export using the capture groups to fill in the blanks
+const patchedReactWrapperExports = "createReactComponent<$1>($2$3autoDefine($2))";
+
+// The autoDefine import is placed below this line
+const reactLibImport = "import { createReactComponent } from './react-component-lib';";
 
 (async () => {
   try {
     const filePath = resolve(`${__dirname}/../src/components.ts`);
     const contents = await readFile(filePath, { encoding: "utf8" });
 
-    const defineCustomElementImports = /import { defineCustomElement as defineCalcite.*(\r\n|\r|\n)/gm;
-    const reactWrapperExports = /createReactComponent<(.*)>.*\((['|\w|-]*)(.*)(defineCalcite\w*)\)/g;
+    if (contents.includes(autoDefineImport)) {
+      console.log("SSR patch: skipping, components.ts is already patched");
+      return;
+    }
 
     const patchedContents = contents
-      .replace(
-        "import { createReactComponent } from './react-component-lib';",
-        "$&\nimport { autoDefine } from './auto-define';"
-      )
+      .replace(reactLibImport, `$&\n${autoDefineImport}`)
       .replace(defineCustomElementImports, "")
-      .replace(reactWrapperExports, "createReactComponent<$1>($2$3autoDefine($2))");
+      .replace(reactWrapperExports, patchedReactWrapperExports);
 
     await writeFile(filePath, patchedContents);
   } catch (err) {


### PR DESCRIPTION
**Related Issue:** #7486

## Summary

Enabling Stencil's [`includeImportCustomElements`](https://stenciljs.com/docs/react#includeimportcustomelements) option prevented SSR and vitetest users from being able to explicitly define the custom elements on the client. This patches the Stencil build to ensure the custom elements aren't defined while on the server.