### PR TITLE
refactor(table): Add `striped` property, deprecate `zebra` property

### DIFF
--- a/packages/calcite-components/src/components/table/interfaces.ts
+++ b/packages/calcite-components/src/components/table/interfaces.ts
@@ -9,6 +9,4 @@ export interface TableRowFocusEvent {
 
 export type RowType = "head" | "body" | "foot";
 
-export type TableAppearance = "bordered" | "simple" | "bordered-zebra" | "simple-zebra";
-
 export type TableLayout = "auto" | "fixed";

--- a/packages/calcite-components/src/components/table/resources.ts
+++ b/packages/calcite-components/src/components/table/resources.ts
@@ -1,6 +1,6 @@
 export const CSS = {
   bordered: "bordered",
-  zebra: "zebra",
+  striped: "striped",
   selectionArea: "selection-area",
   paginationArea: "pagination-area",
   container: "container",

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -62,7 +62,7 @@ describe("calcite-table", () => {
         defaultValue: "none",
       },
       {
-        propertyName: "zebra",
+        propertyName: "striped",
         defaultValue: false,
       },
     ]);

--- a/packages/calcite-components/src/components/table/table.scss
+++ b/packages/calcite-components/src/components/table/table.scss
@@ -57,7 +57,7 @@ tbody {
   }
 }
 
