### PR TITLE
build(deps): bump timezone-groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36556,9 +36556,9 @@
       }
     },
     "node_modules/timezone-groups": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.5.0.tgz",
-      "integrity": "sha512-NdAII1zImVw6ndNSqCou4AZ7Ur69VwTKHYYB1HpnlUQLHu1kvwdw3pMZyQgAaXINCHpSviD0Im7zZL8rqbMZNA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.6.0.tgz",
+      "integrity": "sha512-fh083ECJPWzYB9KVc2AsWoQr3D+3KdAnE0/swgVKt1VGEqj2yW0e9LionmH3U/rpJ98t+C1O0SgY0f0aJtTeOQ==",
       "bin": {
         "timezone-groups": "dist/cli.cjs"
       }
@@ -40464,7 +40464,7 @@
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0",
-        "timezone-groups": "0.5.0"
+        "timezone-groups": "0.6.0"
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "1.0.0",
@@ -42717,7 +42717,7 @@
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0",
-        "timezone-groups": "0.5.0"
+        "timezone-groups": "0.6.0"
       }
     },
     "@esri/calcite-components-react": {
@@ -68305,9 +68305,9 @@
       }
     },
     "timezone-groups": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.5.0.tgz",
-      "integrity": "sha512-NdAII1zImVw6ndNSqCou4AZ7Ur69VwTKHYYB1HpnlUQLHu1kvwdw3pMZyQgAaXINCHpSviD0Im7zZL8rqbMZNA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.6.0.tgz",
+      "integrity": "sha512-fh083ECJPWzYB9KVc2AsWoQr3D+3KdAnE0/swgVKt1VGEqj2yW0e9LionmH3U/rpJ98t+C1O0SgY0f0aJtTeOQ=="
     },
     "tiny-inflate": {
       "version": "1.0.3",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -74,7 +74,7 @@
     "form-request-submit-polyfill": "2.0.0",
     "lodash-es": "4.17.21",
     "sortablejs": "1.15.0",
-    "timezone-groups": "0.5.0"
+    "timezone-groups": "0.6.0"
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "1.0.0",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

v0.6.0 improves browser compatibility by targeting ES2020. 