### PR TITLE
feat(combobox): add single-persist selection mode

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -83,10 +83,10 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
 
   /**
    * Specifies the selection mode:
-   * - `multiple` allows any number of selected items (default),
-   * - `single` allows only one selection,
-   * - `single-persist` is like single, but does not allow deselecting,
-   * - `ancestors` is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
+   * - "multiple" allows any number of selected items (default),
+   * - "single" allows only one selection,
+   * - "single-persist" allow and require one open item,
+   * - "ancestors" is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    *
    * @internal
    */

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -23,7 +23,7 @@ import {
   updateHostInteraction,
 } from "../../utils/interactive";
 import { ComboboxChildElement } from "../combobox/interfaces";
-import { getAncestors, getDepth } from "../combobox/utils";
+import { getAncestors, getDepth, isSingleLike } from "../combobox/utils";
 import { Scale, SelectionMode } from "../interfaces";
 import { CSS } from "./resources";
 
@@ -85,12 +85,13 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
    * Specifies the selection mode:
    * - `multiple` allows any number of selected items (default),
    * - `single` allows only one selection,
+   * - `single-persist` is like single, but does not allow deselecting,
    * - `ancestors` is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    *
    * @internal
    */
   @Prop({ reflect: true }) selectionMode: Extract<
-    "single" | "ancestors" | "multiple",
+    "single" | "single-persist" | "ancestors" | "multiple",
     SelectionMode
   > = "multiple";
 
