### PR TITLE
docs: remove invalid css style [skip ci]

### DIFF
--- a/packages/calcite-components/src/demos/combobox.html
+++ b/packages/calcite-components/src/demos/combobox.html
@@ -36,7 +36,7 @@
 
   <body>
     <demo-dom-swapper>
-      <h1 style="margin: 0 fit; text-align: center">Combobox</h1>
+      <h1 style="margin: 0; text-align: center">Combobox</h1>
 
       <!-- Header -->
       <div class="parent">


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Removes an invalid CSS style applied inline to the body on the combobox demo page.