### PR TITLE
fix(panel): fix collapse action title and reverse icon direction

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -432,7 +432,7 @@ export class Panel
         icon={collapsed ? icons[0] : icons[1]}
         onClick={this.collapse}
         text={collapse}
-        title={!collapsed ? expand : collapse}
+        title={collapsed ? expand : collapse}
       />
     ) : null;
 

--- a/packages/calcite-components/src/components/panel/resources.ts
+++ b/packages/calcite-components/src/components/panel/resources.ts
@@ -22,8 +22,8 @@ export const ICONS = {
   menu: "ellipsis",
   backLeft: "chevron-left",
   backRight: "chevron-right",
-  expand: "chevron-up",
-  collapse: "chevron-down",
+  expand: "chevron-down",
+  collapse: "chevron-up",
 };
 
 export const SLOTS = {


### PR DESCRIPTION
**Related Issue:** #7930

## Summary

- invert expand/collapse title attribute value.
- reverse icon direction.