### PR TITLE
fix(input-date-picker): ensure range icon toggles open corresponding date-picker

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1375,7 +1375,7 @@ export namespace Components {
         /**
           * End date currently active.
          */
-        "endDate": Date;
+        "endDate"?: Date;
         /**
           * The range of dates currently being hovered.
          */
@@ -1403,7 +1403,7 @@ export namespace Components {
         /**
           * Start date currently active.
          */
-        "startDate": Date;
+        "startDate"?: Date;
     }
     interface CalciteDatePickerMonthHeader {
         /**
@@ -1507,7 +1507,7 @@ export namespace Components {
          */
         "scale": Scale;
         /**
-          * Specifies the selection mode for `calcite-dropdown-item` children: - `"multiple"` allows any number of selected items, - `"single"` allows only one selection, - `"none"` doesn't allow for any selection.
+          * Specifies the selection mode for `calcite-dropdown-item` children: `"multiple"` allows any number of selected items, `"single"` allows only one selection, `"none"` doesn't allow for any selection.
          */
         "selectionMode": Extract<"none" | "single" | "multiple", SelectionMode>;
     }
@@ -8558,11 +8558,11 @@ declare namespace LocalJSX {
          */
         "numberingSystem"?: NumberingSystem;
         /**
-          * Emits when a user changes the component's date. For `range` events, use `calciteDatePickerRangeChange`.
+          * Fires when a user changes the component's date. For `range` events, use `calciteDatePickerRangeChange`.
          */
         "onCalciteDatePickerChange"?: (event: CalciteDatePickerCustomEvent<void>) => void;
         /**
-          * Emits when a user changes the component's date `range`. For components without `range` use `calciteDatePickerChange`.
+          * Fires when a user changes the component's date `range`. For components without `range` use `calciteDatePickerChange`.
          */
         "onCalciteDatePickerRangeChange"?: (event: CalciteDatePickerCustomEvent<void>) => void;
         /**
@@ -8616,11 +8616,11 @@ declare namespace LocalJSX {
          */
         "highlighted"?: boolean;
         /**
-          * Emits when user selects day.
+          * Fires when user selects day.
          */
         "onCalciteDaySelect"?: (event: CalciteDatePickerDayCustomEvent<void>) => void;
         /**
-          * Emits when user hovers over a day.
+          * Fires when user hovers over a day.
          */
         "onCalciteInternalDayHover"?: (event: CalciteDatePickerDayCustomEvent<void>) => void;
         /**
@@ -8686,12 +8686,12 @@ declare namespace LocalJSX {
          */
         "onCalciteInternalDatePickerActiveDateChange"?: (event: CalciteDatePickerMonthCustomEvent<Date>) => void;
         /**
-          * Emits when user hovers the date.
+          * Fires when user hovers the date.
          */
         "onCalciteInternalDatePickerHover"?: (event: CalciteDatePickerMonthCustomEvent<Date>) => void;
         "onCalciteInternalDatePickerMouseOut"?: (event: CalciteDatePickerMonthCustomEvent<void>) => void;
         /**
-          * Emits when user selects the date.
+          * Fires when user selects the date.
          */
         "onCalciteInternalDatePickerSelect"?: (event: CalciteDatePickerMonthCustomEvent<Date>) => void;
         /**
@@ -8734,7 +8734,7 @@ declare namespace LocalJSX {
          */
         "min"?: Date;
         /**
-          * Changes to active date
+          * Fires to active date
          */
         "onCalciteInternalDatePickerSelect"?: (event: CalciteDatePickerMonthHeaderCustomEvent<Date>) => void;
         /**
@@ -8825,7 +8825,7 @@ declare namespace LocalJSX {
          */
         "scale"?: Scale;
         /**
-          * Specifies the selection mode for `calcite-dropdown-item` children: - `"multiple"` allows any number of selected items, - `"single"` allows only one selection, - `"none"` doesn't allow for any selection.
+          * Specifies the selection mode for `calcite-dropdown-item` children: `"multiple"` allows any number of selected items, `"single"` allows only one selection, `"none"` doesn't allow for any selection.
          */
         "selectionMode"?: Extract<"none" | "single" | "multiple", SelectionMode>;
     }
@@ -8855,7 +8855,7 @@ declare namespace LocalJSX {
          */
         "label"?: string;
         /**
-          * Emits when the component is selected.
+          * Fires when the component is selected.
          */
         "onCalciteDropdownItemSelect"?: (event: CalciteDropdownItemCustomEvent<void>) => void;
         "onCalciteInternalDropdownCloseRequest"?: (event: CalciteDropdownItemCustomEvent<void>) => void;
@@ -8948,7 +8948,7 @@ declare namespace LocalJSX {
          */
         "messages"?: FilterMessages;
         /**
-          * Emits when the filter text changes.
+          * Fires when the filter text changes.
          */
         "onCalciteFilterChange"?: (event: CalciteFilterCustomEvent<void>) => void;
         /**
@@ -9097,15 +9097,15 @@ declare namespace LocalJSX {
          */
         "messages"?: HandleMessages;
         /**
-          * Emits whenever the component is selected or unselected.
+          * Fires whenever the component is selected or unselected.
          */
         "onCalciteHandleChange"?: (event: CalciteHandleCustomEvent<void>) => void;
         /**
-          * Emits when the handle is selected and the up or down arrow key is pressed.
+          * Fires when the handle is selected and the up or down arrow key is pressed.
          */
         "onCalciteHandleNudge"?: (event: CalciteHandleCustomEvent<HandleNudge>) => void;
         /**
-          * Emits when the assistive text has changed.
+          * Fires when the assistive text has changed.
          */
         "onCalciteInternalAssistiveTextChange"?: (event: CalciteHandleCustomEvent<HandleChange>) => void;
         /**

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -387,6 +387,10 @@ describe("calcite-input-date-picker", () => {
         return (await calendar.isVisible()) && calendarPosition === type;
       }
 
+      async function resetFocus(page: E2EPage): Promise<void> {
+        await page.mouse.click(0, 0);
+      }
+
       it("toggles the date picker when clicked", async () => {
         const calendar = await page.find(`calcite-input-date-picker >>> .${CSS.calendarWrapper}`);
 
@@ -409,6 +413,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start date input
 
+        await resetFocus(page);
         await startInput.click();
         await page.waitForChanges();
 
@@ -421,6 +426,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start date toggle icon
 
+        await resetFocus(page);
         await startInputToggle.click();
         await page.waitForChanges();
 
@@ -433,6 +439,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end date input
 
+        await resetFocus(page);
         await endInput.click();
         await page.waitForChanges();
 
@@ -445,6 +452,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end date toggle icon
 
+        await resetFocus(page);
         await endInputToggle.click();
         await page.waitForChanges();
 
@@ -457,6 +465,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start date input and toggle icon
 
+        await resetFocus(page);
         await startInput.click();
         await page.waitForChanges();
 
@@ -469,6 +478,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start toggle icon and date input
 
+        await resetFocus(page);
         await startInputToggle.click();
         await page.waitForChanges();
 
@@ -481,6 +491,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end date input and toggle icon
 
+        await resetFocus(page);
         await endInput.click();
         await page.waitForChanges();
 
@@ -493,6 +504,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end toggle icon and date input
 
+        await resetFocus(page);
         await endInputToggle.click();
         await page.waitForChanges();
 
@@ -505,6 +517,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start date input and end toggle icon
 
+        await resetFocus(page);
         await startInput.click();
         await page.waitForChanges();
 
@@ -517,6 +530,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via start toggle icon and date input
 
+        await resetFocus(page);
         await startInputToggle.click();
         await page.waitForChanges();
 
@@ -533,6 +547,7 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end date input and start toggle icon
 
+        await resetFocus(page);
         await endInput.click();
         await page.waitForChanges();
 
@@ -545,11 +560,13 @@ describe("calcite-input-date-picker", () => {
 
         // toggling via end toggle icon and start date input
 
+        await resetFocus(page);
         await endInputToggle.click();
         await page.waitForChanges();
 
         expect(await isCalendarVisible(calendar, "end")).toBe(true);
 
+        await resetFocus(page);
         await startInput.click();
         await page.waitForChanges();
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -724,7 +724,7 @@ export class InputDatePicker
 
   @State() effectiveLocale = "";
 
-  @State() focusedInput: "start" | "end";
+  @State() focusedInput: "start" | "end" = "start";
 
   @State() private localeData: DateLocaleData;
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -682,7 +682,8 @@ export class InputDatePicker
 
   renderToggleIcon(open: boolean): VNode {
     return (
-      <span class={CSS.toggleIcon}>
+      // we set tab index to -1 to prevent delegatesFocus from stealing focus before we can set it
+      <span class={CSS.toggleIcon} tabIndex={-1}>
         <calcite-icon
           icon={open ? "chevron-up" : "chevron-down"}
           scale={getIconScale(this.scale)}
@@ -723,7 +724,7 @@ export class InputDatePicker
 
   @State() effectiveLocale = "";
 
-  @State() focusedInput: "start" | "end" = "start";
+  @State() focusedInput: "start" | "end";
 
   @State() private localeData: DateLocaleData;
 
@@ -774,24 +775,17 @@ export class InputDatePicker
 
   private onInputWrapperClick = (event: MouseEvent) => {
     const { range, endInput, startInput, currentOpenInput } = this;
-    if (!range || !this.open) {
-      this.open = !this.open;
-      return;
-    }
-
     const currentTarget = event.currentTarget as HTMLDivElement;
     const position = currentTarget.getAttribute("data-position") as "start" | "end";
     const path = event.composedPath();
-    const wasToggleClicked = path.find((el: HTMLElement) => {
-      return el.classList?.contains(CSS.toggleIcon);
-    });
+    const wasToggleClicked = path.find((el: HTMLElement) => el.classList?.contains(CSS.toggleIcon));
 
     if (wasToggleClicked) {
       const targetInput = position === "start" ? startInput : endInput;
       targetInput.setFocus();
     }
 
-    if (currentOpenInput === position) {
+    if (!range || !this.open || currentOpenInput === position) {
       this.open = !this.open;
     }
   };


### PR DESCRIPTION
**Related Issue:** #7965

## Summary

This fixes an issue that caused the start date picker to be toggled when the end date icon was clicked.