### PR TITLE
chore: update token transformer to align with sd-transforms@0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "storybook": "6.5.16",
         "storybook-addon-themes": "6.1.0",
         "storybook-rtl-addon": "0.3.3",
-        "style-dictionary": "3.7.1",
+        "style-dictionary": "3.9.0",
         "stylelint": "15.10.3",
         "stylelint-config-recommended-scss": "12.0.0",
         "stylelint-use-logical-spec": "5.0.0",
@@ -13053,122 +13053,6 @@
       },
       "engines": {
         "node": ">=17.0.0"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/style-dictionary": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.9.0.tgz",
-      "integrity": "sha512-mnq8QfPJoj3ellKHRKZwmCgYUGgwYtoagW5edyKpR09O1W4/XqBdeKXoY/LbeIKqHrqVR7sGgk6E/dNYkPS4aA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "change-case": "^4.1.2",
-        "commander": "^8.3.0",
-        "fs-extra": "^10.0.0",
-        "glob": "^7.2.0",
-        "json5": "^2.2.2",
-        "jsonc-parser": "^3.0.0",
-        "lodash": "^4.17.15",
-        "tinycolor2": "^1.4.1"
-      },
-      "bin": {
-        "style-dictionary": "bin/style-dictionary"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@tokens-studio/sd-transforms/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@tokens-studio/types": {
@@ -40752,9 +40636,9 @@
       }
     },
     "node_modules/style-dictionary": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.7.1.tgz",
-      "integrity": "sha512-yYU9Z/J8Znj9T9oJVjo8VOYamrOxv0UbBKPjhSt+PharxrhyQCM4RWb71fgEfv2pK9KO8G83/0ChDNQZ1mn0wQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.9.0.tgz",
+      "integrity": "sha512-mnq8QfPJoj3ellKHRKZwmCgYUGgwYtoagW5edyKpR09O1W4/XqBdeKXoY/LbeIKqHrqVR7sGgk6E/dNYkPS4aA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -40762,7 +40646,7 @@
         "commander": "^8.3.0",
         "fs-extra": "^10.0.0",
         "glob": "^7.2.0",
-        "json5": "^2.2.0",
+        "json5": "^2.2.2",
         "jsonc-parser": "^3.0.0",
         "lodash": "^4.17.15",
         "tinycolor2": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "storybook": "6.5.16",
     "storybook-addon-themes": "6.1.0",
     "storybook-rtl-addon": "0.3.3",
-    "style-dictionary": "3.7.1",
+    "style-dictionary": "3.9.0",
     "stylelint": "15.10.3",
     "stylelint-config-recommended-scss": "12.0.0",
     "stylelint-use-logical-spec": "5.0.0",

--- a/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
@@ -811,7 +811,8 @@ export const calciteZIndex5 = "500";
 export const calciteZIndex6 = "600";
 export const calciteZIndex7 = "700";
 export const calciteZIndex8 = "800";
-export const calciteZIndex9 = "900";"
+export const calciteZIndex9 = "900";
+"
 `;
 
 exports[`generated tokens ES6 global should match 1`] = `
@@ -1013,7 +1014,8 @@ export const calciteZIndexDropdown = "600";
 export const calciteZIndexOverlay = "700";
 export const calciteZIndexModal = "800";
 export const calciteZIndexPopup = "900";
-export const calciteZIndexTooltip = "901";"
+export const calciteZIndexTooltip = "901";
+"
 `;
 
 exports[`generated tokens ES6 types should match 1`] = `
@@ -1068,26 +1070,42 @@ export const calciteColorBorder3 : { light: string, dark: string };
 export const calciteColorBorderInput : { light: string, dark: string };
 export const calciteColorBorderGhost : { light: string, dark: string };
 export const calciteColorBorderWhite : { light: string, dark: string };
