### PR TITLE
fix(input-time-zone): fix error caused by time zone group filtering

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -118,19 +118,18 @@ export async function createTimeZoneItems(
         const indexOffsets: number[] = [];
         let removedSoFar = 0;
 
-        group.tzs = group.tzs.filter((tz) => {
+        group.tzs.forEach((tz, index) => {
           if (timeZoneNameBlockList.includes(tz)) {
             removedSoFar++;
-            return false;
           }
-
-          indexOffsets.push(removedSoFar);
-          return true;
+          indexOffsets[index] = removedSoFar;
         });
 
+        group.tzs = group.tzs.filter((tz) => !timeZoneNameBlockList.includes(tz));
+
         group.labelTzIndices = group.labelTzIndices
-          .map((index) => index - (indexOffsets[index] || 0))
-          .filter((index) => index < group.tzs.length);
+          .map((index) => index - indexOffsets[index])
+          .filter((index) => index >= 0 && index < group.tzs.length);
       });
 
       return timeZoneGroups


### PR DESCRIPTION
**Related Issue:** #7944

## Summary

Addresses an issue caused by time zone label index adjustment (from time zone group filtering) ended up as -1 and cause an error when using it as a lookup index.

This also adds missing tests from https://github.com/Esri/calcite-design-system/pull/7947/.
