### PR TITLE
fix(list-item): restore tabbability when an item's disabled prop is toggled

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -313,7 +313,7 @@ export class ListItem
   }
 
   componentDidRender(): void {
-    updateHostInteraction(this, "managed");
+    updateHostInteraction(this);
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/utils/interactive.ts
+++ b/packages/calcite-components/src/utils/interactive.ts
@@ -88,7 +88,7 @@ const captureOnlyOptions = { capture: true } as const;
  * technically, users can override `tabindex` and restore keyboard navigation, but this will be considered user error
  *
  * @param component
- * @param hostIsTabbable
+ * @param hostIsTabbable – when set to true or its predicate returns true, the host is tabbable and will be managed by the helper. Set to "managed" for cases where a component's parent determines which item is tabbable (i.e., sets `tabindex` to allow tabbing).
  */
 export function updateHostInteraction(
   component: InteractiveComponent,


### PR DESCRIPTION
**Related Issue:** #7335 

## Summary

Drop "managed" as the `hostIsTabbable ` argument since the parent does not control its tabbability (`tabindex`).

This also adds info to `updateHostInteraction`'s doc.