### PR TITLE
ci(next): attempt to fix tests by copying steps in passing pr check

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -24,6 +24,7 @@ jobs:
       - name: e2e test
         run: |
           npm install
+          npm run build
           npm test
       - name: storybook/next deployment
         env:


### PR DESCRIPTION
## Summary

We have consistent timeout test failures on `main`, which is preventing `next` deployments. Strangely, the tests are passing on the PR check and locally. I'm not sure what's going on and it's hard to troubleshoot because it only occurs in the CI. 

I'm adding a "supposedly" redundant build to the next deployment workflow to align with the passing e2e PR check:

https://github.com/Esri/calcite-design-system/blob/01288a3575e1388c49f0fe6b66d863306b3f8c06/.github/workflows/pr-e2e.yml#L32

I must have forgotten to remove the extra build in the PR check when I set up the monorepo. It shouldn't be required because we have turbo set up to build before testing:

https://github.com/Esri/calcite-design-system/blob/01288a3575e1388c49f0fe6b66d863306b3f8c06/turbo.json#L13-L15

This shouldn't add additional time because turbo will use the cache from the previous build during `npm test`. Maybe a second or two for cache lookup, but nothing substantial. 

If this hail mary doesn't work (which is my guess), then it's back to the drawing board. If it does work somehow, then additional investigation/changes will be required on my end to untangle things.