### PR TITLE
ci: fix versioning script async issue that committed too early

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49411,8 +49411,8 @@
         "tslib": "2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^16.2.0",
-        "@angular/core": "^16.2.0"
+        "@angular/common": ">=16.0.0",
+        "@angular/core": ">=16.0.0"
       }
     },
     "packages/calcite-components-react": {

--- a/support/syncLinkedPackageVersions.ts
+++ b/support/syncLinkedPackageVersions.ts
@@ -32,7 +32,7 @@
       throw new Error(`Unable to find data for the HEAD linked package: ${LINKED_VERSIONS_HEAD_PACKAGE}`);
     }
 
-    LINKED_VERSIONS_TRACKING_PACKAGES.forEach(async (pkg) => {
+    for (const pkg of LINKED_VERSIONS_TRACKING_PACKAGES) {
       const trackingPackageData = packagesData.find((data: PackageData) => data.name === pkg);
 
       if (!trackingPackageData) {
@@ -77,7 +77,7 @@
 
         await fs.writeFile(packageChangelogPath, updatedChangelogContent);
       }
-    });
+    }
 
     // get updated data for deployable packages
     const changedPackagesData: Array<PackageData> = JSON.parse((await exec("npx lerna changed --json")).stdout.trim());
@@ -88,9 +88,9 @@
     await exec(`git add --all && git commit -m 'chore: release ${releaseTarget}'`);
 
     // create git tags with the updated versions
-    changedPackagesData.forEach(async (pkg: PackageData) => {
+    for (const pkg of changedPackagesData) {
       await exec(`git tag -a "${pkg.name}@${pkg.version}" HEAD -m "${pkg.name}@${pkg.version}"`);
-    });
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
## Summary

Resolve an async issue that caused the versioning script to commit before it finished writing changes to the angular package's changelog and README. This issue arose in #8167 so it never actually caused any issues in a real release.