### PR TITLE
fix(table): Fix double border on `bordered` Table Rows in `table-footer`

### DIFF
--- a/packages/calcite-components/src/components/table/table.stories.ts
+++ b/packages/calcite-components/src/components/table/table.stories.ts
@@ -1066,7 +1066,7 @@ export const tableCellCssBackgroundVariable_TestOnly = (): string =>
   </calcite-table>`;
 
 export const tableBorderedWithStripedAndSingleFooter_TestOnly = (): string =>
-  html`<calcite-table striped bordered caption="Simple-bordered-with-footer table" dir="rtl" selection-mode="multiple">
+  html`<calcite-table striped bordered caption="Simple-bordered-with-footer table" selection-mode="multiple">
     <calcite-table-row slot="table-header">
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -1100,7 +1100,7 @@ export const tableBorderedWithStripedAndSingleFooter_TestOnly = (): string =>
   </calcite-table>`;
 
 export const tableBorderedWithMultipleFooter_TestOnly = (): string =>
-  html`<calcite-table bordered caption="Simple-bordered-with-footer table" dir="rtl" selection-mode="multiple">
+  html`<calcite-table bordered caption="Simple-bordered-with-footer table" selection-mode="multiple">
     <calcite-table-row slot="table-header">
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
       <calcite-table-header heading="Heading" description="Description"></calcite-table-header>

--- a/packages/calcite-components/src/components/table/table.stories.ts
+++ b/packages/calcite-components/src/components/table/table.stories.ts
@@ -1065,6 +1065,80 @@ export const tableCellCssBackgroundVariable_TestOnly = (): string =>
     </calcite-table-row>
   </calcite-table>`;
 
+export const tableBorderedWithStripedAndSingleFooter_TestOnly = (): string =>
+  html`<calcite-table striped bordered caption="Simple-bordered-with-footer table" dir="rtl" selection-mode="multiple">
+    <calcite-table-row slot="table-header">
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row slot="table-footer">
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+    </calcite-table-row>
+  </calcite-table>`;
+
+export const tableBorderedWithMultipleFooter_TestOnly = (): string =>
+  html`<calcite-table bordered caption="Simple-bordered-with-footer table" dir="rtl" selection-mode="multiple">
+    <calcite-table-row slot="table-header">
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+      <calcite-table-cell>cell</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row slot="table-footer">
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+    </calcite-table-row>
+    <calcite-table-row slot="table-footer">
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+      <calcite-table-cell>foot</calcite-table-cell>
+    </calcite-table-row>
+  </calcite-table>`;
+
 export const darkModeRTL_TestOnly = (): string =>
   html`<calcite-table striped caption="Simple-striped table" dir="rtl">
     <calcite-table-row slot="table-header">

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -326,6 +326,7 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
       row.numbered = this.numbered;
       row.scale = this.scale;
       row.readCellContentsToAT = this.readCellContentsToAT;
+      row.lastVisibleRow = allRows?.indexOf(row) === this.allRows.length - 1;
     });
 
     const colCount =

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -326,7 +326,7 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
       row.numbered = this.numbered;
       row.scale = this.scale;
       row.readCellContentsToAT = this.readCellContentsToAT;
-      row.lastVisibleRow = allRows?.indexOf(row) === this.allRows.length - 1;
+      row.lastVisibleRow = allRows?.indexOf(row) === allRows.length - 1;
     });
 
     const colCount =

--- a/packages/calcite-components/src/demos/table.html
+++ b/packages/calcite-components/src/demos/table.html
@@ -3168,6 +3168,30 @@
             <calcite-chip scale="s">Another thing</calcite-chip>
           </calcite-table-cell>
         </calcite-table-row>
+        <calcite-table-row slot="table-footer">
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell alignment="end">78</calcite-table-cell>
+          <calcite-table-cell><calcite-chip scale="s" icon="smile">Happy</calcite-chip></calcite-table-cell>
+          <calcite-table-cell alignment="center">
+            <calcite-chip scale="s">Another thing</calcite-chip>
+          </calcite-table-cell>
+        </calcite-table-row>
+        <calcite-table-row slot="table-footer">
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell>footer</calcite-table-cell>
+          <calcite-table-cell alignment="end">78</calcite-table-cell>
+          <calcite-table-cell><calcite-chip scale="s" icon="smile">Happy</calcite-chip></calcite-table-cell>
+          <calcite-table-cell alignment="center">
+            <calcite-chip scale="s">Another thing</calcite-chip>
+          </calcite-table-cell>
+        </calcite-table-row>
       </calcite-table>
 
       <h3>Localized numbers</h3>
@@ -4025,7 +4049,7 @@
       </calcite-table>
 
       <h3>selection-mode multiple with selected at load</h3>
-      <calcite-table selection-mode="multiple" numbered caption="selection-mode multiple and numbered table">
+      <calcite-table bordered selection-mode="multiple" numbered caption="selection-mode multiple and numbered table">
         <calcite-action slot="selection-actions" icon="layer"></calcite-action>
         <calcite-action slot="selection-actions" icon="send"></calcite-action>
         <calcite-action slot="selection-actions" icon="copy"></calcite-action>
@@ -4187,6 +4211,8 @@
         page-size="4"
         selection-mode="multiple"
         numbered
+        striped
+        bordered
         caption="selection-mode multiple with selected at load"
       >
         <calcite-action slot="selection-actions" icon="layer"></calcite-action>


### PR DESCRIPTION
**Related Issue:** #8508

## Summary
Adds a conditional class to Table Rows slotted in `table-footer` slot to prevent double border. We were doing this for body rows, but not footer rows. Adds screenshot tests to verify and updates some local samples to show this combination of props / slotted content.


| Before  | After |
| ------------- | ------------ | 
| <img width="997" alt="Screenshot 2023-12-27 at 4 46 36 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/ac65ab72-6455-4c05-bcb2-480af2ae65f4"> | <img width="997" alt="Screenshot 2023-12-27 at 4 46 01 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/fac52ec6-9695-4f07-bb2b-35c5f7bac373"> | 
<img width="997" alt="Screenshot 2023-12-27 at 4 47 09 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/1de8bcac-f4c9-48c4-a00b-4b635b350691"> | <img width="997" alt="Screenshot 2023-12-27 at 4 48 17 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/28f3246a-bf9f-48d3-b145-44d24e121a47"> |
<img width="997" alt="Screenshot 2023-12-27 at 4 49 07 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/b15a90a0-7265-4929-a418-224e6cae975a"> | <img width="997" alt="Screenshot 2023-12-27 at 4 48 37 PM" src="https://github.com/Esri/calcite-design-system/assets/4733155/c4a235c7-6565-4b0a-8a0c-c5f8944557ff"> |