### PR TITLE
fix(pagination): prevents console error when page-size is set to zero

### DIFF
--- a/packages/calcite-components/src/components/pagination/pagination.e2e.ts
+++ b/packages/calcite-components/src/components/pagination/pagination.e2e.ts
@@ -189,6 +189,27 @@ describe("calcite-pagination", () => {
     });
   });
 
+  describe("pageSize", () => {
+    let page: E2EPage;
+    let pagination: E2EElement;
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent(`<calcite-pagination start-item="1" total-items="5" page-size="1"></calcite-pagination>`);
+      pagination = await page.find("calcite-pagination");
+    });
+
+    it("should set pageSize to one when set to zero via attribute", async () => {
+      expect(await pagination.getProperty("pageSize")).toBe(1);
+    });
+
+    it("should set pageSize to one when set to zero programmatically", async () => {
+      expect(await pagination.getProperty("pageSize")).toBe(10);
+      pagination.setProperty("pageSize", 0);
+      await page.waitForChanges();
+      expect(await pagination.getProperty("pageSize")).toBe(1);
+    });
+  });
+
   describe("number locale support", () => {
     let page: E2EPage;
     let element: E2EElement;

--- a/packages/calcite-components/src/components/pagination/pagination.e2e.ts
+++ b/packages/calcite-components/src/components/pagination/pagination.e2e.ts
@@ -190,19 +190,17 @@ describe("calcite-pagination", () => {
   });
 
   describe("pageSize", () => {
-    let page: E2EPage;
-    let pagination: E2EElement;
-    beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(`<calcite-pagination start-item="1" total-items="5" page-size="1"></calcite-pagination>`);
-      pagination = await page.find("calcite-pagination");
-    });
-
     it("should set pageSize to one when set to zero via attribute", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-pagination start-item="1" total-items="5" page-size="0"></calcite-pagination>`);
+      const pagination = await page.find("calcite-pagination");
       expect(await pagination.getProperty("pageSize")).toBe(1);
     });
 
     it("should set pageSize to one when set to zero programmatically", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-pagination start-item="1" total-items="50" page-size="10"></calcite-pagination>`);
+      const pagination = await page.find("calcite-pagination");
       expect(await pagination.getProperty("pageSize")).toBe(10);
       pagination.setProperty("pageSize", 0);
       await page.waitForChanges();

--- a/packages/calcite-components/src/components/pagination/pagination.tsx
+++ b/packages/calcite-components/src/components/pagination/pagination.tsx
@@ -113,13 +113,12 @@ export class Pagination
   @Prop({ reflect: true }) totalItems = 0;
 
   @Watch("totalItems")
-  handleTotalItems(): void {
-    this.totalPages = this.totalItems / this.pageSize;
-  }
-
   @Watch("pageSize")
-  handlePageSize(): void {
-    this.handleTotalPages();
+  handleTotalPages(): void {
+    if (this.pageSize < 1) {
+      this.pageSize = 1;
+    }
+    this.totalPages = this.totalItems / this.pageSize;
   }
 
   // --------------------------------------------------------------------------
@@ -301,13 +300,6 @@ export class Pagination
     this.emitUpdate();
   };
 
-  private handleTotalPages(): void {
-    if (this.pageSize < 1) {
-      this.pageSize = 1;
-    }
-    this.totalPages = this.totalItems / this.pageSize;
-  }
-
   //--------------------------------------------------------------------------
   //
   //  Render Methods
@@ -393,12 +385,6 @@ export class Pagination
 
   renderPage(start: number): VNode {
     const { pageSize } = this;
-
-    // if(pageSize === 0 ) {
-
-    //   this.pageSize === 1
-    //   console.log("pagesizeeeeee",pageSize)
-    // }
     const page = Math.floor(start / pageSize) + (pageSize === 1 ? 0 : 1);
 
     numberStringFormatter.numberFormatOptions = {

--- a/packages/calcite-components/src/components/pagination/pagination.tsx
+++ b/packages/calcite-components/src/components/pagination/pagination.tsx
@@ -101,7 +101,7 @@ export class Pagination
   @Prop() numberingSystem: NumberingSystem;
 
   /** Specifies the number of items per page. */
-  @Prop({ reflect: true }) pageSize = 20;
+  @Prop({ mutable: true, reflect: true }) pageSize = 20;
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
@@ -112,10 +112,14 @@ export class Pagination
   /** Specifies the total number of items. */
   @Prop({ reflect: true }) totalItems = 0;
 
-  @Watch("pageSize")
   @Watch("totalItems")
-  handleTotalPages(): void {
+  handleTotalItems(): void {
     this.totalPages = this.totalItems / this.pageSize;
+  }
+
+  @Watch("pageSize")
+  handlePageSize(): void {
+    this.handleTotalPages();
   }
 
   // --------------------------------------------------------------------------
@@ -297,6 +301,13 @@ export class Pagination
     this.emitUpdate();
   };
 
+  private handleTotalPages(): void {
+    if (this.pageSize < 1) {
+      this.pageSize = 1;
+    }
+    this.totalPages = this.totalItems / this.pageSize;
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Render Methods
@@ -382,6 +393,12 @@ export class Pagination
 
   renderPage(start: number): VNode {
     const { pageSize } = this;
+
+    // if(pageSize === 0 ) {
+
+    //   this.pageSize === 1
+    //   console.log("pagesizeeeeee",pageSize)
+    // }
     const page = Math.floor(start / pageSize) + (pageSize === 1 ? 0 : 1);
 
     numberStringFormatter.numberFormatOptions = {


### PR DESCRIPTION
**Related Issue:** #2093 

## Summary

Prevents console error messages when `page-size` is set to `0` via attribute or programmatically. 