### PR TITLE
ci(eslint): disable jsdoc/require-property-type

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -77,6 +77,7 @@ module.exports = {
     "jsdoc/check-tag-names": "off",
     "jsdoc/require-jsdoc": "off",
     "jsdoc/require-param-type": "off",
+    "jsdoc/require-property-type": "off",
     "jsdoc/require-returns-type": "off",
     "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
     "lines-between-class-members": ["error", "always"],


### PR DESCRIPTION
**Related Issue:** #7747, #7326

## Summary

Disable [`jsdoc/require-property-type`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-property-type.md) in favor of using Typescript.