### PR TITLE
fix(date-picker): set start of week to monday in zh-CN

### DIFF
--- a/packages/calcite-components/src/components/date-picker/assets/date-picker/nls/zh-CN.json
+++ b/packages/calcite-components/src/components/date-picker/assets/date-picker/nls/zh-CN.json
@@ -2,7 +2,7 @@
   "default-calendar": "gregorian",
   "separator": "/",
   "unitOrder": "YYYY/MM/DD",
-  "weekStart": 7,
+  "weekStart": 1,
   "placeholder": "YYYY/MM/DD",
   "days": {
     "abbreviated": ["周日", "周一", "周二", "周三", "周四", "周五", "周六"],


### PR DESCRIPTION
**Related Issue:** #7382

## Summary
Updates the `date-picker` first day of the week in the `zh-CN` locale to Monday (`周一`), previously set as Sunday (`周日`).