### PR TITLE
chore: align expected node engine with volta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Our code base is written in TypeScript and must adhere to specific conventions a
 
 ## Getting a development environment set up
 
-An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure to use the major versions of Node/NPM specified in [`package.json`](./package.json).
+An installation of Node is required for development. If you don't have Node installed, we recommend [Volta](https://docs.volta.sh/guide/getting-started), which will automatically use the Node/NPM versions pinned at the bottom of [`package.json`](./package.json). If you prefer a different Node version manager, make sure to use the major versions of Node/NPM specified under the "volta" key in [`package.json`](./package.json).
 
 We also recommend installing the following extensions in your editor of choice: TypeScript, TailwindCSS, ESLint, Stylelint, and Prettier. If you use VS Code, you will see a pop up in the bottom right corner prompting you to install or view the workspaces's recommended extensions. Here are instructions for manually installing the extensions in a variety of editors:
 

--- a/package.json
+++ b/package.json
@@ -110,9 +110,6 @@
     "workbox-build": "7.0.0"
   },
   "license": "SEE LICENSE.md",
-  "engines": {
-    "node": ">=18.0.0"
-  },
   "packageManager": "npm@10.1.0",
   "volta": {
     "node": "18.18.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "license": "SEE LICENSE.md",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "packageManager": "npm@10.1.0",
   "volta": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -86,5 +86,8 @@
     "@stencil/sass": "3.0.5",
     "@stencil/state-tunnel": "1.0.1"
   },
-  "license": "SEE LICENSE.md"
+  "license": "SEE LICENSE.md",
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -86,8 +86,5 @@
     "@stencil/sass": "3.0.5",
     "@stencil/state-tunnel": "1.0.1"
   },
-  "license": "SEE LICENSE.md",
-  "engines": {
-    "node": ">=16.0.0"
-  }
+  "license": "SEE LICENSE.md"
 }

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -87,7 +87,7 @@
     "@stencil/state-tunnel": "1.0.1"
   },
   "license": "SEE LICENSE.md",
-  "volta": {
-    "extends": "../../package.json"
+  "engines": {
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Trying to build the Calcite Design System packages with node 16 fails. It requires at least node 18.
