### PR TITLE
docs: add homepage to npm packages

### DIFF
--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -2,6 +2,7 @@
   "name": "@esri/calcite-components-react",
   "sideEffects": false,
   "version": "1.7.0-next.13",
+  "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "A set of React components that wrap calcite components",
   "license": "SEE LICENSE.md",
   "scripts": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@esri/calcite-components",
   "version": "1.7.0-next.13",
+  "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "Web Components for Esri's Calcite Design System.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",


### PR DESCRIPTION
**Related Issue:** #7625 

## Summary
Adds the [project homepage](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#homepage) to our `calcite-components` and `calcite-components-react` packages.

Similar to the `@arcgis/core`'s page:

```json
"name": "@arcgis/core",
"version": "4.27.6",
"homepage": "https://js.arcgis.com",
"description": "ArcGIS Maps SDK for JavaScript: A complete 2D and 3D mapping and data visualization API",
```

![image](https://github.com/Esri/calcite-design-system/assets/5023024/a46dbbf9-acbc-4292-9ca8-c3cdd607a9b1)
