### PR TITLE
fix(select): allow setting an option value to an empty string

### DIFF
--- a/packages/calcite-components/src/components/option/option.e2e.ts
+++ b/packages/calcite-components/src/components/option/option.e2e.ts
@@ -60,6 +60,20 @@ describe("calcite-option", () => {
     expect(await option.getProperty("label")).toBe(optionText);
     expect(await option.getProperty("value")).toBe(optionText);
 
+    option.setProperty("label", "");
+    option.setProperty("value", "");
+    await page.waitForChanges();
+
+    expect(await option.getProperty("label")).toBe(optionText);
+    expect(await option.getProperty("value")).toBe("");
+
+    option.setProperty("label", null);
+    option.setProperty("value", null);
+    await page.waitForChanges();
+
+    expect(await option.getProperty("label")).toBe(optionText);
+    expect(await option.getProperty("value")).toBe(optionText);
+
     const alternateLabel = "dos";
     await option.setProperty("innerText", alternateLabel);
     await page.waitForChanges();

--- a/packages/calcite-components/src/components/option/option.tsx
+++ b/packages/calcite-components/src/components/option/option.tsx
@@ -92,14 +92,21 @@ export class Option {
   private ensureTextContentDependentProps(): void {
     const {
       el: { textContent },
+      internallySetLabel,
+      internallySetValue,
+      label,
+      value,
     } = this;
 
-    if (!this.label || this.label === this.internallySetLabel) {
+    if (!label || label === internallySetLabel) {
       this.label = textContent;
       this.internallySetLabel = textContent;
     }
 
-    if (!this.value || this.value === this.internallySetValue) {
+    if (
+      value == null /* intentional loose equals to handle both undefined & null */ ||
+      value === internallySetValue
+    ) {
       this.value = textContent;
       this.internallySetValue = textContent;
     }


### PR DESCRIPTION
**Related Issue:** #4032

## Summary

This fixes an issue where an empty string value was treated as value not set and would therefore fall back to the label as the value.