### PR TITLE
docs: updates d thru i component usage examples

### DIFF
--- a/packages/calcite-components/src/components/date-picker/usage/Range.md
+++ b/packages/calcite-components/src/components/date-picker/usage/Range.md
@@ -1,5 +1,9 @@
 You can also add range property to activate date range mode. In this mode, you will have to set the value property directly on the component's instance to an array of date strings.
 
 ```html
-<calcite-date-picker range min="2020-02-01" max="2021-01-01" />
+<calcite-date-picker min="2020-01-01" max="2021-01-31" range />
+```
+
+```js
+document.querySelector("calcite-date-picker").value = ["2020-01-03", "2020-01-05"];
 ```

--- a/packages/calcite-components/src/components/dropdown/usage/Basic.md
+++ b/packages/calcite-components/src/components/dropdown/usage/Basic.md
@@ -1,10 +1,12 @@
+Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`.
+
 ```html
 <calcite-dropdown>
-  <calcite-button slot="trigger">Open Dropdown</calcite-button>
+  <calcite-button slot="trigger">Choose a fruit</calcite-button>
   <calcite-dropdown-group>
-    <calcite-dropdown-item>Relevance</calcite-dropdown-item>
-    <calcite-dropdown-item selected>Date modified</calcite-dropdown-item>
-    <calcite-dropdown-item>Title</calcite-dropdown-item>
+    <calcite-dropdown-item>Apple</calcite-dropdown-item>
+    <calcite-dropdown-item selected>Orange</calcite-dropdown-item>
+    <calcite-dropdown-item>Banana</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>
 ```

--- a/packages/calcite-components/src/components/dropdown/usage/Disabling-close-on-select.md
+++ b/packages/calcite-components/src/components/dropdown/usage/Disabling-close-on-select.md
@@ -1,12 +1,12 @@
-You can choose to leave the dropdown open when an item is selected with the `close-on-select-disabled` attribute. Note that this will only apply when the `calcite-dropdown-group` selection mode is set to `single` or `multi` - dropdowns will always close when an item in `none` selection mode is selected.
+You can choose to leave the Dropdown open when an item is selected with the `close-on-select-disabled` attribute. Note that this will only apply when the `calcite-dropdown-group`'s `selectionMode` is set to `"single"` or `"multiple"`. Dropdowns will always close when the `calcite-dropdown-group`'s `selectionMode` is `"none"`.
 
 ```html
 <calcite-dropdown close-on-select-disabled>
-  <calcite-button id="trigger" slot="trigger">Open dropdown</calcite-button>
-  <calcite-dropdown-group id="group-1" selection-mode="single">
-    <calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>
-    <calcite-dropdown-item id="item-2" selected> Dropdown Item Content </calcite-dropdown-item>
-    <calcite-dropdown-item id="item-3"> Dropdown Item Content </calcite-dropdown-item>
+  <calcite-button id="trigger" slot="trigger">Choose a fruit</calcite-button>
+  <calcite-dropdown-group id="fruits" selection-mode="single">
+    <calcite-dropdown-item id="apple">Apple</calcite-dropdown-item>
+    <calcite-dropdown-item id="orange" selected>Orange</calcite-dropdown-item>
+    <calcite-dropdown-item id="banana">Banana</calcite-dropdown-item>
   </calcite-dropdown-group>
 </calcite-dropdown>
 ```

--- a/packages/calcite-components/src/components/dropdown/usage/Groups.md
+++ b/packages/calcite-components/src/components/dropdown/usage/Groups.md
@@ -1,14 +1,14 @@
-You can combine groups in a single dropdown, with varying selection modes:
+You can combine groups in a single Dropdown, with different `selectionMode`s:
 
 ```html
 <calcite-dropdown>
-  <calcite-button slot="trigger">Open Dropdown</calcite-button>
-  <calcite-dropdown-group group-title="Select one">
+  <calcite-button slot="trigger">Add to cart</calcite-button>
+  <calcite-dropdown-group group-title="Select one fruit">
     <calcite-dropdown-item>Apple</calcite-dropdown-item>
     <calcite-dropdown-item selected>Orange</calcite-dropdown-item>
