### PR TITLE
fix(table): Improve scrollbar display

### DIFF
--- a/packages/calcite-components/src/components/table/table.scss
+++ b/packages/calcite-components/src/components/table/table.scss
@@ -24,7 +24,7 @@
 }
 
 .table-container {
-  @apply overflow-x-scroll whitespace-nowrap;
+  @apply overflow-x-auto whitespace-nowrap;
 }
 
 .table-container:not(.bordered) {


### PR DESCRIPTION
**Related Issue:** #7892 

## Summary
Updates the css rule to only display scrollbars in Windows when scrolling is occurring.


| Before | After  |
| ------------- | ------------- |
| <img width="600" alt="Screenshot 2023-10-09 at 10 06 40 AM" src="https://github.com/Esri/calcite-design-system/assets/4733155/867f58cd-c892-4e71-8364-36a253921f9b">| <img width="600" alt="Screenshot 2023-10-09 at 10 06 51 AM" src="https://github.com/Esri/calcite-design-system/assets/4733155/ed2eb94c-5721-4a61-9815-febbbc80b1e2"> |

Tested / screenshots taken through Windows VM.