-.zebra {
+.striped {
   ::slotted(calcite-table-row:nth-child(2n + 1)) {
     --calcite-table-row-background: var(--calcite-color-foreground-2);
   }

--- a/packages/calcite-components/src/components/table/table.stories.ts
+++ b/packages/calcite-components/src/components/table/table.stories.ts
@@ -21,7 +21,7 @@ export const simple = (): string =>
     caption="${text("caption", "Simple table")}"
     ${boolean("numbered", false)}
     ${boolean("bordered", false)}
-    ${boolean("zebra", false)}
+    ${boolean("striped", false)}
     caption="Simple table"
   >
     <calcite-table-row slot="table-header">
@@ -50,7 +50,7 @@ export const simple = (): string =>
     </calcite-table-row>
   </calcite-table>`;
 
-export const simpleZebra_TestOnly = (): string => html`<calcite-table zebra caption="Simple-zebra table">
+export const simpleStriped_TestOnly = (): string => html`<calcite-table striped caption="Simple-striped table">
   <calcite-table-row slot="table-header">
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -104,7 +104,42 @@ export const bordered_TestOnly = (): string => html`<calcite-table bordered capt
   </calcite-table-row>
 </calcite-table>`;
 
-export const borderedZebra_TestOnly = (): string => html`<calcite-table bordered zebra caption="Bordered zebra table">
+export const borderedStriped_TestOnly = (): string => html`<calcite-table
+  bordered
+  striped
+  caption="Bordered striped table"
+>
+  <calcite-table-row slot="table-header">
+    <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+    <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+    <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+    <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+  </calcite-table-row>
+  <calcite-table-row>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+  </calcite-table-row>
+  <calcite-table-row>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+  </calcite-table-row>
+  <calcite-table-row>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+    <calcite-table-cell>cell</calcite-table-cell>
+  </calcite-table-row>
+</calcite-table>`;
+
+export const deprecatedZebraStriped_TestOnly = (): string => html`<calcite-table
+  bordered
+  zebra
+  caption="Bordered striped table"
+>
   <calcite-table-row slot="table-header">
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -158,7 +193,7 @@ export const alignments_TestOnly = (): string => html`<calcite-table numbered>
   </calcite-table-row>
 </calcite-table>`;
 
-export const disabledRows_TestOnly = (): string => html`<calcite-table caption="Bordered-zebra table">
+export const disabledRows_TestOnly = (): string => html`<calcite-table caption="Bordered-striped table">
   <calcite-table-row slot="table-header">
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
     <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -278,7 +313,7 @@ export const layoutFixed_TestOnly = (): string => html`<calcite-table layout="fi
 
 export const rowSpanAndColSpan_TestOnly = (): string => html`<calcite-table
   bordered
-  zebra
+  striped
   caption="Using row-span and col-span table"
 >
   <calcite-table-row slot="table-header">
@@ -318,7 +353,7 @@ export const rowSpanAndColSpan_TestOnly = (): string => html`<calcite-table
 
 export const rowSpanAndColSpanNumbered_TestOnly = (): string => html`<calcite-table
   bordered
-  zebra
+  striped
   numbered
   caption="Using row-span and col-span table"
 >
@@ -359,7 +394,7 @@ export const rowSpanAndColSpanNumbered_TestOnly = (): string => html`<calcite-ta
 
 export const rowSpanAndColSpan3_TestOnly = (): string => html`<calcite-table
   bordered
-  zebra
+  striped
   caption="Using row-span and col-span table"
 >
   <calcite-table-row slot="table-header">
@@ -957,7 +992,7 @@ export const localized_TestOnly = (): string => html`<calcite-table
 </calcite-table>`;
 
 export const tableCellCssBackgroundVariable_TestOnly = (): string =>
-  html`<calcite-table zebra caption="Simple-zebra table" dir="rtl" selection-mode="multiple">
+  html`<calcite-table striped caption="Simple-striped table" dir="rtl" selection-mode="multiple">
     <calcite-table-row slot="table-header">
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -985,7 +1020,7 @@ export const tableCellCssBackgroundVariable_TestOnly = (): string =>
   </calcite-table>`;
 
 export const darkModeRTL_TestOnly = (): string =>
-  html`<calcite-table zebra caption="Simple-zebra table" dir="rtl">
+  html`<calcite-table striped caption="Simple-striped table" dir="rtl">
     <calcite-table-row slot="table-header">
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -1015,7 +1050,7 @@ export const darkModeRTL_TestOnly = (): string =>
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
 
 export const darkModeRTLWithSelection_TestOnly = (): string =>
-  html`<calcite-table zebra caption="Simple-zebra table" dir="rtl" selection-mode="multiple">
+  html`<calcite-table striped caption="Simple-striped table" dir="rtl" selection-mode="multiple">
     <calcite-table-row slot="table-header">
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -84,8 +84,15 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
   @Prop({ reflect: true }) selectionMode: Extract<"none" | "multiple" | "single", SelectionMode> =
     "none";
 
-  /** When `true`, displays zebra styling in the component. */
+  /**
+   * When `true`, displays striped styling in the component.
+   *
+   * @deprecated Use the `striped` property instead.
+   */
   @Prop({ reflect: true }) zebra = false;
+
+  /** When `true`, displays striped styling in the component. */
+  @Prop({ reflect: true }) striped = false;
 
   @Watch("groupSeparator")
   @Watch("numbered")
@@ -499,7 +506,7 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
           <div
             class={{
               [CSS.bordered]: this.bordered,
-              [CSS.zebra]: this.zebra,
+              [CSS.striped]: this.striped || this.zebra,
               [CSS.tableContainer]: true,
             }}
           >

--- a/packages/calcite-components/src/demos/table.html
+++ b/packages/calcite-components/src/demos/table.html
@@ -1439,8 +1439,8 @@
           <span>Features</span>
           <calcite-chip-group selection-mode="multiple" id="preview-chips">
             <calcite-chip appearance="outline-fill" icon="number-circle-1" value="numbered">Numbered</calcite-chip>
-            <calcite-chip appearance="outline-fill" icon="list-rectangle" value="zebra">Zebra</calcite-chip>
-            <calcite-chip appearance="outline-fill" icon="border-radius-sharp" value="Bordered">Bordered</calcite-chip>
+            <calcite-chip appearance="outline-fill" icon="list-rectangle" value="striped">Striped</calcite-chip>
+            <calcite-chip appearance="outline-fill" icon="border-radius-sharp" value="bordered">Bordered</calcite-chip>
           </calcite-chip-group>
         </div>
         <div>
@@ -2885,8 +2885,8 @@
         </calcite-table-row>
       </calcite-table>
 
-      <h3>zebra</h3>
-      <calcite-table zebra caption="zebra">
+      <h3>striped</h3>
+      <calcite-table striped caption="striped">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -2941,8 +2941,8 @@
         </calcite-table-row>
       </calcite-table>
 
-      <h3>Bordered-zebra</h3>
-      <calcite-table bordered zebra caption="Bordered-zebra table">
+      <h3>Bordered-striped</h3>
+      <calcite-table bordered striped caption="Bordered-striped table">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -2998,7 +2998,7 @@
       </calcite-table>
 
       <h3>Disabled rows</h3>
-      <calcite-table caption="Bordered-zebra table">
+      <calcite-table caption="Bordered-striped table">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -3187,7 +3187,7 @@
       </calcite-table>
 
       <h3>Using row-span and col-span</h3>
-      <calcite-table bordered zebra caption="Using row-span and col-span table">
+      <calcite-table bordered striped caption="Using row-span and col-span table">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description" col-span="7"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -3224,7 +3224,7 @@
       </calcite-table>
 
       <h3>Using row-span and col-span and numbered</h3>
-      <calcite-table bordered zebra numbered caption="Using row-span and col-span table">
+      <calcite-table bordered striped numbered caption="Using row-span and col-span table">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description" col-span="7"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -3261,7 +3261,7 @@
       </calcite-table>
 
       <h3>Using row-span and col-span</h3>
-      <calcite-table bordered zebra caption="Using row-span and col-span table">
+      <calcite-table bordered striped caption="Using row-span and col-span table">
         <calcite-table-row slot="table-header">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header col-span="3" heading="Heading" description="Description"></calcite-table-header>


### PR DESCRIPTION
**Related Issue:** #7906 

## Summary
Updates nomenclature for this Table property, and adds Chromatic test for the deprecated property. Also removes a related, but unused type definition.