### PR TITLE
ci(renovate): run on weekdays and don't pin peerDeps

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "npm:unpublishSafe", "workarounds:typesNodeVersioning"],
+  "extends": [
+    "config:base",
+    "npm:unpublishSafe",
+    "workarounds:typesNodeVersioning",
+    ":pinAllExceptPeerDependencies",
+    ":widenPeerDependencies"
+  ],
   "platformCommit": true,
-  "rangeStrategy": "pin",
   "enabledManagers": ["npm"],
   "timezone": "America/Los_Angeles",
-  "schedule": ["before 5am on tuesday and thursday"],
+  "schedule": ["before 5am on every weekday"],
   "labels": ["dependencies"],
   "ignoreDeps": [
     "@types/jest",


### PR DESCRIPTION
**Related Issue:** #8102

## Summary
We don't want to pin peer deps, because our users should be allowed to update the version of packages they use in their app w/o throwing errors due to calcite. Also, increasing the frequency of renovate updates to ensure we don't fall behind.