### PR TITLE
fix(block-section): wraps long text over to a new line when toggle switch is displayed

### DIFF
--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -39,9 +39,6 @@
     px-0
     py-2;
 
-  &:focus {
-    @apply focus-outset;
-  }
   &:hover {
     @apply text-color-1;
   }
@@ -65,9 +62,13 @@
 
   .focus-guard {
     --calcite-label-margin-bottom: 0;
-    @apply absolute pointer-events-none;
+    @apply pointer-events-none;
     inset-inline-end: 0;
     margin-inline-start: theme("margin.1");
+  }
+
+  &:focus {
+    @apply focus-outset;
   }
 }
 

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -59,6 +59,7 @@
 
 .toggle--switch-container {
   @apply flex items-center relative bg-transparent w-full;
+  word-break: break-word;
 
   .focus-guard {
     --calcite-label-margin-bottom: 0;

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -39,6 +39,9 @@
     px-0
     py-2;
 
+  &:focus {
+    @apply focus-outset;
+  }
   &:hover {
     @apply text-color-1;
   }
@@ -63,13 +66,9 @@
 
   .focus-guard {
     --calcite-label-margin-bottom: 0;
-    @apply pointer-events-none;
+    @apply absolute pointer-events-none;
     inset-inline-end: 0;
     margin-inline-start: theme("margin.1");
-  }
-
-  &:focus {
-    @apply focus-outset;
   }
 }
 
@@ -89,6 +88,12 @@
 
 .status-icon.invalid {
   color: theme("colors.danger");
+}
+
+:host([toggle-display="switch"]) .toggle {
+  .toggle--switch__content {
+    margin-inline-end: 1.75rem;
+  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -92,7 +92,7 @@
 
 :host([toggle-display="switch"]) .toggle {
   .toggle--switch__content {
-    margin-inline-end: 1.75rem;
+    @apply me-7;
   }
 }
 

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -216,6 +216,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
           class={{
             [CSS.toggleSwitchContainer]: true,
           }}
+          tabIndex={0}
         >
           <div
             aria-controls={IDS.content}
@@ -228,7 +229,6 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
             onClick={this.toggleSection}
             onKeyDown={this.handleHeaderKeyDown}
             role="button"
-            tabIndex={0}
             title={toggleLabel}
           >
             <div class={CSS.toggleSwitchContent}>

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -216,7 +216,6 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
           class={{
             [CSS.toggleSwitchContainer]: true,
           }}
-          tabIndex={0}
         >
           <div
             aria-controls={IDS.content}
@@ -229,6 +228,7 @@ export class BlockSection implements LocalizedComponent, T9nComponent, LoadableC
             onClick={this.toggleSection}
             onKeyDown={this.handleHeaderKeyDown}
             role="button"
+            tabIndex={0}
             title={toggleLabel}
           >
             <div class={CSS.toggleSwitchContent}>

--- a/packages/calcite-components/src/components/block/block.stories.ts
+++ b/packages/calcite-components/src/components/block/block.stories.ts
@@ -312,3 +312,15 @@ export const scrollingContainerSetup_TestOnly = (): string => html`<style>
   </script>`;
 
 scrollingContainerSetup_TestOnly.parameters = { chromatic: { delay: 500 } };
+
+export const toggleDisplayWithLongText_TestOnly = (): string => html`<calcite-block
+  open
+  heading="Calcite block"
+  style="width:150px"
+>
+  <calcite-block-section id="block-section" open text="Calcite block superlongggggtext" toggle-display="switch">
+    <calcite-notice open>
+      <div slot="message">Some more complex options.</div>
+    </calcite-notice>
+  </calcite-block-section>
+</calcite-block>`;


### PR DESCRIPTION
**Related Issue:** #7698 

## Summary

Wraps long text to a new line when `toggle-display='switch'`