### PR TITLE
fix(checkbox): make label property public

### DIFF
--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -80,15 +80,11 @@ export class Checkbox
    */
   @Prop({ reflect: true, mutable: true }) indeterminate = false;
 
-  /**
-   * Accessible name for the component.
-   *
-   * @internal
-   */
+  /** Accessible name for the component. */
   @Prop() label: string;
 
   /** Specifies the name of the component on form submission. */
-  @Prop({ reflect: true }) name;
+  @Prop({ reflect: true }) name: string;
 
   /**
    * When `true`, the component must have a value in order for the form to submit.


### PR DESCRIPTION
Related issue: #8182

## Summary

The `label` property was unintentionally marked as internal.