### PR TITLE
refactor(xbutton): extract icon scale from utility function

### DIFF
--- a/packages/calcite-components/src/components/functional/XButton.tsx
+++ b/packages/calcite-components/src/components/functional/XButton.tsx
@@ -20,6 +20,7 @@ export function XButton({
   label,
   onClick,
   ref,
+  scale,
 }: XButtonOptions): FunctionalComponent {
   return (
     <button
@@ -33,7 +34,7 @@ export function XButton({
       // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
       ref={ref}
     >
-      <calcite-icon icon="x" scale={getIconScale(this.scale)} />
+      <calcite-icon icon="x" scale={getIconScale(scale)} />
     </button>
   );
 }

--- a/packages/calcite-components/src/components/functional/XButton.tsx
+++ b/packages/calcite-components/src/components/functional/XButton.tsx
@@ -1,6 +1,7 @@
 import { FunctionalComponent, h } from "@stencil/core";
 import { JSXAttributes, JSXBase } from "@stencil/core/internal";
 import { Scale } from "../interfaces";
+import { getIconScale } from "../../utils/component";
 
 export interface XButtonOptions extends JSXAttributes {
   disabled: boolean;
@@ -19,7 +20,6 @@ export function XButton({
   label,
   onClick,
   ref,
-  scale,
 }: XButtonOptions): FunctionalComponent {
   return (
     <button
@@ -33,7 +33,7 @@ export function XButton({
       // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
       ref={ref}
     >
-      <calcite-icon icon="x" scale={scale === "l" ? "m" : "s"} />
+      <calcite-icon icon="x" scale={getIconScale(this.scale)} />
     </button>
   );
 }


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/7765

## Summary
Finalizes up the above issue by tackling the `XButton.tsx` (functional component) discussed in https://github.com/Esri/calcite-design-system/issues/7765#issuecomment-1779672451 and https://github.com/Esri/calcite-design-system/issues/7765#issuecomment-1779748973.


cc: @jcfranco and related PR #7973