### PR TITLE
fix(block, block-section): improve a11y

### DIFF
--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -1,4 +1,4 @@
-import { CSS, TEXT } from "./resources";
+import { CSS } from "./resources";
 import { accessible, defaults, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
@@ -87,9 +87,8 @@ describe("calcite-block-section", () => {
     });
 
     it("can be toggled", async () => {
-      const page = await newE2EPage({
-        html: `<calcite-block-section toggle-display="switch"></calcite-block-section>`,
-      });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-block-section text="text" toggle-display="switch"></calcite-block-section>`);
       await assertToggleBehavior(page);
     });
 
@@ -119,7 +118,8 @@ describe("calcite-block-section", () => {
     });
 
     it("can be toggled", async () => {
-      const page = await newE2EPage({ html: "<calcite-block-section></calcite-block-section>" });
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-block-section text="text"></calcite-block-section>`);
       await assertToggleBehavior(page);
     });
   });
@@ -172,20 +172,28 @@ describe("calcite-block-section", () => {
     const element = await page.find("calcite-block-section");
     const toggleSpy = await element.spyOnEvent("calciteBlockSectionToggle");
     const toggle = await page.find(`calcite-block-section >>> .${CSS.toggle}`);
+    const text = await element.getProperty("text");
 
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    function getExpectedAriaExpandedValue(open: boolean): string | null {
+      return toggle.classList.contains(CSS.toggleSwitch) ? null : open.toString();
+    }
+
+    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
+    expect(toggle.getAttribute("aria-label")).toBe(text);
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
+    expect(toggle.getAttribute("aria-label")).toBe(text);
+    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(true));
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-label")).toBe(text);
+    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
 
     const keyboardToggleEmitter =
       toggle.tagName === "CALCITE-ACTION"
@@ -206,13 +214,15 @@ describe("calcite-block-section", () => {
 
     expect(toggleSpy).toHaveReceivedEventTimes(3);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
+    expect(toggle.getAttribute("aria-label")).toBe(text);
+    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(true));
 
     await keyboardToggleEmitter.press("Enter");
     await page.waitForChanges();
 
     expect(toggleSpy).toHaveReceivedEventTimes(4);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-label")).toBe(text);
+    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
   }
 });

--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -172,28 +172,20 @@ describe("calcite-block-section", () => {
     const element = await page.find("calcite-block-section");
     const toggleSpy = await element.spyOnEvent("calciteBlockSectionToggle");
     const toggle = await page.find(`calcite-block-section >>> .${CSS.toggle}`);
-    const text = await element.getProperty("text");
 
-    function getExpectedAriaExpandedValue(open: boolean): string | null {
-      return toggle.classList.contains(CSS.toggleSwitch) ? null : open.toString();
-    }
-
-    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
-    expect(toggle.getAttribute("aria-label")).toBe(text);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(text);
-    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(true));
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(text);
-    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
     const keyboardToggleEmitter =
       toggle.tagName === "CALCITE-ACTION"
@@ -214,15 +206,13 @@ describe("calcite-block-section", () => {
 
     expect(toggleSpy).toHaveReceivedEventTimes(3);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(text);
-    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(true));
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
 
     await keyboardToggleEmitter.press("Enter");
     await page.waitForChanges();
 
     expect(toggleSpy).toHaveReceivedEventTimes(4);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(text);
-    expect(toggle.getAttribute("aria-expanded")).toBe(getExpectedAriaExpandedValue(false));
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
   }
 });

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -60,11 +60,18 @@
   word-wrap: anywhere;
 }
 
