### PR TITLE
fix(sheet): Update shadow style in display-mode="float"

### DIFF
--- a/packages/calcite-components/src/components/sheet/sheet.scss
+++ b/packages/calcite-components/src/components/sheet/sheet.scss
@@ -69,9 +69,10 @@
   --calcite-sheet-hidden-position-internal: translate3d(0, 1rem, 0);
 }
 
-:host([display-mode="float"]) .container {
-  @apply shadow-2;
+:host([display-mode="float"]) .content {
+  @apply shadow-2-sm;
 }
+
 :host([display-mode="overlay"][position="inline-start"]) .container {
   box-shadow: var(--calcite-scrim-shadow-inline-start-internal);
 }


### PR DESCRIPTION
## Summary
Fixes shadow set on incorrect container in Sheet while in `display-mode="float"`, and updates to use the same shadow variable as Modal. Was only noticed when the scrim color was overridden to a lighter color. cc @driskull cc @SkyeSeitz 


Before:
<img width="480" alt="Screenshot 2023-09-01 at 6 01 13 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/90ba6e67-0ebd-40ba-a787-9b227682a6ba">

After:
<img width="480" alt="Screenshot 2023-09-01 at 6 01 03 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/8d5795c5-e487-46cf-aa22-562825b06b0e">
