### PR TITLE
fix(combobox): clear custom input value on blur

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -160,7 +160,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
     this.selected = !this.selected;
   }
 
-  itemClickHandler = (): void => {
+  private itemClickHandler = (): void => {
     this.toggleSelected();
   };
 

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -160,8 +160,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
     this.selected = !this.selected;
   }
 
-  itemClickHandler = (event: MouseEvent): void => {
-    event.preventDefault();
+  itemClickHandler = (): void => {
     this.toggleSelected();
   };
 

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1792,7 +1792,7 @@ describe("calcite-combobox", () => {
         return comboboxEl.getBoundingClientRect().toJSON();
       });
 
-      await inputEl.type("asdf");
+      await inputEl.type("three");
       await page.waitForChanges();
       await page.mouse.move(10, 2 * comboboxRect.bottom);
       await page.mouse.down();
@@ -1801,7 +1801,7 @@ describe("calcite-combobox", () => {
       await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.id)).not.toBe("myCombobox");
       expect(await inputEl.getProperty("value")).toBe("");
-      expect(await combobox.getProperty("value")).toBe(allowCustomValues ? "asdf" : "");
+      expect(await combobox.getProperty("value")).toBe(allowCustomValues ? "three" : "");
     }
 
     selectionModes.forEach((mode) => {
@@ -1838,15 +1838,16 @@ describe("calcite-combobox", () => {
       await inputEl.focus();
       await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.id)).toBe("myCombobox");
-      await page.keyboard.type("asdf");
+      await page.keyboard.type("three");
       await page.waitForChanges();
       await page.keyboard.press("Tab");
       await page.waitForChanges();
       await page.keyboard.press("Tab");
       await page.waitForChanges();
       expect(await inputEl.getProperty("value")).toBe("");
-      expect(await combobox.getProperty("value")).toBe(allowCustomValues ? "asdf" : "");
+      expect(await combobox.getProperty("value")).toBe(allowCustomValues ? "three" : "");
     }
+
     selectionModes.forEach((mode) => {
       it(`should clear the input on blur when selectionMode=${mode}`, async () => {
         await clearInputValueOnBlur(mode);

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -492,6 +492,7 @@ describe("calcite-combobox", () => {
 
           await selectItem(item1);
           expect(await combobox.getProperty("value")).toBe("one");
+          expect(await combobox.getProperty("open")).toBe(true);
         });
 
         it("multiple-selection mode allows toggling selection once the selected item is selected", async () => {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -298,7 +298,12 @@ export class Combobox
       return;
     }
 
-    this.setInactiveIfNotContained(event);
+    const composedPath = event.composedPath();
+
+    if (composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
+      return;
+    }
+    this.determineCustomValueAllowed();
   }
 
   @Listen("calciteComboboxItemChange")
@@ -580,6 +585,10 @@ export class Combobox
         } else if (this.open) {
           this.open = false;
           event.preventDefault();
+        } else if (!this.allowCustomValues && this.text) {
+          this.clearInputValue();
+          this.filterItems("");
+          this.updateActiveItemIndex(-1);
         }
         break;
       case "ArrowLeft":
@@ -761,13 +770,7 @@ export class Combobox
     this.updateActiveItemIndex(targetIndex);
   }
 
-  private setInactiveIfNotContained = (event: Event): void => {
-    const composedPath = event.composedPath();
-
-    if (!this.open || composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
-      return;
-    }
-
+  private determineCustomValueAllowed = (): void => {
     if (!this.allowCustomValues && this.textInput.value) {
       this.clearInputValue();
       this.filterItems("");
@@ -1146,10 +1149,6 @@ export class Combobox
     this.textInput?.focus();
   };
 
-  comboboxBlurHandler = (event: FocusEvent): void => {
-    this.setInactiveIfNotContained(event);
-  };
-
   //--------------------------------------------------------------------------
   //
   //  Render Methods
@@ -1225,7 +1224,6 @@ export class Combobox
           disabled={disabled}
           id={`${inputUidPrefix}${guid}`}
           key="input"
-          onBlur={this.comboboxBlurHandler}
           onFocus={this.comboboxFocusHandler}
           onInput={this.inputHandler}
           placeholder={placeholder}

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -303,7 +303,18 @@ export class Combobox
     if (composedPath.includes(this.el) || composedPath.includes(this.referenceEl)) {
       return;
     }
-    this.determineCustomValueAllowed();
+
+    if (!this.allowCustomValues && this.textInput.value) {
+      this.clearInputValue();
+      this.filterItems("");
+      this.updateActiveItemIndex(-1);
+    }
+
+    if (this.allowCustomValues && this.text.trim().length) {
+      this.addCustomChip(this.text);
+    }
+
+    this.open = false;
   }
 
   @Listen("calciteComboboxItemChange")
@@ -769,20 +780,6 @@ export class Combobox
 
     this.updateActiveItemIndex(targetIndex);
   }
-
-  private determineCustomValueAllowed = (): void => {
-    if (!this.allowCustomValues && this.textInput.value) {
-      this.clearInputValue();
-      this.filterItems("");
-      this.updateActiveItemIndex(-1);
-    }
-
-    if (this.allowCustomValues && this.text.trim().length) {
-      this.addCustomChip(this.text);
-    }
-
-    this.open = false;
-  };
 
   setFloatingEl = (el: HTMLDivElement): void => {
     this.floatingEl = el;


### PR DESCRIPTION
**Related Issue:** #2162 

## Summary

Clears input value on `blur` if the value has no matching `combobox-item` when `allowCustomValue` property is set to `false`