### PR TITLE
feat(flow): add support for custom flow-item elements

### DIFF
--- a/packages/calcite-components/conventions/README.md
+++ b/packages/calcite-components/conventions/README.md
@@ -409,3 +409,33 @@ The [`globalAttributes`](../src/utils/globalAttributes.ts) util was specifically
 ### BigDecimal
 
 `BigDecimal` is a [number util](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/src/utils/number.ts) that helps with [arbitrary precision arithmetic](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). The util is adopted from a [Stack Overflow answer](https://stackoverflow.com/a/66939244) with some small changes. There are some usage examples in [`number.spec.ts`](../src/utils/number.spec.ts).
+
+### Custom child element support
+
+In order to support certain architectures, parent components might need to handle custom elements that wrap their expected child items within shadow DOM that would prevent discovery when querying the DOM.
+
+For such cases, the following pattern will enable developers to create custom child/item components and have them work seamlessly with parent components.
+
+#### Parent component
+
+- Must provide a `customItemSelectors` property to allow querying for custom elements in addition to their expected children.
+- An interface for `HTML<ChildComponentItem>Element` must be created in the parent's `interfaces.d.ts` file, where the necessary child APIs must be extracted.
+  **`parent/interfaces.d.ts`**
+  ```ts
+  type ChildComponentLike = Pick<HTMLCalciteChildElement, "required" | "props" | "from" | "parent"> & HTMLElement;
+  ```
+  **`parent/parent.tsx`**
+  ```tsx
+    @Prop() selectedItem: HTMLChildComponentElement | ChildComponentLike;
+  ```
+
+#### Custom child component
+
+- Must implement the element interface expected by the parent (e.g., `ChildComponentLike`).
+
+#### Notes
+
+- This pattern should be applied sparingly and on a case-by-case basis.
+- We can refine this pattern as we go on, but additional modifications needed to handle the custom items workflow will be considered out-of-scope and thus not supported.
+- Until we have documentation covering creating custom elements, `customItemSelectors` must be made internal and any `ChildComponentLike` types must be excluded from the doc.
+- Please refer to https://github.com/Esri/calcite-design-system/pull/7608/ as an example on how this pattern is applied.

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -298,7 +298,7 @@ describe("calcite-flow", () => {
   it("supports custom flow-items", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
-      <calcite-flow extra-item-selector="custom-flow-item">
+      <calcite-flow custom-item-selectors="custom-flow-item">
         <calcite-flow-item heading="flow-item-1" id="first">
           <p>😃</p>
         </calcite-flow-item>

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -5,6 +5,7 @@ import { accessible, focusable, hidden, renders } from "../../tests/commonTests"
 import { CSS as ITEM_CSS } from "../flow-item/resources";
 import { CSS } from "./resources";
 import { isElementFocused } from "../../tests/utils";
+import { FlowItemLikeElement } from "./interfaces";
 
 describe("calcite-flow", () => {
   describe("renders", () => {
@@ -292,5 +293,138 @@ describe("calcite-flow", () => {
       expect(items[4].getAttribute("hidden")).toBe(null);
       expect(await items[4].getProperty("showBackButton")).toBe(false);
     });
+  });
+
+  it("supports custom flow-items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-flow extra-item-selector="custom-flow-item">
+        <calcite-flow-item heading="flow-item-1" id="first">
+          <p>😃</p>
+        </calcite-flow-item>
+        <custom-flow-item heading="custom-flow-item" id="second">
+          <p>🥸</p>
+        </custom-flow-item>
+        <calcite-flow-item heading="flow-item-2" id="third">
+          <p>😃</p>
+        </calcite-flow-item>
+      </calcite-flow>
+    `);
+
+    await page.evaluate(async () => {
+      class CustomFlowItem extends HTMLElement implements FlowItemLikeElement {
+        private flowItemEl: HTMLCalciteFlowItemElement;
+
+        constructor() {
+          super();
+          const shadow = this.attachShadow({ mode: "open" });
+
+          shadow.innerHTML = `
+                <style>
+                  :host {
+                    display: flex;
+                    background: #bdf2c4;
+                  }
+                </style>
+                <calcite-flow-item id="internalFlowItem">
+                  <slot></slot>
+                </calcite-flow-item>
+              `;
+
+          this.flowItemEl = shadow.getElementById("internalFlowItem") as HTMLCalciteFlowItemElement;
+        }
+
+        connectedCallback(): void {
+          this.flowItemEl.setAttribute("heading", this.getAttribute("heading"));
+          this.flowItemEl.setAttribute("show-back-button", this.getAttribute("show-back-button"));
+          this.flowItemEl.setAttribute("menu-open", this.getAttribute("menu-open"));
+        }
+
+        get heading(): string {
+          return this.getAttribute("heading");
+        }
+
+        set heading(value: string) {
+          this.flowItemEl.heading = value;
+        }
+
+        get hidden(): boolean {
+          return this.hasAttribute("hidden");
+        }
+
+        set hidden(value: boolean) {
+          this.toggleAttribute("hidden", value);
+          this.flowItemEl.toggleAttribute("hidden", value);
+        }
+
+        get menuOpen(): boolean {
+          return this.hasAttribute("menu-open");
+        }
+
+        set menuOpen(value: boolean) {
+          this.toggleAttribute("menu-open", value);
+          this.flowItemEl.menuOpen = value;
+        }
+
+        get showBackButton(): boolean {
+          return this.hasAttribute("show-back-button");
+        }
+
+        set showBackButton(value: boolean) {
+          this.toggleAttribute("show-back-button", value);
+          this.flowItemEl.showBackButton = value;
+        }
+
+        async beforeBack(): Promise<void> {
+          // no op
+        }
+
+        async setFocus(): Promise<void> {
+          await this.flowItemEl.setFocus();
+        }
+      }
+
+      customElements.define("custom-flow-item", CustomFlowItem);
+    });
+
+    const flow = await page.find("calcite-flow");
+    const displayedItemSelector = "calcite-flow > *:not([hidden])";
+    let displayedItem = await page.find(displayedItemSelector);
+
+    expect(await flow.getProperty("childElementCount")).toBe(3);
+    expect(displayedItem.id).toBe("third");
+
+    await page.evaluate(
+      async (displayedItemSelector: string, ITEM_CSS) => {
+        document
+          .querySelector(displayedItemSelector)
+          .shadowRoot.querySelector<HTMLCalciteActionElement>(`.${ITEM_CSS.backButton}`)
+          .click();
+      },
+      displayedItemSelector,
+      ITEM_CSS
+    );
+    await page.waitForChanges();
+
+    displayedItem = await page.find(displayedItemSelector);
+    expect(await flow.getProperty("childElementCount")).toBe(2);
+    expect(displayedItem.id).toBe("second");
+
+    await page.evaluate(
+      async (displayedItemSelector: string, ITEM_CSS) => {
+        document
+          .querySelector(displayedItemSelector)
+          .shadowRoot.querySelector("calcite-flow-item")
+          .shadowRoot.querySelector<HTMLCalciteActionElement>(`.${ITEM_CSS.backButton}`)
+          .click();
+      },
+      displayedItemSelector,
+      ITEM_CSS
+    );
+    await page.waitForChanges();
+
+    displayedItem = await page.find(displayedItemSelector);
+    expect(await flow.getProperty("childElementCount")).toBe(1);
+    expect(displayedItem.id).toBe("first");
   });
 });

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -137,11 +137,11 @@ export class Flow implements LoadableComponent {
   };
 
   updateFlowProps = (): void => {
-    const { el, items } = this;
+    const { customItemSelectors, el, items } = this;
 
     const newItems = Array.from<FlowItemLikeElement>(
       el.querySelectorAll(
-        `calcite-flow-item${this.customItemSelectors ? `,${this.customItemSelectors}` : ""}`
+        `calcite-flow-item${customItemSelectors ? `,${customItemSelectors}` : ""}`
       )
     ).filter((flowItem) => flowItem.closest("calcite-flow") === el);
 

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -68,11 +68,11 @@ export class Flow implements LoadableComponent {
   // --------------------------------------------------------------------------
 
   /**
-   * This property enables the component to consider other elements implementing flow-item's interface.
+   * This property enables the component to consider other custom elements implementing flow-item's interface.
    *
    * @internal
    */
-  @Prop() extraItemSelector: string;
+  @Prop() customItemSelectors: string;
 
   // --------------------------------------------------------------------------
   //
@@ -141,7 +141,7 @@ export class Flow implements LoadableComponent {
 
     const newItems = Array.from<FlowItemLikeElement>(
       el.querySelectorAll(
-        `calcite-flow-item${this.extraItemSelector ? `,${this.extraItemSelector}` : ""}`
+        `calcite-flow-item${this.customItemSelectors ? `,${this.customItemSelectors}` : ""}`
       )
     ).filter((flowItem) => flowItem.closest("calcite-flow") === el);
 

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -1,6 +1,6 @@
-import { Component, Element, h, Listen, Method, State, VNode } from "@stencil/core";
+import { Component, Element, h, Listen, Method, Prop, State, VNode } from "@stencil/core";
 import { createObserver } from "../../utils/observers";
-import { FlowDirection } from "./interfaces";
+import { FlowDirection, FlowItemLikeElement } from "./interfaces";
 import { CSS } from "./resources";
 import {
   componentFocusable,
@@ -28,7 +28,7 @@ export class Flow implements LoadableComponent {
    * Removes the currently active `calcite-flow-item`.
    */
   @Method()
-  async back(): Promise<HTMLCalciteFlowItemElement> {
+  async back(): Promise<HTMLCalciteFlowItemElement | FlowItemLikeElement> {
     const { items } = this;
 
     const lastItem = items[items.length - 1];
@@ -63,6 +63,19 @@ export class Flow implements LoadableComponent {
 
   // --------------------------------------------------------------------------
   //
+  //  Public Properties
+  //
+  // --------------------------------------------------------------------------
+
+  /**
+   * This property enables the component to consider other elements implementing flow-item's interface.
+   *
+   * @internal
+   */
+  @Prop() extraItemSelector: string;
+
+  // --------------------------------------------------------------------------
+  //
   //  Private Properties
   //
   // --------------------------------------------------------------------------
@@ -73,7 +86,7 @@ export class Flow implements LoadableComponent {
 
   @State() itemCount = 0;
 
-  @State() items: HTMLCalciteFlowItemElement[] = [];
+  @State() items: FlowItemLikeElement[] = [];
 
   itemMutationObserver = createObserver("mutation", () => this.updateFlowProps());
 
@@ -126,9 +139,11 @@ export class Flow implements LoadableComponent {
   updateFlowProps = (): void => {
     const { el, items } = this;
 
-    const newItems: HTMLCalciteFlowItemElement[] = Array.from(
-      el.querySelectorAll("calcite-flow-item")
-    ).filter((flowItem) => flowItem.closest("calcite-flow") === el) as HTMLCalciteFlowItemElement[];
+    const newItems = Array.from<FlowItemLikeElement>(
+      el.querySelectorAll(
+        `calcite-flow-item${this.extraItemSelector ? `,${this.extraItemSelector}` : ""}`
+      )
+    ).filter((flowItem) => flowItem.closest("calcite-flow") === el);
 
     const oldItemCount = items.length;
     const newItemCount = newItems.length;

--- a/packages/calcite-components/src/components/flow/interfaces.ts
+++ b/packages/calcite-components/src/components/flow/interfaces.ts
@@ -1,1 +1,7 @@
 export type FlowDirection = "advancing" | "retreating";
+
+export type FlowItemLikeElement = Pick<
+  HTMLCalciteFlowItemElement,
+  "beforeBack" | "menuOpen" | "setFocus" | "showBackButton"
+> &
+  HTMLElement;

--- a/packages/calcite-components/src/demos/flow.html
+++ b/packages/calcite-components/src/demos/flow.html
@@ -47,6 +47,10 @@
               <!-- image -->
               <div slot="footer">test</div>
             </calcite-flow-item>
+            <calcite-flow-item heading="yet another item">
+              <!-- image -->
+              <div slot="footer">le sigh</div>
+            </calcite-flow-item>
           </calcite-flow>
         </div>
       </div>
@@ -124,6 +128,98 @@
             });
           </script>
         </div>
+      </div>
+
+      <div class="parent">
+        <div class="child right-aligned-text">custom flow-item support</div>
+
+        <div class="child">
+          <calcite-flow extra-item-selector="custom-flow-item">
+            <calcite-flow-item heading="calcite-panel">
+              <img src="https://via.placeholder.com/250x250.png?text=calcite-flow-item" />
+            </calcite-flow-item>
+            <!-- note: declarative shadow DOM only works in Chrome -->
+            <custom-flow-item heading="custom-flow-item" show-back-button>
+              <template shadowrootmode="open">
+                <style>
+                  :host {
+                    display: flex;
+                    background: #bdf2c4;
+                  }
+                </style>
+                <calcite-flow-item id="internalFlowItem">
+                  <slot></slot>
+                </calcite-flow-item>
+              </template>
+
+              <img src="https://via.placeholder.com/250x250.png?text=custom-flow-item" />
+            </custom-flow-item>
+            <calcite-flow-item heading="calcite-panel">
+              <img src="https://via.placeholder.com/250x250.png?text=calcite-panel" />
+            </calcite-flow-item>
+          </calcite-flow>
+        </div>
+        <script>
+          class CustomFlowItem extends HTMLElement {
+            constructor() {
+              super();
+              this.flowItemEl = this.shadowRoot.getElementById("internalFlowItem");
+            }
+
+            get heading() {
+              return this.getAttribute("heading");
+            }
+            set heading(value) {
+              this.setAttribute("heading", value);
+              this.flowItemEl.heading = value;
+            }
+
+            get hidden() {
+              return this.getAttribute("hidden");
+            }
+            set hidden(value) {
+              // no need to set global attribute
+              this.flowItemEl.hidden = value;
+            }
+
+            get menuOpen() {
+              return this.getAttribute("menu-open");
+            }
+            set menuOpen(value) {
+              this.setAttribute("menu-open", value);
+              this.flowItemEl.menuOpen = value;
+            }
+
+            get showBackButton() {
+              return this.getAttribute("show-back-button");
+            }
+            set showBackButton(value) {
+              this.setAttribute("show-back-button", value);
+              this.flowItemEl.showBackButton = value;
+            }
+
+            attributeChangedCallback(attributeName, oldValue, newValue) {
+              if (attributeName === "heading") {
+                this.heading = newValue;
+              } else if (attributeName === "hidden") {
+                this.hidden = newValue;
+              } else if (attributeName === "menu-open") {
+                this.menuOpen = newValue;
+              } else if (attributeName === "show-back-button") {
+                this.showBackButton = newValue;
+              }
+            }
+
+            static get observedAttributes() {
+              return ["heading", "hidden", "menu-open", "show-back-button"];
+            }
+
+            async setFocus() {
+              await this.flowItemEl.setFocus();
+            }
+          }
+          customElements.define("custom-flow-item", CustomFlowItem);
+        </script>
       </div>
     </demo-dom-swapper>
   </body>

--- a/packages/calcite-components/src/demos/flow.html
+++ b/packages/calcite-components/src/demos/flow.html
@@ -34,113 +34,28 @@
 
   <body>
     <demo-dom-swapper>
-      <!-- basic -->
-      <div class="parent">
-        <div class="child right-aligned-text">basic</div>
-
-        <div class="child">
-          <calcite-flow>
-            <calcite-flow-item heading="one, two, three, four">
-              <!-- image -->
-            </calcite-flow-item>
-            <calcite-flow-item heading="tell me that you love me more">
-              <!-- image -->
-              <div slot="footer">test</div>
-            </calcite-flow-item>
-            <calcite-flow-item heading="yet another item">
-              <!-- image -->
-              <div slot="footer">le sigh</div>
-            </calcite-flow-item>
-          </calcite-flow>
-        </div>
-      </div>
-
-      <!-- menu-actions & footer -->
-      <div class="parent">
-        <div class="child right-aligned-text">menu-actions & footer</div>
-
-        <div class="child">
-          <calcite-flow>
-            <calcite-flow-item heading="What are the most popular commute alternatives?">
-              <button slot="header-menu-actions">Reset</button>
-              <button slot="header-menu-actions">Rename</button>
-              <button slot="footer">Save</button>
-              <button slot="footer">Cancel</button>
-            </calcite-flow-item>
-          </calcite-flow>
-        </div>
-      </div>
-
-      <!-- adding new items to flow -->
-      <div class="parent">
-        <div class="child right-aligned-text">adding new items to flow</div>
-
-        <div class="child">
-          <calcite-flow id="flow">
-            <calcite-flow-item
-              heading="What are the most popular commute alternatives?"
-              description="I don't have an answer to this questions. Stop asking me this question."
-            >
-              <button slot="menu-actions">Reset</button>
-              <button slot="menu-actions">Rename</button>
-              <button slot="footer" class="btn">Save</button>
-              <button slot="footer" class="btn btn-secondary">Cancel</button>
-              <p><img src="https://placeimg.com/300/200/nature" alt="placeholder" /></p>
-              <p><img src="https://placeimg.com/300/200/nature" alt="placeholder" /></p>
-            </calcite-flow-item>
-          </calcite-flow>
-          <calcite-button id="add-panel" appearance="solid" icon-end="plus" scale="l">Add Flow Item</calcite-button>
-          <script>
-            const flowNode = document.getElementById("flow");
-
-            const addFlowButtonNode = document.getElementById("add-panel");
-
-            addFlowButtonNode.addEventListener("click", function () {
-              const newNode = document.createElement("calcite-flow-item");
-
-              newNode.beforeBack = function () {
-                newNode.loading = true;
-                newNode.disabled = true;
-                return new Promise((resolve) =>
-                  setTimeout(() => {
-                    newNode.disabled = false;
-                    newNode.loading = false;
-                    resolve();
-                  }, 1000)
-                );
-              };
-
-              newNode.heading = "Item " + (flowNode.childElementCount + 1);
-              newNode.description = "I don't have an answer to this questions. Stop asking me this question.";
-              newNode.innerHTML = `
-          <p><img src="https://placeimg.com/300/200/nature" alt="nature" /></p>
-          <p><img src="https://placeimg.com/300/200/nature" alt="nature" /></p>
-          <calcite-action label="pencil icon" slot="menu-actions" icon="pencil"></calcite-action>
-          <button slot="footer">Save</button>
-          <button slot="footer">Cancel</button>
-        `;
-              flowNode.appendChild(newNode);
-              setTimeout(function () {
-                const newDiv = document.createElement("div");
-                newDiv.innerHTML = "new div who dis?";
-                newNode.appendChild(newDiv);
-              }, 100);
-            });
-          </script>
-        </div>
-      </div>
-
       <div class="parent">
         <div class="child right-aligned-text">custom flow-item support</div>
 
         <div class="child">
           <calcite-flow extra-item-selector="custom-flow-item">
-            <calcite-flow-item heading="calcite-panel">
+            <calcite-flow-item heading="flow-item-1">
               <img src="https://via.placeholder.com/250x250.png?text=calcite-flow-item" />
             </calcite-flow-item>
-            <!-- note: declarative shadow DOM only works in Chrome -->
-            <custom-flow-item heading="custom-flow-item" show-back-button>
-              <template shadowrootmode="open">
+            <custom-flow-item heading="custom-flow-item">
+              <img src="https://via.placeholder.com/250x250.png?text=custom-flow-item" />
+            </custom-flow-item>
+            <calcite-flow-item heading="flow-item-2">
+              <img src="https://via.placeholder.com/250x250.png?text=calcite-panel" />
+            </calcite-flow-item>
+          </calcite-flow>
+          <script>
+            class CustomFlowItem extends HTMLElement {
+              constructor() {
+                super();
+                const shadow = this.attachShadow({ mode: "open" });
+
+                shadow.innerHTML = `
                 <style>
                   :host {
                     display: flex;
@@ -150,76 +65,64 @@
                 <calcite-flow-item id="internalFlowItem">
                   <slot></slot>
                 </calcite-flow-item>
-              </template>
+              `;
 
-              <img src="https://via.placeholder.com/250x250.png?text=custom-flow-item" />
-            </custom-flow-item>
-            <calcite-flow-item heading="calcite-panel">
-              <img src="https://via.placeholder.com/250x250.png?text=calcite-panel" />
-            </calcite-flow-item>
-          </calcite-flow>
-        </div>
-        <script>
-          class CustomFlowItem extends HTMLElement {
-            constructor() {
-              super();
-              this.flowItemEl = this.shadowRoot.getElementById("internalFlowItem");
-            }
+                this.flowItemEl = shadow.getElementById("internalFlowItem");
+              }
 
-            get heading() {
-              return this.getAttribute("heading");
-            }
-            set heading(value) {
-              this.setAttribute("heading", value);
-              this.flowItemEl.heading = value;
-            }
+              connectedCallback() {
+                this.flowItemEl.setAttribute("heading", this.getAttribute("heading"));
+                this.flowItemEl.setAttribute("show-back-button", this.getAttribute("show-back-button"));
+                this.flowItemEl.setAttribute("menu-open", this.getAttribute("menu-open"));
+              }
 
-            get hidden() {
-              return this.getAttribute("hidden");
-            }
-            set hidden(value) {
-              // no need to set global attribute
-              this.flowItemEl.hidden = value;
-            }
+              get heading() {
+                return this.getAttribute("heading");
+              }
 
-            get menuOpen() {
-              return this.getAttribute("menu-open");
-            }
-            set menuOpen(value) {
-              this.setAttribute("menu-open", value);
-              this.flowItemEl.menuOpen = value;
-            }
+              set heading(value) {
+                this.flowItemEl.heading = value;
+              }
 
-            get showBackButton() {
-              return this.getAttribute("show-back-button");
-            }
-            set showBackButton(value) {
-              this.setAttribute("show-back-button", value);
-              this.flowItemEl.showBackButton = value;
-            }
+              get hidden() {
+                return this.hasAttribute("hidden");
+              }
 
-            attributeChangedCallback(attributeName, oldValue, newValue) {
-              if (attributeName === "heading") {
-                this.heading = newValue;
-              } else if (attributeName === "hidden") {
-                this.hidden = newValue;
-              } else if (attributeName === "menu-open") {
-                this.menuOpen = newValue;
-              } else if (attributeName === "show-back-button") {
-                this.showBackButton = newValue;
+              set hidden(value) {
+                this.toggleAttribute("hidden", value);
+                this.flowItemEl.toggleAttribute("hidden", value);
+              }
+
+              get menuOpen() {
+                return this.hasAttribute("menu-open");
+              }
+
+              set menuOpen(value) {
+                this.toggleAttribute("menu-open", value);
+                this.flowItemEl.menuOpen = value;
+              }
+
+              get showBackButton() {
+                return this.hasAttribute("show-back-button");
+              }
+
+              set showBackButton(value) {
+                this.toggleAttribute("show-back-button", value);
+                this.flowItemEl.showBackButton = value;
+              }
+
+              async beforeBack() {
+                // no op
+              }
+
+              async setFocus() {
+                await this.flowItemEl.setFocus();
               }
             }
 
-            static get observedAttributes() {
-              return ["heading", "hidden", "menu-open", "show-back-button"];
-            }
-
-            async setFocus() {
-              await this.flowItemEl.setFocus();
-            }
-          }
-          customElements.define("custom-flow-item", CustomFlowItem);
-        </script>
+            customElements.define("custom-flow-item", CustomFlowItem);
+          </script>
+        </div>
       </div>
     </demo-dom-swapper>
   </body>


### PR DESCRIPTION
**Related Issue:** #6237 

## Summary

This enables `flow` to work with custom components using shadow DOM wrapping `flow-item`. 

Custom components will have to implement the [`FlowItemLike`](https://github.com/Esri/calcite-design-system/pull/7608/files#diff-82c222ab365cde13a1f1288d936611519dfd9bee1e283164b260ca554c04a191R3-R7) interface and set the new `custom-item-selectors`/`customItemSelectors` attr/prop to target custom components (see [E2E test](https://github.com/Esri/calcite-design-system/pull/7608/files#diff-9b86e64de24dfca441533c63ae0f6834bff10bffbde23fd8bb3989a2259e356cR315-R387) for vanilla JS example).

**Note**: `customItemSelectors` is intentionally marked internal since we don't have any documentation yet on developing custom components, which this is meant to support. We could additionally hide `FlowItemLike` in the doc site to avoid confusion until we have more documentation on this use case. I'm open to suggestions on this. @geospatialem @macandcheese @driskull 