### PR TITLE
ci: automate research spike issue completion

### DIFF
--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -21,12 +21,6 @@ module.exports = async ({ github, context }) => {
     };
 
     /* Modify labels */
-
-    /* Tries to remove labels */
-    /* If the label is not associated with the issue,
-       the error is logged and the script will continue. */
-
-    // Try to remove "spike" label
     try {
       await github.rest.issues.removeLabel({
         ...issueProps,
@@ -36,7 +30,6 @@ module.exports = async ({ github, context }) => {
       console.log("The 'spike' label is not associated with the issue", err);
     }
 
-    // Try to remove "1 - assigned" label
     try {
       await github.rest.issues.removeLabel({
         ...issueProps,

--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -1,0 +1,70 @@
+// When the "spike complete" label is added to an issue:
+// 1. Modifies the labels,
+// 2. Updates the assignees and milestone, and
+// 3. Generates a notification to the Calcite project manager(s)
+//
+// The secret is formatted like so: person1, person2, person3
+//
+// Note the script automatically adds the "@" character in to notify the project manager(s)
+module.exports = async ({ github, context }) => {
+  const { managers } = process.env;
+  const { label } = context.payload;
+
+  if (label && label.name === "spike complete") {
+    // Add a "@" character to notify the user
+    const calcite_managers = managers.split(",").map((v) => " @" + v.trim());
+
+    const issueProps = {
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    };
+
+    /* Modify labels */
+
+    /* Tries to remove labels */
+    /* If the label is not associated with the issue,
+       the error is logged and the script will continue. */
+
+    // Try to remove "spike" label
+    try {
+      await github.rest.issues.removeLabel({
+        ...issueProps,
+        name: "spike",
+      });
+    } catch (err) {
+      console.log("The 'spike' label is not associated with the issue", err);
+    }
+
+    // Try to remove "1 - assigned" label
+    try {
+      await github.rest.issues.removeLabel({
+        ...issueProps,
+        name: "1 - assigned",
+      });
+    } catch (err) {
+      console.log("The '1 - assigned' label is not associated with the issue", err);
+    }
+
+    // Add labels
+    await github.rest.issues.addLabels({
+      ...issueProps,
+      labels: ["0 - new", "needs milestone"],
+    });
+
+    /* Update issue */
+
+    // Clear assignees and milestone
+    await github.rest.issues.update({
+      ...issueProps,
+      assignees: [],
+      milestone: null,
+    });
+
+    // Add a comment to notify the project manager(s)
+    await github.rest.issues.createComment({
+      ...issueProps,
+      body: `cc ${calcite_managers}`,
+    });
+  }
+};

--- a/.github/workflows/spike-complete.yml
+++ b/.github/workflows/spike-complete.yml
@@ -1,0 +1,21 @@
+name: "Spike complete"
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  ready-for-dev:
+    if: github.event.label.name == 'spike complete'
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        env:
+          managers: ${{secrets.CALCITE_MANAGERS}}
+        with:
+          script: |
+            const action = require('${{ github.workspace }}/.github/scripts/notifyWhenSpikeComplete.js')
+            await action({github, context, core})


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Adds automation when developers complete research spikes associated with the `spike` label.

How it works:
1. The developer adds the `spike complete` label
2. The script runs, and:
    - The `spike` label is removed
    - If present, the `1 - assigned` label is removed
    - Adds the `0 - new` and `needs milestone` labels
    - All assignees are removed and the milestone is cleared
    - Calcite PMs are notified (currently set to @brittneytewks and myself) to add to an upcoming milestone
        - Also discoverable via the `needs milestone` label 