### PR TITLE
fix: ensure label only focuses the first labelable child

### DIFF
--- a/packages/calcite-components/src/tests/commonTests.ts
+++ b/packages/calcite-components/src/tests/commonTests.ts
@@ -8,7 +8,7 @@ import { html } from "../../support/formatting";
 import { JSX } from "../components";
 import { hiddenFormInputSlotName } from "../utils/form";
 import { MessageBundle } from "../utils/t9n";
-import { GlobalTestProps, skipAnimations } from "./utils";
+import { getFocusedElementProp, GlobalTestProps, skipAnimations } from "./utils";
 import { InteractiveHTMLElement } from "../utils/interactive";
 
 expect.extend(toHaveNoViolations);
@@ -383,10 +383,10 @@ async function assertLabelable({
   focusTargetSelector?: string;
   shadowFocusTargetSelector?: string;
 }): Promise<void> {
-  let component: E2EElement;
   let initialPropertyValue: boolean;
+  const component = await page.find(componentTag);
+
   if (propertyToToggle) {
-    component = await page.find(componentTag);
     initialPropertyValue = await component.getProperty(propertyToToggle);
   }
 
@@ -422,6 +422,12 @@ async function assertLabelable({
     await page.waitForChanges();
     expect(await component.getProperty(propertyToToggle)).toBe(toggledPropertyValue);
   }
+
+  // assert clicking on labelable keeps focus
+  await component.callMethod("click");
+  await page.waitForChanges();
+
+  expect(await getFocusedElementProp(page, "tagName")).toBe(componentTag.toUpperCase());
 }
 
 interface LabelableOptions extends Pick<FocusableOptions, "focusTargetSelector" | "shadowFocusTargetSelector"> {
@@ -459,118 +465,140 @@ export function labelable(componentTagOrHtml: TagOrHTML, options?: LabelableOpti
     return html.includes("id=") ? html : html.replace(componentTag, `${componentTag} id="${id}" `);
   }
 
-  it("is labelable when component is wrapped in a label", async () => {
-    const wrappedHtml = html`<calcite-label> ${labelTitle} ${componentHtml}</calcite-label>`;
-    const wrappedPage: E2EPage = await newE2EPage({ html: wrappedHtml });
-    await wrappedPage.waitForChanges();
+  describe("label wraps labelables", () => {
+    it("is labelable when component is wrapped in a label", async () => {
+      const wrappedHtml = html`<calcite-label>${labelTitle} ${componentHtml}</calcite-label>`;
+      const wrappedPage: E2EPage = await newE2EPage({ html: wrappedHtml });
+      await wrappedPage.waitForChanges();
 
-    await assertLabelable({
-      page: wrappedPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
+      await assertLabelable({
+        page: wrappedPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
+    });
+
+    it("is labelable when wrapping label is set prior to component", async () => {
+      const labelFirstWrappedPage: E2EPage = await newE2EPage();
+      await labelFirstWrappedPage.setContent(`<calcite-label></calcite-label>`);
+      await labelFirstWrappedPage.waitForChanges();
+      await labelFirstWrappedPage.evaluate((componentHtml: string) => {
+        const template = document.createElement("template");
+        template.innerHTML = `${componentHtml}`.trim();
+        const componentNode = template.content.firstChild;
+        const labelEl = document.querySelector("calcite-label");
+        labelEl.append(componentNode);
+      }, componentHtml);
+      await labelFirstWrappedPage.waitForChanges();
+
+      await assertLabelable({
+        page: labelFirstWrappedPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
+    });
+
+    it("is labelable when a component is set first before being wrapped in a label", async () => {
+      const componentFirstWrappedPage: E2EPage = await newE2EPage();
+      await componentFirstWrappedPage.setContent(`${componentHtml}`);
+      await componentFirstWrappedPage.waitForChanges();
+      await componentFirstWrappedPage.evaluate((id: string) => {
+        const componentEl = document.querySelector(`[id='${id}']`);
+        const labelEl = document.createElement("calcite-label");
+        document.body.append(labelEl);
+        labelEl.append(componentEl);
+      }, id);
+      await componentFirstWrappedPage.waitForChanges();
+
+      await assertLabelable({
+        page: componentFirstWrappedPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
+    });
+
+    it("only sets focus on the first labelable when label is clicked", async () => {
+      const componentFirstWrappedPage: E2EPage = await newE2EPage();
+      await componentFirstWrappedPage.setContent(html`
+        <calcite-label>
+          <!-- duplicate tags should be fine as assertion uses first match -->
+          ${componentHtml.replace(id, `${id}-1`)} ${componentHtml.replace(id, `${id}-2`)}
+          ${componentHtml.replace(id, `${id}-3`)}
+        </calcite-label>
+      `);
+      await componentFirstWrappedPage.waitForChanges();
+
+      await assertLabelable({
+        page: componentFirstWrappedPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector: `#${id}-1`,
+      });
     });
   });
 
-  it("is labelable with label set as a sibling to the component", async () => {
-    const siblingHtml = html`
-      <calcite-label for="${id}">${labelTitle}</calcite-label>
-      ${componentHtml}
-    `;
-    const siblingPage: E2EPage = await newE2EPage({ html: siblingHtml });
-    await siblingPage.waitForChanges();
+  describe("label is sibling to labelables", () => {
+    it("is labelable with label set as a sibling to the component", async () => {
+      const siblingHtml = html`
+        <calcite-label for="${id}">${labelTitle}</calcite-label>
+        ${componentHtml}
+      `;
+      const siblingPage: E2EPage = await newE2EPage({ html: siblingHtml });
+      await siblingPage.waitForChanges();
 
-    await assertLabelable({
-      page: siblingPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
+      await assertLabelable({
+        page: siblingPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
     });
-  });
 
-  it("is labelable when sibling label is set prior to component", async () => {
-    const labelFirstSiblingPage: E2EPage = await newE2EPage();
-    await labelFirstSiblingPage.setContent(`<calcite-label for="${id}"></calcite-label>`);
-    await labelFirstSiblingPage.waitForChanges();
-    await labelFirstSiblingPage.evaluate((componentHtml: string) => {
-      const template = document.createElement("template");
-      template.innerHTML = `${componentHtml}`.trim();
-      const componentNode = template.content.firstChild;
-      document.body.append(componentNode);
-    }, componentHtml);
-    await labelFirstSiblingPage.waitForChanges();
+    it("is labelable when sibling label is set prior to component", async () => {
+      const labelFirstSiblingPage: E2EPage = await newE2EPage();
+      await labelFirstSiblingPage.setContent(`<calcite-label for="${id}"></calcite-label>`);
+      await labelFirstSiblingPage.waitForChanges();
+      await labelFirstSiblingPage.evaluate((componentHtml: string) => {
+        const template = document.createElement("template");
+        template.innerHTML = `${componentHtml}`.trim();
+        const componentNode = template.content.firstChild;
+        document.body.append(componentNode);
+      }, componentHtml);
+      await labelFirstSiblingPage.waitForChanges();
 
-    await assertLabelable({
-      page: labelFirstSiblingPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
+      await assertLabelable({
+        page: labelFirstSiblingPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
     });
-  });
 
-  it("is labelable when wrapping label is set prior to component", async () => {
-    const labelFirstWrappedPage: E2EPage = await newE2EPage();
-    await labelFirstWrappedPage.setContent(`<calcite-label for="${id}"></calcite-label>`);
-    await labelFirstWrappedPage.waitForChanges();
-    await labelFirstWrappedPage.evaluate((componentHtml: string) => {
-      const template = document.createElement("template");
-      template.innerHTML = `${componentHtml}`.trim();
-      const componentNode = template.content.firstChild;
-      const labelEl = document.querySelector("calcite-label");
-      labelEl.append(componentNode);
-    }, componentHtml);
-    await labelFirstWrappedPage.waitForChanges();
+    it("is labelable for a component set before sibling label", async () => {
+      const componentFirstSiblingPage: E2EPage = await newE2EPage({ html: componentHtml });
+      await componentFirstSiblingPage.waitForChanges();
+      await componentFirstSiblingPage.evaluate((id: string) => {
+        const label = document.createElement("calcite-label");
+        label.setAttribute("for", `${id}`);
+        document.body.append(label);
+      }, id);
+      await componentFirstSiblingPage.waitForChanges();
 
-    await assertLabelable({
-      page: labelFirstWrappedPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
-    });
-  });
-
-  it("is labelable for a component set before sibling label", async () => {
-    const componentFirstSiblingPage: E2EPage = await newE2EPage({ html: componentHtml });
-    await componentFirstSiblingPage.waitForChanges();
-    await componentFirstSiblingPage.evaluate((id: string) => {
-      const label = document.createElement("calcite-label");
-      label.setAttribute("for", `${id}`);
-      document.body.append(label);
-    }, id);
-    await componentFirstSiblingPage.waitForChanges();
-
-    await assertLabelable({
-      page: componentFirstSiblingPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
-    });
-  });
-
-  it("is labelable when a component is set first before being wrapped in a label", async () => {
-    const componentFirstWrappedPage: E2EPage = await newE2EPage();
-    await componentFirstWrappedPage.setContent(`${componentHtml}`);
-    await componentFirstWrappedPage.waitForChanges();
-    await componentFirstWrappedPage.evaluate((id: string) => {
-      const componentEl = document.querySelector(`[id='${id}']`);
-      const labelEl = document.createElement("calcite-label");
-      labelEl.setAttribute("for", `${id}`);
-      document.body.append(labelEl);
-      labelEl.append(componentEl);
-    }, id);
-    await componentFirstWrappedPage.waitForChanges();
-
-    await assertLabelable({
-      page: componentFirstWrappedPage,
-      componentTag,
-      propertyToToggle,
-      focusTargetSelector,
-      shadowFocusTargetSelector,
+      await assertLabelable({
+        page: componentFirstSiblingPage,
+        componentTag,
+        propertyToToggle,
+        focusTargetSelector,
+        shadowFocusTargetSelector,
+      });
     });
   });
 }

--- a/packages/calcite-components/src/utils/dom.spec.ts
+++ b/packages/calcite-components/src/utils/dom.spec.ts
@@ -17,6 +17,7 @@ import {
   slotChangeHasAssignedNode,
   slotChangeHasTextContent,
   slotChangeHasContent,
+  isBefore,
 } from "./dom";
 import { guidPattern } from "./guid.spec";
 
@@ -571,6 +572,26 @@ describe("dom", () => {
     it("should return null for non shadowed element", () => {
       document.body.innerHTML = html` <div></div> `;
       expect(getShadowRootNode(document.body.querySelector("div"))).toBe(null);
+    });
+  });
+
+  describe("isBefore", () => {
+    let div1: HTMLDivElement;
+    let div2: HTMLDivElement;
+
+    beforeEach(() => {
+      div1 = document.createElement("div");
+      div2 = document.createElement("div");
+    });
+
+    it("should return true if element A is before element B", () => {
+      document.body.append(div1, div2);
+      expect(isBefore(div1, div2)).toBe(true);
+    });
+
+    it("should return false if element A is after element B", () => {
+      document.body.append(div2, div1);
+      expect(isBefore(div1, div2)).toBe(false);
     });
   });
 });

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -583,3 +583,20 @@ export const focusElementInGroup = (
   focusElement(focusTarget);
   return focusTarget;
 };
+
+/**
+ * This helper determines if an element is before another element in the DOM.
+ *
+ * @param a the reference element to compare
+ * @param b the element to compare against
+ *
+ * @returns true when a is before b in the DOM
+ */
+export function isBefore(a: HTMLElement, b: HTMLElement): boolean {
+  if (a.parentNode !== b.parentNode) {
+    return false;
+  }
+
+  const children = Array.from(a.parentNode.children);
+  return children.indexOf(a) < children.indexOf(b);
+}

--- a/packages/calcite-components/src/utils/label.spec.ts
+++ b/packages/calcite-components/src/utils/label.spec.ts
@@ -70,6 +70,8 @@ describe("label", () => {
         expect(labelable.onLabelClick).toHaveBeenCalledTimes(0);
 
         disconnectLabel(labelable);
+
+        expect(labelable.labelEl).toBeNull();
       });
 
       it("supports for attribute", () => {
@@ -96,7 +98,7 @@ describe("label", () => {
 
         disconnectLabel(labelable);
 
-        expect(labelable.labelEl).toBe(labelEl);
+        expect(labelable.labelEl).toBeNull();
 
         labelEl.click();
 
@@ -130,7 +132,7 @@ describe("label", () => {
 
         disconnectLabel(labelable);
 
-        expect(labelable.labelEl).toBe(labelEl);
+        expect(labelable.labelEl).toBeNull();
 
         labelEl.click();
 
@@ -165,7 +167,7 @@ describe("label", () => {
 
         disconnectLabel(labelable);
 
-        expect(labelable.labelEl).toBe(labelEl);
+        expect(labelable.labelEl).toBeNull();
 
         labelEl.click();
 
@@ -202,7 +204,7 @@ describe("label", () => {
 
         disconnectLabel(labelable);
 
-        expect(labelable.labelEl).toBe(labelEl);
+        expect(labelable.labelEl).toBeNull();
 
         labelEl.click();
 
@@ -250,6 +252,67 @@ describe("label", () => {
         labelEl.click();
 
         expect(outerLabelable.onLabelClick).toHaveBeenCalledTimes(1);
+      });
+
+      it("handles the first labelable child only", () => {
+        document.body.innerHTML = `
+        <calcite-label>
+          label
+          <fake-labelable id="first"></fake-labelable>
+          <fake-labelable id="second"></fake-labelable>
+          <fake-labelable id="third"></fake-labelable>
+        </calcite-label>
+      `;
+
+        const labelEl = document.querySelector<HTMLElement>("calcite-label");
+        const fakeLabelableEl1 = document.querySelector<HTMLElement>("#first");
+        const fakeLabelableEl2 = document.querySelector<HTMLElement>("#second");
+        const fakeLabelableEl3 = document.querySelector<HTMLElement>("#third");
+
+        wireUpFakeLabel(labelEl);
+
+        const labelable1 = createFakeLabelable({ el: fakeLabelableEl1 });
+        const labelable2 = createFakeLabelable({ el: fakeLabelableEl2 });
+        const labelable3 = createFakeLabelable({ el: fakeLabelableEl3 });
+
+        // we connect in reverse order to ensure we test last element handles label click first
+        connectLabel(labelable1);
+        connectLabel(labelable2);
+        connectLabel(labelable3);
+
+        expect(labelable1.labelEl).toBe(labelEl);
+        expect(labelable2.labelEl).toBe(labelEl);
+        expect(labelable3.labelEl).toBe(labelEl);
+
+        labelEl.click();
+
+        expect(labelable1.onLabelClick).toHaveBeenCalledTimes(1); // should be 1
+        expect(labelable2.onLabelClick).toHaveBeenCalledTimes(0);
+        expect(labelable3.onLabelClick).toHaveBeenCalledTimes(0);
+
+        disconnectLabel(labelable1);
+
+        labelEl.click();
+
+        expect(labelable1.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable2.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable3.onLabelClick).toHaveBeenCalledTimes(0);
+
+        disconnectLabel(labelable2);
+
+        labelEl.click();
+
+        expect(labelable1.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable2.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable3.onLabelClick).toHaveBeenCalledTimes(1);
+
+        disconnectLabel(labelable3);
+
+        labelEl.click();
+
+        expect(labelable1.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable2.onLabelClick).toHaveBeenCalledTimes(1);
+        expect(labelable3.onLabelClick).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/calcite-components/src/utils/label.ts
+++ b/packages/calcite-components/src/utils/label.ts
@@ -1,4 +1,4 @@
-import { closestElementCrossShadowBoundary, queryElementRoots } from "./dom";
+import { closestElementCrossShadowBoundary, isBefore, queryElementRoots } from "./dom";
 
 export interface LabelableComponent {
   /**
@@ -37,10 +37,11 @@ export const labelConnectedEvent = "calciteInternalLabelConnected";
 export const labelDisconnectedEvent = "calciteInternalLabelDisconnected";
 
 const labelTagName = "calcite-label";
+const labelToLabelables = new WeakMap<HTMLCalciteLabelElement, LabelableComponent[]>();
 const onLabelClickMap = new WeakMap<HTMLCalciteLabelElement, typeof onLabelClick>();
 const onLabelConnectedMap = new WeakMap<LabelableComponent, typeof onLabelConnected>();
 const onLabelDisconnectedMap = new WeakMap<LabelableComponent, typeof onLabelDisconnected>();
-const unlabeledComponents = new Set<LabelableComponent>();
+const unlabeledComponents = new WeakSet<LabelableComponent>();
 
 const findLabelForComponent = (componentEl: HTMLElement): HTMLCalciteLabelElement | null => {
   const { id } = componentEl;
@@ -95,7 +96,10 @@ function hasAncestorCustomElements(label: HTMLCalciteLabelElement, componentEl: 
 export function connectLabel(component: LabelableComponent): void {
   const labelEl = findLabelForComponent(component.el);
 
-  if (onLabelClickMap.has(labelEl) || (!labelEl && unlabeledComponents.has(component))) {
+  if (
+    (onLabelClickMap.has(labelEl) && labelEl === component.labelEl) ||
+    (!labelEl && unlabeledComponents.has(component))
+  ) {
     return;
   }
 
@@ -103,9 +107,16 @@ export function connectLabel(component: LabelableComponent): void {
 
   if (labelEl) {
     component.labelEl = labelEl;
-    const boundOnLabelClick = onLabelClick.bind(component);
-    onLabelClickMap.set(component.labelEl, boundOnLabelClick);
-    component.labelEl.addEventListener(labelClickEvent, boundOnLabelClick);
+
+    const labelables = labelToLabelables.get(labelEl) || [];
+    labelables.push(component);
+    labelToLabelables.set(labelEl, labelables.sort(sortByDOMOrder));
+
+    if (!onLabelClickMap.has(component.labelEl)) {
+      onLabelClickMap.set(component.labelEl, onLabelClick);
+      component.labelEl.addEventListener(labelClickEvent, onLabelClick);
+    }
+
     unlabeledComponents.delete(component);
     document.removeEventListener(labelConnectedEvent, onLabelConnectedMap.get(component));
     onLabelDisconnectedMap.set(component, boundOnLabelDisconnected);
@@ -131,9 +142,23 @@ export function disconnectLabel(component: LabelableComponent): void {
     return;
   }
 
-  const boundOnLabelClick = onLabelClickMap.get(component.labelEl);
-  component.labelEl.removeEventListener(labelClickEvent, boundOnLabelClick);
-  onLabelClickMap.delete(component.labelEl);
+  const labelables = labelToLabelables.get(component.labelEl);
+
+  if (labelables.length === 1) {
+    component.labelEl.removeEventListener(labelClickEvent, onLabelClickMap.get(component.labelEl));
+    onLabelClickMap.delete(component.labelEl);
+  }
+
+  labelToLabelables.set(
+    component.labelEl,
+    labelables.filter((labelable) => labelable !== component).sort(sortByDOMOrder)
+  );
+
+  component.labelEl = null;
+}
+
+function sortByDOMOrder(a: LabelableComponent, b: LabelableComponent): number {
+  return isBefore(a.el, b.el) ? -1 : 1;
 }
 
 /**
@@ -145,18 +170,24 @@ export function getLabelText(component: LabelableComponent): string {
   return component.label || component.labelEl?.textContent?.trim() || "";
 }
 
-function onLabelClick(this: LabelableComponent, event: CustomEvent<{ sourceEvent: MouseEvent }>): void {
-  if (this.disabled) {
+function onLabelClick(this: HTMLCalciteLabelElement, event: CustomEvent<{ sourceEvent: MouseEvent }>): void {
+  const labelClickTarget = event.detail.sourceEvent.target as HTMLElement;
+  const labelables = labelToLabelables.get(this);
+  const clickedLabelable = labelables.find((labelable) => labelable.el === labelClickTarget);
+  const labelableChildClicked = clickedLabelable && labelables.indexOf(clickedLabelable) > 0;
+
+  if (labelableChildClicked) {
+    // no need to forward click as labelable will receive focus
     return;
   }
 
-  const containedLabelableChildClicked = this.el.contains(event.detail.sourceEvent.target as HTMLElement);
+  const firstLabelable = labelables[0];
 
-  if (containedLabelableChildClicked) {
+  if (firstLabelable.disabled) {
     return;
   }
 
-  this.onLabelClick(event);
+  firstLabelable.onLabelClick(event);
 }
 
 function onLabelConnected(this: LabelableComponent): void {


### PR DESCRIPTION
**Related Issue:** #5070 

## Summary

Ensures label clicks focus on the first labelable child and ignores clicks on labelable children (as they will already receive focus).

### Noteworthy changes

#### `label.ts`

* no longer binds label click handler per labelable

#### `commonTests.ts`/`labelable` test helper

* now asserts that a clicked labelable child will own focus
* grouped tests for both wrapped and sibling use cases
* removed unnecessary `for` usage in wrapped test coverage

### `dom.ts`

* add `isBefore` util to determine DOM order of elements (useful for sorting)