### PR TITLE
refactor(alert): remove unnecessary CSS declaration

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -30,7 +30,6 @@ $border-style: 1px solid var(--calcite-ui-border-3);
   w-full
   z-toast;
 
-  container: responsive-container / inline-size;
   border-radius: var(--calcite-border-radius);
   border-block-start: 0 solid transparent;
   border-inline: $border-style;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes responsiveness-related declaration no longer necessary after https://github.com/Esri/calcite-design-system/pull/8195/.