### PR TITLE
refactor(dropdown): remove obsolete logic

### DIFF
--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -648,16 +648,12 @@ export class Dropdown
     this.getFocusableElement(this.items.find((item) => item.selected) || this.items[0]);
   };
 
-  private getFocusableElement(item): void {
+  private getFocusableElement(item: HTMLCalciteDropdownItemElement): void {
     if (!item) {
       return;
     }
 
-    const target = item.attributes.isLink
-      ? item.shadowRoot.querySelector("a")
-      : (item as HTMLCalciteDropdownItemElement);
-
-    focusElement(target);
+    focusElement(item);
   }
 
   private toggleOpenEnd = (): void => {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Cleans up some code that relies on a custom `dropdown-item` attribute (`islink`) that was removed in https://github.com/Esri/calcite-design-system/pull/2106/files#diff-a41ea470fa36ce6cabf5f622a56904c6bbd308964030313c2962a0afe6c19517L172.