### PR TITLE
fix(block): provide textual name on collapse and expansion to AT

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -279,7 +279,7 @@ export class Block
     const toggleLabel = open ? messages.collapse : messages.expand;
 
     const headerContent = (
-      <header class={CSS.header}>
+      <header class={CSS.header} id={IDS.header}>
         {this.renderIcon()}
         {this.renderTitle()}
       </header>
@@ -295,6 +295,7 @@ export class Block
         {collapsible ? (
           <button
             aria-controls={IDS.content}
+            aria-describedby={IDS.header}
             aria-expanded={collapsible ? toAriaBoolean(open) : null}
             class={CSS.toggle}
             id={IDS.toggle}

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -1,6 +1,7 @@
 export const IDS = {
   content: "content",
   toggle: "toggle",
+  header: "header",
 };
 
 export const CSS = {


### PR DESCRIPTION
**Related Issue:** #5565

## Summary
Prior to this proposed fix, NVDA and JAWS were only receiving context that the `block` was expanded or collapsed due to the `title` prop. 

Updates include:

- Adds an `aria-describedby` to provide context of the collapse/expansion in addition to the header (handled via the `id`)
- Adds the `"header"` `id` to the block's `resources.ts`

