### PR TITLE
feat(list): add newIndex and oldIndex event details to calciteListOrderChange event

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -6,6 +6,7 @@ import { debounceTimeout } from "./resources";
 import { CSS } from "../list-item/resources";
 import { DEBOUNCE_TIMEOUT as FILTER_DEBOUNCE_TIMEOUT } from "../filter/resources";
 import { GlobalTestProps, dragAndDrop, isElementFocused } from "../../tests/utils";
+import { DragDetail } from "../../utils/sortableComponent";
 
 const placeholder = placeholderImage({
   width: 140,
@@ -474,6 +475,8 @@ describe("calcite-list", () => {
 
     type TestWindow = GlobalTestProps<{
       calledTimes: number;
+      newIndex: number;
+      oldIndex: number;
     }>;
 
     it("works using a mouse", async () => {
@@ -482,8 +485,10 @@ describe("calcite-list", () => {
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("calcite-list", (list: HTMLCalciteListElement) => {
         (window as TestWindow).calledTimes = 0;
-        list.addEventListener("calciteListOrderChange", () => {
+        list.addEventListener("calciteListOrderChange", (event: CustomEvent<DragDetail>) => {
           (window as TestWindow).calledTimes++;
+          (window as TestWindow).newIndex = event.detail.newIndex;
+          (window as TestWindow).oldIndex = event.detail.oldIndex;
         });
       });
 
@@ -505,6 +510,8 @@ describe("calcite-list", () => {
       await page.waitForChanges();
 
       expect(await page.evaluate(() => (window as TestWindow).calledTimes)).toBe(1);
+      expect(await page.evaluate(() => (window as TestWindow).oldIndex)).toBe(0);
+      expect(await page.evaluate(() => (window as TestWindow).newIndex)).toBe(1);
     });
 
     it("supports dragging items between lists", async () => {

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -481,10 +481,10 @@ describe("calcite-list", () => {
 
     it("works using a mouse", async () => {
       const page = await createSimpleList();
-      const testWindow = window as TestWindow;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("calcite-list", (list: HTMLCalciteListElement) => {
+        const testWindow = window as TestWindow;
         testWindow.calledTimes = 0;
         testWindow.newIndex = -1;
         testWindow.oldIndex = -1;
@@ -512,11 +512,10 @@ describe("calcite-list", () => {
       expect(await second.getProperty("value")).toBe("one");
       await page.waitForChanges();
 
-      const results = await page.evaluate(() => ({
-        calledTimes: testWindow.calledTimes,
-        oldIndex: testWindow.oldIndex,
-        newIndex: testWindow.newIndex,
-      }));
+      const results = await page.evaluate(() => {
+        const testWindow = window as TestWindow;
+        return { calledTimes: testWindow.calledTimes, oldIndex: testWindow.oldIndex, newIndex: testWindow.newIndex };
+      });
 
       expect(results.calledTimes).toBe(1);
       expect(results.oldIndex).toBe(0);
@@ -550,10 +549,9 @@ describe("calcite-list", () => {
 
       await page.waitForChanges();
 
-      const testWindow = window as TestWindow;
-
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.evaluate(() => {
+        const testWindow = window as TestWindow;
         testWindow.calledTimes = 0;
         const lists = document.querySelectorAll("calcite-list");
         lists.forEach((list) =>
@@ -618,7 +616,7 @@ describe("calcite-list", () => {
       expect(await eight.getProperty("value")).toBe("e");
       expect(await ninth.getProperty("value")).toBe("f");
 
-      expect(await page.evaluate(() => testWindow.calledTimes)).toBe(2);
+      expect(await page.evaluate(() => (window as TestWindow).calledTimes)).toBe(2);
     });
 
     it("works using a keyboard", async () => {
@@ -633,10 +631,10 @@ describe("calcite-list", () => {
       await page.waitForChanges();
 
       let totalMoves = 0;
-      const testWindow = window as TestWindow;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("calcite-list", (list: HTMLCalciteListElement) => {
+        const testWindow = window as TestWindow;
         testWindow.calledTimes = 0;
         list.addEventListener("calciteListOrderChange", () => {
           testWindow.calledTimes++;
@@ -656,7 +654,7 @@ describe("calcite-list", () => {
           expect(await itemsAfter[i].getProperty("value")).toBe(expectedValueOrder[i]);
         }
 
-        const calledTimes = await page.evaluate(() => testWindow.calledTimes);
+        const calledTimes = await page.evaluate(() => (window as TestWindow).calledTimes);
 
         expect(calledTimes).toBe(++totalMoves);
       }

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -481,16 +481,17 @@ describe("calcite-list", () => {
 
     it("works using a mouse", async () => {
       const page = await createSimpleList();
+      const testWindow = window as TestWindow;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("calcite-list", (list: HTMLCalciteListElement) => {
-        (window as TestWindow).calledTimes = 0;
-        (window as TestWindow).newIndex = -1;
-        (window as TestWindow).oldIndex = -1;
+        testWindow.calledTimes = 0;
+        testWindow.newIndex = -1;
+        testWindow.oldIndex = -1;
         list.addEventListener("calciteListOrderChange", (event: CustomEvent<DragDetail>) => {
-          (window as TestWindow).calledTimes++;
-          (window as TestWindow).newIndex = event?.detail?.newIndex;
-          (window as TestWindow).oldIndex = event?.detail?.oldIndex;
+          testWindow.calledTimes++;
+          testWindow.newIndex = event?.detail?.newIndex;
+          testWindow.oldIndex = event?.detail?.oldIndex;
         });
       });
 
@@ -512,9 +513,9 @@ describe("calcite-list", () => {
       await page.waitForChanges();
 
       const results = await page.evaluate(() => ({
-        calledTimes: (window as TestWindow).calledTimes,
-        oldIndex: (window as TestWindow).oldIndex,
-        newIndex: (window as TestWindow).newIndex,
+        calledTimes: testWindow.calledTimes,
+        oldIndex: testWindow.oldIndex,
+        newIndex: testWindow.newIndex,
       }));
 
       expect(results.calledTimes).toBe(1);
@@ -549,13 +550,15 @@ describe("calcite-list", () => {
 
       await page.waitForChanges();
 
+      const testWindow = window as TestWindow;
+
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.evaluate(() => {
-        (window as TestWindow).calledTimes = 0;
+        testWindow.calledTimes = 0;
         const lists = document.querySelectorAll("calcite-list");
         lists.forEach((list) =>
           list.addEventListener("calciteListOrderChange", () => {
-            (window as TestWindow).calledTimes++;
+            testWindow.calledTimes++;
           })
         );
       });
@@ -615,7 +618,7 @@ describe("calcite-list", () => {
       expect(await eight.getProperty("value")).toBe("e");
       expect(await ninth.getProperty("value")).toBe("f");
 
-      expect(await page.evaluate(() => (window as TestWindow).calledTimes)).toBe(2);
+      expect(await page.evaluate(() => testWindow.calledTimes)).toBe(2);
     });
 
     it("works using a keyboard", async () => {
@@ -630,12 +633,13 @@ describe("calcite-list", () => {
       await page.waitForChanges();
 
       let totalMoves = 0;
+      const testWindow = window as TestWindow;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("calcite-list", (list: HTMLCalciteListElement) => {
-        (window as TestWindow).calledTimes = 0;
+        testWindow.calledTimes = 0;
         list.addEventListener("calciteListOrderChange", () => {
-          (window as TestWindow).calledTimes++;
+          testWindow.calledTimes++;
         });
       });
 
@@ -652,7 +656,7 @@ describe("calcite-list", () => {
           expect(await itemsAfter[i].getProperty("value")).toBe(expectedValueOrder[i]);
         }
 
-        const calledTimes = await page.evaluate(() => (window as TestWindow).calledTimes);
+        const calledTimes = await page.evaluate(() => testWindow.calledTimes);
 
         expect(calledTimes).toBe(++totalMoves);
       }

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -799,8 +799,10 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
 
     this.calciteListOrderChange.emit({
       dragEl: sortItem,
-      fromEl: null,
-      toEl: null,
+      fromEl: parentEl,
+      toEl: parentEl,
+      newIndex: buddyIndex,
+      oldIndex: startingIndex,
     });
 
     handle.setFocus().then(() => {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -766,23 +766,25 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
     const sameParentItems = enabledListItems.filter((item) => item.parentElement === parentEl);
 
     const lastIndex = sameParentItems.length - 1;
-    const startingIndex = sameParentItems.indexOf(sortItem);
+    const oldIndex = sameParentItems.indexOf(sortItem);
     let appendInstead = false;
-    let buddyIndex: number;
+    let newIndex: number;
 
     if (direction === "up") {
-      if (startingIndex === 0) {
+      if (oldIndex === 0) {
         appendInstead = true;
+        newIndex = lastIndex;
       } else {
-        buddyIndex = startingIndex - 1;
+        newIndex = oldIndex - 1;
       }
     } else {
-      if (startingIndex === lastIndex) {
-        buddyIndex = 0;
-      } else if (startingIndex === lastIndex - 1) {
+      if (oldIndex === lastIndex) {
+        newIndex = 0;
+      } else if (oldIndex === lastIndex - 1) {
         appendInstead = true;
+        newIndex = lastIndex;
       } else {
-        buddyIndex = startingIndex + 2;
+        newIndex = oldIndex + 2;
       }
     }
 
@@ -791,7 +793,7 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
     if (appendInstead) {
       parentEl.appendChild(sortItem);
     } else {
-      parentEl.insertBefore(sortItem, sameParentItems[buddyIndex]);
+      parentEl.insertBefore(sortItem, sameParentItems[newIndex]);
     }
 
     this.updateListItems();
@@ -801,8 +803,8 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
       dragEl: sortItem,
       fromEl: parentEl,
       toEl: parentEl,
-      newIndex: buddyIndex,
-      oldIndex: startingIndex,
+      newIndex,
+      oldIndex,
     });
 
     handle.setFocus().then(() => {

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -5,6 +5,8 @@ export interface DragDetail {
   toEl: HTMLElement;
   fromEl: HTMLElement;
   dragEl: HTMLElement;
+  newIndex: number;
+  oldIndex: number;
 }
 
 export const CSS = {
@@ -93,10 +95,12 @@ export function connectSortableComponent(component: SortableComponent): void {
       group: {
         name: group,
         ...(!!component.canPull && {
-          pull: (to, from, dragEl) => component.canPull({ toEl: to.el, fromEl: from.el, dragEl }),
+          pull: (to, from, dragEl, { newIndex, oldIndex }) =>
+            component.canPull({ toEl: to.el, fromEl: from.el, dragEl, newIndex, oldIndex }),
         }),
         ...(!!component.canPut && {
-          put: (to, from, dragEl) => component.canPut({ toEl: to.el, fromEl: from.el, dragEl }),
+          put: (to, from, dragEl, { newIndex, oldIndex }) =>
+            component.canPut({ toEl: to.el, fromEl: from.el, dragEl, newIndex, oldIndex }),
         }),
       },
     }),
@@ -109,8 +113,8 @@ export function connectSortableComponent(component: SortableComponent): void {
       dragState.active = false;
       onDragEnd();
     },
-    onSort: ({ from: fromEl, item: dragEl, to: toEl }) => {
-      component.onDragSort({ fromEl, dragEl, toEl });
+    onSort: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
+      component.onDragSort({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
   });
 }


### PR DESCRIPTION
**Related Issue:** #7875

## Summary

- Add more useful event details to `calciteListOrderChange` event
- Adds `oldIndex` and `newIndex` properties to the event detail
- Adds test