### PR TITLE
fix: drag and drop should not cause scrollbars to appear.

### DIFF
--- a/packages/calcite-components/src/assets/styles/_sortable.scss
+++ b/packages/calcite-components/src/assets/styles/_sortable.scss
@@ -1,4 +1,9 @@
 @mixin sortable-helper-classes() {
+  .calcite-sortable--ghost,
+  .calcite-sortable--drag {
+    overflow: hidden;
+  }
+
   .calcite-sortable--ghost::before {
     content: "";
     @apply box-border


### PR DESCRIPTION
**Related Issue:** #

## Summary

- Sets any dragged element to have `overflow:hidden` so that any floating ui does not take up space when being dragged.