### PR TITLE
refactor: drop `hidden` prop since it is a global attribute

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -135,13 +135,6 @@ export class InputNumber
   @Prop({ reflect: true }) groupSeparator = false;
 
   /**
-   * When `true`, the component will not be visible.
-   *
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) hidden = false;
-
-  /**
    * Specifies an icon to display.
    *
    * @futureBreaking Remove boolean type as it is not supported.

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -111,13 +111,6 @@ export class InputText
   form: string;
 
   /**
-   * When `true`, the component will not be visible.
-   *
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) hidden = false;
-
-  /**
    * Specifies an icon to display.
    *
    * @futureBreaking Remove boolean type as it is not supported.

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -136,13 +136,6 @@ export class Input
   @Prop({ reflect: true }) groupSeparator = false;
 
   /**
-   * When `true`, the component will not be visible.
-   *
-   * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-   */
-  @Prop({ reflect: true }) hidden = false;
-
-  /**
    * When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
    */
   @Prop({ reflect: true }) icon: string | boolean;

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
@@ -32,6 +32,17 @@ import {
 export class RadioButtonGroup implements LoadableComponent {
   //--------------------------------------------------------------------------
   //
+  //  Global attributes
+  //
+  //--------------------------------------------------------------------------
+
+  @Watch("hidden")
+  handleHiddenChange(): void {
+    this.passPropsToRadioButtons();
+  }
+
+  //--------------------------------------------------------------------------
+  //
   //  Properties
   //
   //--------------------------------------------------------------------------
@@ -41,14 +52,6 @@ export class RadioButtonGroup implements LoadableComponent {
 
   @Watch("disabled")
   onDisabledChange(): void {
-    this.passPropsToRadioButtons();
-  }
-
-  /** When `true`, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable. */
-  @Prop({ reflect: true }) hidden = false;
-
-  @Watch("hidden")
-  onHiddenChange(): void {
     this.passPropsToRadioButtons();
   }
 
@@ -129,7 +132,7 @@ export class RadioButtonGroup implements LoadableComponent {
     if (this.radioButtons.length > 0) {
       this.radioButtons.forEach((radioButton) => {
         radioButton.disabled = this.disabled || radioButton.disabled;
-        radioButton.hidden = this.hidden;
+        radioButton.hidden = this.el.hidden;
         radioButton.name = this.name;
         radioButton.required = this.required;
         radioButton.scale = this.scale;

--- a/packages/calcite-components/src/components/radio-button/radio-button.tsx
+++ b/packages/calcite-components/src/components/radio-button/radio-button.tsx
@@ -48,6 +48,17 @@ export class RadioButton
 {
   //--------------------------------------------------------------------------
   //
+  //  Global attributes
+  //
+  //--------------------------------------------------------------------------
+
+  @Watch("hidden")
+  handleHiddenChange(): void {
+    this.updateTabIndexOfOtherRadioButtonsInGroup();
+  }
+
+  //--------------------------------------------------------------------------
+  //
   //  Properties
   //
   //--------------------------------------------------------------------------
@@ -89,14 +100,6 @@ export class RadioButton
 
   /** The `id` of the component. When omitted, a globally unique identifier is used. */
   @Prop({ reflect: true, mutable: true }) guid: string;
-
-  /** When `true`, the component is not displayed and is not focusable or checkable. */
-  @Prop({ reflect: true }) hidden = false;
-
-  @Watch("hidden")
-  hiddenChanged(): void {
-    this.updateTabIndexOfOtherRadioButtonsInGroup();
-  }
 
   /**
    * The hovered state of the component.
@@ -223,7 +226,7 @@ export class RadioButton
   };
 
   onLabelClick(event: CustomEvent): void {
-    if (this.disabled || this.hidden) {
+    if (this.disabled || this.el.hidden) {
       return;
     }
 

--- a/packages/calcite-components/src/components/tile-select/tile-select.tsx
+++ b/packages/calcite-components/src/components/tile-select/tile-select.tsx
@@ -61,9 +61,6 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   /** The component header text, which displays between the icon and description. */
   @Prop({ reflect: true }) heading: string;
 
-  /** When `true`, the component is not displayed and is not focusable or checkable. */
-  @Prop({ reflect: true }) hidden = false;
-
   /** Specifies an icon to display. */
   @Prop({ reflect: true }) icon: string;
 
@@ -283,7 +280,7 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
     );
     this.input.checked = this.checked;
     this.input.disabled = this.disabled;
-    this.input.hidden = this.hidden;
+    this.input.hidden = this.el.hidden;
     this.input.id = this.guid;
     this.input.label = this.heading || this.name || "";
 

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -62,9 +62,6 @@ export class Tile implements ConditionalSlotComponent, InteractiveComponent {
   /** The component header text, which displays between the icon and description. */
   @Prop({ reflect: true }) heading: string;
 
-  /** When `true`, the component is not displayed and is not focusable.  */
-  @Prop({ reflect: true }) hidden = false;
-
   /** When embed is `"false"`, the URL for the component. */
   @Prop({ reflect: true }) href: string;
 


### PR DESCRIPTION
**Related Issue:** #5548  

## Summary

This removes `hidden` props since it's available on `HTMLElement` (base class for custom elements).