### PR TITLE
fix(stepper): typo in CSS variable for step bar's fill

### DIFF
--- a/packages/calcite-components/src/components/stepper/stepper.scss
+++ b/packages/calcite-components/src/components/stepper/stepper.scss
@@ -86,7 +86,7 @@
   }
 
   .step-bar--inactive {
-    fill: var(--light-ui-border-3, #dfdfdf);
+    fill: var(--calcite-ui-border-3, #dfdfdf);
     fill-opacity: 1;
     block-size: 100%;
   }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Cherry pick fix from https://github.com/Esri/calcite-design-system/pull/8254.