-export const calciteContainerSizeHeightXxs : { min: string, max: string }; // Small handheld devices and mini-windows
-export const calciteContainerSizeHeightXs : { min: string, max: string }; // Handheld devices
-export const calciteContainerSizeHeightSm : { min: string, max: string }; // Small tablets
-export const calciteContainerSizeHeightMd : { min: string, max: string }; // Small laptops
-export const calciteContainerSizeHeightLg : { min: string, max: string }; // Large laptops and desktop computers
-export const calciteContainerSizeHeightXl : { min: string }; // Projectors and televisions
-export const calciteContainerSizeWidthXxs : { min: string, max: string }; // Small handheld devices and mini-windows
-export const calciteContainerSizeWidthXs : { min: string, max: string }; // Handheld devices
-export const calciteContainerSizeWidthSm : { min: string, max: string }; // Small tablets
-export const calciteContainerSizeWidthMd : { min: string, max: string }; // Small laptops
-export const calciteContainerSizeWidthLg : { min: string, max: string }; // Large laptops and desktop computers
-export const calciteContainerSizeWidthXl : { min: string }; // Projectors and televisions
+/** Small handheld devices and mini-windows */
+export const calciteContainerSizeHeightXxs : { min: string, max: string };
+/** Handheld devices */
+export const calciteContainerSizeHeightXs : { min: string, max: string };
+/** Small tablets */
+export const calciteContainerSizeHeightSm : { min: string, max: string };
+/** Small laptops */
+export const calciteContainerSizeHeightMd : { min: string, max: string };
+/** Large laptops and desktop computers */
+export const calciteContainerSizeHeightLg : { min: string, max: string };
+/** Projectors and televisions */
+export const calciteContainerSizeHeightXl : { min: string };
+/** Small handheld devices and mini-windows */
+export const calciteContainerSizeWidthXxs : { min: string, max: string };
+/** Handheld devices */
+export const calciteContainerSizeWidthXs : { min: string, max: string };
+/** Small tablets */
+export const calciteContainerSizeWidthSm : { min: string, max: string };
+/** Small laptops */
+export const calciteContainerSizeWidthMd : { min: string, max: string };
+/** Large laptops and desktop computers */
+export const calciteContainerSizeWidthLg : { min: string, max: string };
+/** Projectors and televisions */
+export const calciteContainerSizeWidthXl : { min: string };
 export const calciteContainerSizeMargin : string;
 export const calciteContainerSizeGutter : string;
-export const calciteContainerSizeContentFluid : string; // for fluid grid widths
-export const calciteContainerSizeContentFixed : string; // only for lg breakpoint fixed grid width
+/** for fluid grid widths */
+export const calciteContainerSizeContentFluid : string;
+/** only for lg breakpoint fixed grid width */
+export const calciteContainerSizeContentFixed : string;
 export const calciteFontFamily : string;
 export const calciteFontFamilyCode : string;
-export const calciteFontWeightLight : string; // For Avenir Next World (secondary font family)
-export const calciteFontWeightNormal : string; // For backwards compatibility only. This token will be removed from the published tokens in the next major in favor of the more descriptive word "regular"
+/** For Avenir Next World (secondary font family) */
+export const calciteFontWeightLight : string;
+/** For backwards compatibility only. This token will be removed from the published tokens in the next major in favor of the more descriptive word "regular" */
+export const calciteFontWeightNormal : string;
 export const calciteFontWeightRegular : string;
 export const calciteFontWeightMedium : string;
 export const calciteFontWeightSemibold : string;
@@ -1099,17 +1117,24 @@ export const calciteFontSizeMd : string;
 export const calciteFontSizeLg : string;
 export const calciteFontSizeXl : string;
 export const calciteFontSizeXxl : string;
-export const calciteFontStyleEmphasis : string; // used in ratings
+/** used in ratings */
+export const calciteFontStyleEmphasis : string;
 export const calciteFontLineHeightFixedSm : string;
 export const calciteFontLineHeightFixedBase : string;
 export const calciteFontLineHeightFixedLg : string;
 export const calciteFontLineHeightFixedXl : string;
-export const calciteFontLineHeightRelative : string; // 1
-export const calciteFontLineHeightRelativeTight : string; // 1.25
-export const calciteFontLineHeightRelativeSnug : string; // 1.375
-export const calciteFontLineHeightRelativeNormal : string; // 1.5
-export const calciteFontLineHeightRelativeRelaxed : string; // 1.625
-export const calciteFontLineHeightRelativeLoose : string; // 2
+/** 1 */
+export const calciteFontLineHeightRelative : string;
+/** 1.25 */
+export const calciteFontLineHeightRelativeTight : string;
+/** 1.375 */
+export const calciteFontLineHeightRelativeSnug : string;
+/** 1.5 */
+export const calciteFontLineHeightRelativeNormal : string;
+/** 1.625 */
+export const calciteFontLineHeightRelativeRelaxed : string;
+/** 2 */
+export const calciteFontLineHeightRelativeLoose : string;
 export const calciteFontLetterSpacingTight : string;
 export const calciteFontLetterSpacingNormal : string;
 export const calciteFontLetterSpacingWide : string;
