### PR TITLE
chore(responsive): add xxs breakpoint prop

### DIFF
--- a/packages/calcite-components/src/utils/responsive.spec.ts
+++ b/packages/calcite-components/src/utils/responsive.spec.ts
@@ -8,10 +8,11 @@ describe("getBreakpoints()", () => {
     document.head.innerHTML = `
       <style>
         :root {
-        --calcite-app-breakpoint-width-lg: 1000px;
-        --calcite-app-breakpoint-width-md: 100px;
-        --calcite-app-breakpoint-width-sm: 10px;
-        --calcite-app-breakpoint-width-xs: 1px;
+        --calcite-app-breakpoint-width-lg: 10000px;
+        --calcite-app-breakpoint-width-md: 1000px;
+        --calcite-app-breakpoint-width-sm: 100px;
+        --calcite-app-breakpoint-width-xs: 10px;
+        --calcite-app-breakpoint-width-xxs: 1px;
       }
       </style>
     `;
@@ -22,6 +23,7 @@ describe("getBreakpoints()", () => {
         medium: toBeInteger(),
         small: toBeInteger(),
         xsmall: toBeInteger(),
+        xxsmall: toBeInteger(),
       },
     });
   });

--- a/packages/calcite-components/src/utils/responsive.ts
+++ b/packages/calcite-components/src/utils/responsive.ts
@@ -4,6 +4,7 @@ export interface Breakpoints {
     medium: number;
     small: number;
     xsmall: number;
+    xxsmall: number;
   };
 }
 
@@ -35,6 +36,7 @@ export async function getBreakpoints(): Promise<Breakpoints> {
           medium: breakpointTokenToNumericalValue(rootStyles, "--calcite-app-breakpoint-width-md"),
           small: breakpointTokenToNumericalValue(rootStyles, "--calcite-app-breakpoint-width-sm"),
           xsmall: breakpointTokenToNumericalValue(rootStyles, "--calcite-app-breakpoint-width-xs"),
+          xxsmall: breakpointTokenToNumericalValue(rootStyles, "--calcite-app-breakpoint-width-xxs"),
         },
       });
     });

--- a/support/dictionaries/dict-calcite-design-system.txt
+++ b/support/dictionaries/dict-calcite-design-system.txt
@@ -73,6 +73,7 @@ tibt
 
 ## sizing
 xsmall
+xxsmall
 
 ## svg
 svgs


### PR DESCRIPTION
**Related Issue:** #7856

## Summary

Updates `breakpoints` lookup object to include `xxs` (added in https://github.com/Esri/calcite-design-system/pull/7992).