### PR TITLE
feat(action-group): add css custom properties to define gap and padding when layout is "grid"

### DIFF
--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -4,6 +4,8 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-gap: Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-padding: Sets the padding when the `layout` property is `"grid"`.
  */
 
 :host {
@@ -14,6 +16,8 @@
   p-0;
 
   --calcite-action-group-columns: 3;
+  --calcite-action-group-gap: theme("gap.px");
+  --calcite-action-group-padding: theme("padding.px");
 }
 
 .container {
@@ -55,10 +59,9 @@
 :host([layout="grid"]) .container {
   @apply bg-background
   grid
-  place-content-stretch
-  gap-px
-  p-px;
-
+  place-content-stretch;
+  gap: var(--calcite-action-group-gap);
+  padding: var(--calcite-action-group-gap);
   grid-template-columns: repeat(var(--calcite-action-group-columns), auto);
 }
 

--- a/packages/calcite-components/src/components/action-group/action-group.stories.ts
+++ b/packages/calcite-components/src/components/action-group/action-group.stories.ts
@@ -22,32 +22,6 @@ export const honorsFlexGrow = (): string => html`<style>
     <calcite-action icon="bluetooth" alignment="center"></calcite-action>
   </calcite-action-group>`;
 
-export const withoutDefinedGridGap = (): string => html` <calcite-action-group layout="grid">
-  <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
-  <calcite-action text="Save" icon="chevron-up"></calcite-action>
-  <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
-  <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
-  <calcite-action text="Layers" icon="layers"></calcite-action>
-  <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
-  <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
-  <calcite-action text="Layers" icon="chevron-down"></calcite-action>
-  <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
-</calcite-action-group>`;
-
-export const withDefinedGridGap = (): string => html`
-  <calcite-action-group layout="grid" style="--calcite-action-group-gap: 0; --calcite-action-group-padding:0;">
-    <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
-    <calcite-action text="Save" icon="chevron-up"></calcite-action>
-    <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
-    <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
-    <calcite-action text="Layers" icon="layers"></calcite-action>
-    <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
-    <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
-    <calcite-action text="Layers" icon="chevron-down"></calcite-action>
-    <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
-  </calcite-action-group>
-`;
-
 export const gridCenteringOfActionsInAGroup = (): string => html`
   <div style="width:400px">
     <calcite-action-group layout="${select("layout", ["horizontal", "vertical", "grid"], "grid")}">
@@ -77,6 +51,32 @@ export const gridCenteringOfActionsInAGroup = (): string => html`
       </calcite-action>
     </calcite-action-group>
   </div>
+`;
+
+export const withoutDefinedGridGap_TestOnly = (): string => html` <calcite-action-group layout="grid">
+  <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
+  <calcite-action text="Save" icon="chevron-up"></calcite-action>
+  <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
+  <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
+  <calcite-action text="Layers" icon="layers"></calcite-action>
+  <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
+  <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
+  <calcite-action text="Layers" icon="chevron-down"></calcite-action>
+  <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
+</calcite-action-group>`;
+
+export const withDefinedGridGap_TestOnly = (): string => html`
+  <calcite-action-group layout="grid" style="--calcite-action-group-gap: 0; --calcite-action-group-padding:0;">
+    <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
+    <calcite-action text="Save" icon="chevron-up"></calcite-action>
+    <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
+    <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
+    <calcite-action text="Layers" icon="layers"></calcite-action>
+    <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
+    <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
+    <calcite-action text="Layers" icon="chevron-down"></calcite-action>
+    <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
+  </calcite-action-group>
 `;
 
 export const arabicLocale_TestOnly = (): string => html`<div style="width:400px">

--- a/packages/calcite-components/src/components/action-group/action-group.stories.ts
+++ b/packages/calcite-components/src/components/action-group/action-group.stories.ts
@@ -22,6 +22,32 @@ export const honorsFlexGrow = (): string => html`<style>
     <calcite-action icon="bluetooth" alignment="center"></calcite-action>
   </calcite-action-group>`;
 
+export const withoutDefinedGridGap = (): string => html` <calcite-action-group layout="grid">
+  <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
+  <calcite-action text="Save" icon="chevron-up"></calcite-action>
+  <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
+  <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
+  <calcite-action text="Layers" icon="layers"></calcite-action>
+  <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
+  <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
+  <calcite-action text="Layers" icon="chevron-down"></calcite-action>
+  <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
+</calcite-action-group>`;
+
+export const withDefinedGridGap = (): string => html`
+  <calcite-action-group layout="grid" style="--calcite-action-group-gap: 0; --calcite-action-group-padding:0;">
+    <calcite-action text="Add" icon="arrow-up-left"></calcite-action>
+    <calcite-action text="Save" icon="chevron-up"></calcite-action>
+    <calcite-action text="Layers" icon="arrow-up-right"></calcite-action>
+    <calcite-action text="Basemaps" icon="chevron-left"></calcite-action>
+    <calcite-action text="Layers" icon="layers"></calcite-action>
+    <calcite-action text="Basemaps" icon="chevron-right"></calcite-action>
+    <calcite-action text="Basemaps" icon="arrow-down-left"></calcite-action>
+    <calcite-action text="Layers" icon="chevron-down"></calcite-action>
+    <calcite-action text="Basemaps" icon="arrow-down-right"></calcite-action>
+  </calcite-action-group>
+`;
+
 export const gridCenteringOfActionsInAGroup = (): string => html`
   <div style="width:400px">
     <calcite-action-group layout="${select("layout", ["horizontal", "vertical", "grid"], "grid")}">


### PR DESCRIPTION
**Related Issue:** #7380

## Summary

- Adds `--calcite-action-group-gap` CSS variable to set the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
- Adds `--calcite-action-group-padding` CSS variable to set the padding when the `layout` property is `"grid"`.
- Add screenshot test