### PR TITLE
fix(color tokens): "input" should be "user-input"

### DIFF
--- a/packages/calcite-design-tokens/src/semantic/color.json
+++ b/packages/calcite-design-tokens/src/semantic/color.json
@@ -147,7 +147,7 @@
           "value": { "light": "{core.color.neutral.blk-030}", "dark": "{core.color.neutral.blk-180}" },
           "type": "color"
         },
-        "input": {
+        "user-input": {
           "value": { "light": "{core.color.neutral.blk-100}", "dark": "{core.color.neutral.blk-130}" },
           "type": "color"
         }


### PR DESCRIPTION
**Related Issue:** #8287

## Summary
Resolves an issue with reserved words in Gasby when trying to generate design tokens documentation