### PR TITLE
fix(combobox-item): do not show icon for disabled item 

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -227,7 +227,7 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
     const isSingleSelect = isSingleLike(this.selectionMode);
     const showDot = isSingleSelect && !this.disabled;
     const defaultIcon = isSingleSelect ? "dot" : "check";
-    const iconPath = this.disabled ? "circle-disallowed" : defaultIcon;
+    const iconPath = this.disabled ? "" : defaultIcon;
 
     const classes = {
       [CSS.label]: true,


### PR DESCRIPTION
**Related Issue:** #7719 

## Summary

Do not show the icon if the combobox-item is disabled.
