### PR TITLE
docs: use example image instead of live url.

### DIFF
--- a/packages/calcite-components/src/components/list/usage/Advanced.md
+++ b/packages/calcite-components/src/components/list/usage/Advanced.md
@@ -22,7 +22,7 @@
   >
     <calcite-action icon="information" label="information" scale="s" slot="actions-start"></calcite-action>
     <calcite-icon scale="l" icon="layer" slot="content-start"></calcite-icon>
-    <calcite-avatar scale="l" slot="content-start" thumbnail="https://placekitten.com/g/300/300"></calcite-avatar>
+    <calcite-avatar scale="l" slot="content-start" thumbnail="my-thumbnail.png"></calcite-avatar>
     <calcite-icon
       scale="s"
       icon="check"

--- a/packages/calcite-components/src/components/stack/readme.md
+++ b/packages/calcite-components/src/components/stack/readme.md
@@ -11,7 +11,7 @@
   <calcite-action appearance="transparent" text="banana" icon="banana" slot="actions-start"></calcite-action>
   <calcite-chip slot="content-start" value="chip" scale="s" appearance="outline">My great chip</calcite-chip>
   Hello World
-  <calcite-avatar slot="content-end" thumbnail="http://placekitten.com/105/105" scale="s"> </calcite-avatar>
+  <calcite-avatar slot="content-end" thumbnail="my-thumbnail.png" scale="s"> </calcite-avatar>
   <calcite-action appearance="transparent" text="Close" icon="x" slot="actions-end"></calcite-action>
 </calcite-stack>
 ```
@@ -22,7 +22,7 @@
 <calcite-stack disabled>
   <calcite-action appearance="transparent" text="banana" icon="banana" slot="actions-start"></calcite-action>
   Hello World
-  <calcite-avatar slot="content-end" thumbnail="http://placekitten.com/105/105" scale="s"> </calcite-avatar>
+  <calcite-avatar slot="content-end" thumbnail="my-thumbnail.png" scale="s"> </calcite-avatar>
   <calcite-chip slot="content-start" value="chip" scale="s" appearance="outline">My great chip</calcite-chip>
   <calcite-action appearance="transparent" text="Close" icon="x" slot="actions-end"></calcite-action>
 </calcite-stack>

--- a/packages/calcite-components/src/components/stack/usage/Basic.md
+++ b/packages/calcite-components/src/components/stack/usage/Basic.md
@@ -3,7 +3,7 @@
   <calcite-action appearance="transparent" text="banana" icon="banana" slot="actions-start"></calcite-action>
   <calcite-chip slot="content-start" value="chip" scale="s" appearance="outline">My great chip</calcite-chip>
   Hello World
-  <calcite-avatar slot="content-end" thumbnail="http://placekitten.com/105/105" scale="s"> </calcite-avatar>
+  <calcite-avatar slot="content-end" thumbnail="my-thumbnail.png" scale="s"> </calcite-avatar>
   <calcite-action appearance="transparent" text="Close" icon="x" slot="actions-end"></calcite-action>
 </calcite-stack>
 ```

--- a/packages/calcite-components/src/components/stack/usage/Disabled.md
+++ b/packages/calcite-components/src/components/stack/usage/Disabled.md
@@ -2,7 +2,7 @@
 <calcite-stack disabled>
   <calcite-action appearance="transparent" text="banana" icon="banana" slot="actions-start"></calcite-action>
   Hello World
-  <calcite-avatar slot="content-end" thumbnail="http://placekitten.com/105/105" scale="s"> </calcite-avatar>
+  <calcite-avatar slot="content-end" thumbnail="my-thumbnail.png" scale="s"> </calcite-avatar>
   <calcite-chip slot="content-start" value="chip" scale="s" appearance="outline">My great chip</calcite-chip>
   <calcite-action appearance="transparent" text="Close" icon="x" slot="actions-end"></calcite-action>
 </calcite-stack>

--- a/packages/calcite-components/src/components/tabs/usage/Basic.md
+++ b/packages/calcite-components/src/components/tabs/usage/Basic.md
@@ -8,7 +8,7 @@
     <calcite-tab-title>Bears</calcite-tab-title>
   </calcite-tab-nav>
   <calcite-tab selected><img src="https://placedog.net/550/600" /></calcite-tab>
-  <calcite-tab><img src="https://placekitten.com/550/600" /></calcite-tab>
-  <calcite-tab><img src="https://placebear.com/550/600" /></calcite-tab>
+  <calcite-tab><img src="my-image.png" /></calcite-tab>
+  <calcite-tab><img src="my-image2.png" /></calcite-tab>
 </calcite-tabs>
 ```

--- a/packages/calcite-components/src/components/tabs/usage/Bordered.md
+++ b/packages/calcite-components/src/components/tabs/usage/Bordered.md
@@ -6,7 +6,7 @@
     <calcite-tab-title>Bears</calcite-tab-title>
   </calcite-tab-nav>
   <calcite-tab selected><img src="https://placedog.net/550/600" /></calcite-tab>
-  <calcite-tab><img src="https://placekitten.com/550/600" /></calcite-tab>
-  <calcite-tab><img src="https://placebear.com/550/600" /></calcite-tab>
+  <calcite-tab><img src="my-image.png" /></calcite-tab>
+  <calcite-tab><img src="my-image2.png" /></calcite-tab>
 </calcite-tabs>
 ```

--- a/packages/calcite-components/src/components/tip-manager/usage/Basic.md
+++ b/packages/calcite-components/src/components/tip-manager/usage/Basic.md
@@ -15,7 +15,7 @@ Renders a tip manager using a group of tips as well as a single tip.
       </p>
     </calcite-tip>
     <calcite-tip heading="Whisker Wisdom" hidden>
-      <img slot="thumbnail" src="https://placekitten.com/400/200" />
+      <img slot="thumbnail" src="my-thumbnail.png" />
       <p>
         Cats use their whiskers not only for balance but also to measure openings. If a cat's whiskers fit through an
         opening, the rest of its body will too!

--- a/packages/calcite-components/src/components/tip/usage/Basic.md
+++ b/packages/calcite-components/src/components/tip/usage/Basic.md
@@ -2,7 +2,7 @@ Renders a close-disabled tip with a heading, thumbnail, info and a link.
 
 ```html
 <calcite-tip close-disabled heading="Kittens">
-  <img slot="thumbnail" src="https://placekitten.com/1000/600" alt="" />
+  <img slot="thumbnail" src="my-thumbnail.png" alt="" />
   <p>
     Did you know that kittens are born with their eyes shut and ears folded? They start to open their eyes and unfold
     their ears after about a week.


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

- removes references to placekitten in markdown files.