### PR TITLE
fix(input-time-zone): update time zone items when item-dependent props change

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -332,6 +332,34 @@ describe("calcite-input-time-zone", () => {
     // we assume maxItems works properly on combobox
     expect(await internalCombobox.getProperty("maxItems")).toBe(7);
   });
+
+  it("recreates time zone items when item-dependent props change", async () => {
+    const page = await newE2EPage();
+    await page.emulateTimezone(testTimeZoneNamesAndOffsets[0].name);
+    await page.setContent(addTimeZoneNamePolyfill(html`<calcite-input-time-zone></calcite-input-time-zone>`));
+    const inputTimeZone = await page.find("calcite-input-time-zone");
+
+    let prevComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
+    await inputTimeZone.setProperty("lang", "es");
+    await page.waitForChanges();
+
+    let currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
+    expect(currComboboxItem).not.toBe(prevComboboxItem);
+
+    prevComboboxItem = currComboboxItem;
+    await inputTimeZone.setProperty("referenceDate", "2021-01-01");
+    await page.waitForChanges();
+
+    currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
+    expect(currComboboxItem).not.toBe(prevComboboxItem);
+
+    prevComboboxItem = currComboboxItem;
+    await inputTimeZone.setProperty("mode", "list");
+    await page.waitForChanges();
+
+    currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
+    expect(currComboboxItem).not.toBe(prevComboboxItem);
+  });
 });
 
 /**

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -111,12 +111,11 @@ export class InputTimeZone
    */
   @Prop({ reflect: true }) mode: TimeZoneMode = "offset";
 
-  @Watch("effectiveLocale")
   @Watch("messages")
   @Watch("mode")
   @Watch("referenceDate")
   handleTimeZoneItemPropsChange(): void {
-    this.createTimeZoneItems();
+    this.updateTimeZoneItemsAndSelection();
   }
 
   /**
@@ -297,6 +296,19 @@ export class InputTimeZone
     );
   }
 
+  private async updateTimeZoneItemsAndSelection(): Promise<void> {
+    this.timeZoneItems = await this.createTimeZoneItems();
+
+    const fallbackValue = this.mode === "offset" ? getUserTimeZoneOffset() : getUserTimeZoneName();
+    const valueToMatch = this.value ?? fallbackValue;
+
+    this.selectedTimeZoneItem = this.findTimeZoneItem(valueToMatch);
+
+    if (!this.selectedTimeZoneItem) {
+      this.selectedTimeZoneItem = this.findTimeZoneItem(fallbackValue);
+    }
+  }
+
   private async createTimeZoneItems(): Promise<TimeZoneItem[]> {
     if (!this.effectiveLocale || !this.messages) {
       return [];
@@ -336,16 +348,7 @@ export class InputTimeZone
     setUpLoadableComponent(this);
     await setUpMessages(this);
 
-    this.timeZoneItems = await this.createTimeZoneItems();
-
-    const fallbackValue = this.mode === "offset" ? getUserTimeZoneOffset() : getUserTimeZoneName();
-    const valueToMatch = this.value ?? fallbackValue;
-
-    this.selectedTimeZoneItem = this.findTimeZoneItem(valueToMatch);
-
-    if (!this.selectedTimeZoneItem) {
-      this.selectedTimeZoneItem = this.findTimeZoneItem(fallbackValue);
-    }
+    await this.updateTimeZoneItemsAndSelection();
 
     const selectedValue = `${this.selectedTimeZoneItem.value}`;
     afterConnectDefaultValueSet(this, selectedValue);


### PR DESCRIPTION
**Related Issue:** #8007

## Summary

This addresses an issue where `input-time-zone` was recreating time zone groups when related props were modified, but these were not affecting state, so the items would remain unchanged.
