### PR TITLE
ci: the current milestone ends after release day

### DIFF
--- a/.github/scripts/limitPullRequestsForMaintenanceReleases.js
+++ b/.github/scripts/limitPullRequestsForMaintenanceReleases.js
@@ -34,6 +34,10 @@ module.exports = async ({ github, context, core }) => {
   }
 
   const currentDate = new Date(Date.now());
+
+  // make sure the milestone is still current on the day of the release
+  currentDate.setUTCHours(0, 0, 0, 0);
+
   for (const milestone of milestones) {
     if (!milestone?.due_on || new Date(milestone?.due_on) < currentDate) {
       console.log(`Skipping open milestone "${milestone.title}" because it is past due or doesn't have a due date.`);

--- a/.github/workflows/limit-prs-for-maintenance-releases.yml
+++ b/.github/workflows/limit-prs-for-maintenance-releases.yml
@@ -2,7 +2,7 @@ name: Maintenance Release Merge Blocker
 on:
   pull_request:
     branches: [main]
-    types: [labeled, unlabeled, synchronize]
+    types: [opened, labeled, unlabeled, synchronize]
 jobs:
   check-milestone:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Ensure the PR check that blocks installs if the current milestone is for maintenance doesn't think the milestone changed until after the release.