### PR TITLE
docs(accordion-item): update component description for vscode

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/readme.md
+++ b/packages/calcite-components/src/components/accordion-item/readme.md
@@ -1,6 +1,6 @@
 # calcite-accordion-item
 
-individual `calcite-accordion` item
+A child component of `calcite-accordion`, where some behavior is inherited from its parent such as the `appearance` and `selectionMode`.
 
 <!-- Auto Generated Below -->
 


### PR DESCRIPTION
**Related Issue:** #6312 

## Summary
- Adds context to VS Code for the `accordion-item` component
- Tests our maintenance limitation when additional labels are present