### PR TITLE
fix(list): Stop emitting calciteListChange when a list-item is disabled or closed.

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -391,10 +391,12 @@ describe("calcite-list", () => {
 
       expect(await isElementFocused(page, "#two")).toBe(true);
 
+      const calciteListChange = await page.spyOnEvent("calciteListChange");
       const listItemThree = await page.find("#three");
       listItemThree.setProperty("disabled", false);
       await page.waitForChanges();
       await page.waitForTimeout(listDebounceTimeout);
+      expect(calciteListChange).toHaveReceivedEventTimes(0);
 
       await list.press("ArrowDown");
 
@@ -404,6 +406,7 @@ describe("calcite-list", () => {
       listItemFour.setProperty("closed", false);
       await page.waitForChanges();
       await page.waitForTimeout(listDebounceTimeout);
+      expect(calciteListChange).toHaveReceivedEventTimes(0);
 
       await list.press("ArrowDown");
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -279,7 +279,7 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
     }
 
     event.stopPropagation();
-    this.updateListItems(true);
+    this.updateListItems();
   }
 
   @Listen("calciteInternalListItemGroupDefaultSlotChange")


### PR DESCRIPTION
**Related Issue:** #7627

## Summary

- calciteListChange shouldn't be emitting when an item is disabled or closed.