### PR TITLE
chore(linting): enable one-var rule

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -88,6 +88,7 @@ module.exports = {
     ],
     "no-new-func": "error",
     "no-unneeded-ternary": "error",
+    "one-var": ["error", "never"],
     "react/forbid-component-props": [
       "warn",
       {

--- a/packages/calcite-components/src/components/color-picker/utils.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.ts
@@ -102,7 +102,10 @@ export function hexToRGB(hex: string, hasAlpha = false): RGB | RGBA {
 
   hex = hex.replace("#", "");
 
-  let r: number, g: number, b: number, a: number;
+  let r: number;
+  let g: number;
+  let b: number;
+  let a: number;
   const isShorthand = hex.length === 3 || hex.length === 4;
 
   if (isShorthand) {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Enables [`one-var`](https://eslint.org/docs/latest/rules/one-var) to prevent consecutive variable declarations. This should make it easier to vertically scan (both the variable and type).

`one-var` to rule them all,
&nbsp;&nbsp;&nbsp;`one-var` to find them,
`one-var` to bring them all
&nbsp;&nbsp;&nbsp;and in the darkness bind them.