-    <calcite-dropdown-item>Grape</calcite-dropdown-item>
+    <calcite-dropdown-item>Banana</calcite-dropdown-item>
   </calcite-dropdown-group>
-  <calcite-dropdown-group group-title="Select multi" selection-mode="multi">
+  <calcite-dropdown-group group-title="Select multiple vegetables" selection-mode="multiple">
     <calcite-dropdown-item>Asparagus</calcite-dropdown-item>
     <calcite-dropdown-item selected>Potato</calcite-dropdown-item>
     <calcite-dropdown-item>Yam</calcite-dropdown-item>

--- a/packages/calcite-components/src/components/fab/usage/Loading-and-disabled.md
+++ b/packages/calcite-components/src/components/fab/usage/Loading-and-disabled.md
@@ -1,4 +1,4 @@
-Renders a `calcite-fab` that is loading and disabled.
+Renders a `calcite-fab` that is `loading` and `disabled`.
 
 ```html
 <calcite-fab loading disabled></calcite-fab>

--- a/packages/calcite-components/src/components/fab/usage/Styling.md
+++ b/packages/calcite-components/src/components/fab/usage/Styling.md
@@ -1,0 +1,5 @@
+Configure styling for a `calcite-fab` to fit your UI and branding with the `appearance` and `kind` attributes/properties:
+
+```html
+<calcite-fab appearance="outline-fill" kind="danger" icon="trash" label="Remove layer"></calcite-fab>
+```

--- a/packages/calcite-components/src/components/fab/usage/With-text.md
+++ b/packages/calcite-components/src/components/fab/usage/With-text.md
@@ -1,4 +1,4 @@
-Renders a `calcite-fab` that displays text along side an icon and a tooltip label.
+Renders a `calcite-fab` that displays text alongside an icon.
 
 ```html
 <calcite-fab label="Performs my custom action" text="Perform Action!" text-enabled></calcite-fab>

--- a/packages/calcite-components/src/components/flow/usage/Basic.md
+++ b/packages/calcite-components/src/components/flow/usage/Basic.md
@@ -1,12 +1,64 @@
-Renders a basic flow with a couple `calcite-panel`s.
+Populate Flow with `calcite-flow-item`s to step inside a `calcite-panel` element with HTML and JavaScript:
 
 ```html
-<calcite-flow>
-  <calcite-panel heading="one, two, three, four">
-    <!-- image -->
-  </calcite-panel>
-  <calcite-panel heading="tell me that you love me more">
-    <!-- image -->
-  </calcite-panel>
-</calcite-flow>
+<calcite-shell>
+  <calcite-shell-panel slot="panel-start" width-scale="l">
+    <calcite-flow id="example-flow">
+      <calcite-flow-item heading="Places of Education">
+        <calcite-block id="first-flow-item-block" heading="Recommended for you" description="4 results" open>
+          <calcite-list>
+            <calcite-list-item label="Narnia Community College" description="Wardobe, IA"> </calcite-list-item>
+            <calcite-list-item label="University of Acme" description="Acmeton, CA"></calcite-list-item>
+            <calcite-list-item label="Roadrunner Trade School" description="Zion, UT"></calcite-list-item>
+            <calcite-list-item label="Cartographic Institute" description="Redlands, CA"> </calcite-list-item>
+          </calcite-list>
+        </calcite-block>
+      </calcite-flow-item>
+    </calcite-flow>
+  </calcite-shell-panel>
+  <calcite-panel heading="Content"></calcite-panel>
+</calcite-shell>
+```
+
+```js
+const flow = document.getElementById("example-flow");
+const items = document.querySelectorAll("calcite-list-item");
+
+items?.forEach((item) => {
+  item.addEventListener("calciteListItemSelect", (event) => {
+    createFlowItem(event, event.target.label, event.target.description, false);
+  });
+});
+
+function createFlowItem(event, title, description, isLastLevel) {
+  const newFlowItem = document.createElement("calcite-flow-item");
+  newFlowItem.heading = !isLastLevel ? title : "Even more details";
+  newFlowItem.description = !isLastLevel ? description : title;
+
+  const block = document.createElement("calcite-block");
+  block.open = true;
+  block.heading = "Details";
+  newFlowItem.append(block);
+
+  const notice = document.createElement("calcite-notice");
+  notice.open = true;
+  notice.width = "full";
+  block.append(notice);
+
+  const noticeMessage = document.createElement("span");
+  noticeMessage.slot = "message";
+  noticeMessage.innerText = !isLastLevel ? `A new Flow Item for ${title}.` : "You've reached the end of the line.";
+  notice.append(noticeMessage);
+
+  if (!isLastLevel) {
+    const button = document.createElement("calcite-button");
+    button.slot = "footer";
+    button.width = "full";
+    button.innerText = "Move to a third Flow Item";
+    button.addEventListener("click", (event) => createFlowItem(event, title, description, true));
+    if (!isLastLevel) newFlowItem.append(button);
+  }
+
+  flow.append(newFlowItem);
+}
 ```

