### PR TITLE
fix(tree): improve keyboard navigation

### DIFF
--- a/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
+++ b/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
@@ -285,8 +285,7 @@ describe("calcite-tree-item", () => {
 
       const item = await page.find("#newbie");
       expect(item).toEqualAttribute("aria-hidden", "false");
-      expect(item).not.toHaveAttribute("calcite-hydrated-hidden");
-      expect(item.tabIndex).toBe(0);
+      expect(item.tabIndex).toBe(-1); // items are programmatically focused
     });
   });
 
@@ -360,61 +359,6 @@ describe("calcite-tree-item", () => {
     await checkbox.click();
     expect(checkbox).not.toHaveAttribute("checked");
     expect(isVisible).toBe(true);
-  });
-
-  it("right arrow key expands subtree and left arrow collapses it", async () => {
-    const page = await newE2EPage({
-      html: `
-        <calcite-tree>
-          <calcite-tree-item id="cables">
-            Cables
-            <calcite-tree slot="children">
-              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
-              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-        </calcite-tree>
-    `,
-    });
-
-    await page.keyboard.press("Tab");
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
-    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(false);
-
-    await page.keyboard.press("ArrowRight");
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
-    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(true);
-
-    await page.keyboard.press("ArrowLeft");
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
-    expect(await page.evaluate(() => (document.activeElement as HTMLCalciteTreeItemElement).expanded)).toBe(false);
-  });
-
-  it("right arrow key focuses first item in expanded subtree", async () => {
-    const page = await newE2EPage({
-      html: `
-        <calcite-tree>
-          <calcite-tree-item id="cables" expanded>
-            Cables
-            <calcite-tree slot="children">
-              <calcite-tree-item id="xlr">XLR Cable</calcite-tree-item>
-              <calcite-tree-item id="instrument">Instrument Cable</calcite-tree-item>
-            </calcite-tree>
-          </calcite-tree-item>
-        </calcite-tree>
-    `,
-    });
-
-    await page.keyboard.press("Tab");
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("cables");
-
-    await page.keyboard.press("ArrowRight");
-
-    expect(await page.evaluate(() => document.activeElement.id)).toBe("xlr");
   });
 
   it("displaying an expanded item is visible", async () => {

--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -12,11 +12,10 @@ import {
   Watch,
 } from "@stencil/core";
 import {
-  slotChangeHasAssignedElement,
   filterDirectChildren,
   getElementDir,
   getSlotted,
-  nodeListToArray,
+  slotChangeHasAssignedElement,
   toAriaBoolean,
 } from "../../utils/dom";
 import {
@@ -186,7 +185,10 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
   }
 
   componentDidRender(): void {
-    updateHostInteraction(this, () => this.parentExpanded || this.depth === 1);
+    updateHostInteraction(
+      this,
+      () => false // programmatically focusable
+    );
   }
 
   //--------------------------------------------------------------------------
@@ -358,8 +360,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
 
   @Listen("keydown")
   keyDownHandler(event: KeyboardEvent): void {
-    let root;
-
     if (this.isActionEndEvent(event)) {
       return;
     }
@@ -382,7 +382,7 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
           return;
         }
         // activates a node, i.e., performs its default action. For parent nodes, one possible default action is to open or close the node. In single-select trees where selection does not follow focus (see note below), the default action is typically to select the focused node.
-        const link = nodeListToArray(this.el.children).find((el) =>
+        const link = Array.from(this.el.children).find((el) =>
           el.matches("a")
         ) as HTMLAnchorElement;
 
@@ -398,33 +398,8 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
             updateItem: true,
           });
         }
-
         event.preventDefault();
-        break;
-      case "Home":
-        root = this.el.closest("calcite-tree:not([child])") as HTMLCalciteTreeElement;
-
-        const firstNode = root.querySelector("calcite-tree-item");
-
-        firstNode?.focus();
-
-        break;
-      case "End":
-        root = this.el.closest("calcite-tree:not([child])");
-
-        let currentNode = root.children[root.children.length - 1]; // last child
-        let currentTree = nodeListToArray(currentNode.children).find((el) =>
-          el.matches("calcite-tree")
-        );
-        while (currentTree) {
-          currentNode = currentTree.children[root.children.length - 1];
-          currentTree = nodeListToArray(currentNode.children).find((el) =>
-            el.matches("calcite-tree")
-          );
-        }
-        currentNode?.focus();
-        break;
-    }
+      }
   }
 
   //--------------------------------------------------------------------------
