### PR TITLE
ci(update-doc): build design tokens to prevent errors

### DIFF
--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -14,6 +14,7 @@ jobs:
       - name: generate doc
         run: |
           npm install
+          npm --workspace=@esri/calcite-design-tokens run build
           npx --workspace=@esri/calcite-components stencil build --docs
           npm run --workspace=@esri/calcite-components lint:md
       - name: commit readme files/create pull request

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           npm install
           npm --workspace=@esri/calcite-design-tokens run build
+          npm --workspace=@esri/eslint-plugin-calcite-components run build
           npx --workspace=@esri/calcite-components stencil build --docs
           npm run --workspace=@esri/calcite-components lint:md
       - name: commit readme files/create pull request


### PR DESCRIPTION
## Summary

Resolves an error in the GitHub Action that updates the component readmes, which was due to not building the design tokens before building the components.

error: https://github.com/Esri/calcite-design-system/actions/runs/7381163545/job/20079386682#step:4:178