### PR TITLE
refactor(card)!: remove deprecated `deselected` message

### DIFF
--- a/packages/calcite-components/src/components/card/assets/card/t9n/messages.json
+++ b/packages/calcite-components/src/components/card/assets/card/t9n/messages.json
@@ -1,5 +1,4 @@
 {
   "select": "Selectable card",
-  "deselect": "Deselect",
   "loading": "Loading"
 }

--- a/packages/calcite-components/src/components/card/assets/card/t9n/messages_en.json
+++ b/packages/calcite-components/src/components/card/assets/card/t9n/messages_en.json
@@ -1,5 +1,4 @@
 {
   "select": "Selectable card",
-  "deselect": "Deselect",
   "loading": "Loading"
 }

--- a/packages/calcite-components/support/generateT9nDocsJSON.ts
+++ b/packages/calcite-components/support/generateT9nDocsJSON.ts
@@ -32,7 +32,12 @@
             const messagesFile = JSON.parse(await readFile(resolve(t9nPath, messagesFilename), { encoding: "utf-8" }));
 
             for (const [key, value] of Object.entries(messagesFile)) {
-              data[component][key][lang] = value;
+              const translationEntries = data[component][key];
+
+              // translation bundles might still have references to strings removed in the `main` and `en` bundle
+              if (translationEntries) {
+                translationEntries[lang] = value;
+              }
             }
           }
         }


### PR DESCRIPTION
**Related Issue:** #6660

## Summary

BREAKING CHANGE: Removed the `deselect` message property – this property was deprecated in #6657 as it is no longer being rendered.
