### PR TITLE
build: ensure patches run after prerender test build

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -19,7 +19,8 @@
     "hydrate/"
   ],
   "scripts": {
-    "build": "npm run util:prep-build-reqs && stencil build && npm run util:patch && npm run util:generate-t9n-docs-json && npm run util:clean-readmes",
+    "build": "npm run util:prep-build-reqs && stencil build",
+    "postbuild": "npm run util:patch && npm run util:generate-t9n-docs-json && npm run util:clean-readmes",
     "build:watch": "npm run util:prep-build-reqs && stencil build --no-docs --watch",
     "build:watch-dev": "npm run util:prep-build-reqs && stencil build --no-docs --dev --watch",
     "build-storybook": "npm run util:build-docs && NODE_OPTIONS=--openssl-legacy-provider build-storybook --output-dir ./docs --quiet",
@@ -37,7 +38,7 @@
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "start": "npm run util:clean-js-files && concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\"",
     "test": "stencil test --no-docs --no-build --spec --e2e",
-    "test:prerender": "stencil build --no-docs --prerender",
+    "test:prerender": "npm run build -- --prerender",
     "test:watch": "npm run build && npm run test -- -- --watchAll",
     "util:build-docs": "npm run util:prep-build-reqs && stencil build --docs --config stencil.storybook.config.ts",
     "util:clean-tested-build": "npm ci && npm test && npm run build",


### PR DESCRIPTION
**Related Issue:** #8421 

## Summary

Ensure the build used for `next` releases includes patches. This fixes a regression caused by #8325, where we removed the extra build on prepublish. The extra build was fixing some issues caused by `npm run test:prerender`, where a build occurred that didn't run pre/post build scripts, including the ESM resolution patch added in #5145.

