### PR TITLE
fix(modal): catch error when beforeClose promise is rejected

### DIFF
--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -196,7 +196,7 @@ it("should handle rejected 'beforeClose' promise'", async () => {
   await page.setContent(`<calcite-modal open></calcite-modal>`);
 
   await page.$eval(
-    "calcite-flow-item",
+    "calcite-modal",
     (elm: HTMLCalciteModalElement) =>
       (elm.beforeClose = (window as typeof window & Pick<typeof elm, "beforeClose">).beforeClose)
   );

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -208,6 +208,27 @@ it("should handle rejected 'beforeClose' promise'", async () => {
   expect(mockCallBack).toHaveBeenCalledTimes(1);
 });
 
+it("should remain open with rejected 'beforeClose' promise'", async () => {
+  const page = await newE2EPage();
+
+  await page.exposeFunction("beforeClose", () => Promise.reject());
+  await page.setContent(`<calcite-modal open></calcite-modal>`);
+
+  await page.$eval(
+    "calcite-modal",
+    (elm: HTMLCalciteModalElement) =>
+      (elm.beforeClose = (window as typeof window & Pick<typeof elm, "beforeClose">).beforeClose)
+  );
+
+  const modal = await page.find("calcite-modal");
+  modal.setProperty("open", false);
+  await page.waitForChanges();
+
+  expect(await modal.getProperty("open")).toBe(true);
+  expect(await modal.getProperty("opened")).toBe(true);
+  expect(modal.getAttribute("open")).toBe(""); // Makes sure attribute is added back
+});
+
 describe("opening and closing behavior", () => {
   it("opens and closes", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -190,7 +190,7 @@ it("calls the beforeClose method prior to closing via attribute", async () => {
 it("should handle rejected 'beforeClose' promise'", async () => {
   const page = await newE2EPage();
 
-  const mockCallBack = jest.fn().mockReturnValue(Promise.reject());
+  const mockCallBack = jest.fn().mockReturnValue(() => Promise.reject());
   await page.exposeFunction("beforeClose", mockCallBack);
 
   await page.setContent(`<calcite-modal open></calcite-modal>`);

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -187,6 +187,27 @@ it("calls the beforeClose method prior to closing via attribute", async () => {
   expect(await modal.getProperty("opened")).toBe(false);
 });
 
+it("should handle rejected 'beforeClose' promise'", async () => {
+  const page = await newE2EPage();
+
+  const mockCallBack = jest.fn().mockReturnValue(Promise.reject());
+  await page.exposeFunction("beforeClose", mockCallBack);
+
+  await page.setContent(`<calcite-modal open></calcite-modal>`);
+
+  await page.$eval(
+    "calcite-flow-item",
+    (elm: HTMLCalciteModalElement) =>
+      (elm.beforeClose = (window as typeof window & Pick<typeof elm, "beforeClose">).beforeClose)
+  );
+
+  const modal = await page.find("calcite-modal");
+  modal.setProperty("open", false);
+  await page.waitForChanges();
+
+  expect(mockCallBack).toHaveBeenCalledTimes(1);
+});
+
 describe("opening and closing behavior", () => {
   it("opens and closes", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -557,7 +557,11 @@ export class Modal
     }
 
     if (this.beforeClose) {
-      await this.beforeClose(this.el);
+      try {
+        await this.beforeClose(this.el);
+      } catch (_error) {
+        return;
+      }
     }
 
     this.ignoreOpenChange = true;

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -503,6 +503,10 @@ export class Modal
 
   @Watch("open")
   async toggleModal(value: boolean): Promise<void> {
+    if (this.ignoreOpenChange) {
+      return;
+    }
+
     onToggleOpenCloseComponent(this);
     if (value) {
       this.transitionEl?.classList.add(CSS.openingIdle);
@@ -560,6 +564,12 @@ export class Modal
       try {
         await this.beforeClose(this.el);
       } catch (_error) {
+        // close prevented
+        requestAnimationFrame(() => {
+          this.ignoreOpenChange = true;
+          this.open = true;
+          this.ignoreOpenChange = false;
+        });
         return;
       }
     }


### PR DESCRIPTION
**Related Issue:** #6381

## Summary

- catch error when beforeClose promise is rejected