### PR TITLE
fix(list-item): Make width of caret icon consistent with selection icon

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -104,8 +104,12 @@ td:focus {
 }
 
 .selection-container {
-  @apply flex px-3;
+  @apply px-3;
   color: var(--calcite-list-item-icon-color);
+}
+
+.open-container {
+  @apply px-3;
 }
 
 .actions-start,


### PR DESCRIPTION
**Related Issue:** None

## Summary

- Currently, the hit area for the expand/collapse of a list item is a bit small. (18px)
- This adds padding consistent with the selection icon

## Current

![image](https://github.com/Esri/calcite-design-system/assets/1231455/8170df37-6f42-4d40-8916-ebad56d73802)

## New

![image](https://github.com/Esri/calcite-design-system/assets/1231455/49eafd0d-13ff-4c60-8b07-f669b39dc50f)


