### PR TITLE
feat(list): Add `calciteListDragStart` and `calciteListDragEnd` events for when a drag starts and ends.

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -659,6 +659,8 @@ describe("calcite-list", () => {
       calledTimes: number;
       newIndex: number;
       oldIndex: number;
+      startCalledTimes: number;
+      endCalledTimes: number;
     }>;
 
     it("works using a mouse", async () => {
@@ -670,10 +672,18 @@ describe("calcite-list", () => {
         testWindow.calledTimes = 0;
         testWindow.newIndex = -1;
         testWindow.oldIndex = -1;
+        testWindow.startCalledTimes = 0;
+        testWindow.endCalledTimes = 0;
         list.addEventListener("calciteListOrderChange", (event: CustomEvent<DragDetail>) => {
           testWindow.calledTimes++;
           testWindow.newIndex = event?.detail?.newIndex;
           testWindow.oldIndex = event?.detail?.oldIndex;
+        });
+        list.addEventListener("calciteListDragEnd", () => {
+          testWindow.endCalledTimes++;
+        });
+        list.addEventListener("calciteListDragStart", () => {
+          testWindow.startCalledTimes++;
         });
       });
 
@@ -696,10 +706,19 @@ describe("calcite-list", () => {
 
       const results = await page.evaluate(() => {
         const testWindow = window as TestWindow;
-        return { calledTimes: testWindow.calledTimes, oldIndex: testWindow.oldIndex, newIndex: testWindow.newIndex };
+
+        return {
+          calledTimes: testWindow.calledTimes,
+          oldIndex: testWindow.oldIndex,
+          newIndex: testWindow.newIndex,
+          endCalledTimes: testWindow.endCalledTimes,
+          startCalledTimes: testWindow.startCalledTimes,
+        };
       });
 
       expect(results.calledTimes).toBe(1);
+      expect(results.startCalledTimes).toBe(1);
+      expect(results.endCalledTimes).toBe(1);
       expect(results.oldIndex).toBe(0);
       expect(results.newIndex).toBe(1);
     });

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -221,6 +221,16 @@ export class List
   @Event({ cancelable: false }) calciteListChange: EventEmitter<void>;
 
   /**
+   * Emits when the component's dragging has ended.
+   */
+  @Event({ cancelable: false }) calciteListDragEnd: EventEmitter<ListDragDetail>;
+
+  /**
+   * Emits when the component's dragging has started.
+   */
+  @Event({ cancelable: false }) calciteListDragStart: EventEmitter<ListDragDetail>;
+
+  /**
    * Emits when the component's filter has changed.
    */
   @Event({ cancelable: false }) calciteListFilter: EventEmitter<void>;
@@ -598,12 +608,20 @@ export class List
     connectSortableComponent(this);
   }
 
-  onDragStart(): void {
+  onGlobalDragStart(): void {
     this.disconnectObserver();
   }
 
-  onDragEnd(): void {
+  onGlobalDragEnd(): void {
     this.connectObserver();
+  }
+
+  onDragEnd(): void {
+    this.calciteListDragEnd.emit();
+  }
+
+  onDragStart(): void {
+    this.calciteListDragStart.emit();
   }
 
   onDragSort(detail: ListDragDetail): void {

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
@@ -154,6 +154,10 @@ export class SortableList implements InteractiveComponent, SortableComponent {
     this.beginObserving();
   }
 
+  onDragEnd(): void {}
+
+  onDragStart(): void {}
+
   onDragSort(): void {
     this.items = Array.from(this.el.children);
     this.calciteListOrderChange.emit();

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
@@ -146,11 +146,11 @@ export class SortableList implements InteractiveComponent, SortableComponent {
   //
   // --------------------------------------------------------------------------
 
-  onDragStart(): void {
+  onGlobalDragStart(): void {
     this.endObserving();
   }
 
-  onDragEnd(): void {
+  onGlobalDragEnd(): void {
     this.beginObserving();
   }
 

--- a/packages/calcite-components/src/components/value-list/value-list.tsx
+++ b/packages/calcite-components/src/components/value-list/value-list.tsx
@@ -341,6 +341,10 @@ export class ValueList<
     initializeObserver.call(this);
   }
 
+  onDragEnd(): void {}
+
+  onDragStart(): void {}
+
   onDragSort(): void {
     this.items = Array.from(this.el.querySelectorAll<ItemElement>("calcite-value-list-item"));
     const values = this.items.map((item) => item.value);

--- a/packages/calcite-components/src/components/value-list/value-list.tsx
+++ b/packages/calcite-components/src/components/value-list/value-list.tsx
@@ -333,11 +333,11 @@ export class ValueList<
   //
   // --------------------------------------------------------------------------
 
-  onDragStart(): void {
+  onGlobalDragStart(): void {
     cleanUpObserver.call(this);
   }
 
-  onDragEnd(): void {
+  onGlobalDragEnd(): void {
     initializeObserver.call(this);
   }
 

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -72,12 +72,12 @@ export interface SortableComponent {
   /**
    * Called when a component's dragging ends.
    */
-  onDragEnd?: (detail: DragDetail) => void;
+  onDragEnd: (detail: DragDetail) => void;
 
   /**
    * Called when a component's dragging starts.
    */
-  onDragStart?: (detail: DragDetail) => void;
+  onDragStart: (detail: DragDetail) => void;
 
   /**
    * Called by any change to the list (add / update / remove).

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -60,19 +60,29 @@ export interface SortableComponent {
   canPut: (detail: DragDetail) => boolean;
 
   /**
+   * Called when any sortable component drag starts.
+   */
+  onGlobalDragStart: () => void;
+
+  /**
+   * Called when any sortable component drag ends.
+   */
+  onGlobalDragEnd: () => void;
+
+  /**
+   * Called when a component's dragging ends.
+   */
+  onDragEnd?: (detail: DragDetail) => void;
+
+  /**
+   * Called when a component's dragging starts.
+   */
+  onDragStart?: (detail: DragDetail) => void;
+
+  /**
    * Called by any change to the list (add / update / remove).
    */
   onDragSort: (detail: DragDetail) => void;
-
-  /**
-   * Called when a sortable component drag starts.
-   */
-  onDragStart: () => void;
-
-  /**
-   * Called when a sortable component drag ends.
-   */
-  onDragEnd: () => void;
 }
 
 export interface SortableComponentItem {
@@ -119,13 +129,15 @@ export function connectSortableComponent(component: SortableComponent): void {
     }),
     handle,
     filter: "[drag-disabled]",
-    onStart: () => {
+    onStart: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       dragState.active = true;
-      onDragStart();
+      onGlobalDragStart();
+      component.onDragStart({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
-    onEnd: () => {
+    onEnd: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       dragState.active = false;
-      onDragEnd();
+      onGlobalDragEnd();
+      component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
     onSort: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       component.onDragSort({ fromEl, dragEl, toEl, newIndex, oldIndex });
@@ -157,10 +169,10 @@ export function dragActive(component: SortableComponent): boolean {
   return component.dragEnabled && dragState.active;
 }
 
-function onDragStart(): void {
-  Array.from(sortableComponentSet).forEach((component) => component.onDragStart());
+function onGlobalDragStart(): void {
+  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragStart());
 }
 
-function onDragEnd(): void {
-  Array.from(sortableComponentSet).forEach((component) => component.onDragEnd());
+function onGlobalDragEnd(): void {
+  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragEnd());
 }

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -60,12 +60,12 @@ export interface SortableComponent {
   canPut: (detail: DragDetail) => boolean;
 
   /**
-   * Called when any sortable component drag starts.
+   * Called when any sortable component drag starts. For internal use only. Any public drag events should emit within `onDragStart()`.
    */
   onGlobalDragStart: () => void;
 
   /**
-   * Called when any sortable component drag ends.
+   * Called when any sortable component drag ends. For internal use only. Any public drag events should emit within `onDragEnd()`.
    */
   onGlobalDragEnd: () => void;
 


### PR DESCRIPTION
**Related Issue:** #8367

## Summary

- Adds event `calciteListDragEnd` to `list`
- Adds event `calciteListDragStart` to `list`
- Refactors global drag event name in `SortableComponent`.
- Adds test
