### PR TITLE
fix(action-menu):  fix closing action menu after a drag occurs

### DIFF
--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -135,6 +135,10 @@ describe("calcite-action-menu", () => {
 
     const actionMenu = await page.find("calcite-action-menu");
 
+    const popover = await page.find("calcite-action-menu >>> calcite-popover");
+
+    expect(await popover.getProperty("autoClose")).toBe(true);
+
     expect(await actionMenu.getProperty("open")).toBe(true);
 
     const outside = await page.find("#outside");

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   h,
-  Listen,
   Method,
   Prop,
   State,
@@ -132,21 +131,6 @@ export class ActionMenu implements LoadableComponent {
    *
    */
   @Event({ cancelable: false }) calciteActionMenuOpen: EventEmitter<void>;
-
-  @Listen("pointerdown", { target: "window" })
-  closeCalciteActionMenuOnClick(event: PointerEvent): void {
-    if (!isPrimaryPointerButton(event)) {
-      return;
-    }
-
-    const composedPath = event.composedPath();
-
-    if (composedPath.includes(this.el)) {
-      return;
-    }
-
-    this.open = false;
-  }
 
   // --------------------------------------------------------------------------
   //
@@ -304,10 +288,12 @@ export class ActionMenu implements LoadableComponent {
 
     return (
       <calcite-popover
+        autoClose={true}
         flipPlacements={flipPlacements}
         focusTrapDisabled={true}
         label={label}
         offsetDistance={0}
+        onCalcitePopoverClose={this.close}
         open={open}
         overlayPositioning={overlayPositioning}
         placement={placement}
@@ -512,5 +498,9 @@ export class ActionMenu implements LoadableComponent {
   toggleOpen = (value = !this.open): void => {
     this.el.addEventListener("calcitePopoverOpen", this.toggleOpenEnd);
     this.open = value;
+  };
+
+  close = (): void => {
+    this.open = false;
   };
 }

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -293,7 +293,7 @@ export class ActionMenu implements LoadableComponent {
         focusTrapDisabled={true}
         label={label}
         offsetDistance={0}
-        onCalcitePopoverClose={this.close}
+        onCalcitePopoverClose={this.handlePopoverClose}
         open={open}
         overlayPositioning={overlayPositioning}
         placement={placement}
@@ -500,7 +500,7 @@ export class ActionMenu implements LoadableComponent {
     this.open = value;
   };
 
-  close = (): void => {
+  private handlePopoverClose = (): void => {
     this.open = false;
   };
 }


### PR DESCRIPTION
**Related Issue:** #7445

## Summary

- Set autoClose on internal popover
- Remove event listener on window
- Listen for popover close to set `open` property to false.
- Updates existing test. (Already a test to ensure closure of menu when clicking outside)