### PR TITLE
refactor: remove @ts-ignore needed for Stencil missing  in JSX types

### DIFF
--- a/packages/calcite-components/src/utils/interactive.tsx
+++ b/packages/calcite-components/src/utils/interactive.tsx
@@ -194,8 +194,6 @@ export function InteractiveContainer(
   children: VNode[],
 ): FunctionalComponent {
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore-error - `inert` is missing from Stencil's types (see https://github.com/ionic-team/stencil/issues/5071)
     <div class={CSS.container} inert={disabled}>
       {...children}
     </div>


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

[Stencil 4.8.0](https://github.com/ionic-team/stencil/blob/main/CHANGELOG.md#-480-2023-11-27) added `inert` to the JSX types, so this is no longer needed.