### PR TITLE
fix(list-item): Do not call preventDefault on enter key within slotted actions

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -133,6 +133,41 @@ describe("calcite-list-item", () => {
     expect(eventSpy).toHaveReceivedEventTimes(1);
   });
 
+  it("does not emit calciteListItemSelect on Enter within action slots", async () => {
+    const page = await newE2EPage({
+      html: `<calcite-list-item selection-mode="single" label="hello" description="world" active><calcite-action
+      appearance="transparent"
+      icon="banana"
+      text="menu"
+      label="menu"
+      slot="filter-actions-start"
+    ></calcite-action>
+    <calcite-action
+      appearance="transparent"
+      icon="sort-ascending"
+      text="menu"
+      label="menu"
+      slot="filter-actions-end"
+    ></calcite-action></calcite-list-item>`,
+    });
+
+    await page.waitForChanges();
+
+    const eventSpy = await page.spyOnEvent("calciteListItemSelect");
+
+    const actionsStart = await page.find(`calcite-list-item >>> .${CSS.actionsStart}`);
+    await actionsStart.focus();
+    await page.keyboard.press("Enter");
+
+    expect(eventSpy).toHaveReceivedEventTimes(0);
+
+    const actionsEnd = await page.find(`calcite-list-item >>> .${CSS.actionsEnd}`);
+    await actionsEnd.focus();
+    await page.keyboard.press("Enter");
+
+    expect(eventSpy).toHaveReceivedEventTimes(0);
+  });
+
   it("emits calciteListItemSelect on click", async () => {
     const page = await newE2EPage({
       html: `<calcite-list-item selection-mode="single" label="hello" description="world"></calcite-list-item>`,

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -1,6 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { defaults, disabled, focusable, hidden, renders, slots } from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
+import { html } from "../../../support/formatting";
 
 describe("calcite-list-item", () => {
   describe("renders", () => {
@@ -134,22 +135,23 @@ describe("calcite-list-item", () => {
   });
 
   it("does not emit calciteListItemSelect on Enter within action slots", async () => {
-    const page = await newE2EPage({
-      html: `<calcite-list-item selection-mode="single" label="hello" description="world" active><calcite-action
-      appearance="transparent"
-      icon="banana"
-      text="menu"
-      label="menu"
-      slot="filter-actions-start"
-    ></calcite-action>
-    <calcite-action
-      appearance="transparent"
-      icon="sort-ascending"
-      text="menu"
-      label="menu"
-      slot="filter-actions-end"
-    ></calcite-action></calcite-list-item>`,
-    });
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-list-item selection-mode="single" label="hello" description="world" active
+      ><calcite-action
+        appearance="transparent"
+        icon="banana"
+        text="menu"
+        label="menu"
+        slot="filter-actions-start"
+      ></calcite-action>
+      <calcite-action
+        appearance="transparent"
+        icon="sort-ascending"
+        text="menu"
+        label="menu"
+        slot="filter-actions-end"
+      ></calcite-action
+    ></calcite-list-item>`);
 
     await page.waitForChanges();
 

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -703,7 +703,11 @@ export class ListItem
     const cells = [actionsStartEl, contentEl, actionsEndEl].filter(Boolean);
     const currentIndex = cells.findIndex((cell) => composedPath.includes(cell));
 
-    if (key === "Enter") {
+    if (
+      key === "Enter" &&
+      !composedPath.includes(actionsStartEl) &&
+      !composedPath.includes(actionsEndEl)
+    ) {
       event.preventDefault();
       this.toggleSelected();
     } else if (key === "ArrowRight") {


### PR DESCRIPTION
**Related Issue:** #7676

## Summary

- Enter key on any of the actions containers will not do anything
- So enter key will no longer be prevented
- Adds test