### PR TITLE
feat(input-date-picker): normalize year to current century

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -905,5 +905,18 @@ describe("calcite-input-date-picker", () => {
       expect(await element.getProperty("value")).toEqual(["2020-01-01", "2020-02-02"]);
       expect(changeEvent).toHaveReceivedEventTimes(2);
     });
+
+    it("should normalize year to current century when value is changed programmatically in range", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-date-picker normalize-year  range></calcite-input-date-picker>");
+      const element = await page.find("calcite-input-date-picker");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+
+      element.setProperty("value", ["00-03-07", "00-03-08"]);
+      await page.waitForChanges();
+
+      expect(await element.getProperty("value")).toEqual(["2000-03-07", "2000-03-08"]);
+      expect(changeEvent).toHaveReceivedEventTimes(0);
+    });
   });
 });

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -849,4 +849,71 @@ describe("calcite-input-date-picker", () => {
 
     expect(await getActiveMonth(page)).toBe("October");
   });
+
+  describe("normalize year", () => {
+    it("should normalize year to current century when user types the value", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-input-date-picker normalize-year></calcite-input-date-picker>`);
+
+      const element = await page.find("calcite-input-date-picker");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+      const wrapper = (
+        await page.waitForFunction(() =>
+          document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
+        )
+      ).asElement();
+      expect(await wrapper.isIntersectingViewport()).toBe(true);
+
+      await element.click();
+      await page.waitForChanges();
+
+      await page.keyboard.type("3/7/20");
+      await page.keyboard.press("Enter");
+      await page.waitForChanges();
+
+      expect(await element.getProperty("value")).toBe("2020-03-07");
+      expect(await element.getProperty("valueAsDate")).toBeDefined();
+
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+    });
+
+    it("should normalize year to current century when value is parsed as attribute", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-input-date-picker normalize-year value="20-01-01"></calcite-input-date-picker>`
+      );
+
+      const element = await page.find("calcite-input-date-picker");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+
+      expect(await element.getProperty("value")).toBe("2020-01-01");
+      expect(await element.getProperty("valueAsDate")).toBeDefined();
+
+      expect(changeEvent).toHaveReceivedEventTimes(0);
+    });
+
+    it("should normalize year to current century when user types the value in range", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-date-picker normalize-year  range></calcite-input-date-picker>");
+      const element = await page.find("calcite-input-date-picker");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+
+      await element.click();
+      await page.waitForChanges();
+
+      await page.keyboard.type("1/1/20");
+      await page.keyboard.press("Enter");
+      await page.waitForChanges();
+
+      expect(await element.getProperty("value")).toEqual(["2020-01-01", ""]);
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+
+      await page.keyboard.type("2/2/20");
+      await page.keyboard.press("Enter");
+      await page.waitForChanges();
+
+      expect(await element.getProperty("value")).toEqual(["2020-01-01", "2020-02-02"]);
+      expect(changeEvent).toHaveReceivedEventTimes(2);
+    });
+  });
 });

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -857,23 +857,15 @@ describe("calcite-input-date-picker", () => {
 
       const element = await page.find("calcite-input-date-picker");
       const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
-      const wrapper = (
-        await page.waitForFunction(() =>
-          document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(".calendar-picker-wrapper")
-        )
-      ).asElement();
-      expect(await wrapper.isIntersectingViewport()).toBe(true);
 
       await element.click();
       await page.waitForChanges();
-
       await page.keyboard.type("3/7/20");
       await page.keyboard.press("Enter");
       await page.waitForChanges();
 
       expect(await element.getProperty("value")).toBe("2020-03-07");
       expect(await element.getProperty("valueAsDate")).toBeDefined();
-
       expect(changeEvent).toHaveReceivedEventTimes(1);
     });
 
@@ -888,7 +880,6 @@ describe("calcite-input-date-picker", () => {
 
       expect(await element.getProperty("value")).toBe("2020-01-01");
       expect(await element.getProperty("valueAsDate")).toBeDefined();
-
       expect(changeEvent).toHaveReceivedEventTimes(0);
     });
 
