### PR TITLE
chore(deps): update calcite-ui-icons to 3.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3092,9 +3092,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.23.9",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.23.9.tgz",
-      "integrity": "sha512-9rbdZEV/v2gq7p11KtLxMamamwG9iH2z/8m3y2GFn7HzF9CqOMYP6fwBu4XBjk3uW05+5T6Vksz7Xn9obq9wrg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.1.tgz",
+      "integrity": "sha512-mPy4i2ivT8d4ytmtK3gOVfo+ldYUIeRRKPgBTExGf5pZBIS6xIu+g5OYqAhTquREivnQBoMMzo2FgDZhKxnuSg==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -40459,7 +40459,7 @@
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.23.9",
+        "@esri/calcite-ui-icons": "3.24.1",
         "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -42682,7 +42682,7 @@
       "version": "file:packages/calcite-components",
       "requires": {
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.23.9",
+        "@esri/calcite-ui-icons": "3.24.1",
         "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
         "@floating-ui/dom": "1.5.1",
         "@stencil-community/eslint-plugin": "0.5.0",
@@ -42714,9 +42714,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.23.9",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.23.9.tgz",
-      "integrity": "sha512-9rbdZEV/v2gq7p11KtLxMamamwG9iH2z/8m3y2GFn7HzF9CqOMYP6fwBu4XBjk3uW05+5T6Vksz7Xn9obq9wrg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.1.tgz",
+      "integrity": "sha512-mPy4i2ivT8d4ytmtK3gOVfo+ldYUIeRRKPgBTExGf5pZBIS6xIu+g5OYqAhTquREivnQBoMMzo2FgDZhKxnuSg==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "1.0.0",
-    "@esri/calcite-ui-icons": "3.23.9",
+    "@esri/calcite-ui-icons": "3.24.1",
     "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates `calcite-ui-icons` to `3.24.1`, released yesterday, 8/30, for the upcoming CC `1.7.0` release.