### PR TITLE
feat(inline-editable): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -4,7 +4,6 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-inline-editable-background-color: Specifies the background color of the component.
- * @prop --calcite-inline-editable-size: Specifies the size of the component.
  */
 :host {
   --calcite-inline-editable-background-color: var(--calcite-ui-foreground-1);
@@ -13,15 +12,15 @@
 }
 
 :host([scale="s"]) {
-  --calcite-inline-editable-size: 1.5rem;
+  --calcite-internal-inline-editable-size: 1.5rem;
 }
 
 :host([scale="m"]) {
-  --calcite-inline-editable-size: 2rem;
+  --calcite-internal-inline-editable-size: 2rem;
 }
 
 :host([scale="l"]) {
-  --calcite-inline-editable-size: 2.75rem;
+  --calcite-internal-inline-editable-size: 2.75rem;
 }
 
 :host(:not([editing-enabled]):not([disabled]):hover) {
@@ -43,7 +42,7 @@
 
 .controls-wrapper {
   @apply flex;
-  block-size: var(--calcite-inline-editable-size);
+  block-size: var(--calcite-internal-inline-editable-size);
 }
 
 @include disabled();

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -1,36 +1,37 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-inline-editable-background-color: Specifies the background color of the component.
+ * @prop --calcite-inline-editable-size: Specifies the size of the component.
+ */
 :host {
+  --calcite-inline-editable-background-color: var(--calcite-ui-foreground-1);
+
   @apply block;
 }
 
 :host([scale="s"]) {
-  .controls-wrapper {
-    @apply h-6;
-  }
+  --calcite-inline-editable-size: 1.5rem;
 }
 
 :host([scale="m"]) {
-  .controls-wrapper {
-    @apply h-8;
-  }
+  --calcite-inline-editable-size: 2rem;
 }
 
 :host([scale="l"]) {
-  .controls-wrapper {
-    @apply h-11;
-  }
+  --calcite-inline-editable-size: 2.75rem;
 }
 
-:host(:not([editing-enabled]):not([disabled])) {
-  .wrapper {
-    &:hover {
-      @apply bg-foreground-2;
-    }
-  }
+:host(:not([editing-enabled]):not([disabled]):hover) {
+  --calcite-inline-editable-background-color: var(--calcite-color-foreground-2);
 }
 
 .wrapper {
-  @apply bg-foreground-1
-    transition-default
+  background-color: var(--calcite-inline-editable-background-color);
+
+  @apply transition-default
     box-border
     flex
     justify-between;
@@ -42,12 +43,8 @@
 
 .controls-wrapper {
   @apply flex;
+  block-size: var(--calcite-inline-editable-size);
 }
 
-@include disabled() {
-  .cancel-editing-button-wrapper {
-    @apply border-color-2;
-  }
-}
-
+@include disabled();
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds the following component tokens:

* `--calcite-inline-editable-background-color`
* `--calcite-inline-editable-size`

**Note**: this removes disabled styling for the editing button wrapper as it was not being applied (no border style set).
