### PR TITLE
fix(action-menu): keep internal popover open property in sync

### DIFF
--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -139,6 +139,8 @@ describe("calcite-action-menu", () => {
 
     expect(await popover.getProperty("autoClose")).toBe(true);
 
+    expect(await popover.getProperty("open")).toBe(true);
+
     expect(await actionMenu.getProperty("open")).toBe(true);
 
     const outside = await page.find("#outside");
@@ -148,6 +150,8 @@ describe("calcite-action-menu", () => {
     await page.waitForChanges();
 
     expect(await actionMenu.getProperty("open")).toBe(false);
+
+    expect(await popover.getProperty("open")).toBe(false);
   });
 
   it("should close menu if slotted action is clicked", async () => {

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -43,6 +43,10 @@ export class ActionMenu implements LoadableComponent {
   //
   // --------------------------------------------------------------------------
 
+  connectedCallback(): void {
+    this.connectMenuButtonEl();
+  }
+
   componentWillLoad(): void {
     setUpLoadableComponent(this);
   }
@@ -294,6 +298,7 @@ export class ActionMenu implements LoadableComponent {
         label={label}
         offsetDistance={0}
         onCalcitePopoverClose={this.handlePopoverClose}
+        onCalcitePopoverOpen={this.handlePopoverOpen}
         open={open}
         overlayPositioning={overlayPositioning}
         placement={placement}
@@ -498,6 +503,10 @@ export class ActionMenu implements LoadableComponent {
   toggleOpen = (value = !this.open): void => {
     this.el.addEventListener("calcitePopoverOpen", this.toggleOpenEnd);
     this.open = value;
+  };
+
+  private handlePopoverOpen = (): void => {
+    this.open = true;
   };
 
   private handlePopoverClose = (): void => {


### PR DESCRIPTION
**Related Issue:** #7445

## Summary

- Keep open property in sync with open property of internal popover
- Update menu button element when connectedCallback occurs.
- Add test
