### PR TITLE
fix(combobox): fix issue causing value to be cleared when selecting an item (Windows + trackpad)

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -761,17 +761,17 @@ export class Combobox
     this.updateActiveItemIndex(targetIndex);
   }
 
-  setInactiveIfNotContained = (event: Event): void => {
+  private setInactiveIfNotContained = (event: Event): void => {
     const composedPath = event.composedPath();
+
+    if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
+      return;
+    }
 
     if (!this.allowCustomValues && this.textInput.value) {
       this.clearInputValue();
       this.filterItems("");
       this.updateActiveItemIndex(-1);
-    }
-
-    if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
-      return;
     }
 
     if (this.allowCustomValues && this.text.trim().length) {


### PR DESCRIPTION
**Related Issue:** #7934 

## Summary

Updates the component to consistently bail on blur handling logic if the input is blurred, but focus is still within the component.

### Notes

* the regression was introduced by https://github.com/Esri/calcite-design-system/pull/7721/
* due to time constraints, testing will be tackled in a follow-up issue as it's not easy to reproduce in an E2E test.