### PR TITLE
fix(button): don't needlessly overwrite title

### DIFF
--- a/packages/calcite-components/src/components/button/button.e2e.ts
+++ b/packages/calcite-components/src/components/button/button.e2e.ts
@@ -648,26 +648,44 @@ describe("calcite-button", () => {
     t9n("calcite-button");
   });
 
-  it("shows tooltip for buttons with truncated long text", async () => {
-    const shortText = "Hi!";
-    const longText =
-      "This_long_text_contains_a_coded_map_for_hidden_treasures_of_Edward_Teach_aka_Blackbeard_._If_only_you_could_access_it_you_could_buy_out_The_Magic_Castle_on_Franklin_ave_Los_Angeles_like_you_ve_always_wanted.";
+  describe('automatic tooltip', ()=>{
 
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-button id="one" style="width: 100px">${longText}</calcite-button>
-      <calcite-button id="two" style="width: 100px">${shortText}</calcite-button>
-    `);
-    await page.waitForChanges();
+    it("shows tooltip for buttons with truncated long text", async () => {
+      const shortText = "Hi!";
+      const longText =
+        "This_long_text_contains_a_coded_map_for_hidden_treasures_of_Edward_Teach_aka_Blackbeard_._If_only_you_could_access_it_you_could_buy_out_The_Magic_Castle_on_Franklin_ave_Los_Angeles_like_you_ve_always_wanted.";
 
-    const button1 = await page.find(`calcite-button[id='one'] >>> button`);
-    const button2 = await page.find(`calcite-button[id='two'] >>> button`);
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-button id="one" style="width: 100px">${longText}</calcite-button>
+        <calcite-button id="two" style="width: 100px">${shortText}</calcite-button>
+      `);
+      await page.waitForChanges();
 
-    expect(button1).toHaveAttribute("title");
-    expect(button2).not.toHaveAttribute("title");
+      const button1 = await page.find(`calcite-button[id='one'] >>> button`);
+      const button2 = await page.find(`calcite-button[id='two'] >>> button`);
 
-    expect(button1.textContent.length).toBeLessThan(longText.length);
-    expect(button1.getAttribute("title")).toEqual(longText);
+      expect(button1).toHaveAttribute("title");
+      expect(button2).not.toHaveAttribute("title");
+
+      expect(button1.textContent.length).toBeLessThan(longText.length);
+      expect(button1.getAttribute("title")).toEqual(longText);
+    });
+
+    it("does not show tooltip for buttons without text content", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-button style="width:32px;height:32px" scale="s">
+          <calcite-icon icon="compass-needle" scale="m" />
+        </calcite-button>
+      `);
+      await page.waitForChanges();
+
+      const button = await page.find(`calcite-button >>> button`);
+
+      expect(button).not.toHaveAttribute("title");
+    });
+
   });
 
   it("should set aria-expanded attribute on shadowDOM element when used as trigger", async () => {

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -404,7 +404,7 @@ export class Button
   private setTooltipText = (): void => {
     const { contentEl } = this;
     if (contentEl) {
-      this.tooltipText = contentEl.offsetWidth < contentEl.scrollWidth ? this.el.innerText : null;
+      this.tooltipText = contentEl.offsetWidth < contentEl.scrollWidth ? this.el.innerText || null : null;
     }
   };
 


### PR DESCRIPTION
**Related Issue:** #8417

## Summary

In my application I set `title` attribute on the `<calcite-button>`, but it wasn't being displayed because the shadow DOM's `<button>` had an empty title attribute (`title=""`) which was overwriting the title set on the calcite-button.


Reproduction:
1. [Codepen example](https://codepen.io/maxpatiiuk/pen/KKJEaER?editors=1000)
2. Hover over the button - no tooltip is shown
3. Remove the "title" attribute from the `<button>`, and tooltip is visible

Video reproduction:

https://github.com/Esri/calcite-design-system/assets/40512816/d338be3e-667d-45ab-a29f-bc79d84df353