@@ -900,7 +891,6 @@ describe("calcite-input-date-picker", () => {
 
       await element.click();
       await page.waitForChanges();
-
       await page.keyboard.type("1/1/20");
       await page.keyboard.press("Enter");
       await page.waitForChanges();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -96,3 +96,16 @@ export const darkModeRTL_TestOnly = (): string => html`
   </div>
 `;
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
+
+export const normalizeYearWithGermanLocale_TestOnly = (): string => html`
+  <div style="width: 400px">
+    <calcite-input-date-picker normalize-year range lang="de"></calcite-input-date-picker>
+  </div>
+  <script>
+    (async () => {
+      await customElements.whenDefined("calcite-input-date-picker");
+      const inputDatePicker = await document.querySelector("calcite-input-date-picker").componentOnReady();
+      inputDatePicker.value = ["00-03-07", "00-03-08"];
+    })();
+  </script>
+`;

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -1140,12 +1140,13 @@ export class InputDatePicker
 
     const dateParts = value.split("-");
     const year = Number(dateParts[0]);
+    const isTwoDigitYear = year < 100;
 
-    if (!this.normalizeYear || year > 1000) {
+    if (!this.normalizeYear || !isTwoDigitYear) {
       return value;
     }
 
-    if (year < 1000) {
+    if (isTwoDigitYear) {
       const normalizedYear = this.normalizeToCurrentCentury(year);
       return `${normalizedYear}-${dateParts[1]}-${dateParts[2]}`;
     }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -440,9 +440,8 @@ export class InputDatePicker
     const { open } = this;
     open && this.openHandler(open);
     if (Array.isArray(this.value)) {
-      console.log("value", this.value);
-      const newValue = this.value.map((val) => this.getNormalizedDate(val));
-      this.value = newValue;
+      const normalizedValue = this.value.map((val) => this.getNormalizedDate(val));
+      this.value = normalizedValue;
       this.valueAsDate = getValueAsDateRange(this.value);
     } else if (this.value) {
       try {
@@ -1130,8 +1129,7 @@ export class InputDatePicker
 
   private normalizeToCurrentCentury(twoDigitYear: number) {
     const currentYear = new Date().getFullYear();
-    const currentCentury = Math.floor(currentYear / 100) * 100;
-    const normalizedYear = currentCentury + twoDigitYear;
+    const normalizedYear = Math.floor(currentYear / 100) * 100 + twoDigitYear;
     return normalizedYear;
   }
 
@@ -1140,16 +1138,16 @@ export class InputDatePicker
       return "";
     }
 
-    if (!this.normalizeYear) {
+    const dateParts = value.split("-");
+    const year = Number(dateParts[0]);
+
+    if (!this.normalizeYear || year > 1000) {
       return value;
     }
 
-    const dateParts = value.split("-");
-    const year = Number(dateParts[0]);
     if (year < 1000) {
       const normalizedYear = this.normalizeToCurrentCentury(year);
       return `${normalizedYear}-${dateParts[1]}-${dateParts[2]}`;
     }
-    return value;
   }
 }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -78,6 +78,7 @@ import {
 } from "../../utils/focusTrapComponent";
 import { FocusTrap } from "focus-trap";
 import { guid } from "../../utils/guid";
+import { normalizeToCurrentCentury, isTwoDigitYear } from "./utils";
 
 @Component({
   tag: "calcite-input-date-picker",
@@ -156,13 +157,13 @@ export class InputDatePicker
       let newValueAsDate: Date | Date[];
 
       if (Array.isArray(newValue)) {
-        if (this.isTwoDigitYear(newValue[0]) || this.isTwoDigitYear(newValue[1])) {
+        if (isTwoDigitYear(newValue[0]) || isTwoDigitYear(newValue[1])) {
           this.value = newValue.map((val) => this.getNormalizedDate(val));
           return;
         }
         newValueAsDate = getValueAsDateRange(newValue);
       } else if (newValue) {
-        if (this.isTwoDigitYear(newValue)) {
+        if (isTwoDigitYear(newValue)) {
           this.value = this.getNormalizedDate(newValue);
           return;
         }
@@ -449,14 +450,14 @@ export class InputDatePicker
     const { open } = this;
     open && this.openHandler(open);
     if (Array.isArray(this.value)) {
-      if (this.isTwoDigitYear(this.value[0]) || this.isTwoDigitYear(this.value[1])) {
+      if (isTwoDigitYear(this.value[0]) || isTwoDigitYear(this.value[1])) {
         this.value = this.value.map((val) => this.getNormalizedDate(val));
         return;
       }
       this.valueAsDate = getValueAsDateRange(this.value);
     } else if (this.value) {
       try {
-        if (this.isTwoDigitYear(this.value)) {
+        if (isTwoDigitYear(this.value)) {
           this.value = this.getNormalizedDate(this.value);
           return;
         }
@@ -1050,13 +1051,13 @@ export class InputDatePicker
 
     const newStartDate = valueIsArray ? valueAsDate[0] : null;
     let newStartDateISO = valueIsArray ? dateToISO(newStartDate) : "";
-    if (newStartDateISO && this.isTwoDigitYear(newStartDateISO)) {
+    if (newStartDateISO && isTwoDigitYear(newStartDateISO)) {
       newStartDateISO = this.getNormalizedDate(newStartDateISO);
     }
 
     const newEndDate = valueIsArray ? valueAsDate[1] : null;
     let newEndDateISO = valueIsArray ? dateToISO(newEndDate) : "";
-    if (newEndDateISO && this.isTwoDigitYear(newEndDateISO)) {
+    if (newEndDateISO && isTwoDigitYear(newEndDateISO)) {
       newEndDateISO = this.getNormalizedDate(newEndDateISO);
     }
 
@@ -1092,7 +1093,7 @@ export class InputDatePicker
     const oldValue = this.value;
     let newValue = dateToISO(value as Date);
 
-    if (this.isTwoDigitYear(newValue)) {
+    if (isTwoDigitYear(newValue)) {
       newValue = this.getNormalizedDate(newValue);
     }
 
@@ -1144,12 +1145,6 @@ export class InputDatePicker
           .join("")
       : "";
 
-  private normalizeToCurrentCentury(twoDigitYear: number) {
-    const currentYear = new Date().getFullYear();
-    const normalizedYear = Math.floor(currentYear / 100) * 100 + twoDigitYear;
-    return normalizedYear;
-  }
-
   private getNormalizedDate(value: string): string {
     if (!value) {
       return "";
@@ -1160,15 +1155,7 @@ export class InputDatePicker
     }
 
     const { day, month, year } = datePartsFromISO(value);
-    const normalizedYear = this.normalizeToCurrentCentury(Number(year));
+    const normalizedYear = normalizeToCurrentCentury(Number(year));
     return `${normalizedYear}-${month}-${day}`;
-  }
-
-  private isTwoDigitYear(value: string): boolean {
-    if (!value) {
-      return false;
-    }
-    const { year } = datePartsFromISO(value);
-    return Number(year) < 100;
   }
 }

--- a/packages/calcite-components/src/components/input-date-picker/util.spec.ts
+++ b/packages/calcite-components/src/components/input-date-picker/util.spec.ts
@@ -1,0 +1,20 @@
+import { isTwoDigitYear } from "./utils";
+
+describe("utils", () => {
+  describe("isTwoDigitYear", () => {
+    it("returns whether a given ISO string date has two digit year", () => {
+      expect(isTwoDigitYear("2023-08-01")).toBe(false);
+      expect(isTwoDigitYear("00-08-01")).toBe(true);
+      expect(isTwoDigitYear("")).toBe(false);
+    });
+  });
+
+  describe("normalizedYear", () => {
+    it("return normalized date for a given ISO string date with two digit year", () => {
+      expect(normalizeToCurrentCentury("20-08-01")).toEqual("2020-08-01");
+      expect(normalizeToCurrentCentury("00-08-01")).toBe("2000-08-01");
+      expect(normalizeToCurrentCentury("1-08-01")).toBe("2001-08-01");
+      expect(normalizeToCurrentCentury("")).toBe("");
+    });
+  });
+});

--- a/packages/calcite-components/src/components/input-date-picker/util.spec.ts
+++ b/packages/calcite-components/src/components/input-date-picker/util.spec.ts
@@ -1,4 +1,4 @@
-import { isTwoDigitYear } from "./utils";
+import { isTwoDigitYear, normalizeToCurrentCentury } from "./utils";
 
 describe("utils", () => {
   describe("isTwoDigitYear", () => {
@@ -11,10 +11,9 @@ describe("utils", () => {
 
   describe("normalizedYear", () => {
     it("return normalized date for a given ISO string date with two digit year", () => {
-      expect(normalizeToCurrentCentury("20-08-01")).toEqual("2020-08-01");
-      expect(normalizeToCurrentCentury("00-08-01")).toBe("2000-08-01");
-      expect(normalizeToCurrentCentury("1-08-01")).toBe("2001-08-01");
-      expect(normalizeToCurrentCentury("")).toBe("");
+      expect(normalizeToCurrentCentury(20)).toEqual(2020);
+      expect(normalizeToCurrentCentury(0)).toBe(2000);
+      expect(normalizeToCurrentCentury(1)).toBe(2001);
     });
   });
 });

--- a/packages/calcite-components/src/components/input-date-picker/utils.ts
+++ b/packages/calcite-components/src/components/input-date-picker/utils.ts
@@ -1,0 +1,27 @@
+import { datePartsFromISO } from "../../utils/date";
+
+/**
+ * Specifies if an ISO string date (YYYY-MM-DD) has two digit year.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isTwoDigitYear(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  const { year } = datePartsFromISO(value);
+  return Number(year) < 100;
+}
+
+/**
+ * Returns a normalized year to current century from a given two digit year number.
+ *
+ * @param {number} twoDigitYear
+ * @returns {string}
+ */
+export function normalizeToCurrentCentury(twoDigitYear: number): number {
+  const currentYear = new Date().getFullYear();
+  const normalizedYear = Math.floor(currentYear / 100) * 100 + twoDigitYear;
+  return normalizedYear;
+}

--- a/packages/calcite-components/src/utils/date.spec.ts
+++ b/packages/calcite-components/src/utils/date.spec.ts
@@ -2,6 +2,7 @@ import { DateLocaleData } from "../components/date-picker/utils";
 import {
   dateFromISO,
   dateFromRange,
+  datePartsFromISO,
   dateToISO,
   formatCalendarYear,
   getOrder,
@@ -248,5 +249,12 @@ describe("parseCalendarYear", () => {
   it("parses display calendar years", () => {
     expect(parseCalendarYear(2023, { "default-calendar": "gregorian" } as DateLocaleData)).toBe(2023);
     expect(parseCalendarYear(2566, { "default-calendar": "buddhist" } as DateLocaleData)).toBe(2023);
+  });
+});
+
+describe("datePartsFromISO", () => {
+  it("returns date, year, month from parsed ISO string date", () => {
+    expect(datePartsFromISO("2023-08-01")).toEqual({ day: "01", month: "08", year: "2023" });
+    expect(datePartsFromISO("00-08-01")).toEqual({ day: "01", month: "08", year: "00" });
   });
 });

--- a/packages/calcite-components/src/utils/date.ts
+++ b/packages/calcite-components/src/utils/date.ts
@@ -160,10 +160,10 @@ export function dateToISO(date?: Date): string {
  * Retrieve day, month, and year strings from a ISO string (YYYY-mm-dd)
  *
  * @param string
- * @param ISODate
+ * @param isoDate
  */
-export function datePartsFromISO(ISODate: string): { day: string; month: string; year: string } {
-  const dateParts = ISODate.split("-");
+export function datePartsFromISO(isoDate: string): { day: string; month: string; year: string } {
+  const dateParts = isoDate.split("-");
   return { day: dateParts[2], month: dateParts[1], year: dateParts[0] };
 }
 

--- a/packages/calcite-components/src/utils/date.ts
+++ b/packages/calcite-components/src/utils/date.ts
@@ -157,6 +157,17 @@ export function dateToISO(date?: Date): string {
 }
 
 /**
+ * Retrieve day, month, and year strings from a ISO string (YYYY-mm-dd)
+ *
+ * @param string
+ * @param ISODate
+ */
+export function datePartsFromISO(ISODate: string): { day: string; month: string; year: string } {
+  const dateParts = ISODate.split("-");
+  return { day: dateParts[2], month: dateParts[1], year: dateParts[0] };
+}
+
+/**
  * Check if two dates are the same day, month, year
  *
  * @param d1


### PR DESCRIPTION
**Related Issue:** #7588

## Summary

Normalizes year to current century. 

Ex: If the user types `01/01/20` the `value` will be corrected to `01/01/2020` 