### PR TITLE
fix(combobox, dropdown, input-date-picker, popover, tooltip): fix positioning of component when component is moved

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -439,6 +439,7 @@ export class Combobox
       this.openHandler();
       onToggleOpenCloseComponent(this);
     }
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -209,6 +209,7 @@ export class Dropdown
     }
     connectInteractive(this);
     this.updateItems();
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   componentWillLoad(): void {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -475,6 +475,7 @@ export class InputDatePicker
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -300,6 +300,7 @@ export class Popover
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -163,6 +163,7 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
   }
 
   async componentWillLoad(): Promise<void> {


### PR DESCRIPTION
**Related Issue:** #6121

## Summary

- When a component is moved (via drag and drop or whatever), we need to reconnect floating UI (connectFloatingUI).
- This is needed because it sets up autoUpdating of the reference element so that the reference element is tracked and positioned properly
- Currently, when an a component is moved, this tracking is lost because we were only calling `connectFloatingUI` when the reference element and floating element were created.
- This PR makes sure that we reestablish the floating UI autoUpdate when the component itself is moved.