### PR TITLE
ci: make sure to exit on maitenance milestone failure

### DIFF
--- a/.github/scripts/limitPullRequestsForMaintenanceReleases.js
+++ b/.github/scripts/limitPullRequestsForMaintenanceReleases.js
@@ -51,6 +51,7 @@ module.exports = async ({ github, context, core }) => {
           allowedLabels,
         )}.`,
       );
+      process.exit(1)
     } else {
       core.notice(
         "The current milestone is not for a Maintenance release, ending run.",


### PR DESCRIPTION
**Related Issue:** #7531

## Summary

The action correctly determined that it was a maintenance milestone and [set the error message](https://github.com/Esri/calcite-design-system/actions/runs/5988880275/job/16244580547#step:3:39). However, it looks like [`core.setFailed()`](https://github.com/actions/toolkit/tree/main/packages/core#exit-codes) sets the exit code but doesn't actually exit. And then the else block with `process.exit(0)` overrode the exit code in the next iteration. Explicitly exiting will fix the issue.