### PR TITLE
fix(date-picker): prevent console error when selecting just an end date for input date picker

### DIFF
--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -403,11 +403,6 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
     const start = Array.isArray(valueAsDate) && valueAsDate[0];
     const end = Array.isArray(valueAsDate) && valueAsDate[1];
 
-    if (!start || !end) {
-      this.hoverRange = undefined;
-      return;
-    }
-
     const date = new Date(event.detail);
     this.hoverRange = {
       focused: this.activeRange || "start",
@@ -415,7 +410,7 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
       end,
     };
     if (!this.proximitySelectionDisabled) {
-      if (end) {
+      if (start && end) {
         const startDiff = getDaysDiff(date, start);
         const endDiff = getDaysDiff(date, end);
         if (endDiff > 0) {

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -403,6 +403,11 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
     const start = Array.isArray(valueAsDate) && valueAsDate[0];
     const end = Array.isArray(valueAsDate) && valueAsDate[1];
 
+    if (!start || !end) {
+      this.hoverRange = undefined;
+      return;
+    }
+
     const date = new Date(event.detail);
     this.hoverRange = {
       focused: this.activeRange || "start",


### PR DESCRIPTION
**Related Issue:** #8436

## Summary

- Quick fix to remove console error
- Ideally, I think a user should be able to select the end date first and the whole hover range experience should work. I tried getting that working quickly but wasn't successful. I think we'll need a followup issue.