### PR TITLE
fix(tree): update tree selection per design spec

### DIFF
--- a/packages/calcite-components/src/components/tree-item/interfaces.ts
+++ b/packages/calcite-components/src/components/tree-item/interfaces.ts
@@ -3,10 +3,7 @@ export interface TreeItemSelectDetail {
    * Indicate if an item should be added to the current selection.
    */
   modifyCurrentSelection: boolean;
-  /**
-   * Indicate if an item should be collapsed/expanded even if child selection is enabled.
-   */
-  forceToggle: boolean;
+
   /**
    * Indicates if an item selected & indeterminate properties should be updated.
    * This will be set to true for user interaction changes and false for programmatic changes.

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -174,7 +174,7 @@
 
 :host([selected]) .node-container,
 :host([selected]) .node-container:hover {
-  @apply font-medium text-color-1 text-n1h;
+  @apply font-medium text-color-1;
 
   .bullet-point,
   .checkmark {

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -174,7 +174,7 @@
 
 :host([selected]) .node-container,
 :host([selected]) .node-container:hover {
-  @apply text-color-1 font-medium;
+  @apply font-medium text-color-1 text-n1h;
 
   .bullet-point,
   .checkmark {
@@ -226,14 +226,6 @@
 :host([has-children][expanded]:not([selected]):not([selection-mode="none"])) .node-container {
   ::slotted(*) {
     @apply text-color-1 font-medium;
-  }
-}
-
-// dropdown selected (for children, multichildren selected parents)
-:host([has-children][selected]) .node-container {
-  &[data-selection-mode="children"],
-  &[data-selection-mode="multichildren"] {
-    color: var(--calcite-ui-brand);
   }
 }
 

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -222,13 +222,6 @@
   }
 }
 
-// dropdown expanded and not selected
-:host([has-children][expanded]:not([selected]):not([selection-mode="none"])) .node-container {
-  ::slotted(*) {
-    @apply text-color-1 font-medium;
-  }
-}
-
 .chevron {
   @apply transition-default
     text-color-3

--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -81,7 +81,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
       }
       this.calciteInternalTreeItemSelect.emit({
         modifyCurrentSelection: true,
-        forceToggle: false,
         updateItem: false,
       });
     }
@@ -345,7 +344,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
     }
     this.calciteInternalTreeItemSelect.emit({
       modifyCurrentSelection: this.selectionMode === "ancestors" || this.isSelectionMultiLike,
-      forceToggle: false,
       updateItem: true,
     });
     this.userChangedValue = true;
@@ -372,7 +370,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
         this.userChangedValue = true;
         this.calciteInternalTreeItemSelect.emit({
           modifyCurrentSelection: this.isSelectionMultiLike,
-          forceToggle: false,
           updateItem: true,
         });
         event.preventDefault();
@@ -394,7 +391,6 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
         } else {
           this.calciteInternalTreeItemSelect.emit({
             modifyCurrentSelection: this.isSelectionMultiLike,
-            forceToggle: false,
             updateItem: true,
           });
         }

--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -351,12 +351,12 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
     this.userChangedValue = true;
   }
 
-  iconClickHandler = (event: MouseEvent): void => {
+  private iconClickHandler = (event: MouseEvent): void => {
     event.stopPropagation();
     this.expanded = !this.expanded;
   };
 
-  childrenClickHandler = (event: MouseEvent): void => event.stopPropagation();
+  private childrenClickHandler = (event: MouseEvent): void => event.stopPropagation();
 
   @Listen("keydown")
   keyDownHandler(event: KeyboardEvent): void {

--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -1206,7 +1206,9 @@ describe("calcite-tree", () => {
 
           await directItemClick(page, expandableParentItem);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(false);
+          const onlyExpandsWhenDeselected = selectsItem && selectsChildren;
+
+          expect(await expandableParentItem.getProperty("expanded")).toBe(onlyExpandsWhenDeselected);
           const expectedSelectedItemsAfterCollapsing = canDeselect ? 0 : expectedSelectedItemsAfterExpanding;
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
 
@@ -1214,12 +1216,12 @@ describe("calcite-tree", () => {
 
           await directItemClick(page, expandableParentToggle);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(true);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(!onlyExpandsWhenDeselected);
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
 
           await directItemClick(page, expandableParentToggle);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(false);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(onlyExpandsWhenDeselected);
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
         });
       }

--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -373,7 +373,7 @@ describe("calcite-tree", () => {
         await page.setContent(
           html`<calcite-tree lines selection-mode="multichildren" scale="s">
             <calcite-tree-item id="1"> Child 1 </calcite-tree-item>
-            <calcite-tree-item id="2">
+            <calcite-tree-item id="2" expanded>
               Child 2
               <calcite-tree slot="children">
                 <calcite-tree-item id="3" disabled> Grandchild 1 </calcite-tree-item>
@@ -387,19 +387,19 @@ describe("calcite-tree", () => {
 
         const [item1, item2, item3, item4] = await page.findAll("calcite-tree-item");
 
-        await item1.click();
+        await directItemClick(page, item1);
 
         expect(await tree.getProperty("selectedItems")).toHaveLength(1);
 
-        await item2.click();
+        await directItemClick(page, item2);
 
         expect(await tree.getProperty("selectedItems")).toHaveLength(2);
 
-        await item3.click();
+        await directItemClick(page, item3);
 
         expect(await tree.getProperty("selectedItems")).toHaveLength(2);
 
-        await item4.click();
+        await directItemClick(page, item4);
 
         expect(await tree.getProperty("selectedItems")).toHaveLength(3);
       });
@@ -1139,7 +1139,7 @@ describe("calcite-tree", () => {
         selectionMode: "none",
         canDeselect: false,
         expandableItemClick: {
-          selectsItem: true,
+          selectsItem: false,
           selectsChildren: false,
         },
       },
@@ -1200,15 +1200,13 @@ describe("calcite-tree", () => {
 
           await directItemClick(page, expandableParentItem);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(true);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(!selectsItem);
           const expectedSelectedItemsAfterExpanding = (selectsItem ? 1 : 0) + (selectsChildren ? childItems.length : 0);
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterExpanding);
 
           await directItemClick(page, expandableParentItem);
 
-          const onlyExpandsWhenDeselected = selectsItem && selectsChildren;
-
-          expect(await expandableParentItem.getProperty("expanded")).toBe(onlyExpandsWhenDeselected);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(false);
           const expectedSelectedItemsAfterCollapsing = canDeselect ? 0 : expectedSelectedItemsAfterExpanding;
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
 
@@ -1216,12 +1214,12 @@ describe("calcite-tree", () => {
 
           await directItemClick(page, expandableParentToggle);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(!onlyExpandsWhenDeselected);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(true);
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
 
           await directItemClick(page, expandableParentToggle);
 
-          expect(await expandableParentItem.getProperty("expanded")).toBe(onlyExpandsWhenDeselected);
+          expect(await expandableParentItem.getProperty("expanded")).toBe(false);
           expect(await tree.getProperty("selectedItems")).toHaveLength(expectedSelectedItemsAfterCollapsing);
         });
       }

--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -441,7 +441,7 @@ describe("calcite-tree", () => {
     });
 
     describe(`when tree-item selection-mode is "none"`, () => {
-      it("allows selecting items without a selection", async () => {
+      it("emits selection event without updating selection", async () => {
         const page = await newE2EPage();
         await page.setContent(html`
           <calcite-tree selection-mode="none">
@@ -456,12 +456,12 @@ describe("calcite-tree", () => {
 
         await item1.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(1);
-        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(0);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
 
         await item2.click();
         expect(selectEventSpy).toHaveReceivedEventTimes(2);
-        expect(await tree.getProperty("selectedItems")).toHaveLength(1);
+        expect(await tree.getProperty("selectedItems")).toHaveLength(0);
         expect(await page.findAll("calcite-tree-item[selected]")).toHaveLength(0);
       });
     });

--- a/packages/calcite-components/src/components/tree/tree.stories.ts
+++ b/packages/calcite-components/src/components/tree/tree.stories.ts
@@ -301,3 +301,173 @@ export const OverflowingSubtree = (): string =>
         }, 1000);
       });
     </script>`;
+
+export const allSelectionModesExpanded_TestOnly = (): string => html`
+  <h2>ancestors</h2>
+  <calcite-tree selection-mode="ancestors">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>children</h2>
+  <calcite-tree selection-mode="children">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>multichildren</h2>
+  <calcite-tree selection-mode="multichildren">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>multiple</h2>
+  <calcite-tree selection-mode="multiple">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>none</h2>
+  <calcite-tree selection-mode="none">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>single</h2>
+  <calcite-tree selection-mode="single">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+
+  <h2>single-persist</h2>
+  <calcite-tree selection-mode="single-persist">
+    <calcite-tree-item> <span>Child 1</span> </calcite-tree-item>
+
+    <calcite-tree-item expanded>
+      <span>Child 2</span>
+
+      <calcite-tree slot="children">
+        <calcite-tree-item> <span>Grandchild 1</span> </calcite-tree-item>
+
+        <calcite-tree-item> <span>Grandchild 2</span> </calcite-tree-item>
+
+        <calcite-tree-item>
+          <span>Grandchild 3</span>
+          <calcite-tree slot="children">
+            <calcite-tree-item> <span>Great-Grandchild 1</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 2</span> </calcite-tree-item>
+            <calcite-tree-item> <span>Great-Grandchild 3</span> </calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>
+    </calcite-tree-item>
+  </calcite-tree>
+`;

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -216,7 +216,7 @@ export class Tree {
     }
 
     this.selectedItems = isNoneSelectionMode
-      ? [target]
+      ? []
       : (nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter(
           (i) => i.selected
         ) as HTMLCalciteTreeItemElement[]);

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -170,6 +170,10 @@ export class Tree {
         this.selectionMode === "children" ||
         this.selectionMode === "multichildren");
 
+    const shouldUpdateExpand =
+      ["multiple", "none", "single", "single-persist"].includes(this.selectionMode) &&
+      target.hasChildren;
+
     const targetItems: HTMLCalciteTreeItemElement[] = [];
 
     if (shouldSelect) {
@@ -186,6 +190,13 @@ export class Tree {
           treeItem.selected = false;
         }
       });
+    }
+
+    if (
+      shouldUpdateExpand &&
+      ["multiple", "none", "single", "single-persist"].includes(this.selectionMode)
+    ) {
+      target.expanded = !target.expanded;
     }
 
     if (shouldDeselectAllChildren) {

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -144,8 +144,8 @@ export class Tree {
     event.stopPropagation();
 
     if (this.selectionMode === "ancestors") {
-      if (event.detail.updateItem) {
-        target.expanded = !target.expanded;
+      if (event.detail.updateItem && !target.expanded && !target.selected) {
+        target.expanded = true;
       }
 
       this.updateAncestorTree(event);

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -156,6 +156,8 @@ export class Tree {
         (target.hasChildren &&
           (this.selectionMode === "children" || this.selectionMode === "multichildren")));
 
+    const shouldDeselectAllChildren = this.selectionMode === "multichildren" && target.hasChildren;
+
     const shouldModifyToCurrentSelection =
       !isNoneSelectionMode &&
       event.detail.modifyCurrentSelection &&
@@ -182,6 +184,15 @@ export class Tree {
       selectedItems.forEach((treeItem) => {
         if (!targetItems.includes(treeItem)) {
           treeItem.selected = false;
+        }
+      });
+    }
+
+    if (shouldDeselectAllChildren) {
+      childItems.forEach((item) => {
+        item.selected = false;
+        if (item.hasChildren) {
+          item.expanded = false;
         }
       });
     }

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -131,14 +131,14 @@ export class Tree {
 
   @Listen("calciteInternalTreeItemSelect")
   onInternalTreeItemSelect(event: CustomEvent<TreeItemSelectDetail>): void {
+    if (this.child) {
+      return;
+    }
+
     const target = event.target as HTMLCalciteTreeItemElement;
     const childItems = nodeListToArray(
       target.querySelectorAll("calcite-tree-item")
     ) as HTMLCalciteTreeItemElement[];
-
-    if (this.child) {
-      return;
-    }
 
     event.preventDefault();
     event.stopPropagation();

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -144,10 +144,6 @@ export class Tree {
     event.stopPropagation();
 
     if (this.selectionMode === "ancestors") {
-      if (event.detail.updateItem && !target.expanded && !target.selected) {
-        target.expanded = true;
-      }
-
       this.updateAncestorTree(event);
       return;
     }
@@ -172,12 +168,6 @@ export class Tree {
         this.selectionMode === "children" ||
         this.selectionMode === "multichildren");
 
-    const shouldUpdateExpand =
-      ["children", "multichildren"].includes(this.selectionMode) ||
-      (["ancestors", "multiple", "none", "single", "single-persist"].includes(this.selectionMode) &&
-        target.hasChildren &&
-        !event.detail.forceToggle);
-
     const targetItems: HTMLCalciteTreeItemElement[] = [];
 
     if (shouldSelect) {
@@ -196,23 +186,11 @@ export class Tree {
       });
     }
 
-    if (shouldUpdateExpand) {
-      if (
-        ["ancestors", "multiple", "none", "single", "single-persist"].includes(this.selectionMode)
-      ) {
-        target.expanded = !target.expanded;
-      } else if (this.selectionMode === "multichildren") {
-        target.expanded = !target.selected;
-      } else if (this.selectionMode === "children") {
-        target.expanded = target.selected ? !target.expanded : true;
-      }
-    }
-
     if (shouldModifyToCurrentSelection) {
       window.getSelection().removeAllRanges();
     }
 
-    if ((shouldModifyToCurrentSelection && target.selected) || event.detail.forceToggle) {
+    if (shouldModifyToCurrentSelection && target.selected) {
       targetItems.forEach((treeItem) => {
         if (!treeItem.disabled) {
           treeItem.selected = false;


### PR DESCRIPTION
**Related Issue:** #6971 

## Summary

* toggle non-selectable parents when clicked w/o affecting selection (`multiple`, `none`, `single`, `single-persist`)
* update selection color & text weight (`children`, `multichildren`)