### PR TITLE
ci: update spike complete automation to try removing dev lifecycle label

### DIFF
--- a/.github/scripts/notifyWhenSpikeComplete.js
+++ b/.github/scripts/notifyWhenSpikeComplete.js
@@ -39,6 +39,15 @@ module.exports = async ({ github, context }) => {
       console.log("The '1 - assigned' label is not associated with the issue", err);
     }
 
+    try {
+      await github.rest.issues.removeLabel({
+        ...issueProps,
+        name: "2 - in development",
+      });
+    } catch (err) {
+      console.log("The '2 - in development' label is not associated with the issue", err);
+    }
+
     // Add labels
     await github.rest.issues.addLabels({
       ...issueProps,


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Tries to remove the `2 - in development` lifecycle label, if present on the issue when completing a spike to properly clear all the labels. cc: @jcfranco 

Refer to https://github.com/Esri/calcite-design-system/issues/7692#issuecomment-1797088523 and https://github.com/Esri/calcite-design-system/issues/7692#issuecomment-1797802671 for additional context.