### PR TITLE
fix(combobox): fix filtering to avoid showing unrelated items

### DIFF
--- a/packages/calcite-components/src/components/combobox-item-group/combobox-item-group.scss
+++ b/packages/calcite-components/src/components/combobox-item-group/combobox-item-group.scss
@@ -53,3 +53,5 @@
 ::slotted(calcite-combobox-item-group:not([after-empty-group])) {
   padding-block-start: var(--calcite-combobox-item-spacing-unit-l);
 }
+
+@include base-component();

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -143,6 +143,53 @@ describe("calcite-combobox", () => {
     disabled("calcite-combobox");
   });
 
+  it("filter properly when items have duplicate values with parents", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`
+        <calcite-combobox>
+          <calcite-combobox-item-group label="arcgis-app-identity">
+            <calcite-combobox-item
+              value="./html/arcgis-app-identity/index.html"
+              text-label="index.html"
+            ></calcite-combobox-item>
+          </calcite-combobox-item-group>
+          <calcite-combobox-item-group label="arcgis-configuration-editor">
+            <calcite-combobox-item
+              value="./html/arcgis-configuration-editor/composite-field-editor.html"
+              text-label="composite-field-editor.html"
+            ></calcite-combobox-item>
+            <calcite-combobox-item
+              value="./html/arcgis-configuration-editor/index.html"
+              text-label="index.html"
+            ></calcite-combobox-item>
+            <calcite-combobox-item
+              value="./html/arcgis-configuration-editor/rule-editor.html"
+              text-label="rule-editor.html"
+            ></calcite-combobox-item>
+          </calcite-combobox-item-group>
+        </calcite-combobox>
+      `
+    );
+
+    const combobox = await page.find("calcite-combobox");
+    await combobox.click();
+    await page.waitForChanges();
+    await combobox.type("conf");
+    await page.waitForChanges();
+
+    const items = await page.findAll("calcite-combobox-item");
+    const groups = await page.findAll("calcite-combobox-item-group");
+
+    expect(await groups[0].isVisible()).toBe(false);
+    expect(await items[0].isVisible()).toBe(false);
+
+    expect(await groups[1].isVisible()).toBe(true);
+    expect(await items[1].isVisible()).toBe(true);
+    expect(await items[2].isVisible()).toBe(true);
+    expect(await items[3].isVisible()).toBe(true);
+  });
+
   it("filtering does not match property with value of undefined", async () => {
     const page = await newE2EPage({
       html: html`

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -796,7 +796,7 @@ export class Combobox
   };
 
   private getMaxScrollerHeight(): number {
-    const items = this.getCombinedItems().filter((item) => !item.hidden);
+    const items = this.getItemsAndGroups().filter((item) => !item.hidden);
 
     const { maxItems } = this;
 
@@ -843,36 +843,30 @@ export class Combobox
     }
   };
 
-  getCombinedItems(): ComboboxChildElement[] {
+  getItemsAndGroups(): ComboboxChildElement[] {
     return [...this.groupItems, ...this.items];
   }
 
   private filterItems = (() => {
     const find = (item: ComboboxChildElement, filteredData: ItemData[]) =>
       item &&
-      filteredData.some(({ label, value }) => {
-        if (isGroup(item)) {
-          return value === item.label;
-        }
-
-        return (
-          value === item.textLabel ||
-          value === item.value ||
-          label === item.textLabel ||
-          label === item.value
-        );
-      });
+      filteredData.some(({ label, value }) =>
+        isGroup(item) ? label === item.label : value === item.value && label === item.textLabel
+      );
 
     return debounce((text: string): void => {
       const filteredData = filter(this.data, text);
-      const items = this.getCombinedItems();
-      items.forEach((item) => {
+      const itemsAndGroups = this.getItemsAndGroups();
+
+      itemsAndGroups.forEach((item) => {
         const hidden = !find(item, filteredData);
         item.hidden = hidden;
         const [parent, grandparent] = item.ancestors;
+
         if (find(parent, filteredData) || find(grandparent, filteredData)) {
           item.hidden = false;
         }
+
         if (!hidden) {
           item.ancestors.forEach((ancestor) => (ancestor.hidden = false));
         }


### PR DESCRIPTION
**Related Issue:** #6814 

## Summary

This fixes an issue with the logic matching items to the internal filtered data. Filtered data corresponds to items, so both `label` and `value` need to match vs one or the other.

Also, hidden groups are visually hidden now. They were being displayed because the host was missing the base `hidden` styles.