### PR TITLE
fix(button, list, pick-list, value-list)!: prevent loading prop from affecting interactivity

### DIFF
--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -160,15 +160,6 @@
 
 @include disabled();
 
-:host([loading]:not([disabled])) {
-  @extend %non-interactive-host-contents;
-
-  button,
-  a {
-    @apply opacity-disabled;
-  }
-}
-
 @keyframes loader-in {
   0% {
     inline-size: 0;

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -267,12 +267,12 @@ export class Button
           [CSS.iconStartEmpty]: !this.iconStart,
           [CSS.iconEndEmpty]: !this.iconEnd,
         }}
-        disabled={this.disabled || this.loading}
+        disabled={this.disabled}
         href={childElType === "a" && this.href}
         name={childElType === "button" && this.name}
         onClick={this.handleClick}
         rel={childElType === "a" && this.rel}
-        tabIndex={this.disabled || this.loading ? -1 : null}
+        tabIndex={this.disabled ? -1 : null}
         target={childElType === "a" && this.target}
         title={this.tooltipText}
         type={childElType === "button" && this.type}

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -429,7 +429,7 @@ export class List implements InteractiveComponent, LoadableComponent, SortableCo
                     />
                     <calcite-filter
                       aria-label={filterPlaceholder}
-                      disabled={loading || disabled}
+                      disabled={disabled}
                       items={dataForFilter}
                       onCalciteFilterChange={this.handleFilterChange}
                       placeholder={filterPlaceholder}

--- a/packages/calcite-components/src/components/pick-list/pick-list.e2e.ts
+++ b/packages/calcite-components/src/components/pick-list/pick-list.e2e.ts
@@ -9,7 +9,6 @@ import {
   focusing,
   itemRemoval,
   keyboardNavigation,
-  loadingState,
   selectionAndDeselection,
 } from "./shared-list-tests";
 
@@ -193,10 +192,6 @@ describe("calcite-pick-list", () => {
 
   describe("item removal", () => {
     itemRemoval("pick");
-  });
-
-  describe("loading state", () => {
-    loadingState("pick");
   });
 
   describe("setFocus", () => {

--- a/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
+++ b/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
@@ -54,7 +54,7 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes<any>
           {filterEnabled ? (
             <calcite-filter
               aria-label={filterPlaceholder}
-              disabled={loading || disabled}
+              disabled={disabled}
               items={dataForFilter}
               onCalciteFilterChange={handleFilterEvent}
               placeholder={filterPlaceholder}

--- a/packages/calcite-components/src/components/pick-list/shared-list-tests.ts
+++ b/packages/calcite-components/src/components/pick-list/shared-list-tests.ts
@@ -548,22 +548,6 @@ export function filterBehavior(listType: ListType): void {
   });
 }
 
-export function loadingState(listType: ListType): void {
-  it("loading", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<calcite-${listType}-list loading>
-        <calcite-${listType}-list-item value="one" label="One"></calcite-${listType}-list-item>
-      </calcite-${listType}-list>`);
-
-    const list = await page.find(`calcite-${listType}-list`);
-    const item1 = await list.find("[value=one]");
-    const toggleSpy = await list.spyOnEvent("calciteListChange");
-
-    await item1.click();
-    expect(toggleSpy).toHaveReceivedEventTimes(0);
-  });
-}
-
 export function itemRemoval(listType: ListType): void {
   const pickListGroupHtml = html` <calcite-pick-list-group
       label="Will be removed when slotted 'parent item' is removed"

--- a/packages/calcite-components/src/components/value-list/value-list.e2e.ts
+++ b/packages/calcite-components/src/components/value-list/value-list.e2e.ts
@@ -8,7 +8,6 @@ import {
   focusing,
   itemRemoval,
   keyboardNavigation,
-  loadingState,
   selectionAndDeselection,
 } from "../pick-list/shared-list-tests";
 import { CSS, ICON_TYPES } from "./resources";
@@ -97,10 +96,6 @@ describe("calcite-value-list", () => {
 
   describe("item removal", () => {
     itemRemoval("value");
-  });
-
-  describe("loading state", () => {
-    loadingState("value");
   });
 
   describe("setFocus", () => {


### PR DESCRIPTION
**Related Issue:** #7590

## Summary

This updates some components to avoid setting `disabled` on internal, supporting components when `loading` was set to true.

BREAKING CHANGE: Setting `loading` prop to true no longer prevents interaction nor applies disabled styles. If you'd like to block interaction when loading, please set `disabled` along with `loading`.