@@ -1215,7 +1240,8 @@ export const calciteZIndexDropdown : string;
 export const calciteZIndexOverlay : string;
 export const calciteZIndexModal : string;
 export const calciteZIndexPopup : string;
-export const calciteZIndexTooltip : string;"
+export const calciteZIndexTooltip : string;
+"
 `;
 
 exports[`generated tokens ES6 types should match 2`] = `
@@ -1438,17 +1464,22 @@ export const calciteContainerSize1440 : string;
 export const calciteFontFamilyAvenirNextPro : string;
 export const calciteFontFamilyAvenirNextWorld : string;
 export const calciteFontFamilyMonaco : string;
-export const calciteFontStyleItalic : string; // used in ratings
-export const calciteFontWeightUltralight : string; // only for Avenir Next World (secondary font family)
+/** used in ratings */
+export const calciteFontStyleItalic : string;
+/** only for Avenir Next World (secondary font family) */
+export const calciteFontWeightUltralight : string;
 export const calciteFontWeightThin : string;
-export const calciteFontWeightLight : string; // only for Avenir Next World (secondary font family)
+/** only for Avenir Next World (secondary font family) */
+export const calciteFontWeightLight : string;
 export const calciteFontWeightRegular : string;
 export const calciteFontWeightMedium : string;
 export const calciteFontWeightMediumItalic : string;
 export const calciteFontWeightDemi : string;
 export const calciteFontWeightBold : string;
-export const calciteFontWeightExtrabold : string; // only for Avenir Next World (secondary font family)
-export const calciteFontWeightBlack : string; // only for Avenir Next World (secondary font family)
+/** only for Avenir Next World (secondary font family) */
+export const calciteFontWeightExtrabold : string;
+/** only for Avenir Next World (secondary font family) */
+export const calciteFontWeightBlack : string;
 export const calciteFontWeightHeavy : string;
 export const calciteFontTextDecorationNone : string;
 export const calciteFontTextDecorationUnderline : string;
@@ -1524,7 +1555,8 @@ export const calciteZIndex5 : string;
 export const calciteZIndex6 : string;
 export const calciteZIndex7 : string;
 export const calciteZIndex8 : string;
-export const calciteZIndex9 : string;"
+export const calciteZIndex9 : string;
+"
 `;
 
 exports[`generated tokens SCSS core should match 1`] = `

--- a/packages/calcite-design-tokens/support/token-transformer/registerCalciteTransformers.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/registerCalciteTransformers.ts
@@ -24,7 +24,6 @@ export async function registerCalciteTransformers(sd: StyleDictionary): Promise<
   // we need to pass "expand: false" so that we can use our own custom JSON file parser.
   // any references to "ts/..." below are references to these Token Studio transformers
   // https://github.com/tokens-studio/sd-transforms
-  // @ts-expect-error - @token-studio does not keep their types up to date.
   await registerTransforms(sd, {
     expand: false,
   });

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueCheckEvaluateMath.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueCheckEvaluateMath.ts
@@ -14,7 +14,7 @@ export function evaluateMathInValue(value: any): any {
     }, {} as Record<string, any>);
   }
 
-  return typeof value === "string" || typeof value === "number" ? checkAndEvaluateMath(`${value}`) : value;
+  return typeof value === "string" || typeof value === "number" ? `${checkAndEvaluateMath(`${value}`)}` : value;
 }
 
 export const transformValuesEvaluateMath: CalledTransformerFunction<any> = (token) => {


### PR DESCRIPTION
**Related Issue:** #8146

## Summary

Resolves issues with https://github.com/Esri/calcite-design-system/pull/8146

- [x] Add StyleDictionary latest version (there was a types conflict because sd-transforms was using a newer version.)
- [x] Update transformValueEvaluateMath to return a string even when the value is a number. This was necessary because the sd-transformer it relied on changed their return type.
- [x] Update Snapshot with minor changes
  - sd-transformer changed the default comment style for es6 output
  - sd-transformer added a new line at the end of es6 output tokens
