### PR TITLE
build(angular): chage calcite-components to a dep from peerDep/devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21941,12 +21941,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-request-submit-polyfill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ==",
-      "dev": true
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -49413,15 +49407,12 @@
       "version": "1.10.1-next.3",
       "license": "SEE LICENSE.md",
       "dependencies": {
+        "@esri/calcite-components": "1.10.1-next.3",
         "tslib": "2.3.0"
-      },
-      "devDependencies": {
-        "@esri/calcite-components": "1.10.1-next.3"
       },
       "peerDependencies": {
         "@angular/common": "^16.2.0",
-        "@angular/core": "^16.2.0",
-        "@esri/calcite-components": "1.10.1-next.3"
+        "@angular/core": "^16.2.0"
       }
     },
     "packages/calcite-components-react": {
@@ -68781,12 +68772,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "form-request-submit-polyfill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-      "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ==",
-      "dev": true
     },
     "format": {
       "version": "0.2.2",

--- a/packages/calcite-components-angular/projects/component-library/README.md
+++ b/packages/calcite-components-angular/projects/component-library/README.md
@@ -8,13 +8,11 @@ The following is an outline of the steps required to use `@esri/calcite-componen
 
 ### Install the packages
 
-Install the Angular wrapper components along with [`@esri/calcite-components`](https://www.npmjs.com/package/@esri/calcite-components):
-
 ```sh
-npm install @esri/calcite-components @esri/calcite-components-angular
+npm install @esri/calcite-components-angular
 ```
 
-Make sure the versions of the two packages remain the same when updating your dependencies.
+This package includes the compatible version of the main component library as a dependency, so no need to install `@esri/calcite-components` separately.
 
 ### Copy local assets
 

--- a/packages/calcite-components-angular/projects/component-library/ng-package.json
+++ b/packages/calcite-components-angular/projects/component-library/ng-package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "./dist",
+  "allowedNonPeerDependencies": ["@esri/calcite-components"],
   "lib": {
     "entryFile": "src/public-api.ts"
   }

--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/Esri/calcite-design-system/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^16.2.0",
-    "@angular/core": "^16.2.0"
+    "@angular/common": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   },
   "dependencies": {
     "@esri/calcite-components": "1.10.1-next.3",

--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -17,13 +17,10 @@
   },
   "peerDependencies": {
     "@angular/common": "^16.2.0",
-    "@angular/core": "^16.2.0",
-    "@esri/calcite-components": "1.10.1-next.3"
-  },
-  "devDependencies": {
-    "@esri/calcite-components": "1.10.1-next.3"
+    "@angular/core": "^16.2.0"
   },
   "dependencies": {
+    "@esri/calcite-components": "1.10.1-next.3",
     "tslib": "2.3.0"
   },
   "lerna": {


### PR DESCRIPTION
## Summary

Changes calcite-components to a dependency of the angular wrapper, versus a peerDep and devDep. 

Stencil has it as a peerDep because it is required for the user. arcgis-web-components and us added it as a devDep so the monorepo dependency tree would catch it.

Putting it as a dep resolves both of the above, and it prevents the user from needing to install it on their end. It seems like lerna doesn't bump the peerDep when versioning local packages so it falls behind, which causes issues.

Note: we did the same thing for the react wrapper for convenience, even before we moved it to the monorepo