### PR TITLE
docs(tab-nav, table, tabs, tile-select, tree, value-list): consistent api description refs

### DIFF
--- a/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
@@ -49,7 +49,7 @@ export class TabNav {
   @Prop({ reflect: true }) syncId: string;
 
   /**
-   * Specifies the component's selected tab-title.
+   * Specifies the component's selected `calcite-tab-title`.
    *
    * @readonly
    */

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -74,13 +74,13 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
   /** Specifies the Unicode numeral system used by the component for localization. */
   @Prop({ reflect: true }) numberingSystem?: NumberingSystem;
 
-  /** Specifies the page size of the component. When `true`, renders `calcite-pagination` */
+  /** Specifies the page size of the component. When `true`, renders `calcite-pagination`. */
   @Prop({ reflect: true }) pageSize = 0;
 
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
-  /** Specifies the selection mode of the component. */
+  /** Specifies the selection mode - `"none"` (no `calcite-table-row` selections), `"single"` (allow one `calcite-table-row` selection), or `"multiple"` (allow any number of `calcite-table-row` selections). */
   @Prop({ reflect: true }) selectionMode: Extract<"none" | "multiple" | "single", SelectionMode> =
     "none";
 

--- a/packages/calcite-components/src/components/tabs/tabs.tsx
+++ b/packages/calcite-components/src/components/tabs/tabs.tsx
@@ -26,12 +26,12 @@ export class Tabs {
   @Prop({ reflect: true }) layout: TabLayout = "inline";
 
   /**
-   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to the `calcite-tabs`, defaults to `top`.
+   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to the `calcite-tabs`.
    */
   @Prop({ reflect: true }) position: TabPosition = "top";
 
   /**
-   * Specifies the size of the component, defaults to `m`.
+   * Specifies the size of the component.
    */
   @Prop({ reflect: true }) scale: Scale = "m";
 

--- a/packages/calcite-components/src/components/tile-select/tile-select.tsx
+++ b/packages/calcite-components/src/components/tile-select/tile-select.tsx
@@ -87,7 +87,7 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   /**
    * The selection mode of the component.
    *
-   * Use radio for single selection, and checkbox for multiple selections.
+   * Use `"radio"` for single selection, and `"checkbox"` for multiple selections.
    */
   @Prop({ reflect: true }) type: TileSelectType = "radio";
 

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -29,7 +29,7 @@ export class Tree {
   //
   //--------------------------------------------------------------------------
 
-  /** Displays indentation guide lines. */
+  /** When `true`, displays indentation guide lines. */
   @Prop({ mutable: true, reflect: true }) lines = false;
 
   /**

--- a/packages/calcite-components/src/components/value-list/value-list.tsx
+++ b/packages/calcite-components/src/components/value-list/value-list.tsx
@@ -103,7 +103,7 @@ export class ValueList<
   @Prop({ reflect: true }) disabled = false;
 
   /**
-   * When provided, the method will be called to determine whether the element can  move from the list.
+   * When provided, the method will be called to determine whether the element can move from the list.
    */
   @Prop() canPull: (detail: DragDetail) => boolean;
 
@@ -458,7 +458,7 @@ export class ValueList<
   //
   // --------------------------------------------------------------------------
 
-  /** Returns the currently selected items */
+  /** Returns the component's selected items. */
   @Method()
   async getSelectedItems(): Promise<Map<string, HTMLCalciteValueListItemElement>> {
     return this.selectedValues;


### PR DESCRIPTION
**Related Issue:** #7071

## Summary
Updates doc consistency across t and v-named components defined in the above issue for props, events, methods, and css vars, including:
- `tab-nav`
- `table`
- `tabs`
- `tile-select`
- `tree`
- `value-list`