### PR TITLE
docs(action, action-pad): update usage and action's `tooltip` slot 

### DIFF
--- a/packages/calcite-components/src/components/action-pad/usage/Tooltip.md
+++ b/packages/calcite-components/src/components/action-pad/usage/Tooltip.md
@@ -3,11 +3,6 @@ Renders an action pad with a tooltip on the expand action.
 ```html
 <calcite-action-pad id="action-pad-test">
   <calcite-action text="Add" icon="plus"></calcite-action>
+  <calcite-tooltip slot="expand-tooltip">Let's expand</calcite-tooltip>
 </calcite-action-pad>
-<calcite-tooltip id="tooltip">Expand</calcite-tooltip>
-<script>
-  var actionPad = document.getElementById("action-pad-test");
-  var tooltip = document.getElementById("tooltip");
-  actionPad.tooltipExpand = tooltip;
-</script>
 ```

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -40,6 +40,7 @@ import { CSS, SLOTS } from "./resources";
 
 /**
  * @slot - A slot for adding a `calcite-icon`.
+ *  @slot tooltip - A slot for adding a `calcite-tooltip`.
  */
 @Component({
   tag: "calcite-action",

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -40,7 +40,7 @@ import { CSS, SLOTS } from "./resources";
 
 /**
  * @slot - A slot for adding a `calcite-icon`.
- *  @slot tooltip - A slot for adding a `calcite-tooltip`.
+ * @slot tooltip - A slot for adding a `calcite-tooltip`.
  */
 @Component({
   tag: "calcite-action",


### PR DESCRIPTION
**Related Issue:** #6374

## Summary
Includes a doc cleanup 🧹  for our a-named components, which include:
- `action`: discovered the use for a `tooltip` slot, which wasn't documented, should it be? ❓ 
- `action-pad`: updates the tooltip use sample to the `"expand-tooltip"` slot