### PR TITLE
fix(flow): catch error when beforeBack promise is rejected

### DIFF
--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -116,6 +116,27 @@ describe("calcite-flow", () => {
       expect(mockCallBack).toHaveBeenCalledTimes(1);
     });
 
+    it("should handle rejected 'beforeBack' promise'", async () => {
+      const page = await newE2EPage();
+
+      const mockCallBack = jest.fn().mockReturnValue(Promise.reject());
+      await page.exposeFunction("beforeBack", mockCallBack);
+
+      await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
+
+      await page.$eval(
+        "calcite-flow-item",
+        (elm: HTMLCalciteFlowItemElement) =>
+          (elm.beforeBack = (window as typeof window & Pick<typeof elm, "beforeBack">).beforeBack)
+      );
+
+      const flow = await page.find("calcite-flow");
+
+      await flow.callMethod("back");
+
+      expect(mockCallBack).toHaveBeenCalledTimes(1);
+    });
+
     it("frame advancing should add animation class", async () => {
       const page = await newE2EPage();
 

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -119,7 +119,7 @@ describe("calcite-flow", () => {
     it("should handle rejected 'beforeBack' promise'", async () => {
       const page = await newE2EPage();
 
-      const mockCallBack = jest.fn().mockReturnValue(Promise.reject());
+      const mockCallBack = jest.fn().mockReturnValue(() => Promise.reject());
       await page.exposeFunction("beforeBack", mockCallBack);
 
       await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -102,6 +102,8 @@ describe("calcite-flow", () => {
 
       await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
 
+      expect(await page.findAll("calcite-flow-item")).toHaveLength(1);
+
       await page.$eval(
         "calcite-flow-item",
         (elm: HTMLCalciteFlowItemElement) =>
@@ -114,6 +116,7 @@ describe("calcite-flow", () => {
 
       expect(backValue).toBeDefined();
       expect(mockCallBack).toHaveBeenCalledTimes(1);
+      expect(await page.findAll("calcite-flow-item")).toHaveLength(0);
     });
 
     it("should handle rejected 'beforeBack' promise'", async () => {
@@ -135,6 +138,28 @@ describe("calcite-flow", () => {
       await flow.callMethod("back");
 
       expect(mockCallBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not remove flow-item on rejected 'beforeBack' promise'", async () => {
+      const page = await newE2EPage();
+
+      await page.exposeFunction("beforeBack", () => Promise.reject());
+
+      await page.setContent(`<calcite-flow><calcite-flow-item></calcite-flow-item></calcite-flow>`);
+
+      expect(await page.findAll("calcite-flow-item")).toHaveLength(1);
+
+      await page.$eval(
+        "calcite-flow-item",
+        (elm: HTMLCalciteFlowItemElement) =>
+          (elm.beforeBack = (window as typeof window & Pick<typeof elm, "beforeBack">).beforeBack)
+      );
+
+      const flow = await page.find("calcite-flow");
+
+      await flow.callMethod("back");
+
+      expect(await page.findAll("calcite-flow-item")).toHaveLength(1);
     });
 
     it("frame advancing should add animation class", async () => {

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -44,6 +44,7 @@ export class Flow implements LoadableComponent {
     try {
       await beforeBack.call(lastItem);
     } catch (_error) {
+      // back prevented
       return;
     }
 

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -41,7 +41,11 @@ export class Flow implements LoadableComponent {
       ? lastItem.beforeBack
       : (): Promise<void> => Promise.resolve();
 
-    await beforeBack.call(lastItem);
+    try {
+      await beforeBack.call(lastItem);
+    } catch (_error) {
+      return;
+    }
 
     lastItem.remove();
 


### PR DESCRIPTION
**Related Issue:** None

## Summary

- catch error when beforeBack promise is rejected
