### PR TITLE
fix(list-item): adds border between last item in a group and slotted item

### DIFF
--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -33,10 +33,6 @@
   margin-block-start: 1px;
 }
 
-::slotted(calcite-list-item:first-of-type) {
-  @apply shadow-none;
-}
-
 // removes shadow for the first item in filteredItems of the list.
 ::slotted(calcite-list-item[data-filter]) {
   @apply shadow-none;

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -768,3 +768,43 @@ export const listWithEmptyChildList_TestOnly = (): string => html`<calcite-list
     <calcite-list drag-enabled group="nested" selection-mode="single"></calcite-list>
   </calcite-list-item>
 </calcite-list>`;
+
+export const listWithGroupedAndSlottedItems_TestOnly = (): string => html`<calcite-list filter-enabled>
+  <calcite-list-item-group heading="Outdoor recreation">
+    <calcite-list-item label="Hiking trails" description="Designated routes for hikers to use." value="hiking-trails">
+      <calcite-action slot="actions-end" icon="layer" text="Trails layer"></calcite-action>
+    </calcite-list-item>
+    <calcite-list-item label="Waterfalls" description="Vertical drops from a river." value="waterfalls">
+      <calcite-action slot="actions-end" icon="layer" text="Waterfalls layer"></calcite-action>
+    </calcite-list-item>
+  </calcite-list-item-group>
+  <calcite-list-item label="Rivers" description="Large naturally flowing watercourses." value="rivers">
+    <calcite-action slot="actions-end" icon="layer" text="Rivers layer"></calcite-action>
+  </calcite-list-item>
+  <calcite-list-item label="Estuaries" description="Where the river meets the sea." value="estuaries">
+    <calcite-action slot="actions-end" icon="layer" text="Estuaries layer"></calcite-action>
+  </calcite-list-item>
+  <calcite-list-item
+    label="Park offices"
+    description="Home base for park staff to converse with visitors."
+    value="offices"
+  >
+    <calcite-action slot="actions-end" icon="layer" text="Offices layer"></calcite-action>
+  </calcite-list-item>
+  <calcite-list-item-group heading="Buildings">
+    <calcite-list-item
+      label="Guest lodges"
+      description="Small houses available for visitors to book for stays."
+      value="lodges"
+    >
+      <calcite-action slot="actions-end" icon="layer" text="Lodges layer"></calcite-action>
+    </calcite-list-item>
+    <calcite-list-item
+      label="Yurts"
+      description="Insulated portable rounded structures similar to tents."
+      value="yurts"
+    >
+      <calcite-action slot="actions-end" icon="layer" text="Yurts layer"></calcite-action>
+    </calcite-list-item>
+  </calcite-list-item-group>
+</calcite-list>`;


### PR DESCRIPTION
**Related Issue:** #7546 

## Summary

Adds border between last `calcite-list-item` in a `calcite-list-item-group` and next slotted `calcite-list-item`.