--- a/packages/calcite-components/src/components/flow/usage/Menu-actions-and-footer-actions.md
+++ b/packages/calcite-components/src/components/flow/usage/Menu-actions-and-footer-actions.md
@@ -1,12 +1,20 @@
-Renders a flow with menu-actions and footer in the form of buttons.
+Renders a flow with `"header-actions-start"`, `"header-actions-end"`, `"header-menu-actions"`, `"fab"`, and `"footer"` slots.
 
 ```html
-<calcite-flow>
-  <calcite-panel heading="What are the most popular commute alternatives?">
-    <button slot="header-menu-actions">Reset</button>
-    <button slot="header-menu-actions">Rename</button>
-    <button slot="footer">Save</button>
-    <button slot="footer">Cancel</button>
-  </calcite-panel>
-</calcite-flow>
+<calcite-shell>
+  <calcite-shell-panel slot="panel-start" width-scale="l">
+    <calcite-flow>
+      <calcite-flow-item heading="Map Options">
+        <calcite-action icon="question" text="Information" slot="header-actions-start"></calcite-action>
+        <calcite-action icon="save" text="Save" slot="header-actions-end"></calcite-action>
+        <calcite-action icon="reset" text-enabled text="Reset" slot="header-menu-actions"></calcite-action>
+        <calcite-action icon="pencil" text-enabled text="Rename" slot="header-menu-actions"> </calcite-action>
+        <calcite-fab slot="fab"></calcite-fab>
+        <calcite-button width="half" slot="footer" appearance="outline">Cancel</calcite-button>
+        <calcite-button width="half" slot="footer">Next</calcite-button>
+      </calcite-flow-item>
+    </calcite-flow>
+  </calcite-shell-panel>
+  <calcite-panel heading="Map"></calcite-panel>
+</calcite-shell>
 ```

--- a/packages/calcite-components/src/components/icon/usage/Custom-icon-color.md
+++ b/packages/calcite-components/src/components/icon/usage/Custom-icon-color.md
@@ -1,4 +1,4 @@
-To use a custom color for the icon fill, you can add a class to the `calcite-icon` component with the desired color.
+To use a custom color for the icon fill, you can supply your desired color to the `--calcite-ui-icon-color` CSS variable:
 
 ```html
 <calcite-icon class="my-icon-color-class" icon="arrowBoldLeft"></calcite-icon>
@@ -6,6 +6,6 @@ To use a custom color for the icon fill, you can add a class to the `calcite-ico
 
 ```css
 .my-icon-color-class {
-  color: #007ac2;
+  --calcite-ui-icon-color: #007ac2;
 }
 ```

