### PR TITLE
ci(deploy-latest): use volta's pinned node version

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## Summary

Update the deploy-latest workflow to use the Node version pinned by volta to prevent build errors:

https://github.com/Esri/calcite-design-system/actions/runs/7067688502/job/19241371459#step:5:691


Pushing this through so I can release, cc @jcfranco 