### PR TITLE
fix(modal): calciteModalClose should emit on close button click

### DIFF
--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -23,7 +23,7 @@ describe("calcite-modal properties", () => {
     const modal = await page.find("calcite-modal");
     modal.setProperty("closeButtonDisabled", true);
     await page.waitForChanges();
-    const closeButton = await page.find("calcite-modal >>> .close");
+    const closeButton = await page.find(`calcite-modal >>> .${CSS.close}`);
     expect(closeButton).toBe(null);
   });
 
@@ -311,7 +311,7 @@ describe("opening and closing behavior", () => {
     const modalBeforeClose = page.waitForEvent("calciteModalBeforeClose");
     const modalClose = page.waitForEvent("calciteModalClose");
 
-    const closeButton = await page.find("calcite-modal >>> .close");
+    const closeButton = await page.find(`calcite-modal >>> .${CSS.close}`);
     await closeButton.click();
 
     await modalBeforeClose;
@@ -499,7 +499,7 @@ describe("calcite-modal accessibility checks", () => {
     const createModalHTML = (contentHTML?: string, attrs?: string) =>
       `<calcite-modal open ${attrs}>${contentHTML}</calcite-modal>`;
 
-    const closeButtonTargetSelector = ".close";
+    const closeButtonTargetSelector = `.${CSS.close}`;
     const focusableContentTargetClass = "test";
 
     const focusableContentHTML = html`<h3 slot="header">Title</h3>
@@ -568,7 +568,7 @@ describe("calcite-modal accessibility checks", () => {
     modal.setProperty("open", true);
     await page.waitForChanges();
     expect(await modal.isVisible()).toBe(true);
-    const closeButton = await page.find("calcite-modal >>> .close");
+    const closeButton = await page.find(`calcite-modal >>> .${CSS.close}`);
     await closeButton.click();
     await page.waitForChanges();
     expect(await modal.isVisible()).toBe(false);

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -298,6 +298,31 @@ describe("opening and closing behavior", () => {
     ]);
   });
 
+  it("emits when closing on click", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-modal open></calcite-modal>`);
+    const modal = await page.find("calcite-modal");
+
+    await page.waitForChanges();
+    expect(await modal.isVisible()).toBe(true);
+
+    const beforeCloseSpy = await modal.spyOnEvent("calciteModalBeforeClose");
+    const closeSpy = await modal.spyOnEvent("calciteModalClose");
+    const modalBeforeClose = page.waitForEvent("calciteModalBeforeClose");
+    const modalClose = page.waitForEvent("calciteModalClose");
+
+    const closeButton = await page.find("calcite-modal >>> .close");
+    await closeButton.click();
+
+    await modalBeforeClose;
+    await modalClose;
+
+    expect(beforeCloseSpy).toHaveReceivedEventTimes(1);
+    expect(closeSpy).toHaveReceivedEventTimes(1);
+
+    expect(await modal.isVisible()).toBe(false);
+  });
+
   it("emits when set to open on initial render", async () => {
     const page = await newProgrammaticE2EPage();
 

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -349,6 +349,8 @@ export class Modal
   //
   //--------------------------------------------------------------------------
 
+  ignoreOpenChange = false;
+
   @Element() el: HTMLCalciteModalElement;
 
   modalContent: HTMLDivElement;
@@ -501,6 +503,10 @@ export class Modal
 
   @Watch("open")
   async toggleModal(value: boolean): Promise<void> {
+    if (this.ignoreOpenChange) {
+      return;
+    }
+
     onToggleOpenCloseComponent(this);
     if (value) {
       this.transitionEl?.classList.add(CSS.openingIdle);
@@ -559,7 +565,9 @@ export class Modal
       } catch (_error) {
         // close prevented
         requestAnimationFrame(() => {
+          this.ignoreOpenChange = true;
           this.open = true;
+          this.ignoreOpenChange = false;
         });
         return;
       }

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -504,6 +504,7 @@ export class Modal
   @Watch("open")
   async toggleModal(value: boolean): Promise<void> {
     if (this.ignoreOpenChange) {
+      this.ignoreOpenChange = false;
       return;
     }
 
@@ -532,10 +533,6 @@ export class Modal
    * @param ignoreOpenChange - Ignores the open watcher.
    */
   private openModal(ignoreOpenChange = false) {
-    if (this.ignoreOpenChange) {
-      return;
-    }
-
     this.ignoreOpenChange = ignoreOpenChange;
     this.el.addEventListener("calciteModalOpen", this.openEnd);
     this.open = true;
@@ -551,7 +548,6 @@ export class Modal
       // use an inline style instead of a utility class to avoid global class declarations.
       document.documentElement.style.setProperty("overflow", "hidden");
     }
-    this.ignoreOpenChange = false;
   }
 
   private handleOutsideClose = (): void => {
@@ -568,10 +564,6 @@ export class Modal
    * @param ignoreOpenChange - Ignores the open watcher.
    */
   closeModal = async (ignoreOpenChange = false): Promise<void> => {
-    if (this.ignoreOpenChange) {
-      return;
-    }
-
     if (this.beforeClose) {
       try {
         await this.beforeClose(this.el);
@@ -580,7 +572,6 @@ export class Modal
         requestAnimationFrame(() => {
           this.ignoreOpenChange = true;
           this.open = true;
-          this.ignoreOpenChange = false;
         });
         return;
       }
@@ -590,7 +581,6 @@ export class Modal
     this.open = false;
     this.opened = false;
     this.removeOverflowHiddenClass();
-    this.ignoreOpenChange = false;
   };
 
   private removeOverflowHiddenClass(): void {

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -172,7 +172,6 @@ export class Modal
     setUpLoadableComponent(this);
     // when modal initially renders, if active was set we need to open as watcher doesn't fire
     if (this.open) {
-      onToggleOpenCloseComponent(this);
       requestAnimationFrame(() => this.openModal());
     }
   }
@@ -502,18 +501,25 @@ export class Modal
   }
 
   @Watch("open")
-  async toggleModal(value: boolean): Promise<void> {
+  toggleModal(value: boolean): void {
     if (this.ignoreOpenChange) {
       return;
     }
 
+    if (value) {
+      this.openModal();
+    } else {
+      this.closeModal();
+    }
+  }
+
+  @Watch("opened")
+  handleOpenedChange(value: boolean): void {
     onToggleOpenCloseComponent(this);
     if (value) {
       this.transitionEl?.classList.add(CSS.openingIdle);
-      this.openModal();
     } else {
       this.transitionEl?.classList.add(CSS.closingIdle);
-      this.closeModal();
     }
   }
 

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -290,7 +290,7 @@ export class Modal
         aria-label={this.messages.close}
         class={CSS.close}
         key="button"
-        onClick={this.closeModal}
+        onClick={this.handleCloseClick}
         title={this.messages.close}
         // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
         ref={(el) => (this.closeButtonEl = el)}
@@ -510,10 +510,10 @@ export class Modal
     onToggleOpenCloseComponent(this);
     if (value) {
       this.transitionEl?.classList.add(CSS.openingIdle);
-      this.openModal();
+      this.openModal(true);
     } else {
       this.transitionEl?.classList.add(CSS.closingIdle);
-      this.closeModal();
+      this.closeModal(true);
     }
   }
 
@@ -522,13 +522,21 @@ export class Modal
     this.el.removeEventListener("calciteModalOpen", this.openEnd);
   };
 
-  /** Open the modal */
-  private openModal() {
+  private handleCloseClick = () => {
+    this.closeModal();
+  };
+
+  /**
+   * Open the modal
+   *
+   * @param ignoreOpenChange - Ignores the open watcher.
+   */
+  private openModal(ignoreOpenChange = false) {
     if (this.ignoreOpenChange) {
       return;
     }
 
-    this.ignoreOpenChange = true;
+    this.ignoreOpenChange = ignoreOpenChange;
     this.el.addEventListener("calciteModalOpen", this.openEnd);
     this.open = true;
     this.opened = true;
@@ -554,8 +562,12 @@ export class Modal
     this.closeModal();
   };
 
-  /** Close the modal, first running the `beforeClose` method */
-  closeModal = async (): Promise<void> => {
+  /**
+   * Close the modal, first running the `beforeClose` method
+   *
+   * @param ignoreOpenChange - Ignores the open watcher.
+   */
+  closeModal = async (ignoreOpenChange = false): Promise<void> => {
     if (this.ignoreOpenChange) {
       return;
     }
@@ -574,7 +586,7 @@ export class Modal
       }
     }
 
-    this.ignoreOpenChange = true;
+    this.ignoreOpenChange = ignoreOpenChange;
     this.open = false;
     this.opened = false;
     this.removeOverflowHiddenClass();

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -532,10 +532,6 @@ export class Modal
     this.open = false;
   };
 
-  /**
-   * Open the modal
-   *
-   */
   private openModal() {
     this.el.addEventListener("calciteModalOpen", this.openEnd);
     this.opened = true;
@@ -560,10 +556,6 @@ export class Modal
     this.open = false;
   };
 
-  /**
-   * Close the modal, first running the `beforeClose` method
-   *
-   */
   closeModal = async (): Promise<void> => {
     if (this.beforeClose) {
       try {

--- a/packages/calcite-components/src/demos/modal.html
+++ b/packages/calcite-components/src/demos/modal.html
@@ -1092,6 +1092,22 @@
             Custom width and height preview
           </calcite-button>
         </div>
+
+        <!--
+        **************************************************
+        * beforeClose rejected
+        **************************************************
+        -->
+        <div class="child">
+          <calcite-modal id="js-modal-before-close">
+            <h3 slot="header">Test rejected beforeClose</h3>
+            <div slot="content">test</div>
+            <calcite-button slot="secondary" width="full" appearance="outline">Cancel</calcite-button>
+          </calcite-modal>
+          <calcite-button onClick="openModal('#js-modal-before-close')" appearance="outline" scale="s">
+            beforeClose rejected
+          </calcite-button>
+        </div>
       </div>
 
       <!-- Magic code that makes every calcite link work -->
@@ -1100,6 +1116,11 @@
         const heightInput = document.querySelector("#css-modal-height-adjuster");
         const widthInput = document.querySelector("#css-modal-width-adjuster");
         const optionsSegmentedControl = document.querySelector("#css-modal-options-adjuster");
+        const beforeCloseRejected = document.getElementById("js-modal-before-close");
+
+        beforeCloseRejected.beforeClose = () => {
+          return new Promise((_resolve, reject) => setTimeout(reject, 300));
+        };
 
         heightInput.addEventListener("calciteInputInput", (event) => {
           customSizeModal.style.setProperty("--calcite-modal-height", event.target.value);

--- a/packages/calcite-components/src/utils/openCloseComponent.ts
+++ b/packages/calcite-components/src/utils/openCloseComponent.ts
@@ -15,6 +15,11 @@ export interface OpenCloseComponent {
   open?: boolean;
 
   /**
+   * When true, the component is open.
+   */
+  opened?: boolean;
+
+  /**
    *  Specifies the name of transitionProp.
    */
   transitionProp?: string;
@@ -55,22 +60,26 @@ const componentToTransitionListeners = new WeakMap<
   [HTMLDivElement, typeof transitionStart, typeof transitionEnd]
 >();
 
-function transitionStart(event: TransitionEvent): void {
+function transitionStart(this: OpenCloseComponent, event: TransitionEvent): void {
   if (event.propertyName === this.openTransitionProp && event.target === this.transitionEl) {
-    this.open ? this.onBeforeOpen() : this.onBeforeClose();
+    isOpen(this) ? this.onBeforeOpen() : this.onBeforeClose();
   }
 }
-function transitionEnd(event: TransitionEvent): void {
+function transitionEnd(this: OpenCloseComponent, event: TransitionEvent): void {
   if (event.propertyName === this.openTransitionProp && event.target === this.transitionEl) {
-    this.open ? this.onOpen() : this.onClose();
+    isOpen(this) ? this.onOpen() : this.onClose();
   }
 }
 
+function isOpen(component: OpenCloseComponent): boolean {
+  return "opened" in component ? component.opened : component.open;
+}
+
 function emitImmediately(component: OpenCloseComponent, nonOpenCloseComponent = false): void {
-  (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+  (nonOpenCloseComponent ? component[component.transitionProp] : isOpen(component))
     ? component.onBeforeOpen()
     : component.onBeforeClose();
-  (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+  (nonOpenCloseComponent ? component[component.transitionProp] : isOpen(component))
     ? component.onOpen()
     : component.onClose();
 }
@@ -131,7 +140,7 @@ export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpe
         if (event.propertyName === component.openTransitionProp && event.target === component.transitionEl) {
           clearTimeout(fallbackTimeoutId);
           component.transitionEl.removeEventListener("transitionstart", onStart);
-          (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+          (nonOpenCloseComponent ? component[component.transitionProp] : isOpen(component))
             ? component.onBeforeOpen()
             : component.onBeforeClose();
         }
@@ -139,7 +148,7 @@ export function onToggleOpenCloseComponent(component: OpenCloseComponent, nonOpe
 
       function onEndOrCancel(event: TransitionEvent): void {
         if (event.propertyName === component.openTransitionProp && event.target === component.transitionEl) {
-          (nonOpenCloseComponent ? component[component.transitionProp] : component.open)
+          (nonOpenCloseComponent ? component[component.transitionProp] : isOpen(component))
             ? component.onOpen()
             : component.onClose();
 


### PR DESCRIPTION
**Related Issue:** #7655

## Summary

- Updates openCloseComponent helper to consider `opened` property for components that have it
- Update modal to emit correctly on close click
- Add test
- @jcfranco for risk consideration.