### PR TITLE
feat(action-menu): Add appearance property to configure trigger appearance

### DIFF
--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -37,6 +37,10 @@ describe("calcite-action-menu", () => {
   describe("defaults", () => {
     defaults("calcite-action-menu", [
       {
+        propertyName: "appearance",
+        defaultValue: "solid",
+      },
+      {
         propertyName: "expanded",
         defaultValue: false,
       },

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -1,6 +1,5 @@
 :host {
-  @apply bg-foreground-1
-  text-color-2
+  @apply text-color-2
   text-1
   box-border
   flex

--- a/packages/calcite-components/src/components/action-menu/action-menu.stories.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.stories.ts
@@ -20,6 +20,24 @@ export const simple = (): string =>
     </calcite-action-menu>
   `;
 
+export const simpleSolid_TestOnly = (): string =>
+  html`<div style="background-color:#99ccff">
+    <calcite-action-menu>
+      <calcite-action text="Plus" icon="plus" text-enabled></calcite-action>
+      <calcite-action text="Minus" icon="minus" text-enabled></calcite-action>
+      <calcite-action text="Table" icon="table" text-enabled></calcite-action>
+    </calcite-action-menu>
+  </div> `;
+
+export const simpleTransparent_TestOnly = (): string =>
+  html`<div style="background-color:#99ccff">
+    <calcite-action-menu appearance="transparent">
+      <calcite-action text="Plus" icon="plus" text-enabled></calcite-action>
+      <calcite-action text="Minus" icon="minus" text-enabled></calcite-action>
+      <calcite-action text="Table" icon="table" text-enabled></calcite-action>
+    </calcite-action-menu>
+  </div> `;
+
 export const open = (): string =>
   html`
     <calcite-action-menu open>

--- a/packages/calcite-components/src/components/action-menu/action-menu.stories.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.stories.ts
@@ -20,17 +20,8 @@ export const simple = (): string =>
     </calcite-action-menu>
   `;
 
-export const simpleSolid_TestOnly = (): string =>
-  html`<div style="background-color:#99ccff">
-    <calcite-action-menu>
-      <calcite-action text="Plus" icon="plus" text-enabled></calcite-action>
-      <calcite-action text="Minus" icon="minus" text-enabled></calcite-action>
-      <calcite-action text="Table" icon="table" text-enabled></calcite-action>
-    </calcite-action-menu>
-  </div> `;
-
 export const simpleTransparent_TestOnly = (): string =>
-  html`<div style="background-color:#99ccff">
+  html`<div style="background-color:red">
     <calcite-action-menu appearance="transparent">
       <calcite-action text="Plus" icon="plus" text-enabled></calcite-action>
       <calcite-action text="Minus" icon="minus" text-enabled></calcite-action>

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -22,7 +22,7 @@ import {
   setComponentLoaded,
   setUpLoadableComponent,
 } from "../../utils/loadable";
-import { Scale } from "../interfaces";
+import { Appearance, Scale } from "../interfaces";
 import { CSS, ICONS, SLOTS } from "./resources";
 
 const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
@@ -61,6 +61,9 @@ export class ActionMenu implements LoadableComponent {
   //  Properties
   //
   // --------------------------------------------------------------------------
+
+  /** Specifies the appearance of the component. */
+  @Prop({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> = "solid";
 
   /**
    * When `true`, the component is expanded.
@@ -263,11 +266,12 @@ export class ActionMenu implements LoadableComponent {
   };
 
   renderMenuButton(): VNode {
-    const { label, scale, expanded } = this;
+    const { appearance, label, scale, expanded } = this;
 
     const menuButtonSlot = (
       <slot name={SLOTS.trigger} onSlotchange={this.setMenuButtonEl}>
         <calcite-action
+          appearance={appearance}
           class={CSS.defaultTrigger}
           icon={ICONS.menu}
           scale={scale}


### PR DESCRIPTION
**Related Issue:** None

## Summary

- Adds `appearance` property to `calcite-action-menu`.
- Allows menu to configure the default action's appearance
- Adds test
- Adds screenshot tests