### PR TITLE
ci: stop linting auto generated component doc

### DIFF
--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -15,7 +15,6 @@ jobs:
         run: |
           npm install
           npx --workspace=@esri/calcite-components stencil build --docs
-          npm run --workspace=@esri/calcite-components lint:md
       - name: commit readme files/create pull request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
## Summary
The doc update script is failing due to linting issues with the auto-generated component readmes. Removing the lint step.