### PR TITLE
fix(input-number): prevents mutating value on blur

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -1736,4 +1736,28 @@ describe("calcite-input-number", () => {
     await page.waitForChanges();
     expect(await inputNumber.getProperty("value")).toEqual(value);
   });
+
+  it("should not change the value when user Tab out of the input with ArrowUp/ArrowDown keys are down", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-input-number value="0"></calcite-input-number>`);
+    const calciteInputNumberInput = await page.spyOnEvent("calciteInputNumberInput");
+    const input = await page.find("calcite-input-number");
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
+
+    await page.keyboard.press("Tab");
+    await page.waitForChanges();
+    await page.keyboard.down("ArrowUp");
+    // timeout is used to simulate long press.
+    await page.waitForTimeout(3000);
+    await page.keyboard.press("Tab");
+    await page.waitForChanges();
+
+    const totalNudgesUp = calciteInputNumberInput.length;
+    expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(totalNudgesUp);
+
+    await page.waitForTimeout(3000);
+    expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
+    expect(calciteInputNumberInput).toHaveReceivedEventTimes(totalNudgesUp);
+  });
 });

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -591,6 +591,7 @@ export class InputNumber
   };
 
   private inputNumberBlurHandler = () => {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
     this.calciteInternalInputNumberBlur.emit();
     this.emitChangeIfUserModified();
   };


### PR DESCRIPTION
**Related Issue:** #7188 

## Summary

Prevents increasing/decreasing the value in `calcite-input-number` on `blur` via keyboard or mouse