### PR TITLE
fix(input): prevents mutating value on `blur` when `type="number"`

### DIFF
--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -665,6 +665,7 @@ export class Input
   };
 
   private inputBlurHandler = () => {
+    window.clearInterval(this.nudgeNumberValueIntervalId);
     this.calciteInternalInputBlur.emit();
     this.emitChangeIfUserModified();
   };


### PR DESCRIPTION
**Related Issue:** #8243 

## Summary
Prevents increasing/decreasing the value in `<calcite-input type="number" />` on `blur` using `Tab`