--- a/packages/calcite-components/src/components/inline-editable/usage/Basic.md
+++ b/packages/calcite-components/src/components/inline-editable/usage/Basic.md
@@ -2,6 +2,6 @@ There is no need to set a theme or scale on the `<calcite-inline-editable>` comp
 
 ```html
 <calcite-inline-editable>
-  <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+  <calcite-input value="City of Acme Tree Survey" placeholder="City of Acme Tree Survey"></calcite-input>
 </calcite-inline-editable>
 ```

--- a/packages/calcite-components/src/components/inline-editable/usage/With-label.md
+++ b/packages/calcite-components/src/components/inline-editable/usage/With-label.md
@@ -1,8 +1,8 @@
 ```html
 <calcite-label>
-  My great label
-  <calcite-inline-editable controls>
-    <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+  Survey name
+  <calcite-inline-editable>
+    <calcite-input value="City of Acme Tree Survey" placeholder="City of Acme Tree Survey"></calcite-input>
   </calcite-inline-editable>
 </calcite-label>
 ```

--- a/packages/calcite-components/src/components/inline-editable/usage/With-save-and-cancel-controls.md
+++ b/packages/calcite-components/src/components/inline-editable/usage/With-save-and-cancel-controls.md
@@ -1,5 +1,7 @@
+Add "Save" and "Cancel" controls:
+
 ```html
 <calcite-inline-editable controls>
-  <calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+  <calcite-input value="City of Acme Tree Survey" placeholder="City of Acme Tree Survey"></calcite-input>
 </calcite-inline-editable>
 ```

--- a/packages/calcite-components/src/components/input-date-picker/usage/Basic.md
+++ b/packages/calcite-components/src/components/input-date-picker/usage/Basic.md
@@ -2,13 +2,7 @@
 <div style="width: 400px">
   <calcite-label layout="inline">
     Date
-    <calcite-input-date-picker
-      min="2016-08-09"
-      max="2023-12-18"
-      lang="en"
-      role="application"
-      layout="horizontal"
-    ></calcite-input-date-picker>
+    <calcite-input-date-picker min="2016-08-09" max="2023-12-18" lang="en"></calcite-input-date-picker>
   </calcite-label>
 </div>
 ```

--- a/packages/calcite-components/src/components/input-date-picker/usage/Range.md
+++ b/packages/calcite-components/src/components/input-date-picker/usage/Range.md
@@ -1,0 +1,9 @@
+Add a `range` to the component. To set the component's value use the JavaScript `value` property with an array of strings:
+
+```html
+<calcite-input-date-picker min="2016-08-09" max="2023-12-18" lang="en" range></calcite-input-date-picker>
+```
+
+```js
+document.querySelector("calcite-input-date-picker").value = ["2023-10-01", "2023-11-30"];
+```

--- a/packages/calcite-components/src/components/input-message/usage/Basic.md
+++ b/packages/calcite-components/src/components/input-message/usage/Basic.md
@@ -1,10 +1,10 @@
 ```html
 <calcite-label>
-  My great label
-  <calcite-input status="invalid" placeholder="“Enter" your information”></calcite-input>
-  <calcite-input-message status="invalid"
-    >That's not going to work out.
-    <calcite-button appearance="inline" href="">Learn more</calcite-button></calcite-input-message
-  >
+  Desired subdomain
+  <calcite-input suffix-text=".city-of-acme.gov" placeholder="Enter your subdomain" value="big-map-fan">
+  </calcite-input>
+  <calcite-input-message icon="check-circle" status="valid">
+    Excellent news - this domain is available.
+  </calcite-input-message>
 </calcite-label>
 ```

--- a/packages/calcite-components/src/components/input-number/usage/Basic.md
+++ b/packages/calcite-components/src/components/input-number/usage/Basic.md
@@ -1,0 +1,3 @@
+```html
+<calcite-input-number placeholder="Offset distance" step="0.25" suffix-text="miles"></calcite-input-number>
+```

--- a/packages/calcite-components/src/components/input-number/usage/Integer.md
+++ b/packages/calcite-components/src/components/input-number/usage/Integer.md
@@ -1,0 +1,8 @@
+Restrict the component to integer numbers only with `integer`, which will disable exponential notation.
+
+```html
+<calcite-label layout="inline">
+  Birds observed
+  <calcite-input-number placeholder="Number of birds" step="1" min="0" integer></calcite-input-number>
+</calcite-label>
+```

--- a/packages/calcite-components/src/components/input-text/usage/Basic.md
+++ b/packages/calcite-components/src/components/input-text/usage/Basic.md
@@ -1,0 +1,3 @@
+```html
+<calcite-input-text placeholder="Enter your region"></calcite-input-text>
+```

--- a/packages/calcite-components/src/components/input/usage/Basic.md
+++ b/packages/calcite-components/src/components/input/usage/Basic.md
@@ -1,3 +1,3 @@
 ```html