-.toggle--switch {
-  calcite-switch {
-    @apply pointer-events-none;
+.toggle--switch-container {
+  @apply flex items-center relative bg-transparent w-full;
+
+  .focus-guard {
+    --calcite-label-margin-bottom: 0;
+    @apply absolute pointer-events-none;
+    inset-inline-end: 0;
     margin-inline-start: theme("margin.1");
   }
+}
+
+.toggle--switch {
   .status-icon {
     margin-inline-start: theme("margin.2");
   }

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -25,14 +25,13 @@ import {
 import { Status } from "../interfaces";
 import { BlockSectionMessages } from "./assets/block-section/t9n";
 import { BlockSectionToggleDisplay } from "./interfaces";
-import { CSS, ICONS } from "./resources";
+import { CSS, ICONS, IDS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
   setComponentLoaded,
   setUpLoadableComponent,
 } from "../../utils/loadable";
-import { guid } from "../../utils/guid";
 
 /**
  * @slot - A slot for adding custom content.
@@ -116,8 +115,6 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockSectionElement;
-
-  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -213,49 +210,50 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
 
     const toggleLabel = open ? messages.collapse : messages.expand;
 
-    const { guid } = this;
-    const contentId = `${guid}-content`;
-    const toggleId = `${guid}-toggle`;
-    const headerId = `${guid}-header`;
-
     const headerNode =
       toggleDisplay === "switch" ? (
         <div
-          aria-controls={contentId}
-          aria-expanded={toAriaBoolean(open)}
-          aria-labelledby={headerId}
           class={{
-            [CSS.toggle]: true,
-            [CSS.toggleSwitch]: true,
+            [CSS.toggleSwitchContainer]: true,
           }}
-          id={toggleId}
-          onClick={this.toggleSection}
-          onKeyDown={this.handleHeaderKeyDown}
-          role="button"
-          tabIndex={0}
-          title={toggleLabel}
         >
-          <div class={CSS.toggleSwitchContent} id={headerId}>
-            <span class={CSS.toggleSwitchText}>{text}</span>
+          <div
+            aria-controls={IDS.content}
+            aria-expanded={toAriaBoolean(open)}
+            class={{
+              [CSS.toggle]: true,
+              [CSS.toggleSwitch]: true,
+            }}
+            id={IDS.toggle}
+            onClick={this.toggleSection}
+            onKeyDown={this.handleHeaderKeyDown}
+            role="button"
+            tabIndex={0}
+            title={toggleLabel}
+          >
+            <div class={CSS.toggleSwitchContent}>
+              <span class={CSS.toggleSwitchText}>{text}</span>
+            </div>
+            {this.renderStatusIcon()}
           </div>
-          <calcite-switch aria-hidden="true" checked={open} scale="s" tabIndex={-1} />
-          {this.renderStatusIcon()}
+          {/* we use calcite-label to use a simple component that will allow us to prevent keyboard focus by setting tabindex="-1" on the host */}
+          <calcite-label class={CSS.focusGuard} layout="inline" tabIndex={-1}>
+            <calcite-switch checked={open} label={toggleLabel} scale="s" />
+          </calcite-label>
         </div>
       ) : (
         <button
-          aria-controls={contentId}
+          aria-controls={IDS.content}
           aria-expanded={toAriaBoolean(open)}
           class={{
             [CSS.sectionHeader]: true,
             [CSS.toggle]: true,
           }}
-          id={toggleId}
+          id={IDS.toggle}
           onClick={this.toggleSection}
         >
           <calcite-icon icon={arrowIcon} scale="s" />
-          <span class={CSS.sectionHeaderText} id={headerId}>
-            {text}
-          </span>
+          <span class={CSS.sectionHeaderText}>{text}</span>
           {this.renderStatusIcon()}
         </button>
       );
@@ -263,13 +261,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
     return (
       <Host>
         {headerNode}
-        <section
-          aria-labelledby={toggleId}
-          aria-live="polite"
-          class={CSS.content}
-          hidden={!open}
-          id={contentId}
-        >
+        <section aria-labelledby={IDS.toggle} class={CSS.content} hidden={!open} id={IDS.content}>
           <slot />
         </section>
       </Host>

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -13,7 +13,6 @@ import {
 } from "@stencil/core";
 
 import { focusFirstTabbable, getElementDir, toAriaBoolean } from "../../utils/dom";
-import { guid } from "../../utils/guid";
 import { isActivationKey } from "../../utils/key";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
 import {
@@ -26,7 +25,7 @@ import {
 import { Status } from "../interfaces";
 import { BlockSectionMessages } from "./assets/block-section/t9n";
 import { BlockSectionToggleDisplay } from "./interfaces";
-import { CSS, ICONS } from "./resources";
+import { CSS, ICONS, IDS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
@@ -116,8 +115,6 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockSectionElement;
-
-  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -213,27 +210,24 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
 
     const toggleLabel = open ? messages.collapse : messages.expand;
 
-    const { guid } = this;
-    const regionId = `${guid}-region`;
-    const buttonId = `${guid}-button`;
-
     const headerNode =
       toggleDisplay === "switch" ? (
         <div
-          aria-controls={regionId}
+          aria-controls={IDS.content}
           aria-expanded={toAriaBoolean(open)}
+          aria-labelledby={IDS.header}
           class={{
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true,
           }}
-          id={buttonId}
+          id={IDS.toggle}
           onClick={this.toggleSection}
           onKeyDown={this.handleHeaderKeyDown}
           role="button"
           tabIndex={0}
           title={toggleLabel}
         >
-          <div class={CSS.toggleSwitchContent}>
+          <div class={CSS.toggleSwitchContent} id={IDS.header}>
             <span class={CSS.toggleSwitchText}>{text}</span>
           </div>
           <calcite-switch aria-hidden="true" checked={open} scale="s" tabIndex={-1} />
@@ -241,17 +235,19 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
         </div>
       ) : (
         <button
-          aria-controls={regionId}
+          aria-controls={IDS.content}
           aria-expanded={toAriaBoolean(open)}
           class={{
             [CSS.sectionHeader]: true,
             [CSS.toggle]: true,
           }}
-          id={buttonId}
+          id={IDS.toggle}
           onClick={this.toggleSection}
         >
           <calcite-icon icon={arrowIcon} scale="s" />
-          <span class={CSS.sectionHeaderText}>{text}</span>
+          <span class={CSS.sectionHeaderText} id={IDS.header}>
+            {text}
+          </span>
           {this.renderStatusIcon()}
         </button>
       );
@@ -259,7 +255,13 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
     return (
       <Host>
         {headerNode}
-        <section aria-labelledby={buttonId} class={CSS.content} hidden={!open} id={regionId}>
+        <section
+          aria-labelledby={IDS.toggle}
+          aria-live="polite"
+          class={CSS.content}
+          hidden={!open}
+          id={IDS.content}
+        >
           <slot />
         </section>
       </Host>

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -25,13 +25,14 @@ import {
 import { Status } from "../interfaces";
 import { BlockSectionMessages } from "./assets/block-section/t9n";
 import { BlockSectionToggleDisplay } from "./interfaces";
-import { CSS, ICONS, IDS } from "./resources";
+import { CSS, ICONS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
   setComponentLoaded,
   setUpLoadableComponent,
 } from "../../utils/loadable";
+import { guid } from "../../utils/guid";
 
 /**
  * @slot - A slot for adding custom content.
@@ -115,6 +116,8 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockSectionElement;
+
+  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -210,24 +213,29 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
 
     const toggleLabel = open ? messages.collapse : messages.expand;
 
+    const { guid } = this;
+    const contentId = `${guid}-content`;
+    const toggleId = `${guid}-toggle`;
+    const headerId = `${guid}-header`;
+
     const headerNode =
       toggleDisplay === "switch" ? (
         <div
-          aria-controls={IDS.content}
+          aria-controls={contentId}
           aria-expanded={toAriaBoolean(open)}
-          aria-labelledby={IDS.header}
+          aria-labelledby={headerId}
           class={{
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true,
           }}
-          id={IDS.toggle}
+          id={toggleId}
           onClick={this.toggleSection}
           onKeyDown={this.handleHeaderKeyDown}
           role="button"
           tabIndex={0}
           title={toggleLabel}
         >
-          <div class={CSS.toggleSwitchContent} id={IDS.header}>
+          <div class={CSS.toggleSwitchContent} id={headerId}>
             <span class={CSS.toggleSwitchText}>{text}</span>
           </div>
           <calcite-switch aria-hidden="true" checked={open} scale="s" tabIndex={-1} />
@@ -235,17 +243,17 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
         </div>
       ) : (
         <button
-          aria-controls={IDS.content}
+          aria-controls={contentId}
           aria-expanded={toAriaBoolean(open)}
           class={{
             [CSS.sectionHeader]: true,
             [CSS.toggle]: true,
           }}
-          id={IDS.toggle}
+          id={toggleId}
           onClick={this.toggleSection}
         >
           <calcite-icon icon={arrowIcon} scale="s" />
-          <span class={CSS.sectionHeaderText} id={IDS.header}>
+          <span class={CSS.sectionHeaderText} id={headerId}>
             {text}
           </span>
           {this.renderStatusIcon()}
@@ -256,11 +264,11 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
       <Host>
         {headerNode}
         <section
-          aria-labelledby={IDS.toggle}
+          aria-labelledby={toggleId}
           aria-live="polite"
           class={CSS.content}
           hidden={!open}
-          id={IDS.content}
+          id={contentId}
         >
           <slot />
         </section>

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -221,7 +221,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
       toggleDisplay === "switch" ? (
         <div
           aria-controls={regionId}
-          aria-label={toggleLabel}
+          aria-label={text}
           class={{
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true,
@@ -241,13 +241,13 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
       ) : (
         <button
           aria-controls={regionId}
-          aria-label={toggleLabel}
+          aria-expanded={toAriaBoolean(open)}
+          aria-label={text}
           class={{
             [CSS.sectionHeader]: true,
             [CSS.toggle]: true,
           }}
           id={buttonId}
-          name={toggleLabel}
           onClick={this.toggleSection}
         >
           <calcite-icon icon={arrowIcon} scale="s" />
@@ -259,7 +259,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
     return (
       <Host>
         {headerNode}
-        <section
+        <article
           aria-expanded={toAriaBoolean(open)}
           aria-labelledby={buttonId}
           class={CSS.content}
@@ -267,7 +267,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
           id={regionId}
         >
           <slot />
-        </section>
+        </article>
       </Host>
     );
   }

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -221,7 +221,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
       toggleDisplay === "switch" ? (
         <div
           aria-controls={regionId}
-          aria-label={text}
+          aria-expanded={toAriaBoolean(open)}
           class={{
             [CSS.toggle]: true,
             [CSS.toggleSwitch]: true,
@@ -229,20 +229,20 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
           id={buttonId}
           onClick={this.toggleSection}
           onKeyDown={this.handleHeaderKeyDown}
+          role="button"
           tabIndex={0}
           title={toggleLabel}
         >
           <div class={CSS.toggleSwitchContent}>
             <span class={CSS.toggleSwitchText}>{text}</span>
           </div>
-          <calcite-switch checked={open} label={toggleLabel} scale="s" tabIndex={-1} />
+          <calcite-switch aria-hidden="true" checked={open} scale="s" tabIndex={-1} />
           {this.renderStatusIcon()}
         </div>
       ) : (
         <button
           aria-controls={regionId}
           aria-expanded={toAriaBoolean(open)}
-          aria-label={text}
           class={{
             [CSS.sectionHeader]: true,
             [CSS.toggle]: true,
@@ -259,15 +259,9 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
     return (
       <Host>
         {headerNode}
-        <article
-          aria-expanded={toAriaBoolean(open)}
-          aria-labelledby={buttonId}
-          class={CSS.content}
-          hidden={!open}
-          id={regionId}
-        >
+        <section aria-labelledby={buttonId} class={CSS.content} hidden={!open} id={regionId}>
           <slot />
-        </article>
+        </section>
       </Host>
     );
   }

--- a/packages/calcite-components/src/components/block-section/resources.ts
+++ b/packages/calcite-components/src/components/block-section/resources.ts
@@ -1,13 +1,20 @@
+export const IDS = {
+  content: "content",
+  toggle: "toggle",
+};
+
 export const CSS = {
   content: "content",
+  focusGuard: "focus-guard",
   invalid: "invalid",
-  toggle: "toggle",
-  toggleSwitch: "toggle--switch",
-  toggleSwitchContent: "toggle--switch__content",
-  toggleSwitchText: "toggle--switch__text",
   sectionHeader: "section-header",
   sectionHeaderText: "section-header__text",
   statusIcon: "status-icon",
+  toggle: "toggle",
+  toggleSwitch: "toggle--switch",
+  toggleSwitchContainer: "toggle--switch-container",
+  toggleSwitchContent: "toggle--switch__content",
+  toggleSwitchText: "toggle--switch__text",
   valid: "valid",
 };
 

--- a/packages/calcite-components/src/components/block-section/resources.ts
+++ b/packages/calcite-components/src/components/block-section/resources.ts
@@ -1,9 +1,3 @@
-export const IDS = {
-  content: "content",
-  header: "header",
-  toggle: "toggle",
-};
-
 export const CSS = {
   content: "content",
   invalid: "invalid",

--- a/packages/calcite-components/src/components/block-section/resources.ts
+++ b/packages/calcite-components/src/components/block-section/resources.ts
@@ -11,11 +11,6 @@ export const CSS = {
   valid: "valid",
 };
 
-export const TEXT = {
-  collapse: "Collapse",
-  expand: "Expand",
-};
-
 export const ICONS = {
   menuOpen: "chevron-down",
   menuClosedLeft: "chevron-left",

--- a/packages/calcite-components/src/components/block-section/resources.ts
+++ b/packages/calcite-components/src/components/block-section/resources.ts
@@ -1,3 +1,9 @@
+export const IDS = {
+  content: "content",
+  header: "header",
+  toggle: "toggle",
+};
+
 export const CSS = {
   content: "content",
   invalid: "invalid",

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { CSS, SLOTS, TEXT } from "./resources";
+import { CSS, SLOTS } from "./resources";
 import { accessible, defaults, disabled, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 
@@ -136,31 +136,34 @@ describe("calcite-block", () => {
   });
 
   it("allows toggling its content", async () => {
-    const page = await newE2EPage({ html: "<calcite-block collapsible></calcite-block>" });
+    const heading = "heading";
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-block collapsible heading=${heading}></calcite-block>`);
+    const messages = await import(`./assets/block/t9n/messages.json`);
 
     const element = await page.find("calcite-block");
     const toggleSpy = await element.spyOnEvent("calciteBlockToggle");
     const toggle = await page.find(`calcite-block >>> .${CSS.toggle}`);
 
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(toggle.getAttribute("title")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("title")).toBe(messages.expand);
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.collapse);
+    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
-    expect(toggle.getAttribute("title")).toBe(TEXT.collapse);
+    expect(toggle.getAttribute("title")).toBe(messages.collapse);
 
     await toggle.click();
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(toggle.getAttribute("title")).toBe(TEXT.expand);
+    expect(toggle.getAttribute("title")).toBe(messages.expand);
   });
 
   describe("header", () => {

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -145,7 +145,6 @@ describe("calcite-block", () => {
     const toggleSpy = await element.spyOnEvent("calciteBlockToggle");
     const toggle = await page.find(`calcite-block >>> .${CSS.toggle}`);
 
-    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(toggle.getAttribute("title")).toBe(messages.expand);
 
@@ -153,7 +152,6 @@ describe("calcite-block", () => {
 
     expect(toggleSpy).toHaveReceivedEventTimes(1);
     expect(await element.getProperty("open")).toBe(true);
-    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(toggle.getAttribute("title")).toBe(messages.collapse);
 
@@ -161,7 +159,6 @@ describe("calcite-block", () => {
 
     expect(toggleSpy).toHaveReceivedEventTimes(2);
     expect(await element.getProperty("open")).toBe(false);
-    expect(toggle.getAttribute("aria-label")).toBe(heading);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(toggle.getAttribute("title")).toBe(messages.expand);
   });

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -34,14 +34,13 @@ import {
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Status } from "../interfaces";
 import { BlockMessages } from "./assets/block/t9n";
-import { CSS, ICONS, SLOTS } from "./resources";
+import { CSS, ICONS, IDS, SLOTS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
   setComponentLoaded,
   setUpLoadableComponent,
 } from "../../utils/loadable";
-import { guid } from "../../utils/guid";
 
 /**
  * @slot - A slot for adding custom content.
@@ -156,8 +155,6 @@ export class Block
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockElement;
-
-  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -281,13 +278,8 @@ export class Block
 
     const toggleLabel = open ? messages.collapse : messages.expand;
 
-    const { guid } = this;
-    const contentId = `${guid}-content`;
-    const toggleId = `${guid}-toggle`;
-    const headerId = `${guid}-header`;
-
     const headerContent = (
-      <header class={CSS.header} id={headerId}>
+      <header class={CSS.header}>
         {this.renderIcon()}
         {this.renderTitle()}
       </header>
@@ -302,11 +294,10 @@ export class Block
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? (
           <button
-            aria-controls={contentId}
+            aria-controls={IDS.content}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
-            aria-labelledby={headerId}
             class={CSS.toggle}
-            id={toggleId}
+            id={IDS.toggle}
             onClick={this.onHeaderClick}
             title={toggleLabel}
           >
@@ -345,13 +336,7 @@ export class Block
           }}
         >
           {headerNode}
-          <section
-            aria-labelledby={toggleId}
-            aria-live="polite"
-            class={CSS.content}
-            hidden={!open}
-            id={contentId}
-          >
+          <section aria-labelledby={IDS.toggle} class={CSS.content} hidden={!open} id={IDS.content}>
             {this.renderScrim()}
           </section>
         </article>

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -292,7 +292,7 @@ export class Block
     const hasMenuActions = !!getSlotted(el, SLOTS.headerMenuActions);
     const collapseIcon = open ? ICONS.opened : ICONS.closed;
 
-    const { guid } = this;
+    const { guid, heading } = this;
     const regionId = `${guid}-region`;
     const buttonId = `${guid}-button`;
 
@@ -303,7 +303,7 @@ export class Block
           <button
             aria-controls={regionId}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
-            aria-label={toggleLabel}
+            aria-label={heading}
             class={CSS.toggle}
             id={buttonId}
             onClick={this.onHeaderClick}
@@ -344,7 +344,7 @@ export class Block
           }}
         >
           {headerNode}
-          <section
+          <article
             aria-expanded={toAriaBoolean(open)}
             aria-labelledby={buttonId}
             class={CSS.content}
@@ -352,7 +352,7 @@ export class Block
             id={regionId}
           >
             {this.renderScrim()}
-          </section>
+          </article>
         </article>
       </Host>
     );

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -34,13 +34,14 @@ import {
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Status } from "../interfaces";
 import { BlockMessages } from "./assets/block/t9n";
-import { CSS, ICONS, IDS, SLOTS } from "./resources";
+import { CSS, ICONS, SLOTS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
   setComponentLoaded,
   setUpLoadableComponent,
 } from "../../utils/loadable";
+import { guid } from "../../utils/guid";
 
 /**
  * @slot - A slot for adding custom content.
@@ -155,6 +156,8 @@ export class Block
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockElement;
+
+  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -278,8 +281,13 @@ export class Block
 
     const toggleLabel = open ? messages.collapse : messages.expand;
 
+    const { guid } = this;
+    const contentId = `${guid}-content`;
+    const toggleId = `${guid}-toggle`;
+    const headerId = `${guid}-header`;
+
     const headerContent = (
-      <header class={CSS.header} id={IDS.header}>
+      <header class={CSS.header} id={headerId}>
         {this.renderIcon()}
         {this.renderTitle()}
       </header>
@@ -294,11 +302,11 @@ export class Block
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? (
           <button
-            aria-controls={IDS.content}
+            aria-controls={contentId}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
-            aria-labelledby={IDS.header}
+            aria-labelledby={headerId}
             class={CSS.toggle}
-            id={IDS.toggle}
+            id={toggleId}
             onClick={this.onHeaderClick}
             title={toggleLabel}
           >
@@ -338,11 +346,11 @@ export class Block
         >
           {headerNode}
           <section
-            aria-labelledby={IDS.toggle}
+            aria-labelledby={toggleId}
             aria-live="polite"
             class={CSS.content}
             hidden={!open}
-            id={IDS.content}
+            id={contentId}
           >
             {this.renderScrim()}
           </section>

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -292,7 +292,7 @@ export class Block
     const hasMenuActions = !!getSlotted(el, SLOTS.headerMenuActions);
     const collapseIcon = open ? ICONS.opened : ICONS.closed;
 
-    const { guid, heading } = this;
+    const { guid } = this;
     const regionId = `${guid}-region`;
     const buttonId = `${guid}-button`;
 
@@ -303,7 +303,6 @@ export class Block
           <button
             aria-controls={regionId}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
-            aria-label={heading}
             class={CSS.toggle}
             id={buttonId}
             onClick={this.onHeaderClick}
@@ -344,15 +343,9 @@ export class Block
           }}
         >
           {headerNode}
-          <article
-            aria-expanded={toAriaBoolean(open)}
-            aria-labelledby={buttonId}
-            class={CSS.content}
-            hidden={!open}
-            id={regionId}
-          >
+          <section aria-labelledby={buttonId} class={CSS.content} hidden={!open} id={regionId}>
             {this.renderScrim()}
-          </article>
+          </section>
         </article>
       </Host>
     );

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -17,7 +17,6 @@ import {
   disconnectConditionalSlotComponent,
 } from "../../utils/conditionalSlot";
 import { focusFirstTabbable, getSlotted, toAriaBoolean } from "../../utils/dom";
-import { guid } from "../../utils/guid";
 import {
   connectInteractive,
   disconnectInteractive,
@@ -35,7 +34,7 @@ import {
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Status } from "../interfaces";
 import { BlockMessages } from "./assets/block/t9n";
-import { CSS, ICONS, SLOTS } from "./resources";
+import { CSS, ICONS, IDS, SLOTS } from "./resources";
 import {
   componentFocusable,
   LoadableComponent,
@@ -156,8 +155,6 @@ export class Block
   // --------------------------------------------------------------------------
 
   @Element() el: HTMLCalciteBlockElement;
-
-  private guid = guid();
 
   @State() effectiveLocale: string;
 
@@ -282,7 +279,7 @@ export class Block
     const toggleLabel = open ? messages.collapse : messages.expand;
 
     const headerContent = (
-      <header class={CSS.header}>
+      <header class={CSS.header} id={IDS.header}>
         {this.renderIcon()}
         {this.renderTitle()}
       </header>
@@ -292,19 +289,16 @@ export class Block
     const hasMenuActions = !!getSlotted(el, SLOTS.headerMenuActions);
     const collapseIcon = open ? ICONS.opened : ICONS.closed;
 
-    const { guid } = this;
-    const regionId = `${guid}-region`;
-    const buttonId = `${guid}-button`;
-
     const headerNode = (
       <div class={CSS.headerContainer}>
         {this.dragHandle ? <calcite-handle /> : null}
         {collapsible ? (
           <button
-            aria-controls={regionId}
+            aria-controls={IDS.content}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
+            aria-labelledby={IDS.header}
             class={CSS.toggle}
-            id={buttonId}
+            id={IDS.toggle}
             onClick={this.onHeaderClick}
             title={toggleLabel}
           >
@@ -343,7 +337,13 @@ export class Block
           }}
         >
           {headerNode}
-          <section aria-labelledby={buttonId} class={CSS.content} hidden={!open} id={regionId}>
+          <section
+            aria-labelledby={IDS.toggle}
+            aria-live="polite"
+            class={CSS.content}
+            hidden={!open}
+            id={IDS.content}
+          >
             {this.renderScrim()}
           </section>
         </article>

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -1,20 +1,25 @@
+export const IDS = {
+  content: "content",
+  toggle: "toggle",
+};
+
 export const CSS = {
+  button: "button",
   container: "container",
   content: "content",
+  controlContainer: "control-container",
+  description: "description",
+  header: "header",
   headerContainer: "header-container",
+  heading: "heading",
   icon: "icon",
+  invalid: "invalid",
   statusIcon: "status-icon",
+  summary: "summary",
+  title: "title",
   toggle: "toggle",
   toggleIcon: "toggle-icon",
-  title: "title",
-  heading: "heading",
-  header: "header",
-  button: "button",
-  summary: "summary",
-  description: "description",
-  controlContainer: "control-container",
   valid: "valid",
-  invalid: "invalid",
 };
 
 export const SLOTS = {

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -1,3 +1,9 @@
+export const IDS = {
+  content: "content",
+  header: "header",
+  toggle: "toggle",
+};
+
 export const CSS = {
   container: "container",
   content: "content",

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -17,13 +17,6 @@ export const CSS = {
   invalid: "invalid",
 };
 
-export const TEXT = {
-  collapse: "Collapse",
-  expand: "Expand",
-  loading: "Loading",
-  options: "Options",
-};
-
 export const SLOTS = {
   icon: "icon",
   control: "control",

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -1,9 +1,3 @@
-export const IDS = {
-  content: "content",
-  header: "header",
-  toggle: "toggle",
-};
-
 export const CSS = {
   container: "container",
   content: "content",


### PR DESCRIPTION
**Related Issue:** #5565 

## Summary

Updated HTML to improve a11y.

**Note**: this removes references to outdated `TEXT` constants, which were used before translations were built-in.