### PR TITLE
build: bump stencil-eslint-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46845,7 +46845,7 @@
       "version": "1.0.0-rc.1",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "stencil-eslint-core": "0.3.1"
+        "stencil-eslint-core": "0.4.1"
       },
       "peerDependencies": {
         "eslint": ">=8.0.0"
@@ -46967,9 +46967,9 @@
       }
     },
     "packages/eslint-plugin-calcite-components/node_modules/stencil-eslint-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stencil-eslint-core/-/stencil-eslint-core-0.3.1.tgz",
-      "integrity": "sha512-z1yp1+Qzr6C/X4RgaCt0egDu5CsIrZzMCr9eGMmQTnSU1leVbSJB5aoI/KWv8qe8k7b1LCit46Ff3udRJ96Lfw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/stencil-eslint-core/-/stencil-eslint-core-0.4.1.tgz",
+      "integrity": "sha512-Nep0M+YNzHBK/Y0rzoKP6+VlNp9TkoliWFQBcKb2JRP/lJiPxwlUegs9eXUfzQoJ38AG/Hq8COi8xI5rc/jNJQ==",
       "dependencies": {
         "eslint-utils": "~3.0.0",
         "tsutils": "~3.21.0"

--- a/packages/eslint-plugin-calcite-components/package.json
+++ b/packages/eslint-plugin-calcite-components/package.json
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "stencil-eslint-core": "0.3.1"
+    "stencil-eslint-core": "0.4.1"
   },
   "peerDependencies": {
     "eslint": ">=8.0.0"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Bumps `stencil-eslint-core` to the latest after fixing an [issue that was causing linting to fail on commit](https://github.com/jcfranco/stencil-eslint-core/pull/154) (thanks, @benelan! 🎉).