-<calcite-input value="Entered value" placeholder="My placeholder"></calcite-input>
+<calcite-input placeholder="Enter your region"></calcite-input>
 ```

--- a/packages/calcite-components/src/components/input/usage/Clearable.md
+++ b/packages/calcite-components/src/components/input/usage/Clearable.md
@@ -1,6 +1,8 @@
+Display a clear button when the component has a value with the `clearable` attribute:
+
 ```html
 <calcite-label>
-  Clearable item
-  <calcite-input clearable value="My great name" placeholder="John Doe"></calcite-input>
+  Full name
+  <calcite-input clearable value="John Doe" placeholder="John Doe"></calcite-input>
 </calcite-label>
 ```

--- a/packages/calcite-components/src/components/input/usage/Native-events.md
+++ b/packages/calcite-components/src/components/input/usage/Native-events.md
@@ -5,11 +5,14 @@ You must use `focusin`/`focusout` instead of `focus`/`blur` because these events
 All events return an element and a value:
 
 ```js
-input.addEventListener("focusin", logFocus);
-input.addEventListener("focusout", logBlur);
+inputEl.addEventListener("focusin", logFocus);
+inputEl.addEventListener("focusout", logBlur);
 
-function logChange() {
-  console.log(event.target.element);
+function logFocus() {
+  console.log(event.target);
+}
+
+function logBlur() {
   console.log(event.target.value);
 }
 ```

--- a/packages/calcite-components/src/components/input/usage/With-message.md
+++ b/packages/calcite-components/src/components/input/usage/With-message.md
@@ -1,7 +1,14 @@
 ```html
-<calcite-label for="info">
-  My great label
-  <calcite-input id="info" placeholder="Enter your information"></calcite-input>
-  <calcite-input-message icon="3d-glasses"> Here's something you should know about this input </calcite-input-message>
+<calcite-label>
+  Desired subdomain
+  <calcite-input
+    suffix-text=".city-of-acme.gov"
+    status="invalid"
+    placeholder="Enter your subdomain"
+    value="i-love-maps"
+  ></calcite-input>
+  <calcite-input-message icon="frown" status="invalid">
+    Apologies, this subdomain has already been registered.
+  </calcite-input-message>
 </calcite-label>
 ```


### PR DESCRIPTION
**Related Issue:** #6374 

## Summary
Updates component usage examples for the following `d` through `i` named components:
- `date-picker`: 
  - Showcase `range` types with the JS `value` prop.
- `dropdown`: 
  - Update `selectionMode` value from `"multi"` to `"multiple"`
  - Consistent usage samples
- `fab`: 
  - Add description
  - Adds new styling sample 
- `flow`
  - Updates to doc site samples for more robust usage examples
- `icon`
  - Showcase css var
- `inline-editable`
  - Consistent usage samples
- `input`
  - Various improvements across samples
- `input-date-picker`
  - Update basic example for clarity
  - Adds `range` example
- `input-message`
  - Updates to doc site sample for a more robust usage example
- `input-number`
  - Adds new samples including `integer` example
- `input-text`
  - Adds new sample