### PR TITLE
test(input-time-zone): restore skipped tests

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -16,16 +16,17 @@ import {
 import { toUserFriendlyName } from "./utils";
 
 describe("calcite-input-time-zone", () => {
+  // for stability, we use time zones that are unaffected by daylight savings time
   const testTimeZoneNamesAndOffsets = [
-    { name: "America/Los_Angeles", offset: -420, label: "GMT-7" },
-    { name: "America/Denver", offset: -360, label: "GMT-6" },
-    { name: "Europe/London", offset: 60, label: "GMT+1" },
+    { name: "America/Mexico_City", offset: -360, label: "GMT-6" },
+    { name: "America/Phoenix", offset: -420, label: "GMT-7" },
+    { name: "Pacific/Guam", offset: 600, label: "GMT+10" },
   ];
 
   async function simpleTestProvider(): Promise<TagAndPage> {
     const page = await newE2EPage();
     await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
-    await page.setContent(addTimeZoneNamePolyfill(html` <calcite-input-time-zone></calcite-input-time-zone>`));
+    await page.setContent(addTimeZoneNamePolyfill(html`<calcite-input-time-zone></calcite-input-time-zone>`));
 
     return {
       page,
@@ -44,7 +45,7 @@ describe("calcite-input-time-zone", () => {
   describe("formAssociated", () => {
     formAssociated(
       {
-        tagOrHTML: addTimeZoneNamePolyfill(html` <calcite-input-time-zone></calcite-input-time-zone>`),
+        tagOrHTML: addTimeZoneNamePolyfill(html`<calcite-input-time-zone></calcite-input-time-zone>`),
         beforeContent: async (page) => {
           await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         },
@@ -66,7 +67,7 @@ describe("calcite-input-time-zone", () => {
 
   describe("labelable", () => {
     labelable({
-      tagOrHTML: addTimeZoneNamePolyfill(html` <calcite-input-time-zone></calcite-input-time-zone>`),
+      tagOrHTML: addTimeZoneNamePolyfill(html`<calcite-input-time-zone></calcite-input-time-zone>`),
       beforeContent: async (page) => {
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
       },
@@ -108,7 +109,7 @@ describe("calcite-input-time-zone", () => {
 
   describe("mode", () => {
     describe("offset (default)", () => {
-      describe.skip("selects user's matching time zone offset on initialization", () => {
+      describe("selects user's matching time zone offset on initialization", () => {
         testTimeZoneNamesAndOffsets.forEach(({ name, offset, label }) => {
           it(`selects default time zone for "${name}"`, async () => {
             const page = await newE2EPage();
@@ -126,12 +127,12 @@ describe("calcite-input-time-zone", () => {
         });
       });
 
-      it.skip("allows users to preselect a time zone offset", async () => {
+      it("allows users to preselect a time zone offset", async () => {
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         await page.setContent(
           await addTimeZoneNamePolyfill(
-            html` <calcite-input-time-zone value="${testTimeZoneNamesAndOffsets[1].offset}"></calcite-input-time-zone>`
+            html`<calcite-input-time-zone value="${testTimeZoneNamesAndOffsets[1].offset}"></calcite-input-time-zone>`
           )
         );
 
@@ -148,7 +149,7 @@ describe("calcite-input-time-zone", () => {
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         await page.setContent(
-          await addTimeZoneNamePolyfill(html` <calcite-input-time-zone value="9000"></calcite-input-time-zone>`)
+          await addTimeZoneNamePolyfill(html`<calcite-input-time-zone value="9000"></calcite-input-time-zone>`)
         );
 
         const input = await page.find("calcite-input-time-zone");
@@ -164,7 +165,7 @@ describe("calcite-input-time-zone", () => {
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         await page.setContent(
-          await addTimeZoneNamePolyfill(html` <calcite-input-time-zone value="60"></calcite-input-time-zone>`)
+          await addTimeZoneNamePolyfill(html`<calcite-input-time-zone value="600"></calcite-input-time-zone>`)
         );
 
         const input = await page.find("calcite-input-time-zone");
@@ -177,13 +178,14 @@ describe("calcite-input-time-zone", () => {
       });
 
       it("looks up in label and time zone groups (not displayed)", async () => {
-        const searchTerms = ["London", "Belfast", "GMT-12"];
+        const displayLabelSearchTerm = "Guam";
+        const groupedTimeZoneSearchTerm = "Chuuk";
+        const gmtSearchTerm = "GMT-12";
+        const searchTerms = [displayLabelSearchTerm, groupedTimeZoneSearchTerm, gmtSearchTerm];
 
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
-        await page.setContent(
-          await addTimeZoneNamePolyfill(html` <calcite-input-time-zone></calcite-input-time-zone>`)
-        );
+        await page.setContent(await addTimeZoneNamePolyfill(html`<calcite-input-time-zone></calcite-input-time-zone>`));
 
         const input = await page.find("calcite-input-time-zone");
 
@@ -256,7 +258,7 @@ describe("calcite-input-time-zone", () => {
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         await page.setContent(
-          await addTimeZoneNamePolyfill(html` <calcite-input-time-zone
+          await addTimeZoneNamePolyfill(html`<calcite-input-time-zone
             mode="name"
             value="${testTimeZoneNamesAndOffsets[1].name}"
           ></calcite-input-time-zone>`)
@@ -277,7 +279,7 @@ describe("calcite-input-time-zone", () => {
         const page = await newE2EPage();
         await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
         await page.setContent(
-          await addTimeZoneNamePolyfill(html` <calcite-input-time-zone
+          await addTimeZoneNamePolyfill(html`<calcite-input-time-zone
             mode="name"
             value="Does/Not/Exist"
           ></calcite-input-time-zone>`)
@@ -323,7 +325,7 @@ describe("calcite-input-time-zone", () => {
     const page = await newE2EPage();
     await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
     await page.setContent(
-      addTimeZoneNamePolyfill(html` <calcite-input-time-zone max-items="7"></calcite-input-time-zone>`)
+      addTimeZoneNamePolyfill(html`<calcite-input-time-zone max-items="7"></calcite-input-time-zone>`)
     );
     const internalCombobox = await page.find("calcite-input-time-zone >>> calcite-combobox");
 
@@ -339,7 +341,7 @@ describe("calcite-input-time-zone", () => {
  * @param testHtml
  */
 function addTimeZoneNamePolyfill(testHtml: string): string {
-  return html` <script type="module">
+  return html`<script type="module">
       const OriginalDateTimeFormat = Intl.DateTimeFormat;
 
       class ExtendedDateTimeFormat extends OriginalDateTimeFormat {
@@ -371,12 +373,12 @@ function addTimeZoneNamePolyfill(testHtml: string): string {
             } else {
               offsetString =
                 "GMT" +
-                (timeZone === "America/Los_Angeles"
-                  ? "-7"
-                  : timeZone === "America/Denver"
+                (timeZone === "America/Mexico_City"
                   ? "-6"
-                  : timeZone === "Europe/London" || timeZone === "Europe/Belfast"
-                  ? "+1"
+                  : timeZone === "America/Phoenix"
+                  ? "-7"
+                  : timeZone === "Pacific/Guam" || timeZone === "Pacific/Chuuk"
+                  ? "+10"
                   : "+0");
             }
 
@@ -406,9 +408,9 @@ function addTimeZoneNamePolyfill(testHtml: string): string {
       Intl.supportedValuesOf = function (key) {
         if (key === "timeZone") {
           return [
-            "America/Los_Angeles",
-            "America/Denver",
-            "Europe/London",
+            "America/Mexico_City",
+            "America/Phoenix",
+            "Pacific/Guam",
 
             // not available in Chromium v92 at time of testing
             "Etc/GMT+1",
@@ -437,7 +439,7 @@ function addTimeZoneNamePolyfill(testHtml: string): string {
             "Etc/GMT-7",
             "Etc/GMT-8",
             "Etc/GMT-9",
-            "Europe/Belfast",
+            "Pacific/Chuuk",
           ];
         }
       };

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
@@ -10,8 +10,7 @@ export default {
     chromatic: { delay: 1500 },
     notes: readme,
     options: {
-      // for stability, we use a timezone unaffected by daylight savings time
-      timezone: "America/Mexico_City",
+      timezone: "America/Los_Angeles",
     },
   },
   ...storyFilters(),
@@ -29,9 +28,9 @@ export const timeZoneNameMode_TestOnly = (): string => html`
   <calcite-input-time-zone mode="name" open></calcite-input-time-zone>
 `;
 
-export const initialNameSelected_TestOnly = (): string =>
-  // for stability, we use a timezone unaffected by daylight savings time
-  html`<calcite-input-time-zone mode="name" value="America/Phoenix"></calcite-input-time-zone>`;
+export const initialNameSelected_TestOnly = (): string => html`
+  <calcite-input-time-zone mode="name" value="America/Ciudad_Juarez"></calcite-input-time-zone>
+`;
 
 export const initialOffsetSelected_TestOnly = (): string => html`
   <calcite-input-time-zone value="-360"></calcite-input-time-zone>

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
@@ -10,7 +10,8 @@ export default {
     chromatic: { delay: 1500 },
     notes: readme,
     options: {
-      timezone: "America/Los_Angeles",
+      // for stability, we use a timezone unaffected by daylight savings time
+      timezone: "America/Mexico_City",
     },
   },
   ...storyFilters(),
@@ -28,9 +29,9 @@ export const timeZoneNameMode_TestOnly = (): string => html`
   <calcite-input-time-zone mode="name" open></calcite-input-time-zone>
 `;
 
-export const initialNameSelected_TestOnly = (): string => html`
-  <calcite-input-time-zone mode="name" value="America/Ciudad_Juarez"></calcite-input-time-zone>
-`;
+export const initialNameSelected_TestOnly = (): string =>
+  // for stability, we use a timezone unaffected by daylight savings time
+  html`<calcite-input-time-zone mode="name" value="America/Phoenix"></calcite-input-time-zone>`;
 
 export const initialOffsetSelected_TestOnly = (): string => html`
   <calcite-input-time-zone value="-360"></calcite-input-time-zone>


### PR DESCRIPTION
**Related Issue:** #8086

## Summary

Updates skipped test to use time zones that are unaffected by DST.

✨🧪🔨✨