### PR TITLE
test(spec): resolve jsdom type errors

### DIFF
--- a/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
@@ -68,7 +68,9 @@ describe("focusTrapComponent", () => {
 
       // we clobber Stencil's custom Mock document implementation
       const { window: win } = new JSDOM();
-      window = win as any; // make window references use JSDOM
+
+      // make window references use JSDOM (which is a subset, hence the type cast)
+      window = win as any as Window & typeof globalThis;
       globalThis.MutationObserver = window.MutationObserver; // needed for focus-trap
 
       type TestGlobal = GlobalTestProps<{ calciteConfig: CalciteConfig }>;

--- a/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
@@ -68,7 +68,7 @@ describe("focusTrapComponent", () => {
 
       // we clobber Stencil's custom Mock document implementation
       const { window: win } = new JSDOM();
-      window = win; // make window references use JSDOM
+      window = win as any; // make window references use JSDOM
       globalThis.MutationObserver = window.MutationObserver; // needed for focus-trap
 
       type TestGlobal = GlobalTestProps<{ calciteConfig: CalciteConfig }>;

--- a/packages/calcite-components/src/utils/globalAttributes.spec.ts
+++ b/packages/calcite-components/src/utils/globalAttributes.spec.ts
@@ -13,7 +13,7 @@ describe("globalAttributes", () => {
     // we clobber Stencil's custom Mock document implementation
     const { window: win } = new JSDOM();
 
-    window = win; // make window references use JSDOM
+    window = win as any; // make window references use JSDOM
     const fakeComponent = win.document.createElement("fake-component");
     win.document.body.append(fakeComponent);
 
@@ -54,7 +54,7 @@ describe("globalAttributes", () => {
     // we clobber Stencil's custom Mock document implementation
     const { window: win } = new JSDOM();
 
-    window = win; // make window references use JSDOM
+    window = win as any; // make window references use JSDOM
     const fakeComponent = win.document.createElement("fake-component");
     win.document.body.append(fakeComponent);
 

--- a/packages/calcite-components/src/utils/globalAttributes.spec.ts
+++ b/packages/calcite-components/src/utils/globalAttributes.spec.ts
@@ -13,7 +13,8 @@ describe("globalAttributes", () => {
     // we clobber Stencil's custom Mock document implementation
     const { window: win } = new JSDOM();
 
-    window = win as any; // make window references use JSDOM
+    // make window references use JSDOM (which is a subset, hence the type cast)
+    window = win as any as Window & typeof globalThis;
     const fakeComponent = win.document.createElement("fake-component");
     win.document.body.append(fakeComponent);
 
@@ -54,7 +55,8 @@ describe("globalAttributes", () => {
     // we clobber Stencil's custom Mock document implementation
     const { window: win } = new JSDOM();
 
-    window = win as any; // make window references use JSDOM
+    // make window references use JSDOM (which is a subset, hence the type cast)
+    window = win as any as Window & typeof globalThis;
     const fakeComponent = win.document.createElement("fake-component");
     win.document.body.append(fakeComponent);
 


### PR DESCRIPTION
## Summary

Resolves some JSDOM type errors that were causing issues with `npm start`. I wouldn't normally use `any`, but it's to fix types for a hack in spec tests. Here are the error messages that appeared in `npm start`:

```
[ ERROR ]  TypeScript: ./src/utils/focusTrapComponent.spec.ts:71:7
           Type 'DOMWindow' is not assignable to type 'Window & typeof globalThis'.

     L70:  const { window: win } = new JSDOM();
     L71:  window = win; // make window references use JSDOM
     L72:  globalThis.MutationObserver = window.MutationObserver; // needed for focus-trap

[ ERROR ]  TypeScript: ./src/utils/globalAttributes.spec.ts:16:5
           Type 'DOMWindow' is not assignable to type 'Window & typeof globalThis'.Type 'DOMWindow' is not assignable
           to type 'Window'.Types of property 'self' are incompatible.Type 'DOMWindow' is not assignable to type
           'Window & typeof globalThis'.Type 'DOMWindow' is missing the following properties from type 'typeof
           globalThis': AnalyserNode, Animation, AnimationEffect, AnimationEvent, and 536 more.

     L16:      window = win; // make window references use JSDOM
     L17:      const fakeComponent = win.document.createElement("fake-component");

[ ERROR ]  TypeScript: ./src/utils/globalAttributes.spec.ts:57:5
           Type 'DOMWindow' is not assignable to type 'Window & typeof globalThis'.

     L57:      window = win; // make window references use JSDOM
     L58:      const fakeComponent = win.document.createElement("fake-component");

[32:11.9]  rebuild failed, watching for changes... in 181 ms
```