### PR TITLE
chore(deps): update calcite-ui-icons to 3.24.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,9 +3104,9 @@
       "dev": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.6.tgz",
-      "integrity": "sha512-dZxFZDNEvW/RYWctafvC2ppctlP7tXlRe8E9YThqtso267FHXeDYixSbE8bVw7sznys7+hLbaGmXObo+YEKK4g==",
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.7.tgz",
+      "integrity": "sha512-HpACY1r6DtRuiPlppfckLYtZEzbCrmZM1s3SZZvCbamcWi4RcFV8CgGFHlWLgprRTFiI82Qh27LoMnzjOc0eFA==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -40468,7 +40468,7 @@
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.24.6",
+        "@esri/calcite-ui-icons": "3.24.7",
         "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
         "@stencil-community/eslint-plugin": "0.5.0",
         "@stencil/postcss": "2.1.0",
@@ -42700,7 +42700,7 @@
       "version": "file:packages/calcite-components",
       "requires": {
         "@esri/calcite-design-tokens": "1.0.0",
-        "@esri/calcite-ui-icons": "3.24.6",
+        "@esri/calcite-ui-icons": "3.24.7",
         "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
         "@floating-ui/dom": "1.5.3",
         "@stencil-community/eslint-plugin": "0.5.0",
@@ -42733,9 +42733,9 @@
       "dev": true
     },
     "@esri/calcite-ui-icons": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.6.tgz",
-      "integrity": "sha512-dZxFZDNEvW/RYWctafvC2ppctlP7tXlRe8E9YThqtso267FHXeDYixSbE8bVw7sznys7+hLbaGmXObo+YEKK4g==",
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.24.7.tgz",
+      "integrity": "sha512-HpACY1r6DtRuiPlppfckLYtZEzbCrmZM1s3SZZvCbamcWi4RcFV8CgGFHlWLgprRTFiI82Qh27LoMnzjOc0eFA==",
       "dev": true
     },
     "@esri/eslint-plugin-calcite-components": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "1.0.0",
-    "@esri/calcite-ui-icons": "3.24.6",
+    "@esri/calcite-ui-icons": "3.24.7",
     "@esri/eslint-plugin-calcite-components": "^0.2.3-next.4",
     "@stencil-community/eslint-plugin": "0.5.0",
     "@stencil/postcss": "2.1.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates calcite-ui-icons to `3.24.7`, released yesterday, for the upcoming CC release.