### PR TITLE
ci: don't link design-token version to CC version

### DIFF
--- a/support/syncLinkedPackageVersions.ts
+++ b/support/syncLinkedPackageVersions.ts
@@ -11,7 +11,7 @@
     const LINKED_VERSIONS_HEAD_PACKAGE = "@esri/calcite-components";
 
     // next releases will be blocked if HEAD's version is less than a TRACKING package's version
-    const LINKED_VERSIONS_TRACKING_PACKAGES = ["@esri/calcite-components-react", "@esri/calcite-design-tokens"];
+    const LINKED_VERSIONS_TRACKING_PACKAGES = ["@esri/calcite-components-react"];
 
     interface PackageData {
       name: string;


### PR DESCRIPTION
**Related Issue:** #

## Summary

We don't want the design tokens version to be in sync with the CC version, that is just for the component wrapper packages.