@@ -533,3 +508,4 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
     this.hasEndActions = slotChangeHasAssignedElement(event);
   };
 }
+

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -253,16 +253,9 @@ export class Tree {
     const root = this.el;
     const target = event.target as HTMLCalciteTreeItemElement;
 
-    if (
-      !(isTreeItem(target) && this.el.contains(target)) ||
-      (event.key !== "ArrowRight" &&
-        event.key !== "ArrowDown" &&
-        event.key !== "ArrowLeft" &&
-        event.key !== "ArrowUp" &&
-        event.key !== "Home" &&
-        event.key !== "End" &&
-        event.key !== "Tab")
-    ) {
+    const supportedKeys = ["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End", "Tab"];
+
+    if (!(isTreeItem(target) && this.el.contains(target)) || !supportedKeys.includes(event.key)) {
       return;
     }
 

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -9,10 +9,10 @@ import {
   Prop,
   VNode,
 } from "@stencil/core";
-import { focusElement, getRootNode, nodeListToArray } from "../../utils/dom";
+import { focusElement, nodeListToArray } from "../../utils/dom";
 import { Scale, SelectionMode } from "../interfaces";
 import { TreeItemSelectDetail } from "../tree-item/interfaces";
-import { getEnabledSiblingItem } from "./utils";
+import { getTraversableItems, isTreeItem } from "./utils";
 
 /**
  * @slot - A slot for `calcite-tree-item` elements.
@@ -85,6 +85,7 @@ export class Tree {
                 this.selectionMode === "multiple" || this.selectionMode === "multichildren"
               ).toString()
         }
+        onKeyDown={this.keyDownHandler}
         role={!this.child ? "tree" : undefined}
         tabIndex={this.getRootTabIndex()}
       >
@@ -244,72 +245,103 @@ export class Tree {
     event.stopPropagation();
   }
 
-  @Listen("keydown")
-  keyDownHandler(event: KeyboardEvent): void {
-    const root = this.el.closest("calcite-tree:not([child])") as HTMLCalciteTreeElement;
+  private keyDownHandler = (event: KeyboardEvent): void => {
+    if (this.child) {
+      return;
+    }
+
+    const root = this.el;
     const target = event.target as HTMLCalciteTreeItemElement;
 
-    if (!(root === this.el && target.tagName === "CALCITE-TREE-ITEM" && this.el.contains(target))) {
+    if (
+      !(isTreeItem(target) && this.el.contains(target)) ||
+      (event.key !== "ArrowRight" &&
+        event.key !== "ArrowDown" &&
+        event.key !== "ArrowLeft" &&
+        event.key !== "ArrowUp" &&
+        event.key !== "Home" &&
+        event.key !== "End" &&
+        event.key !== "Tab")
+    ) {
+      return;
+    }
+
+    const traversableItems = getTraversableItems(root);
+
+    if (event.key === "Tab") {
+      // root tabindex will be restored when blurred/focused
+      traversableItems.forEach((item) => (item.tabIndex = -1));
       return;
     }
 
     if (event.key === "ArrowDown") {
-      const next = getEnabledSiblingItem(target.nextElementSibling, "down");
-      if (next) {
-        next.focus();
-        event.preventDefault();
-      }
-
+      const currentItemIndex = traversableItems.indexOf(target);
+      const nextItem = traversableItems[currentItemIndex + 1];
+      nextItem?.focus();
+      event.preventDefault();
       return;
     }
 
     if (event.key === "ArrowUp") {
-      const previous = getEnabledSiblingItem(target.previousElementSibling, "up");
-      if (previous) {
-        previous.focus();
-        event.preventDefault();
-      }
+      const currentItemIndex = traversableItems.indexOf(target);
+      const previousItem = traversableItems[currentItemIndex - 1];
+      previousItem?.focus();
+      event.preventDefault();
+      return;
     }
 
-    if (event.key === "ArrowLeft" && !target.disabled) {
-      // When focus is on an open node, closes the node.
+    if (event.key === "ArrowLeft") {
       if (target.hasChildren && target.expanded) {
         target.expanded = false;
         event.preventDefault();
         return;
       }
 
-      // When focus is on a child node that is also either an end node or a closed node, moves focus to its parent node.
-      const parentItem = target.parentElement.closest("calcite-tree-item");
+      const rootToItemPath = traversableItems.slice(0, traversableItems.indexOf(target)).reverse();
+      const parentItem = rootToItemPath.find((item) => item.depth === target.depth - 1);
 
-      if (parentItem && (!target.hasChildren || target.expanded === false)) {
-        parentItem.focus();
-        event.preventDefault();
-        return;
-      }
+      parentItem?.focus();
+      event.preventDefault();
 
-      // When focus is on a root node that is also either an end node or a closed node, does nothing.
       return;
     }
 
-    if (event.key === "ArrowRight" && !target.disabled) {
-      if (target.hasChildren) {
-        if (target.expanded && getRootNode(this.el).activeElement === target) {
-          // When focus is on an open node, moves focus to the first child node.
-          getEnabledSiblingItem(target.querySelector("calcite-tree-item"), "down")?.focus();
+    if (event.key === "ArrowRight") {
+      if (!target.disabled && target.hasChildren) {
+        if (!target.expanded) {
+          target.expanded = true;
           event.preventDefault();
         } else {
-          // When focus is on a closed node, opens the node; focus does not move.
-          target.expanded = true;
+          const currentItemIndex = traversableItems.indexOf(target);
+          const nextItem = traversableItems[currentItemIndex + 1];
+          nextItem?.focus();
           event.preventDefault();
         }
       }
 
       return;
     }
-  }
 
-  updateAncestorTree(event: CustomEvent<TreeItemSelectDetail>): void {
+    if (event.key === "Home") {
+      const firstNode = traversableItems.shift();
+      if (firstNode) {
+        firstNode.focus();
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (event.key === "End") {
+      const lastNode = traversableItems.pop();
+      if (lastNode) {
+        lastNode.focus();
+        event.preventDefault();
+      }
+      return;
+    }
+  };
+
+  private updateAncestorTree(event: CustomEvent<TreeItemSelectDetail>): void {
     const item = event.target as HTMLCalciteTreeItemElement;
     const updateItem = event.detail.updateItem;
 

--- a/packages/calcite-components/src/components/tree/utils.ts
+++ b/packages/calcite-components/src/components/tree/utils.ts
@@ -1,20 +1,24 @@
-function isTreeItem(element: Element): element is HTMLCalciteTreeItemElement {
-  return element?.matches("calcite-tree-item");
+export function isTreeItem(element: Element): element is HTMLCalciteTreeItemElement {
+  return element?.tagName === "CALCITE-TREE-ITEM";
 }
 
-export function getEnabledSiblingItem(el: Element, direction: "up" | "down"): HTMLCalciteTreeItemElement {
-  const directionProp = direction === "down" ? "nextElementSibling" : "previousElementSibling";
-  let currentEl: Element = el;
-  let enabledEl: HTMLCalciteTreeItemElement | null = null;
+export function getTraversableItems(root: HTMLCalciteTreeElement): HTMLCalciteTreeItemElement[] {
+  return Array.from(root.querySelectorAll<HTMLCalciteTreeItemElement>("calcite-tree-item:not([disabled])")).filter(
+    (item): boolean => {
+      let currentItem: HTMLElement = item;
 
-  while (isTreeItem(currentEl)) {
-    if (!currentEl.disabled) {
-      enabledEl = currentEl;
-      break;
+      while (currentItem !== root && currentItem !== undefined) {
+        const parent = currentItem.parentElement;
+        const traversable = !isTreeItem(parent) || !parent.hasChildren || parent.expanded;
+
+        if (!traversable) {
+          return false;
+        }
+
+        currentItem = currentItem.parentElement;
+      }
+
+      return true;
     }
-
-    currentEl = currentEl[directionProp];
-  }
-
-  return enabledEl;
+  );
 }


### PR DESCRIPTION
**Related Issue:** #6861 

## Summary

Improves tree's keyboard navigation to move across all items and users can now tab to the next focusable element without having to traverse all items.

### Notes

* items are now programmatically-focusable only (e.g., `tabindex="-1"`) since the tree moves focus
* keyboard navigation based on https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-1a/#kbd_label
* consolidated tree tests and improved coverage
* moved all navigation logic to the tree-level
* refactored item traversal logic to cover all cases
* moved tree `keyDownHandler` to use VDOM event.