### PR TITLE
fix(filter): prevent console warning from displaying to end users

### DIFF
--- a/packages/calcite-components/src/components/filter/filter.tsx
+++ b/packages/calcite-components/src/components/filter/filter.tsx
@@ -158,7 +158,9 @@ export class Filter
 
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
-    this.updateFiltered(filter(this.items, this.value));
+    if (this.items.length) {
+      this.updateFiltered(filter(this.items, this.value));
+    }
     await setUpMessages(this);
   }
 
@@ -221,7 +223,7 @@ export class Filter
 
   private filterDebounced = debounce(
     (value: string, emit = false, onFilter?: () => void): void =>
-      this.updateFiltered(filter(this.items, value), emit, onFilter),
+      this.items.length && this.updateFiltered(filter(this.items, value), emit, onFilter),
     DEBOUNCE_TIMEOUT
   );
 


### PR DESCRIPTION
**Related Issue:** #8457

## Summary

- Removes console warning from being displayed to end users