### PR TITLE
build(node): bump npm version and pin node types to v18

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,6 +9,7 @@
   "labels": ["dependencies"],
   "ignoreDeps": [
     "@types/jest",
+    "@types/node",
     "@types/react",
     "@types/react-dom",
     "@whitespace/storybook-addon-html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/jest": "27.0.3",
         "@types/jest-axe": "3.5.6",
         "@types/lodash-es": "4.17.9",
-        "@types/node": "20.4.10",
+        "@types/node": "^18.0.0",
         "@types/react": "^16.7.6",
         "@types/react-dom": "^16.0.9",
         "@types/semver": "7.5.2",
@@ -94,7 +94,7 @@
         "workbox-build": "7.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9509,9 +9509,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.10.tgz",
-      "integrity": "sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -47584,9 +47584,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.4.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.10.tgz",
-      "integrity": "sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "27.0.3",
     "@types/jest-axe": "3.5.6",
     "@types/lodash-es": "4.17.9",
-    "@types/node": "20.4.10",
+    "@types/node": "^18.0.0",
     "@types/react": "^16.7.6",
     "@types/react-dom": "^16.0.9",
     "@types/semver": "7.5.2",
@@ -108,10 +108,11 @@
   },
   "license": "SEE LICENSE.md",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
-  "packageManager": "npm@8.19.4",
+  "packageManager": "npm@10.1.0",
   "volta": {
-    "node": "18.18.0"
+    "node": "18.18.0",
+    "npm": "10.1.0"
   }
 }


### PR DESCRIPTION
**Related Issue:** #7695

## Summary

- Pin the Node types to v18.x.x so we don't get incorrect info
- Prevents Renovate from trying to update the Node types
- Bump NPM to the version that ships with Node v18