### PR TITLE
docs(block, button, checkbox, combobox): update component use

### DIFF
--- a/packages/calcite-components/src/components/block/usage/Always-open.md
+++ b/packages/calcite-components/src/components/block/usage/Always-open.md
@@ -1,7 +1,11 @@
 Renders a header and content that remains open - no collapsible option.
 
 ```html
-<calcite-block heading="When your son becomes a priest, do you call him..." open>
-  <div>Father or Son?</div>
+<calcite-block heading="Dogs" open>
+  <ul>
+    <li>The first species to be domesticated</li>
+    <li>Domesticated from wolves over 15,000 years ago</li>
+    <li>Adapted to human behavior performing many roles such as hunting, protection, military, therapy, etc.</li>
+  </ul>
 </calcite-block>
 ```

--- a/packages/calcite-components/src/components/block/usage/Collapsible.md
+++ b/packages/calcite-components/src/components/block/usage/Collapsible.md
@@ -2,6 +2,6 @@ Renders a header with a clickable icon to toggle the block open and closed.
 
 ```html
 <calcite-block heading="Domestic pets" open collapsible>
-  <calcite-block-section text="puppers rool, kittehs drule"> </calcite-block-section>
+  <calcite-block-section text="puppers rool, kittens drule"> </calcite-block-section>
 </calcite-block>
 ```

--- a/packages/calcite-components/src/components/block/usage/Collapsible.md
+++ b/packages/calcite-components/src/components/block/usage/Collapsible.md
@@ -2,6 +2,12 @@ Renders a header with a clickable icon to toggle the block open and closed.
 
 ```html
 <calcite-block heading="Domestic pets" open collapsible>
-  <calcite-block-section text="puppers rool, kittens drule"> </calcite-block-section>
+  <calcite-block-section text="Dogs" open>
+    <ul>
+      <li>The first species to be domesticated</li>
+      <li>Domesticated from wolves over 15,000 years ago</li>
+      <li>Adapted to human behavior performing many roles such as hunting, protection, military, therapy, etc.</li>
+    </ul>
+  </calcite-block-section>
 </calcite-block>
 ```

--- a/packages/calcite-components/src/components/block/usage/Header-with-control.md
+++ b/packages/calcite-components/src/components/block/usage/Header-with-control.md
@@ -1,7 +1,7 @@
 Renders a header and control with a slot for adding a single HTML element (in the header).
 
 ```html
-<calcite-block heading="This header" description="it has an input">
+<calcite-block heading="A fantastic heading" description="Add a control, such as an editing action">
   <calcite-action icon="pencil" text="edit" slot="control"></calcite-action>
 </calcite-block>
 ```

--- a/packages/calcite-components/src/components/block/usage/Header-with-icon.md
+++ b/packages/calcite-components/src/components/block/usage/Header-with-icon.md
@@ -1,7 +1,7 @@
 Renders a header and icon with the icon.
 
 ```html
-<calcite-block heading="Icon't believe it!">
-  <div slot="icon">🤯</div>
+<calcite-block heading="Dogs">
+  <div slot="icon">🐕</div>
 </calcite-block>
 ```

--- a/packages/calcite-components/src/components/button/usage/Within-form.md
+++ b/packages/calcite-components/src/components/button/usage/Within-form.md
@@ -6,6 +6,6 @@
   </calcite-label>
   <calcite-button type="reset">I should reset the form (type reset)</calcite-button>
   <calcite-button type="button">I should not submit the form (type button)</calcite-button>
-  <calcite-button>Submit</calcite-button>
+  <calcite-button type="submit">Submit</calcite-button>
 </form>
 ```

--- a/packages/calcite-components/src/components/checkbox/usage/Hovered-with-calcite-label.md
+++ b/packages/calcite-components/src/components/checkbox/usage/Hovered-with-calcite-label.md
@@ -1,6 +1,0 @@
-```html
-<calcite-label layout="inline" for="hovered-item">
-  <calcite-checkbox hovered id="hovered-item" name="hovered-item"></calcite-checkbox>
-  To do
-</calcite-label>
-```

--- a/packages/calcite-components/src/components/checkbox/usage/Indeterminate-with-native-label.md
+++ b/packages/calcite-components/src/components/checkbox/usage/Indeterminate-with-native-label.md
@@ -1,6 +1,4 @@
 ```html
-<label for="checked-indeterminate">
-  Status
-  <calcite-checkbox checked indeterminate id="checked-indeterminate" name="checked-indeterminate"></calcite-checkbox>
-</label>
+<calcite-label for="checked-indeterminate">Status</calcite-label>
+<calcite-checkbox checked indeterminate id="checked-indeterminate" name="checked-indeterminate"></calcite-checkbox>
 ```

--- a/packages/calcite-components/src/components/chip-group/usage/Basic.md
+++ b/packages/calcite-components/src/components/chip-group/usage/Basic.md
@@ -1,0 +1,8 @@
+```html
+<calcite-chip-group label="Basemaps">
+  <calcite-chip value="topographic">Topographic</calcite-chip>
+  <calcite-chip value="navigation">Navigation</calcite-chip>
+  <calcite-chip value="streets">Streets</calcite-chip>
+  <calcite-chip value="imagery">Imagery</calcite-chip>
+</calcite-chip-group>
+```

--- a/packages/calcite-components/src/components/chip-group/usage/SinglePersist.md
+++ b/packages/calcite-components/src/components/chip-group/usage/SinglePersist.md
@@ -1,0 +1,8 @@
+```html
+<calcite-chip-group label="Basemaps" selection-mode="single-persist">
+  <calcite-chip value="topographic" selected>Topographic</calcite-chip>
+  <calcite-chip value="navigation">Navigation</calcite-chip>
+  <calcite-chip value="streets">Streets</calcite-chip>
+  <calcite-chip value="imagery">Imagery</calcite-chip>
+</calcite-chip-group>
+```

--- a/packages/calcite-components/src/components/combobox/usage/SinglePersist.md
+++ b/packages/calcite-components/src/components/combobox/usage/SinglePersist.md
@@ -1,0 +1,14 @@
+```html
+<calcite-combobox label="Single selection-mode combobox" selection-mode="single-persist">
+  <calcite-combobox-item value="Trees" text-label="Trees">
+    <calcite-combobox-item
+      value="CommercialDamageAssessment - Damage to Commercial Buildings"
+      text-label="CommercialDamageAssessment - Damage to Commercial Buildings"
+      selected
+    ></calcite-combobox-item>
+    <calcite-combobox-item value="Sequoia" disabled text-label="Sequoia"></calcite-combobox-item>
+    <calcite-combobox-item value="Douglas Fir" text-label="Douglas Fir"></calcite-combobox-item>
+  </calcite-combobox-item>
+  <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
+</calcite-combobox>
+```


### PR DESCRIPTION
**Related Issue:** #6374

## Summary
Audits the b-named and c-named component usages.

Changes included:
- `block`: spelling change
- `button`: adds `type` to submit example
- `checkbox`: 
  - remove hover use
  - add `calcite-label` to use example
- `combobox`
  - add `"single-persist"` `selectionMode`