### PR TITLE
chore(jest, turbo): resolve test run failures

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, rc]
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, rc]
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -142,6 +142,7 @@ export const create: () => Config = () => ({
   testing: {
     watchPathIgnorePatterns: ["<rootDir>/../../node_modules", "<rootDir>/dist", "<rootDir>/www", "<rootDir>/hydrate"],
     moduleNameMapper: {
+      "^@esri/calcite-design-tokens/dist/(.*)$": "<rootDir>/../../node_modules/@esri/calcite-design-tokens/dist/$1",
       "^lodash-es$": "lodash",
     },
     setupFilesAfterEnv: ["<rootDir>/src/tests/setupTests.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
       "cache": false,
       "persistent": true
     },
+    "test": {},
     "clean": {
       "cache": false
     },

--- a/turbo.json
+++ b/turbo.json
@@ -10,9 +10,6 @@
       "cache": false,
       "persistent": true
     },
-    "test": {
-      "dependsOn": ["build"]
-    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
**Related Issue:** #8179

## Summary

Fixes a few test run failures on `rc`:

- a module import issue, see #8201 (thanks  @jcfranco :rocket:)
- remove the `build` prerequisite from turbo's `test` pipeline, which was causing concurrency issues