### PR TITLE
chore: downgrade packages after reverting 2.0.0-next.0 change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45525,7 +45525,7 @@
     },
     "packages/calcite-components": {
       "name": "@esri/calcite-components",
-      "version": "2.0.0-next.1",
+      "version": "1.11.0-next.3",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@floating-ui/dom": "1.5.3",
@@ -49404,10 +49404,10 @@
     },
     "packages/calcite-components-angular/projects/component-library": {
       "name": "@esri/calcite-components-angular",
-      "version": "2.0.0-next.1",
+      "version": "1.11.0-next.3",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-components": "^2.0.0-next.1",
+        "@esri/calcite-components": "1.11.0-next.3",
         "tslib": "2.3.0"
       },
       "peerDependencies": {
@@ -49417,10 +49417,10 @@
     },
     "packages/calcite-components-react": {
       "name": "@esri/calcite-components-react",
-      "version": "2.0.0-next.1",
+      "version": "1.11.0-next.3",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-components": "^2.0.0-next.1"
+        "@esri/calcite-components": "1.11.0-next.3"
       },
       "peerDependencies": {
         "react": ">=16.7",
@@ -52294,14 +52294,14 @@
     "@esri/calcite-components-angular": {
       "version": "file:packages/calcite-components-angular/projects/component-library",
       "requires": {
-        "@esri/calcite-components": "^2.0.0-next.1",
+        "@esri/calcite-components": "1.11.0-next.3",
         "tslib": "2.3.0"
       }
     },
     "@esri/calcite-components-react": {
       "version": "file:packages/calcite-components-react",
       "requires": {
-        "@esri/calcite-components": "^2.0.0-next.1"
+        "@esri/calcite-components": "1.11.0-next.3"
       }
     },
     "@esri/calcite-design-tokens": {

--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components-angular",
-  "version": "2.0.0-next.1",
+  "version": "1.11.0-next.3",
   "sideEffects": false,
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "A set of Angular components that wrap Esri's Calcite Components.",
@@ -20,7 +20,7 @@
     "@angular/core": ">=16.0.0"
   },
   "dependencies": {
-    "@esri/calcite-components": "^2.0.0-next.1",
+    "@esri/calcite-components": "1.11.0-next.3",
     "tslib": "2.3.0"
   },
   "lerna": {

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@esri/calcite-components-react",
   "sideEffects": false,
-  "version": "2.0.0-next.1",
+  "version": "1.11.0-next.3",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "A set of React components that wrap calcite components",
   "license": "SEE LICENSE.md",
@@ -20,7 +20,7 @@
     "dist/"
   ],
   "dependencies": {
-    "@esri/calcite-components": "^2.0.0-next.1"
+    "@esri/calcite-components": "1.11.0-next.3"
   },
   "peerDependencies": {
     "react": ">=16.7",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "2.0.0-next.1",
+  "version": "1.11.0-next.3",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "Web Components for Esri's Calcite Design System.",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
**Related Issue:** #8232

## Summary

Downgrade the versions in `package.json` files to ensure the release goes out as 1x