### PR TITLE
ci(deploy-latest): hardcode node v18

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: package.json
+          node-version: 18
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## Summary

We got a [new error](https://github.com/Esri/calcite-design-system/actions/runs/7067782508/job/19241570336#step:4:9) in the `deploy-latest` workflow. Not sure why it can't find `package.json`, considering I copied that directly from `deploy-next`:

https://github.com/Esri/calcite-design-system/blob/acd95305cd4143580f695f11036e91f47174efa6/.github/workflows/deploy-next.yml#L18-L23

Hardcoding the version for now so we can release. Pushing this one through too, cc @jcfranco 