### PR TITLE
fix(accordian-item): update expanded chevron color

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -123,7 +123,7 @@
 }
 
 :host([expanded]) .expand-icon {
-  @apply text-color-1;
+  @apply text-color-3;
   transform: rotate(var(--calcite-accordion-item-active-icon-rotation));
 }
 
@@ -174,9 +174,6 @@
     @apply text-color-1;
   }
   & .icon {
-    @apply text-color-1;
-  }
-  & .expand-icon {
     @apply text-color-1;
   }
   & .description {


### PR DESCRIPTION
# Adopted https://github.com/Esri/calcite-design-system/pull/8083
 
cc @abp6318
 
---
 
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/7710

## Summary
Updated the chevron color for accordion items to use `ui-text-3`

## Video
https://github.com/Esri/calcite-design-system/assets/60486980/1cb2302a-d869-4536-8ae5-59753a3f37c1
