### PR TITLE
fix(combobox): clears input value on blur

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1087,6 +1087,31 @@ describe("calcite-combobox", () => {
       expect(eventSpy).toHaveReceivedEventTimes(2);
     });
 
+    it("should clear the input on blur when filtered items are empty", async () => {
+      await page.waitForChanges();
+      const combobox = await page.find("calcite-combobox");
+      const inputEl = await page.find(`#myCombobox >>> input`);
+
+      await inputEl.focus();
+      await page.waitForChanges();
+      expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
+      await page.keyboard.type("asdf");
+      await page.waitForChanges();
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+      expect(await combobox.getProperty("value")).toBe("");
+
+      combobox.setProperty("selectionMode", "single");
+      await inputEl.focus();
+      await page.waitForChanges();
+      expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
+      await page.keyboard.type("asdf");
+      await page.waitForChanges();
+      await page.keyboard.press("Tab");
+      await page.waitForChanges();
+      expect(await combobox.getProperty("value")).toBe("");
+    });
+
     describe("keyboard interaction with chips", () => {
       let element;
       let chips;
@@ -1808,6 +1833,66 @@ describe("calcite-combobox", () => {
     comboboxItems.forEach(async (item) => {
       expect(await item.getProperty("selectionMode")).toBe("single");
       expect(await item.getProperty("scale")).toBe("l");
+    });
+  });
+
+  describe("clicked outside", () => {
+    let page: E2EPage;
+
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-combobox id="myCombobox">
+            <calcite-combobox-item id="one" value="one" label="one"></calcite-combobox-item>
+            <calcite-combobox-item id="two" value="two" label="two"></calcite-combobox-item>
+          </calcite-combobox>
+          <calcite-button id="button">click me</calcite-button>
+        `
+      );
+    });
+
+    async function assertClickOutside(selectionMode = "multiple", allowCustomValues = false): Promise<void> {
+      const combobox = await page.find("calcite-combobox");
+      combobox.setProperty("selectionMode", selectionMode);
+      combobox.setProperty("allowCustomValues", allowCustomValues);
+      const inputEl = await page.find(`#myCombobox >>> input`);
+      const buttonEl = await page.find("calcite-button");
+
+      await inputEl.focus();
+      await page.waitForChanges();
+      expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
+      await inputEl.type("asdf");
+      await page.waitForChanges();
+
+      if (allowCustomValues) {
+        await inputEl.press("Enter");
+        await buttonEl.click();
+        await page.waitForChanges();
+        expect(await page.evaluate(() => document.activeElement.id)).toBe("button");
+        expect(await combobox.getProperty("value")).toBe("asdf");
+      } else {
+        await buttonEl.click();
+        await page.waitForChanges();
+        expect(await page.evaluate(() => document.activeElement.id)).toBe("button");
+        expect(await combobox.getProperty("value")).toBe("");
+      }
+    }
+
+    it("should clear input value in single selection-mode", async () => {
+      await assertClickOutside("single");
+    });
+
+    it("should keep input value single selection-mode with allowCustomValues", async () => {
+      await assertClickOutside("single", true);
+    });
+
+    it("should clear input value in multiple selection-mode", async () => {
+      await assertClickOutside();
+    });
+
+    it("should not clear input value in multiple selection-mode with allowCustomValues", async () => {
+      await assertClickOutside("multiple", true);
     });
   });
 });

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1879,19 +1879,19 @@ describe("calcite-combobox", () => {
       }
     }
 
-    it("should clear input value in single selection-mode", async () => {
+    it("should clear input value in single selectionMode", async () => {
       await assertClickOutside("single");
     });
 
-    it("should keep input value single selection-mode with allowCustomValues", async () => {
+    it("should not clear input value in single selectionMode with allowCustomValues", async () => {
       await assertClickOutside("single", true);
     });
 
-    it("should clear input value in multiple selection-mode", async () => {
+    it("should clear input value in multiple selectionMode", async () => {
       await assertClickOutside();
     });
 
-    it("should not clear input value in multiple selection-mode with allowCustomValues", async () => {
+    it("should not clear input value in multiple selectionMode with allowCustomValues", async () => {
       await assertClickOutside("multiple", true);
     });
   });

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -759,21 +759,19 @@ export class Combobox
   setInactiveIfNotContained = (event: Event): void => {
     const composedPath = event.composedPath();
 
+    if (this.textInput) {
+      this.textInput.value = "";
+    }
+    this.text = "";
+    this.filterItems("");
+    this.updateActiveItemIndex(-1);
+
     if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
       return;
     }
 
     if (this.allowCustomValues && this.text.trim().length) {
       this.addCustomChip(this.text);
-    }
-
-    if (isSingleLike(this.selectionMode)) {
-      if (this.textInput) {
-        this.textInput.value = "";
-      }
-      this.text = "";
-      this.filterItems("");
-      this.updateActiveItemIndex(-1);
     }
 
     this.open = false;

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -763,19 +763,15 @@ export class Combobox
 
   setInactiveIfNotContained = (event: Event): void => {
     const composedPath = event.composedPath();
-    const hasCustomInputValue = !this.allowCustomValues && this.textInput.value;
 
-    if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
-      if (hasCustomInputValue) {
-        this.clearInputValue();
-      }
-      return;
-    }
-
-    if (hasCustomInputValue) {
+    if (!this.allowCustomValues && this.textInput.value) {
       this.clearInputValue();
       this.filterItems("");
       this.updateActiveItemIndex(-1);
+    }
+
+    if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
+      return;
     }
 
     if (this.allowCustomValues && this.text.trim().length) {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -535,6 +535,11 @@ export class Combobox
     this.setFocus();
   }
 
+  private clearInputValue(): void {
+    this.textInput.value = "";
+    this.text = "";
+  }
+
   setFilteredPlacements = (): void => {
     const { el, flipPlacements } = this;
 
@@ -758,16 +763,19 @@ export class Combobox
 
   setInactiveIfNotContained = (event: Event): void => {
     const composedPath = event.composedPath();
-
-    if (this.textInput) {
-      this.textInput.value = "";
-    }
-    this.text = "";
-    this.filterItems("");
-    this.updateActiveItemIndex(-1);
+    const hasCustomInputValue = !this.allowCustomValues && this.textInput.value;
 
     if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
+      if (hasCustomInputValue) {
+        this.clearInputValue();
+      }
       return;
+    }
+
+    if (hasCustomInputValue) {
+      this.clearInputValue();
+      this.filterItems("");
+      this.updateActiveItemIndex(-1);
     }
 
     if (this.allowCustomValues && this.text.trim().length) {


### PR DESCRIPTION
**Related Issue:** #2162 

## Summary

Clears the user entered input on `blur` when `allowCustomValues` is set to `false`