@@ -151,7 +152,9 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   // --------------------------------------------------------------------------
 
   toggleSelected(): Promise<void> {
-    if (this.disabled) {
+    const isSinglePersistSelect = this.selectionMode === "single-persist";
+
+    if (this.disabled || (isSinglePersistSelect && this.selected)) {
       return;
     }
 
@@ -222,8 +225,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   }
 
   render(): VNode {
-    const isSingleSelect = this.selectionMode === "single";
-
+    const isSingleSelect = isSingleLike(this.selectionMode);
     const showDot = isSingleSelect && !this.disabled;
     const defaultIcon = isSingleSelect ? "dot" : "check";
     const iconPath = this.disabled ? "circle-disallowed" : defaultIcon;

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -406,6 +406,34 @@ describe("calcite-combobox", () => {
         expect(await combobox.getProperty("value")).toBe("");
       });
 
+      it("single-persist-selection mode does not allow toggling selection once the selected item is clicked", async () => {
+        const page = await newE2EPage();
+        await page.setContent(
+          html`
+            <calcite-combobox selection-mode="single-persist">
+              <calcite-combobox-item value="one" text-label="one"></calcite-combobox-item>
+              <calcite-combobox-item value="two" text-label="two"></calcite-combobox-item>
+            </calcite-combobox>
+          `
+        );
+        const combobox = await page.find("calcite-combobox");
+        const firstOpenEvent = page.waitForEvent("calciteComboboxOpen");
+        await combobox.click();
+        await firstOpenEvent;
+
+        const item1 = await combobox.find("calcite-combobox-item[value=one]");
+
+        await item1.click();
+        expect(await combobox.getProperty("value")).toBe("one");
+
+        const secondOpenEvent = page.waitForEvent("calciteComboboxOpen");
+        await combobox.click();
+        await secondOpenEvent;
+
+        await item1.click();
+        expect(await combobox.getProperty("value")).toBe("one");
+      });
+
       it("multiple-selection mode allows toggling selection once the selected item is clicked", async () => {
         const page = await newE2EPage();
         await page.setContent(

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1188,7 +1188,7 @@ export class Combobox
 
   renderInput(): VNode {
     const { guid, disabled, placeholder, selectionMode, selectedItems, open } = this;
-    const single = selectionMode === "single" || selectionMode === "single-persist";
+    const single = isSingleLike(selectionMode);
     const selectedItem = selectedItems[0];
     const showLabel = !open && single && !!selectedItem;
 
@@ -1285,7 +1285,7 @@ export class Combobox
     const { selectedItems, placeholderIcon, selectionMode, placeholderIconFlipRtl } = this;
     const selectedItem = selectedItems[0];
     const selectedIcon = selectedItem?.icon;
-    const singleSelectionMode = selectionMode === "single" || selectionMode === "single-persist";
+    const singleSelectionMode = isSingleLike(selectionMode);
 
     const iconAtStart =
       !this.open && selectedItem

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -64,7 +64,7 @@ import { Scale, SelectionMode } from "../interfaces";
 import { ComboboxMessages } from "./assets/combobox/t9n";
 import { ComboboxChildElement } from "./interfaces";
 import { ComboboxChildSelector, ComboboxItem, ComboboxItemGroup, CSS } from "./resources";
-import { getItemAncestors, getItemChildren, hasActiveChildren } from "./utils";
+import { getItemAncestors, getItemChildren, hasActiveChildren, isSingleLike } from "./utils";
 import { XButton, CSS as XButtonCSS } from "../functional/XButton";
 
 interface ItemData {
@@ -200,10 +200,11 @@ export class Combobox
    * Specifies the selection mode:
    * - `multiple` allows any number of selected items (default),
    * - `single` allows only one selection,
+   * - `single-persist` is like single, but does not allow deselecting,
    * - `ancestors` is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    */
   @Prop({ reflect: true }) selectionMode: Extract<
-    "single" | "ancestors" | "multiple",
+    "single" | "single-persist" | "ancestors" | "multiple",
     SelectionMode
   > = "multiple";
 
@@ -766,7 +767,7 @@ export class Combobox
       this.addCustomChip(this.text);
     }
 
-    if (this.selectionMode === "single") {
+    if (isSingleLike(this.selectionMode)) {
       if (this.textInput) {
         this.textInput.value = "";
       }
@@ -1003,7 +1004,7 @@ export class Combobox
   }
 
   getNeedsIcon(): boolean {
-    return this.selectionMode === "single" && this.items.some((item) => item.icon);
+    return isSingleLike(this.selectionMode) && this.items.some((item) => item.icon);
   }
 
   resetText(): void {
@@ -1134,7 +1135,7 @@ export class Combobox
   }
 
   isMulti(): boolean {
-    return this.selectionMode !== "single";
+    return this.selectionMode !== "single" && this.selectionMode !== "single-persist";
   }
 
   comboboxFocusHandler = (): void => {
@@ -1187,7 +1188,7 @@ export class Combobox
 
   renderInput(): VNode {
     const { guid, disabled, placeholder, selectionMode, selectedItems, open } = this;
-    const single = selectionMode === "single";
+    const single = selectionMode === "single" || selectionMode === "single-persist";
     const selectedItem = selectedItems[0];
     const showLabel = !open && single && !!selectedItem;
 
@@ -1284,7 +1285,7 @@ export class Combobox
     const { selectedItems, placeholderIcon, selectionMode, placeholderIconFlipRtl } = this;
     const selectedItem = selectedItems[0];
     const selectedIcon = selectedItem?.icon;
-    const singleSelectionMode = selectionMode === "single";
+    const singleSelectionMode = selectionMode === "single" || selectionMode === "single-persist";
 
     const iconAtStart =
       !this.open && selectedItem
@@ -1316,7 +1317,7 @@ export class Combobox
 
   render(): VNode {
     const { guid, label, open } = this;
-    const single = this.selectionMode === "single";
+    const single = isSingleLike(this.selectionMode);
     const isClearable = !this.clearDisabled && this.value?.length > 0;
 
     return (

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -198,10 +198,10 @@ export class Combobox
 
   /**
    * Specifies the selection mode:
-   * - `multiple` allows any number of selected items (default),
-   * - `single` allows only one selection,
-   * - `single-persist` is like single, but does not allow deselecting,
-   * - `ancestors` is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
+   * - "multiple" allows any number of selected items (default),
+   * - "single" allows only one selection,
+   * - "single-persist" allow and require one open item,
+   * - "ancestors" is like multiple, but shows ancestors of selected items as selected, with only deepest children shown in chips.
    */
   @Prop({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "ancestors" | "multiple",

--- a/packages/calcite-components/src/components/combobox/utils.ts
+++ b/packages/calcite-components/src/components/combobox/utils.ts
@@ -2,6 +2,7 @@ import { nodeListToArray } from "../../utils/dom";
 import { ComboboxChildElement } from "./interfaces";
 import { ComboboxChildSelector } from "./resources";
 import { Build } from "@stencil/core";
+import { Combobox } from "./combobox";
 
 export function getAncestors(element: HTMLElement): ComboboxChildElement[] {
   const parent: ComboboxChildElement = element.parentElement?.closest(ComboboxChildSelector);
@@ -38,4 +39,8 @@ export function getDepth(element: HTMLElement): number {
   );
 
   return result.snapshotLength;
+}
+
+export function isSingleLike(selectionMode: Combobox["selectionMode"]): boolean {
+  return selectionMode.includes("single");
 }

--- a/packages/calcite-components/src/demos/combobox.html
+++ b/packages/calcite-components/src/demos/combobox.html
@@ -336,6 +336,127 @@
         </div>
       </div>
 
+      <div class="parent">
+        <div class="child right-aligned-text">Single-persist select</div>
+
+        <div class="child">
+          <calcite-label for="labelSeven">label</calcite-label>
+          <calcite-combobox
+            id="labelSeven"
+            label="test"
+            placeholder="select element"
+            max-items="6"
+            selection-mode="single-persist"
+            scale="s"
+          >
+            <calcite-combobox-item
+              value="New Item"
+              constant
+              text-label="Add new plant"
+              filter-disabled
+            ></calcite-combobox-item>
+            <calcite-combobox-item value="Trees" text-label="Trees">
+              <calcite-combobox-item value="Pine" text-label="Pine">
+                <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+              </calcite-combobox-item>
+              <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+              <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Flowers" text-label="Flowers">
+              <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+              <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+              <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Animals" text-label="Animals">
+              <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+              <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+              <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+            <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+            <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+          </calcite-combobox>
+        </div>
+
+        <div class="child">
+          <calcite-label for="labelEight">label</calcite-label>
+          <calcite-combobox
+            id="labelEight"
+            label="test"
+            placeholder="select element"
+            max-items="6"
+            selection-mode="single-persist"
+            scale="m"
+          >
+            <calcite-combobox-item
+              value="New Item"
+              constant
+              text-label="Add new plant"
+              filter-disabled
+            ></calcite-combobox-item>
+            <calcite-combobox-item value="Trees" text-label="Trees">
+              <calcite-combobox-item value="Pine" text-label="Pine">
+                <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+              </calcite-combobox-item>
+              <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+              <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Flowers" text-label="Flowers">
+              <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+              <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+              <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Animals" text-label="Animals">
+              <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+              <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+              <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+            <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+            <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+          </calcite-combobox>
+        </div>
+
+        <div class="child">
+          <calcite-label for="labelNine">label</calcite-label>
+          <calcite-combobox
+            id="labelNine"
+            label="test"
+            placeholder="select element"
+            max-items="6"
+            selection-mode="single-persist"
+            scale="l"
+          >
+            <calcite-combobox-item
+              value="New Item"
+              constant
+              text-label="Add new plant"
+              filter-disabled
+            ></calcite-combobox-item>
+            <calcite-combobox-item value="Trees" text-label="Trees">
+              <calcite-combobox-item value="Pine" text-label="Pine">
+                <calcite-combobox-item value="Pine Nested" text-label="Pine Nested"></calcite-combobox-item>
+              </calcite-combobox-item>
+              <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+              <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Flowers" text-label="Flowers">
+              <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
+              <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+              <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Animals" text-label="Animals">
+              <calcite-combobox-item value="Birds" text-label="Birds"></calcite-combobox-item>
+              <calcite-combobox-item value="Reptiles" text-label="Reptiles"></calcite-combobox-item>
+              <calcite-combobox-item value="Amphibians" text-label="Amphibians"></calcite-combobox-item>
+            </calcite-combobox-item>
+            <calcite-combobox-item value="Rocks" text-label="Rocks"></calcite-combobox-item>
+            <calcite-combobox-item value="Insects" text-label="Insects"></calcite-combobox-item>
+            <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+          </calcite-combobox>
+        </div>
+      </div>
+
       <!-- A horizontal line -->
       <hr />
 


### PR DESCRIPTION
**Related Issue:** #4738 

## Summary

Adds `single-persist` mode to `calcite-combobox` to allow users to opt-in to this change in selection behavior (vs making it a breaking change on the current `single` selection mode). 

`clearDisabled` would behave the same way unless we want to make an exception to this mode.
