### PR TITLE
fix(input-date-picker): no longer emits redundant change event

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -271,7 +271,7 @@ describe("calcite-input-date-picker", () => {
       const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
 
       await page.$eval("calcite-input-date-picker", (element: any) => {
-        element.valueAsDate = new Date(1687569378304);
+        element.valueAsDate = new Date(1687528800000);
       });
 
       const expectedValue = "2023-06-23";

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -585,7 +585,7 @@ describe("calcite-input-date-picker", () => {
     expect(await getDateInputValue(page, "end")).toEqual(expectedEndDateInputValue);
   });
 
-  it("should return endDate time as 23:59:999 when valueAsFDate property is parsed", async () => {
+  it("should return endDate time as 23:59:999 when valueAsDate property is parsed", async () => {
     const page = await newE2EPage();
     await page.setContent(html` <calcite-input-date-picker layout="horizontal" range></calcite-input-date-picker>`);
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -274,11 +274,8 @@ describe("calcite-input-date-picker", () => {
         element.valueAsDate = new Date(1687528800000);
       });
 
-      const expectedValue = "2023-06-23";
-      const expectedInputValue = "6/23/2023";
-
-      expect(await inputDatePickerEl.getProperty("value")).toEqual(expectedValue);
-      expect(await getDateInputValue(page)).toEqual(expectedInputValue);
+      expect(await inputDatePickerEl.getProperty("value")).toEqual("2023-06-23");
+      expect(await getDateInputValue(page)).toEqual("6/23/2023");
       expect(changeEvent).toHaveReceivedEventTimes(0);
 
       await inputDatePickerEl.click();

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -262,6 +262,34 @@ describe("calcite-input-date-picker", () => {
       expect(changeEvent).toHaveReceivedEventTimes(0);
       expect(await getDateInputValue(page)).toBe("3/7/");
     });
+
+    it("should emit change event only once when valueAsDate is parsed as Unix Time Stamp programmatically and user updates the date", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html` <calcite-input-date-picker></calcite-input-date-picker>`);
+
+      const inputDatePickerEl = await page.find("calcite-input-date-picker");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+
+      await page.$eval("calcite-input-date-picker", (element: any) => {
+        element.valueAsDate = new Date(1687569378304);
+      });
+
+      const expectedValue = "2023-06-23";
+      const expectedInputValue = "6/23/2023";
+
+      expect(await inputDatePickerEl.getProperty("value")).toEqual(expectedValue);
+      expect(await getDateInputValue(page)).toEqual(expectedInputValue);
+      expect(changeEvent).toHaveReceivedEventTimes(0);
+
+      await inputDatePickerEl.click();
+      await page.waitForChanges();
+      await selectDayInMonth(page, 28);
+      await page.waitForChanges();
+
+      expect(await inputDatePickerEl.getProperty("value")).toEqual("2023-06-28");
+      expect(await getDateInputValue(page)).toEqual("6/28/2023");
+      expect(changeEvent).toHaveReceivedEventTimes(1);
+    });
   });
 
   it("should clear active date properly when deleted and committed via keyboard", async () => {
@@ -557,7 +585,7 @@ describe("calcite-input-date-picker", () => {
     expect(await getDateInputValue(page, "end")).toEqual(expectedEndDateInputValue);
   });
 
-  it("should return endDate time as 23:59:999 when valueAsDate property is parsed", async () => {
+  it("should return endDate time as 23:59:999 when valueAsFDate property is parsed", async () => {
     const page = await newE2EPage();
     await page.setContent(html` <calcite-input-date-picker layout="horizontal" range></calcite-input-date-picker>`);
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -447,8 +447,13 @@ export class InputDatePicker
         this.warnAboutInvalidValue(this.value);
         this.value = "";
       }
-    } else if (this.range && this.valueAsDate) {
-      this.setRangeValue(this.valueAsDate as Date[]);
+    } else if (this.valueAsDate) {
+      if (this.range) {
+        this.setRangeValue(this.valueAsDate as Date[]);
+      } else if (!Array.isArray(this.valueAsDate)) {
+        this.userChangedValue = true;
+        this.value = dateToISO(this.valueAsDate);
+      }
     }
 
     if (this.min) {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -451,7 +451,6 @@ export class InputDatePicker
       if (this.range) {
         this.setRangeValue(this.valueAsDate as Date[]);
       } else if (!Array.isArray(this.valueAsDate)) {
-        this.userChangedValue = true;
         this.value = dateToISO(this.valueAsDate);
       }
     }


### PR DESCRIPTION
**Related Issue:** #7218 

## Summary

`calcite-input-date-picker` no longer emits `calciteInputDatePickerChange` event twice when `valueAsDate` is parsed and user changes the date. 