### PR TITLE
docs(action-bar, action-group, action-pad, alert): consistent api decription refs

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-bar-expanded-max-width: optionally specify the expanded max width of the action bar when in "vertical" layout.
+ * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
  */
 
 :host {

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -71,7 +71,7 @@ export class ActionBar
   // --------------------------------------------------------------------------
 
   /**
-   * Specifies the accessible label for the last action-group.
+   * Specifies the accessible label for the last `calcite-action-group`.
    */
   @Prop() actionsEndGroupLabel: string;
 
@@ -98,7 +98,7 @@ export class ActionBar
   }
 
   /**
-   *  The layout direction of the actions.
+   *  Specifies the layout direction of the actions.
    */
   @Prop({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
 

--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -59,7 +59,7 @@ export class ActionGroup
   }
 
   /**
-   * Specifies the label of the component. Required for accessibility.
+   *  Accessible name for the component.
    */
   @Prop() label: string;
 

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-pad-expanded-max-width: optionally specify the expanded max width of the action pad when in "vertical" layout.
+ * @prop --calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
  */
 
 :host {

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -59,7 +59,7 @@ export class ActionPad
   // --------------------------------------------------------------------------
 
   /**
-   * Specifies the accessible label for the last action-group.
+   * Specifies the accessible label for the last `calcite-action-group`.
    */
   @Prop() actionsEndGroupLabel: string;
 

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -87,13 +87,13 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     }
   }
 
-  /** When `true`, the component closes automatically (recommended for passive, non-blocking alerts). */
+  /** When `true`, the component closes automatically. Recommended for passive, non-blocking alerts. */
   @Prop({ reflect: true }) autoClose = false;
 
-  /** Specifies the duration before the component automatically closes (only use with `autoClose`). */
+  /** Specifies the duration before the component automatically closes - only use with `autoClose`. */
   @Prop({ reflect: true }) autoCloseDuration: AlertDuration = "medium";
 
-  /** Specifies the kind of the component (will apply to top border and icon). */
+  /** Specifies the kind of the component, which will apply to top border and icon. */
   @Prop({ reflect: true }) kind: Extract<
     "brand" | "danger" | "info" | "success" | "warning",
     Kind
@@ -116,7 +116,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
    */
   @Prop({ reflect: true }) numberingSystem: NumberingSystem;
 
-  /** Specifies the placement of the component */
+  /** Specifies the placement of the component. */
   @Prop({ reflect: true }) placement: MenuPlacement = "bottom";
 
   /** Specifies the size of the component. */
@@ -371,7 +371,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   //
   //--------------------------------------------------------------------------
 
-  /** Sets focus on the component's "close" button (the first focusable item). */
+  /** Sets focus on the component's "close" button, the first focusable item. */
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);


### PR DESCRIPTION
**Related Issue:** #7071

## Summary
Updates doc consistency across a-named components defined in the above issue for props, events, methods, and css vars, including:
- `action-bar`
- `action-group`
- `action-pad`
- `alert`

cc @DitwanP 