### PR TITLE
build: bump node to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
   },
   "packageManager": "npm@8.19.4",
   "volta": {
-    "node": "16.20.0"
+    "node": "18.18.0"
   }
 }


### PR DESCRIPTION
## Summary

Node v16 died on 9/11 (no that's not a distasteful joke): https://nodejs.dev/en/about/releases/

A variety of packages are dropping support, including ESLint. Bumping Volta's pinned version to v18 (the current LTS).