### PR TITLE
chore: update issue template labels to support workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,6 +1,6 @@
 name: Research
 description: Request an investigation into a specific topic
-labels: ["research", "0 - new", "needs triage"]
+labels: ["spike", "0 - new", "needs triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,6 +1,6 @@
 name: Test
 description: Associate issue for a test (e.g., a new test, an unstable test that was skipped, Chromatic, etc.)
-labels: ["testing", "0 - new", "p - high"]
+labels: ["testing", "0 - new", "p - high", "needs milestone"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
- Updates the test issue template to include the `needs milestone` label
- Replaces the `spike` issue in the research template (previously `research`)


cc @brittneytewks 
