### PR TITLE
fix(angular): publish from the dist directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46311,25 +46311,6 @@
         "node": ">=12"
       }
     },
-    "packages/calcite-components-angular/node_modules/@esri/calcite-components": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.10.0.tgz",
-      "integrity": "sha512-nKTwU7hseSAXTqEQelVfo+qDa5jCGvabky4atRsJxROkHbSQkhdFFfwOrrffHOr9CtZBxtvZhfh/Tb6Nky15hw==",
-      "dev": true,
-      "dependencies": {
-        "@floating-ui/dom": "1.5.3",
-        "@stencil/core": "2.22.3",
-        "@types/color": "3.0.4",
-        "color": "4.2.3",
-        "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.10",
-        "focus-trap": "7.5.4",
-        "form-request-submit-polyfill": "2.0.0",
-        "lodash-es": "4.17.21",
-        "sortablejs": "1.15.0",
-        "timezone-groups": "0.8.0"
-      }
-    },
     "packages/calcite-components-angular/node_modules/@jest/console": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -46734,15 +46715,6 @@
       "peer": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "packages/calcite-components-angular/node_modules/@types/color": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.4.tgz",
-      "integrity": "sha512-OpisS4bqJJwbkkQRrMvURf3DOxBoAg9mysHYI7WgrWpSYHqHGKYBULHdz4ih77SILcLDo/zyHGFyfIl9yb8NZQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/color-convert": "*"
       }
     },
     "packages/calcite-components-angular/node_modules/@types/html-minifier-terser": {
@@ -49444,12 +49416,12 @@
         "tslib": "2.3.0"
       },
       "devDependencies": {
-        "@esri/calcite-components": "1.10.0"
+        "@esri/calcite-components": "1.10.1-next.3"
       },
       "peerDependencies": {
         "@angular/common": "^16.2.0",
         "@angular/core": "^16.2.0",
-        "@esri/calcite-components": "1.10.0"
+        "@esri/calcite-components": "1.10.1-next.3"
       }
     },
     "packages/calcite-components-react": {
@@ -52332,7 +52304,7 @@
     "@esri/calcite-components-angular": {
       "version": "file:packages/calcite-components-angular/projects/component-library",
       "requires": {
-        "@esri/calcite-components": "1.10.0",
+        "@esri/calcite-components": "1.10.1-next.3",
         "tslib": "2.3.0"
       }
     },
@@ -59319,25 +59291,6 @@
           "dev": true,
           "optional": true
         },
-        "@esri/calcite-components": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.10.0.tgz",
-          "integrity": "sha512-nKTwU7hseSAXTqEQelVfo+qDa5jCGvabky4atRsJxROkHbSQkhdFFfwOrrffHOr9CtZBxtvZhfh/Tb6Nky15hw==",
-          "dev": true,
-          "requires": {
-            "@floating-ui/dom": "1.5.3",
-            "@stencil/core": "2.22.3",
-            "@types/color": "3.0.4",
-            "color": "4.2.3",
-            "composed-offset-position": "0.0.4",
-            "dayjs": "1.11.10",
-            "focus-trap": "7.5.4",
-            "form-request-submit-polyfill": "2.0.0",
-            "lodash-es": "4.17.21",
-            "sortablejs": "1.15.0",
-            "timezone-groups": "0.8.0"
-          }
-        },
         "@jest/console": {
           "version": "29.7.0",
           "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -59671,15 +59624,6 @@
           "dev": true,
           "optional": true,
           "peer": true
-        },
-        "@types/color": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.4.tgz",
-          "integrity": "sha512-OpisS4bqJJwbkkQRrMvURf3DOxBoAg9mysHYI7WgrWpSYHqHGKYBULHdz4ih77SILcLDo/zyHGFyfIl9yb8NZQ==",
-          "dev": true,
-          "requires": {
-            "@types/color-convert": "*"
-          }
         },
         "@types/html-minifier-terser": {
           "version": "6.1.0",

--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -18,16 +18,20 @@
   "peerDependencies": {
     "@angular/common": "^16.2.0",
     "@angular/core": "^16.2.0",
-    "@esri/calcite-components": "1.10.0"
+    "@esri/calcite-components": "1.10.1-next.3"
   },
   "devDependencies": {
-    "@esri/calcite-components": "1.10.0"
+    "@esri/calcite-components": "1.10.1-next.3"
   },
   "dependencies": {
     "tslib": "2.3.0"
   },
-  "publishConfig": {
-    "directory": "./dist"
+  "lerna": {
+    "command": {
+      "publish": {
+        "directory": "./dist"
+      }
+    }
   },
   "license": "SEE LICENSE.md"
 }


### PR DESCRIPTION
**Related Issue:** #7860

## Summary

Angular has an unusual workflow where you need to `cd` into the library's `dist` directory and run `npm publish` from there. I found related Lerna issues that culminated in the ability to publish a particular package from a different directory. This is the doc I found for the config option:
https://github.com/lerna/lerna/tree/main/libs/commands/publish#publishconfigdirectory

Unfortunately, it didn't end up working, so `v1.10.1-next.3` of the angular wrapper is broken. I'm not aware of a way to test the results of `lerna publish` without actually publishing.

I ended up copying the config from the `arcgis-web-components` repo's angular wrapper once I remembered they use Lerna.
