### PR TITLE
ci(next): install deps before running npm scripts

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -28,12 +28,13 @@ jobs:
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
+            npm install
+
             if npm run util:is-next-deployable; then
               git config --global user.email "github-actions[bot]@users.noreply.github.com"
               git config --global user.name "github-actions[bot]"
 
-              npm install
-              # version the packages with lerna before building to ensure 
+              # version the packages with lerna before building to ensure
               # the version in the CC source code preamble is correct for deployment
               npm run version:next
               npm run build


### PR DESCRIPTION
**Related Issue:** #8325

## Summary

Resolves [an error](https://github.com/Esri/calcite-design-system/actions/runs/7132693857/job/19423776955#step:4:39) in the `next` deployment CI, which was trying to use `ts-node` before it was installed.

The issue was introduced in the PR linked above, which was fixing a [different error](https://github.com/Esri/calcite-design-system/actions/runs/7119908955/job/19386029658#step:5:545) in the `next` deployment CI.