### PR TITLE
fix(tab-nav): update indicator position when tab icon changes

### DIFF
--- a/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
@@ -267,6 +267,7 @@ export class TabNav {
   @Listen("calciteInternalTabIconChanged")
   iconStartChangeHandler(): void {
     this.updateActiveWidth();
+    this.updateOffsetPosition();
   }
 
   //--------------------------------------------------------------------------

--- a/packages/calcite-components/src/components/tabs/tabs.stories.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.stories.ts
@@ -276,3 +276,22 @@ export const TabChildrenWithPercentageHeights = (): string => html`
 TabChildrenWithPercentageHeights.parameters = {
   chromatic: { delay: 1000 },
 };
+
+export const updateIndicatorOffset_TestOnly = (): string => html`<calcite-tabs>
+    <calcite-tab-nav slot="title-group">
+      <calcite-tab-title id="tab-title">Boats</calcite-tab-title>
+      <calcite-tab-title selected>Ships</calcite-tab-title>
+      <calcite-tab-title>Yachts</calcite-tab-title>
+    </calcite-tab-nav>
+    <calcite-tab>Tab 1 content</calcite-tab>
+    <calcite-tab>Tab 2 content</calcite-tab>
+    <calcite-tab>Tab 3 content</calcite-tab>
+  </calcite-tabs>
+  <script>
+    const tabTitle = document.getElementById("tab-title");
+    setTimeout(() => (tabTitle.iconStart = "bullet-point"), 300);
+  </script>`;
+
+updateIndicatorOffset_TestOnly.parameters = {
+  chromatic: { delay: 1000 },
+};


### PR DESCRIPTION
**Related Issue:** #6821

## Summary

- Updates offset position when tab icon is added
- Add screenshot test