### PR TITLE
fix(alert): avoid clipping by having actions wrap in xs width

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -152,6 +152,7 @@ $border-style: 1px solid var(--calcite-ui-border-3);
 
 .footer {
   @apply flex justify-end order-1 pt-px relative w-full;
+  min-block-size: var(--calcite-alert-footer-height);
 
   &:before {
     content: "";
@@ -166,6 +167,7 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 40em;
   --calcite-alert-spacing-token-small: theme("spacing.2");
   --calcite-alert-spacing-token-large: theme("spacing.3");
+  --calcite-alert-footer-height: theme("height.8");
   --calcite-alert-footer-divider-gap: theme("spacing[0.5]");
 
   @include slotted("title", "*") {
@@ -189,6 +191,7 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 50em;
   --calcite-alert-spacing-token-small: theme("spacing.3");
   --calcite-alert-spacing-token-large: theme("spacing.4");
+  --calcite-alert-footer-height: theme("height.12");
   --calcite-alert-footer-divider-gap: theme("spacing.1");
 
   @include slotted("title", "*") {
@@ -212,6 +215,7 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 60em;
   --calcite-alert-spacing-token-small: theme("spacing.4");
   --calcite-alert-spacing-token-large: theme("spacing.5");
+  --calcite-alert-footer-height: theme("height.16");
   --calcite-alert-footer-divider-gap: theme("spacing.2");
 
   @include slotted("title", "*") {
@@ -316,6 +320,10 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
 }
 
 @container responsive-container (min-width: #{$breakpoint-width-xs}) {
+  .footer {
+    block-size: inherit;
+  }
+
   .content {
     @apply flex-row;
   }

--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -139,7 +139,7 @@ $border-style: 1px solid var(--calcite-ui-border-3);
 }
 
 .actions-end {
-  @apply flex self-stretch;
+  @apply flex flex-wrap self-stretch;
 }
 
 .text-container {
@@ -152,7 +152,6 @@ $border-style: 1px solid var(--calcite-ui-border-3);
 
 .footer {
   @apply flex justify-end order-1 pt-px relative w-full;
-  block-size: var(--calcite-alert-footer-height);
 
   &:before {
     content: "";
@@ -167,7 +166,6 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 40em;
   --calcite-alert-spacing-token-small: theme("spacing.2");
   --calcite-alert-spacing-token-large: theme("spacing.3");
-  --calcite-alert-footer-height: theme("height.8");
   --calcite-alert-footer-divider-gap: theme("spacing[0.5]");
 
   @include slotted("title", "*") {
@@ -191,7 +189,6 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 50em;
   --calcite-alert-spacing-token-small: theme("spacing.3");
   --calcite-alert-spacing-token-large: theme("spacing.4");
-  --calcite-alert-footer-height: theme("height.12");
   --calcite-alert-footer-divider-gap: theme("spacing.1");
 
   @include slotted("title", "*") {
@@ -215,7 +212,6 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   --calcite-alert-width: 60em;
   --calcite-alert-spacing-token-small: theme("spacing.4");
   --calcite-alert-spacing-token-large: theme("spacing.5");
-  --calcite-alert-footer-height: theme("height.16");
   --calcite-alert-footer-divider-gap: theme("spacing.2");
 
   @include slotted("title", "*") {
@@ -337,6 +333,10 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
 }
 
 @container responsive-container (min-width: #{$breakpoint-width-sm}) {
+  .actions-end {
+    @apply flex-nowrap;
+  }
+
   .close {
     @apply self-stretch;
   }
@@ -344,7 +344,6 @@ $alertDurations: "fast" 6000ms, "medium" 10000ms, "slow" 14000ms;
   .footer {
     @apply self-stretch w-auto;
     order: initial;
-    block-size: inherit;
 
     &:before {
       content: none;

--- a/packages/calcite-components/src/components/alert/alert.stories.ts
+++ b/packages/calcite-components/src/components/alert/alert.stories.ts
@@ -235,16 +235,16 @@ const breakpointsStoryTemplate = html`
   <calcite-alert icon open scale="{scale}">
     <div slot="title">title</div>
     <div slot="message">message</div>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Tips" icon="lightbulb"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Get info" icon="attachment"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Contact us" icon="phone"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Tips" icon="lightbulb"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Contact us" icon="phone"></calcite-action>
   </calcite-alert>
   <calcite-alert icon scale="{scale}">
     <div slot="title">title</div>
     <div slot="message">message</div>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Tips" icon="lightbulb"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Get info" icon="attachment"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Contact us" icon="phone"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Tips" icon="lightbulb"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled text="Contact us" icon="phone"></calcite-action>
   </calcite-alert>
   <script>
     (async function () {

--- a/packages/calcite-components/src/components/alert/alert.stories.ts
+++ b/packages/calcite-components/src/components/alert/alert.stories.ts
@@ -235,14 +235,16 @@ const breakpointsStoryTemplate = html`
   <calcite-alert icon open scale="{scale}">
     <div slot="title">title</div>
     <div slot="message">message</div>
-    <calcite-action scale="{scale}" slot="actions-end" title="Tips" icon="lightbulb"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" title="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Tips" icon="lightbulb"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Contact us" icon="phone"></calcite-action>
   </calcite-alert>
   <calcite-alert icon scale="{scale}">
     <div slot="title">title</div>
     <div slot="message">message</div>
-    <calcite-action scale="{scale}" slot="actions-end" title="Tips" icon="lightbulb"></calcite-action>
-    <calcite-action scale="{scale}" slot="actions-end" title="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Tips" icon="lightbulb"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Get info" icon="attachment"></calcite-action>
+    <calcite-action scale="{scale}" slot="actions-end" text-enabled title="Contact us" icon="phone"></calcite-action>
   </calcite-alert>
   <script>
     (async function () {


### PR DESCRIPTION
**Related Issue:** #7921 

## Summary

Prevents actions from overflowing the alert's action container within the xs breakpoint.
