### PR TITLE
chore: add spaces around link inside storybook notice

### DIFF
--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -1,5 +1,3 @@
-import { html } from "../support/formatting";
-
 module.exports = {
   addons: [
     "@storybook/addon-a11y",
@@ -43,7 +41,7 @@ module.exports = {
       return head;
     }
 
-    return html`
+    return `
       <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
       <link rel="stylesheet" href="./build/calcite.css" />
       <script type="module" src="./build/calcite.esm.js"></script>

--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -1,3 +1,5 @@
+import { html } from "../support/formatting";
+
 module.exports = {
   addons: [
     "@storybook/addon-a11y",
@@ -41,24 +43,30 @@ module.exports = {
       return head;
     }
 
-    return `
+    return html`
       <link rel="stylesheet" href="https://webapps-cdn.esri.com/CDN/fonts/v1.4.1/fonts.css" />
       <link rel="stylesheet" href="./build/calcite.css" />
       <script type="module" src="./build/calcite.esm.js"></script>
 
       <template id="internalStorybookNotice">
-        <calcite-notice open icon="exclamation-mark-triangle" closable kind="warning" scale="l" style="font-family: var(--calcite-sans-family)">
-          <div slot="title">This storybook is on the current @next version and is meant for internal, testing purposes only.</div>
+        <calcite-notice
+          open
+          icon="exclamation-mark-triangle"
+          closable
+          kind="warning"
+          scale="l"
+          style="font-family: var(--calcite-sans-family)"
+        >
+          <div slot="title">
+            This storybook is on the current @next version and is meant for internal, testing purposes only.
+          </div>
           <div slot="link">
-            Please refer to the
-            <calcite-link
-              slot="link"
+            Please refer to the&#32;<calcite-link
               title="my action"
               href="https://developers.arcgis.com/calcite-design-system/components/"
             >
-              Calcite Components documentation site
-            </calcite-link>
-            to browse and interact with components.
+              Calcite Components documentation site </calcite-link
+            >&#32;to browse and interact with components.
           </div>
         </calcite-notice>
       </template>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

chore: add spaces around link inside storybook notice

## Issue

<img width="862" alt="image" src="https://github.com/Esri/calcite-design-system/assets/1231455/56d3b0eb-6971-4d7d-a8cd-07303bd171d9">
