### PR TITLE
docs(shell-panel): remove incorrect information from heightScale prop

### DIFF
--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -87,7 +87,7 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
   }
 
   /**
-   * When `layout` is `horizontal`, specifies the maximum height of the component.
+   * When `layout` is `horizontal`, or `layout` is `vertical` and `displayMode` is `float`, specifies the maximum height of the component.
    */
   @Prop({ reflect: true }) heightScale: Scale;
 

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -87,7 +87,7 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
   }
 
   /**
-   * When `layout` is `horizontal`, or `layout` is `vertical` and `displayMode` is `float`, specifies the maximum height of the component.
+   * When `layout` is `horizontal`, specifies the maximum height of the component.
    */
   @Prop({ reflect: true }) heightScale: Scale;
 


### PR DESCRIPTION
**Related Issue:** #8286 

## Summary
Updated the description of the `heightScale` property for `Shell Panel` to correctly reflect the actual behavior.