### PR TITLE
fix(list): fixes dragging nested list items

### DIFF
--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -628,8 +628,6 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
       const items = this.queryListItems(true);
 
       items.forEach((item) => {
-        item.selectionAppearance = selectionAppearance;
-        item.selectionMode = selectionMode;
         item.dragHandle = dragEnabled;
       });
 
@@ -641,6 +639,9 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
     items.forEach((item) => {
       item.selectionAppearance = selectionAppearance;
       item.selectionMode = selectionMode;
+    });
+    const dragItems = this.queryListItems(true);
+    dragItems.forEach((item) => {
       item.dragHandle = dragEnabled;
     });
     this.listItems = items;


### PR DESCRIPTION
**Related Issue:** #7540

## Summary

- Fixes parent and nested lists from competing with each other and setting dragEnabled on children
- Only closest parent will now set the dragEnabled property on its direct children
- The furthest parent will control setting `selectionMode` and `selectionAppearance` on all child items.