### PR TITLE
fix(flow-item): update collapsed property when collapse button is clicked

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -139,10 +139,22 @@ describe("calcite-flow-item", () => {
 
     await page.setContent("<calcite-flow-item collapsible collapsed></calcite-flow-item>");
 
+    const flowItem = await page.find("calcite-flow-item");
     const panel = await page.find(`calcite-flow-item >>> calcite-panel`);
 
+    expect(await flowItem.getProperty("collapsed")).toBe(true);
     expect(await panel.getProperty("collapsed")).toBe(true);
     expect(await panel.getProperty("collapsible")).toBe(true);
+
+    await page.$eval("calcite-flow-item", (flowItem: HTMLCalciteFlowItemElement) => {
+      const panel = flowItem.shadowRoot.querySelector("calcite-panel");
+      const toggleButton = panel.shadowRoot.querySelector("[data-test=collapse]") as HTMLCalciteActionElement;
+      toggleButton.click();
+    });
+
+    await page.waitForChanges();
+
+    expect(await flowItem.getProperty("collapsed")).toBe(false);
   });
 
   it("allows scrolling content", async () => {

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -282,6 +282,7 @@ export class FlowItem
 
   handlePanelToggle = (event: CustomEvent<void>): void => {
     event.stopPropagation();
+    this.collapsed = (event.target as HTMLCalcitePanelElement).collapsed;
     this.calciteFlowItemToggle.emit();
   };
 


### PR DESCRIPTION
**Related Issue:** #7959

## Summary

- Updates collapsed property when `calcitePanelToggle` event is fired.
- Add test