### PR TITLE
feat(flow, flow-item): Allow calciteFlowItemBack event to be cancelled

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -168,7 +168,7 @@ export class FlowItem
   /**
    * Fires when the back button is clicked.
    */
-  @Event({ cancelable: false }) calciteFlowItemBack: EventEmitter<void>;
+  @Event({ cancelable: true }) calciteFlowItemBack: EventEmitter<void>;
 
   /**
    * Fires when the content is scrolled.

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -80,19 +80,55 @@ describe("calcite-flow", () => {
 
     it("goes back when item back button is clicked", async () => {
       const page = await newE2EPage();
-
       await page.setContent(html`<calcite-flow show-back-button>
         <calcite-flow-item id="first"></calcite-flow-item>
         <calcite-flow-item id="second"></calcite-flow-item>
       </calcite-flow>`);
+      await page.waitForChanges();
+
+      let items = await page.findAll("calcite-flow-item");
+
+      expect(items).toHaveLength(2);
+      expect(items[0].id).toBe("first");
+      expect(items[1].id).toBe("second");
 
       const activeItemBackButton = await page.find(`calcite-flow-item:last-of-type >>> .${ITEM_CSS.backButton}`);
       await activeItemBackButton.click();
+      await page.waitForChanges();
 
-      const items = await page.findAll("calcite-flow-item");
+      items = await page.findAll("calcite-flow-item");
 
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe("first");
+    });
+
+    it("does not go back when item back button is clicked and defaultPrevented", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-flow show-back-button>
+        <calcite-flow-item id="first"></calcite-flow-item>
+        <calcite-flow-item id="second"></calcite-flow-item>
+      </calcite-flow>`);
+      await page.waitForChanges();
+
+      let items = await page.findAll("calcite-flow-item");
+
+      expect(items).toHaveLength(2);
+      expect(items[0].id).toBe("first");
+      expect(items[1].id).toBe("second");
+
+      await page.evaluate((backButtonSelector) => {
+        const lastFlowItem = document.querySelector("calcite-flow-item:last-of-type");
+
+        lastFlowItem?.addEventListener("calciteFlowItemBack", (event) => event.preventDefault());
+
+        lastFlowItem?.shadowRoot.querySelector(backButtonSelector)?.click();
+      }, `.${ITEM_CSS.backButton}`);
+      await page.waitForChanges();
+
+      items = await page.findAll("calcite-flow-item");
+      expect(items).toHaveLength(2);
+      expect(items[0].id).toBe("first");
+      expect(items[1].id).toBe("second");
     });
 
     it("setting 'beforeBack' should be called in 'back()'", async () => {

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -125,7 +125,11 @@ export class Flow implements LoadableComponent {
   // --------------------------------------------------------------------------
 
   @Listen("calciteFlowItemBack")
-  async handleItemBackClick(): Promise<void> {
+  async handleItemBackClick(event: CustomEvent): Promise<void> {
+    if (event.defaultPrevented) {
+      return;
+    }
+
     await this.back();
     return this.setFocus();
   }


### PR DESCRIPTION
**Related Issue:**#7869

## Summary

- Supports the cancelling of the `calciteFlowItemBack` event via `preventDefault()`
- Changes event to be cancellable
- Adds test
