### PR TITLE
chore: add npm script for restoring changes to component readmes

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -19,6 +19,8 @@
     "hydrate/"
   ],
   "scripts": {
+    "build": "npm run util:prep-build-reqs && stencil build",
+    "postbuild": "npm run util:patch && npm run util:generate-t9n-docs-json && npm run util:clean-readmes",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && NODE_OPTIONS=--openssl-legacy-provider build-storybook --output-dir ./docs --quiet",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -19,12 +19,10 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:prep-build-reqs && stencil build",
-    "postbuild": "npm run util:patch && npm run util:generate-t9n-docs-json && git restore src/components/*/readme.md",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && NODE_OPTIONS=--openssl-legacy-provider build-storybook --output-dir ./docs --quiet",
-    "clean": "npm run util:clean-js-files && rimraf node_modules dist www hydrate docs .turbo src/components.d.ts",
+    "clean": "npm run util:clean-js-files && npm run util:clean-readmes && rimraf node_modules dist www hydrate docs .turbo src/components.d.ts",
     "deps:update": "updtr --exclude chalk cheerio typescript @types/jest jest jest-cli ts-jest puppeteer @whitespace/storybook-addon-html && npm audit fix",
     "docs": "build-storybook",
     "docs:preview": "npm run util:build-docs && NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_SCREENSHOT_LOCAL_BUILD=true start-storybook",
@@ -55,6 +53,7 @@
     "util:sync-t9n-en-bundles": "ts-node --esm support/syncEnT9nBundles.ts",
     "util:test-types": "tsc --esModuleInterop dist/types/**/*.d.ts dist/components/*.d.ts && ! grep -rnw 'dist/types' -e '<reference types=' && npm run util:clean-js-files",
     "util:clean-js-files": "rimraf --glob -- *.js {src,.storybook,support}/**.js",
+    "util:clean-readmes": "git restore src/components/*/readme.md",
     "util:is-working-tree-clean": "[ -z \"$(git status --porcelain=v1)\" ]"
   },
   "repository": {


### PR DESCRIPTION
## Summary

Adds a `util:clean-readmes` npm script for restoring the auto-generated component readmes. They are updated by some of our other NPM scripts like `docs:preview`. Unfortunately, they can't be easily restored automatically after npm scripts that are closed with CTRL-C because it ends the process. This adds an easy way for people to restore the component readmes until I have time to add a more automated option.