### PR TITLE
feat(card): Add component tokens

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -660,7 +660,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -775,7 +775,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -1070,7 +1070,7 @@ export namespace Components {
          */
         "flipPlacements": EffectivePlacement[];
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -1898,7 +1898,7 @@ export namespace Components {
          */
         "files": FileList | undefined;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2075,7 +2075,7 @@ export namespace Components {
          */
         "focusTrapDisabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2231,7 +2231,7 @@ export namespace Components {
          */
         "enterKeyHint": string;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2401,7 +2401,7 @@ export namespace Components {
          */
         "enterKeyHint": string;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2520,7 +2520,7 @@ export namespace Components {
          */
         "focusTrapDisabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2600,7 +2600,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3040,7 +3040,7 @@ export namespace Components {
          */
         "fillType": "single" | "range";
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3722,7 +3722,7 @@ export namespace Components {
          */
         "focused": boolean;
         /**
-          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3811,7 +3811,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3875,7 +3875,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3952,7 +3952,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4096,7 +4096,7 @@ export namespace Components {
          */
         "detachedHeightScale": Scale;
         /**
-          * Specifies the display mode of the component, where:  `"dock"` full height, displays adjacent to center content,  `"float"` not full height, content is separated detached from `calcite-action-bar`, displays on top of center content, and  `"overlay"` full height, displays on top of center content.
+          * Specifies the display mode of the component, where:  `"dock"` displays at full height adjacent to center content,  `"overlay"` displays at full height on top of center content, and  `"float"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
          */
         "displayMode": DisplayMode1;
         /**
@@ -4134,7 +4134,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4473,7 +4473,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4817,7 +4817,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -5169,6 +5169,7 @@ export namespace Components {
         "selectedItems": HTMLCalciteTreeItemElement[];
         /**
           * Specifies the selection mode of the component, where:  `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,  `"children"` allows any number of selections from one parent from corresponding parent and child selections,  `"multichildren"` allows any number of selections from corresponding parent and child selections,  `"multiple"` allows any number of selections,  `"none"` allows no selections,  `"single"` allows one selection, and  `"single-persist"` allows and requires one selection.
+          * @default "single"
          */
         "selectionMode": SelectionMode;
     }
@@ -7914,7 +7915,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -8029,7 +8030,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -8341,7 +8342,7 @@ declare namespace LocalJSX {
          */
         "flipPlacements"?: EffectivePlacement[];
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9230,7 +9231,7 @@ declare namespace LocalJSX {
          */
         "files"?: FileList | undefined;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9409,7 +9410,7 @@ declare namespace LocalJSX {
          */
         "focusTrapDisabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9461,7 +9462,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputDatePickerBeforeOpen"?: (event: CalciteInputDatePickerCustomEvent<void>) => void;
         /**
-          * Fires when the component's value changes.
+          * Fires when the component's `value` changes.
          */
         "onCalciteInputDatePickerChange"?: (event: CalciteInputDatePickerCustomEvent<void>) => void;
         /**
@@ -9576,7 +9577,7 @@ declare namespace LocalJSX {
          */
         "enterKeyHint"?: string;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9748,7 +9749,7 @@ declare namespace LocalJSX {
          */
         "enterKeyHint"?: string;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9872,7 +9873,7 @@ declare namespace LocalJSX {
          */
         "focusTrapDisabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9900,7 +9901,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputTimePickerBeforeOpen"?: (event: CalciteInputTimePickerCustomEvent<void>) => void;
         /**
-          * Fires when the time value is changed as a result of user input.
+          * Fires when the component's `value` is changes.
          */
         "onCalciteInputTimePickerChange"?: (event: CalciteInputTimePickerCustomEvent<void>) => void;
         /**
@@ -9963,7 +9964,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9996,7 +9997,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputTimeZoneBeforeOpen"?: (event: CalciteInputTimeZoneCustomEvent<void>) => void;
         /**
-          * Fires when the component's value changes.
+          * Fires when the component's `value` changes.
          */
         "onCalciteInputTimeZoneChange"?: (event: CalciteInputTimeZoneCustomEvent<void>) => void;
         /**
@@ -10460,7 +10461,7 @@ declare namespace LocalJSX {
          */
         "fillType"?: "single" | "range";
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11159,7 +11160,7 @@ declare namespace LocalJSX {
          */
         "focused"?: boolean;
         /**
-          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11260,7 +11261,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11324,7 +11325,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11405,7 +11406,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11557,7 +11558,7 @@ declare namespace LocalJSX {
          */
         "detachedHeightScale"?: Scale;
         /**
-          * Specifies the display mode of the component, where:  `"dock"` full height, displays adjacent to center content,  `"float"` not full height, content is separated detached from `calcite-action-bar`, displays on top of center content, and  `"overlay"` full height, displays on top of center content.
+          * Specifies the display mode of the component, where:  `"dock"` displays at full height adjacent to center content,  `"overlay"` displays at full height on top of center content, and  `"float"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
          */
         "displayMode"?: DisplayMode1;
         /**
@@ -11597,7 +11598,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11935,7 +11936,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -12291,7 +12292,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -12657,6 +12658,7 @@ declare namespace LocalJSX {
         "selectedItems"?: HTMLCalciteTreeItemElement[];
         /**
           * Specifies the selection mode of the component, where:  `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,  `"children"` allows any number of selections from one parent from corresponding parent and child selections,  `"multichildren"` allows any number of selections from corresponding parent and child selections,  `"multiple"` allows any number of selections,  `"none"` allows no selections,  `"single"` allows one selection, and  `"single-persist"` allows and requires one selection.
+          * @default "single"
          */
         "selectionMode"?: SelectionMode;
     }

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -660,7 +660,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -775,7 +775,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -1070,7 +1070,7 @@ export namespace Components {
          */
         "flipPlacements": EffectivePlacement[];
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -1898,7 +1898,7 @@ export namespace Components {
          */
         "files": FileList | undefined;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2075,7 +2075,7 @@ export namespace Components {
          */
         "focusTrapDisabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2231,7 +2231,7 @@ export namespace Components {
          */
         "enterKeyHint": string;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2401,7 +2401,7 @@ export namespace Components {
          */
         "enterKeyHint": string;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2520,7 +2520,7 @@ export namespace Components {
          */
         "focusTrapDisabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -2600,7 +2600,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3040,7 +3040,7 @@ export namespace Components {
          */
         "fillType": "single" | "range";
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3722,7 +3722,7 @@ export namespace Components {
          */
         "focused": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3811,7 +3811,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3875,7 +3875,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -3952,7 +3952,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4096,7 +4096,7 @@ export namespace Components {
          */
         "detachedHeightScale": Scale;
         /**
-          * Specifies the display mode of the component, where:  `"dock"` displays at full height adjacent to center content,  `"overlay"` displays at full height on top of center content, and  `"float"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
+          * Specifies the display mode of the component, where:  `"dock"` full height, displays adjacent to center content,  `"float"` not full height, content is separated detached from `calcite-action-bar`, displays on top of center content, and  `"overlay"` full height, displays on top of center content.
          */
         "displayMode": DisplayMode1;
         /**
@@ -4134,7 +4134,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4473,7 +4473,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -4817,7 +4817,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
         /**
@@ -5169,7 +5169,6 @@ export namespace Components {
         "selectedItems": HTMLCalciteTreeItemElement[];
         /**
           * Specifies the selection mode of the component, where:  `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,  `"children"` allows any number of selections from one parent from corresponding parent and child selections,  `"multichildren"` allows any number of selections from corresponding parent and child selections,  `"multiple"` allows any number of selections,  `"none"` allows no selections,  `"single"` allows one selection, and  `"single-persist"` allows and requires one selection.
-          * @default "single"
          */
         "selectionMode": SelectionMode;
     }
@@ -7915,7 +7914,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -8030,7 +8029,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -8342,7 +8341,7 @@ declare namespace LocalJSX {
          */
         "flipPlacements"?: EffectivePlacement[];
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9231,7 +9230,7 @@ declare namespace LocalJSX {
          */
         "files"?: FileList | undefined;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9410,7 +9409,7 @@ declare namespace LocalJSX {
          */
         "focusTrapDisabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9462,7 +9461,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputDatePickerBeforeOpen"?: (event: CalciteInputDatePickerCustomEvent<void>) => void;
         /**
-          * Fires when the component's `value` changes.
+          * Fires when the component's value changes.
          */
         "onCalciteInputDatePickerChange"?: (event: CalciteInputDatePickerCustomEvent<void>) => void;
         /**
@@ -9577,7 +9576,7 @@ declare namespace LocalJSX {
          */
         "enterKeyHint"?: string;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9749,7 +9748,7 @@ declare namespace LocalJSX {
          */
         "enterKeyHint"?: string;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9873,7 +9872,7 @@ declare namespace LocalJSX {
          */
         "focusTrapDisabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9901,7 +9900,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputTimePickerBeforeOpen"?: (event: CalciteInputTimePickerCustomEvent<void>) => void;
         /**
-          * Fires when the component's `value` is changes.
+          * Fires when the time value is changed as a result of user input.
          */
         "onCalciteInputTimePickerChange"?: (event: CalciteInputTimePickerCustomEvent<void>) => void;
         /**
@@ -9964,7 +9963,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -9997,7 +9996,7 @@ declare namespace LocalJSX {
          */
         "onCalciteInputTimeZoneBeforeOpen"?: (event: CalciteInputTimeZoneCustomEvent<void>) => void;
         /**
-          * Fires when the component's `value` changes.
+          * Fires when the component's value changes.
          */
         "onCalciteInputTimeZoneChange"?: (event: CalciteInputTimeZoneCustomEvent<void>) => void;
         /**
@@ -10461,7 +10460,7 @@ declare namespace LocalJSX {
          */
         "fillType"?: "single" | "range";
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11160,7 +11159,7 @@ declare namespace LocalJSX {
          */
         "focused"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The 'ID' of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11261,7 +11260,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11325,7 +11324,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11406,7 +11405,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11558,7 +11557,7 @@ declare namespace LocalJSX {
          */
         "detachedHeightScale"?: Scale;
         /**
-          * Specifies the display mode of the component, where:  `"dock"` displays at full height adjacent to center content,  `"overlay"` displays at full height on top of center content, and  `"float"` does not display at full height with content separately detached from `calcite-action-bar` on top of center content.
+          * Specifies the display mode of the component, where:  `"dock"` full height, displays adjacent to center content,  `"float"` not full height, content is separated detached from `calcite-action-bar`, displays on top of center content, and  `"overlay"` full height, displays on top of center content.
          */
         "displayMode"?: DisplayMode1;
         /**
@@ -11598,7 +11597,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The ID of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -11936,7 +11935,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -12292,7 +12291,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
+          * The `ID` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
         /**
@@ -12658,7 +12657,6 @@ declare namespace LocalJSX {
         "selectedItems"?: HTMLCalciteTreeItemElement[];
         /**
           * Specifies the selection mode of the component, where:  `"ancestors"` displays with a checkbox and allows any number of selections from corresponding parent and child selections,  `"children"` allows any number of selections from one parent from corresponding parent and child selections,  `"multichildren"` allows any number of selections from corresponding parent and child selections,  `"multiple"` allows any number of selections,  `"none"` allows no selections,  `"single"` allows one selection, and  `"single-persist"` allows and requires one selection.
-          * @default "single"
          */
         "selectionMode"?: SelectionMode;
     }

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -1,22 +1,55 @@
+@import "~@esri/calcite-design-tokens/dist/scss/core";
+@import "~@esri/calcite-design-tokens/dist/scss/global";
+
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-card-background-color: Specifies the background color of the component.
+ * @prop --calcite-card-box-shadow: Specifies box shadow of the component.
+ * @prop --calcite-card-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-card-subtitle-color: Specifies the color of the component's `"subtitle"` slot.
+ * @prop --calcite-card-title-color: Specifies the color of the component's `"title"` slot.
+ *
+ */
+
+/*
+  * Internal Properties
+  *
+  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
+  *
+  * --calcite-internal-card-background-color
+  * --calcite-internal-card-border-color
+  * --calcite-internal-card-box-shadow
+  * --calcite-internal-card-corner-radius
+  * --calcite-internal-card-subtitle-color
+  * --calcite-internal-card-title-color
+*/
+
 :host {
   @apply block max-w-full;
-  & .calcite-card-container {
-    @apply bg-foreground-1
-    border-color-2
-    text-color-3
-    relative
+  --calcite-internal-card-background-color: var(--calcite-card-background-color, var(--calcite-color-foreground-1));
+  --calcite-internal-card-border-color: var(--calcite-card-border-color, var(--calcite-color-border-3));
+  --calcite-internal-card-box-shadow: var(--calcite-card-box-shadow, var(--calcite-shadow-none));
+  --calcite-internal-card-corner-radius: var(--calcite-card-corner-radius, var(--calcite-corner-radius-sharp));
+  --calcite-internal-card-subtitle-color: var(--calcite-card-subtitle-color, var(--calcite-color-text-2));
+  --calcite-internal-card-title-color: var(--calcite-card-title-color, var(--calcite-color-text-1));
+}
+
+.calcite-card-container {
+  @apply relative
     flex
     h-full
     flex-col
     justify-between
-    border
-    border-solid
-    shadow-none
     duration-150
     ease-in-out
     overflow-hidden;
-    border-radius: var(--calcite-border-radius-base);
-  }
+  border: 1px solid var(--calcite-internal-card-border-color);
+  border-radius: var(--calcite-internal-card-corner-radius);
+  background-color: var(--calcite-internal-card-background-color);
+  box-shadow: var(--calcite-internal-card-box-shadow);
 }
 
 .container {
@@ -24,64 +57,58 @@
 }
 
 :host([loading]) .calcite-card-container *:not(calcite-loader):not(.calcite-card-loader-container) {
-  @apply pointer-events-none opacity-0;
+  @apply pointer-events-none;
+  opacity: $calcite-opacity-0;
 }
 
 :host([loading]) .calcite-card-loader-container {
-  @apply absolute
-    inset-0
-    flex
-    items-center;
-}
-
-.header,
-.footer {
-  @apply flex px-3 pt-3 pb-1;
+  @apply absolute inset-0 flex items-center;
 }
 
 .header {
-  @apply flex-col;
+  @apply flex flex-col;
+  padding-inline: $calcite-spacing-md;
+  padding-block-start: $calcite-spacing-md;
+  padding-block-end: $calcite-spacing-xxs;
 }
 
 .footer {
-  @apply mt-auto flex-row content-between
-    justify-between
-    px-3
-    pt-1
-    pb-3;
+  @apply flex mt-auto flex-row content-between justify-between;
+  padding-inline: $calcite-spacing-md;
+  padding-block-start: $calcite-spacing-xxs;
+  padding-block-end: $calcite-spacing-md;
 }
 
 .card-content {
-  @apply text-color-3
-    text-n2-wrap
-    p-3;
+  @apply text-n2-wrap;
+  color: var(--calcite-color-text-3);
+  padding: $calcite-spacing-md;
 }
 
 :host([selected]) .calcite-card-container {
-  @apply border-color-brand;
+  border-color: var(--calcite-color-brand);
 }
 
 // slotted content
 @include slotted("title", "*") {
-  @apply text-color-1
-    text-n1-wrap
-    m-0
-    font-medium;
+  @apply text-n1-wrap;
+  margin: 0;
+  font-weight: $calcite-font-weight-medium;
+  color: var(--calcite-internal-card-title-color);
 }
 
 :host([selectable]) {
   .header {
     // prevents overlap with checkbox (default header padding + no-overlap spacing)
-    padding-inline-end: theme("spacing.8");
+    padding-inline-end: $calcite-spacing-xxxl;
   }
 }
 
 @include slotted("subtitle", "*") {
-  @apply text-color-2
-    text-n2-wrap
-    m-0
-    mt-2
-    font-normal;
+  @apply text-n2-wrap font-normal;
+  margin: 0;
+  margin-block-start: $calcite-spacing-sm;
+  color: var(--calcite-internal-card-subtitle-color);
 }
 
 @include slotted("thumbnail", "img") {
@@ -97,9 +124,11 @@
 }
 
 .checkbox-wrapper {
-  @apply absolute m-0 p-0;
-  inset-block-start: theme("spacing.2");
-  inset-inline-end: theme("spacing.2");
+  @apply absolute;
+  inset-block-start: $calcite-spacing-sm;
+  inset-inline-end: $calcite-spacing-sm;
+  margin: 0;
+  padding: 0;
 }
 
 .thumbnail-wrapper {

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -7,7 +7,7 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-card-background-color: Specifies the background color of the component.
- * @prop --calcite-card-box-shadow: Specifies box shadow of the component.
+ * @prop --calcite-card-box-shadow: Specifies the box shadow of the component.
  * @prop --calcite-card-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-card-subtitle-color: Specifies the color of the component's `"subtitle"` slot.
  * @prop --calcite-card-title-color: Specifies the color of the component's `"title"` slot.

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -1,6 +1,3 @@
-@import "~@esri/calcite-design-tokens/dist/scss/core";
-@import "~@esri/calcite-design-tokens/dist/scss/global";
-
 /**
  * CSS Custom Properties
  *
@@ -14,7 +11,7 @@
  *
  */
 
-/*
+/**
   * Internal Properties
   *
   * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
@@ -25,7 +22,7 @@
   * --calcite-internal-card-corner-radius
   * --calcite-internal-card-subtitle-color
   * --calcite-internal-card-title-color
-*/
+  */
 
 :host {
   @apply block max-w-full;

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -96,9 +96,12 @@
 @include slotted("footer-start", "*") {
   @apply text-n2-wrap self-center;
   margin-inline-end: auto;
+  color: var(--calcite-color-text-3);
 }
+
 @include slotted("footer-end", "*") {
   @apply text-n2-wrap self-center;
+  color: var(--calcite-color-text-3);
 }
 
 .checkbox-wrapper {

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -4,6 +4,7 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-card-background-color: Specifies the background color of the component.
+ * @prop --calcite-card-border-color: Specifies the border color of the component.
  * @prop --calcite-card-box-shadow: Specifies the box shadow of the component.
  * @prop --calcite-card-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-card-subtitle-color: Specifies the color of the component's `"subtitle"` slot.

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -11,27 +11,8 @@
  *
  */
 
-/**
-  * Internal Properties
-  *
-  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
-  *
-  * --calcite-internal-card-background-color
-  * --calcite-internal-card-border-color
-  * --calcite-internal-card-box-shadow
-  * --calcite-internal-card-corner-radius
-  * --calcite-internal-card-subtitle-color
-  * --calcite-internal-card-title-color
-  */
-
 :host {
   @apply block max-w-full;
-  --calcite-internal-card-background-color: var(--calcite-card-background-color, var(--calcite-color-foreground-1));
-  --calcite-internal-card-border-color: var(--calcite-card-border-color, var(--calcite-color-border-3));
-  --calcite-internal-card-box-shadow: var(--calcite-card-box-shadow, var(--calcite-shadow-none));
-  --calcite-internal-card-corner-radius: var(--calcite-card-corner-radius, var(--calcite-corner-radius-sharp));
-  --calcite-internal-card-subtitle-color: var(--calcite-card-subtitle-color, var(--calcite-color-text-2));
-  --calcite-internal-card-title-color: var(--calcite-card-title-color, var(--calcite-color-text-1));
 }
 
 .calcite-card-container {
@@ -43,10 +24,10 @@
     duration-150
     ease-in-out
     overflow-hidden;
-  border: 1px solid var(--calcite-internal-card-border-color);
-  border-radius: var(--calcite-internal-card-corner-radius);
-  background-color: var(--calcite-internal-card-background-color);
-  box-shadow: var(--calcite-internal-card-box-shadow);
+  border: var(--calcite-border-width-sm) solid var(--calcite-card-border-color, var(--calcite-color-border-3));
+  border-radius: var(--calcite-card-corner-radius, var(--calcite-corner-radius-sharp));
+  background-color: var(--calcite-card-background-color, var(--calcite-color-foreground-1));
+  box-shadow: var(--calcite-card-box-shadow, var(--calcite-shadow-none));
 }
 
 .container {
@@ -55,7 +36,7 @@
 
 :host([loading]) .calcite-card-container *:not(calcite-loader):not(.calcite-card-loader-container) {
   @apply pointer-events-none;
-  opacity: $calcite-opacity-0;
+  opacity: var(--calcite-opacity-0);
 }
 
 :host([loading]) .calcite-card-loader-container {
@@ -64,48 +45,48 @@
 
 .header {
   @apply flex flex-col;
-  padding-inline: $calcite-spacing-md;
-  padding-block-start: $calcite-spacing-md;
-  padding-block-end: $calcite-spacing-xxs;
+  padding-inline: var(--calcite-spacing-md);
+  padding-block-start: var(--calcite-spacing-md);
+  padding-block-end: var(--calcite-spacing-xxs);
 }
 
 .footer {
   @apply flex mt-auto flex-row content-between justify-between;
-  padding-inline: $calcite-spacing-md;
-  padding-block-start: $calcite-spacing-xxs;
-  padding-block-end: $calcite-spacing-md;
+  padding-inline: var(--calcite-spacing-md);
+  padding-block-start: var(--calcite-spacing-xxs);
+  padding-block-end: var(--calcite-spacing-md);
 }
 
 .card-content {
   @apply text-n2-wrap;
   color: var(--calcite-color-text-3);
-  padding: $calcite-spacing-md;
+  padding: var(--calcite-spacing-md);
 }
 
 :host([selected]) .calcite-card-container {
-  border-color: var(--calcite-color-brand);
+  --calcite-card-container-border-color: var(--calcite-color-brand);
 }
 
 // slotted content
 @include slotted("title", "*") {
   @apply text-n1-wrap;
   margin: 0;
-  font-weight: $calcite-font-weight-medium;
-  color: var(--calcite-internal-card-title-color);
+  font-weight: var(--calcite-font-weight)-medium;
+  color: var(--calcite-card-title-color, var(--calcite-color-text-1));
 }
 
 :host([selectable]) {
   .header {
     // prevents overlap with checkbox (default header padding + no-overlap spacing)
-    padding-inline-end: $calcite-spacing-xxxl;
+    padding-inline-end: var(--calcite-spacing-xxxl);
   }
 }
 
 @include slotted("subtitle", "*") {
   @apply text-n2-wrap font-normal;
   margin: 0;
-  margin-block-start: $calcite-spacing-sm;
-  color: var(--calcite-internal-card-subtitle-color);
+  margin-block-start: var(--calcite-spacing-sm);
+  color: var(--calcite-card-subtitle-color, var(--calcite-color-text-2));
 }
 
 @include slotted("thumbnail", "img") {
@@ -122,8 +103,8 @@
 
 .checkbox-wrapper {
   @apply absolute;
-  inset-block-start: $calcite-spacing-sm;
-  inset-inline-end: $calcite-spacing-sm;
+  inset-block-start: var(--calcite-spacing-sm);
+  inset-inline-end: var(--calcite-spacing-sm);
   margin: 0;
   padding: 0;
 }

--- a/packages/calcite-components/src/components/card/card.scss
+++ b/packages/calcite-components/src/components/card/card.scss
@@ -36,7 +36,7 @@
 
 :host([loading]) .calcite-card-container *:not(calcite-loader):not(.calcite-card-loader-container) {
   @apply pointer-events-none;
-  opacity: var(--calcite-opacity-0);
+  opacity: $calcite-opacity-0;
 }
 
 :host([loading]) .calcite-card-loader-container {
@@ -71,7 +71,7 @@
 @include slotted("title", "*") {
   @apply text-n1-wrap;
   margin: 0;
-  font-weight: var(--calcite-font-weight)-medium;
+  font-weight: var(--calcite-font-weight-medium);
   color: var(--calcite-card-title-color, var(--calcite-color-text-1));
 }
 

--- a/packages/calcite-components/src/components/card/card.stories.ts
+++ b/packages/calcite-components/src/components/card/card.stories.ts
@@ -234,11 +234,11 @@ darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
 
 export const theming_TestOnly = (): string => html`
   <calcite-card
-    style="--calcite-card-corner-radius: var(--calcite-corner-radius-round),
-      --calcite-card-background-color: var(--calcite-color-foreground-3),
-      --calcite-card-border-color: var(--calcite-color-status-success),
-      --calcite-card-box-shadow: var(--calcite-shadow-md),
-      --calcite-card-title-color: var(--calcite-color-status-success),
+    style="--calcite-card-corner-radius: var(--calcite-corner-radius-round);
+      --calcite-card-background-color: var(--calcite-color-foreground-3);
+      --calcite-card-border-color: var(--calcite-color-status-success);
+      --calcite-card-box-shadow: var(--calcite-shadow-md);
+      --calcite-card-title-color: var(--calcite-color-status-success);
       --calcite-card-subtitle-color: var(--calcite-color-status-danger)"
   >
     <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>

--- a/packages/calcite-components/src/components/card/card.stories.ts
+++ b/packages/calcite-components/src/components/card/card.stories.ts
@@ -181,7 +181,7 @@ export const thumbnailRounded = (): string => html`
   <div id="card-container" style="width:260px;">
     <style>
       calcite-card {
-        --calcite-border-radius-base: 12px;
+        --calcite-card-corner-radius: 12px;
       }
     </style>
     <calcite-card>
@@ -231,3 +231,19 @@ export const darkModeRTL_TestOnly = (): string => html`
 `;
 
 darkModeRTL_TestOnly.parameters = { modes: modesDarkDefault };
+
+export const theming_TestOnly = (): string => html`
+  <calcite-card
+    style="--calcite-card-corner-radius: var(--calcite-corner-radius-round),
+      --calcite-card-background-color: var(--calcite-color-foreground-3),
+      --calcite-card-border-color: var(--calcite-color-status-success),
+      --calcite-card-box-shadow: var(--calcite-shadow-md),
+      --calcite-card-title-color: var(--calcite-color-status-success),
+      --calcite-card-subtitle-color: var(--calcite-color-status-danger)"
+  >
+    <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
+    <span slot="subtitle"
+      >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
+    >
+  </calcite-card>
+`;

--- a/packages/calcite-components/src/demos/card.html
+++ b/packages/calcite-components/src/demos/card.html
@@ -28,8 +28,14 @@
         padding: 0 18px;
       }
 
-      .rounded {
-        --calcite-border-radius-base: 5px;
+      .themed {
+        --calcite-card-corner-radius: var(--calcite-corner-radius-round);
+        --calcite-card-background-color: var(--calcite-color-foreground-3);
+        --calcite-card-border-color: var(--calcite-color-status-success);
+        --calcite-card-box-shadow: var(--calcite-shadow-md);
+        --calcite-card-title-color: var(--calcite-color-status-success);
+        --calcite-card-subtitle-color: var(--calcite-color-status-danger);
+        --calcite-card-content-padding: 24px;
       }
     </style>
     <script src="_assets/head.js"></script>
@@ -45,10 +51,9 @@
         **************************************************
       -->
       <div class="parent">
-        <!-- text only -->
         <div class="child">
-          <p>No buttons, not selectable</p>
-          <calcite-card>
+          <p>Themed</p>
+          <calcite-card class="themed">
             <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
             <span slot="subtitle"
               >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
@@ -56,10 +61,10 @@
           </calcite-card>
         </div>
 
-        <!-- text only, selectable, and border-radius -->
-        <div class="child rounded">
-          <p>No buttons, selectable, border-radius</p>
-          <calcite-card selectable>
+        <!-- text only -->
+        <div class="child">
+          <p>No buttons, not selectable</p>
+          <calcite-card>
             <h3 slot="title">ArcGIS Online: Gallery and Organization pages</h3>
             <span slot="subtitle"
               >A great example of a study description that might wrap to a line or two, but isn't overly verbose.</span
@@ -79,7 +84,7 @@
           <p>Card with several buttons</p>
 
           <calcite-card>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/180" />
             <h3 slot="title">Portland Businesses</h3>
             <span slot="subtitle"
               >by
@@ -136,7 +141,7 @@
         <div class="child">
           <p>Card with two buttons</p>
           <calcite-card selectable>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">My great Workforce project that might wrap two lines</h3>
             <span slot="subtitle">Johnathan Smith</span>
             <span slot="footer-start">Nov 25, 2018</span>
@@ -165,7 +170,7 @@
         <div class="child">
           <p>Selectable and selected card</p>
           <calcite-card selected selectable>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
 
             <h3 slot="title">ArcGIS Online Sign In and Sign Up</h3>
             <span slot="subtitle"
@@ -180,7 +185,7 @@
         <div class="child">
           <p>Deselect example</p>
           <calcite-card selectable>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
 
             <h3 slot="title">Translated select and deselect example</h3>
             <span slot="subtitle"
@@ -201,7 +206,7 @@
         <div class="child">
           <p>Loading</p>
           <calcite-card loading>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
 
             <h3 slot="title">Loading example</h3>
             <span slot="subtitle"
@@ -215,7 +220,7 @@
         <div class="child">
           <p>Submit button</p>
           <calcite-card selectable>
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">Untitled experience</h3>
             <span slot="subtitle">Subtext</span>
             <calcite-button slot="footer-start" width="full">Go</calcite-button>
@@ -232,7 +237,7 @@
         <div class="child">
           <p>thumbnail-position="block-start"</p>
           <calcite-card thumbnail-position="block-start">
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">Portland Businesses</h3>
             <span slot="subtitle"
               >by
@@ -274,7 +279,7 @@
         <div class="child">
           <p>thumbnail-position="block-end"</p>
           <calcite-card thumbnail-position="block-end">
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">Portland Businesses</h3>
             <span slot="subtitle"
               >by
@@ -318,7 +323,7 @@
         <div class="child">
           <p>thumbnail-position="inline-start"</p>
           <calcite-card thumbnail-position="inline-start">
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">Portland Businesses</h3>
             <span slot="subtitle"
               >by
@@ -360,7 +365,7 @@
         <div class="child">
           <p>thumbnail-position="inline-end"</p>
           <calcite-card thumbnail-position="inline-end">
-            <img slot="thumbnail" alt="Sample image alt" src="https://placem.at/places?w=260&h=160&txt=0" />
+            <img slot="thumbnail" alt="Sample image alt" src="https://placebear.com/280/80" />
             <h3 slot="title">Portland Businesses</h3>
             <span slot="subtitle"
               >by

--- a/packages/calcite-components/src/demos/card.html
+++ b/packages/calcite-components/src/demos/card.html
@@ -35,7 +35,6 @@
         --calcite-card-box-shadow: var(--calcite-shadow-md);
         --calcite-card-title-color: var(--calcite-color-status-success);
         --calcite-card-subtitle-color: var(--calcite-color-status-danger);
-        --calcite-card-content-padding: 24px;
       }
     </style>
     <script src="_assets/head.js"></script>


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds the following public component css properties:
`--calcite-card-background-color`: Specifies the background color of the component.
`--calcite-card-border-color`: Specifies the border color of the component.
`--calcite-card-box-shadow`: Specifies the box shadow of the component.
`--calcite-card-corner-radius`: Specifies the corner radius of the component.
`--calcite-card-subtitle-color`: Specifies the color of the component's `"subtitle"` slot.
`--calcite-card-title-color`: Specifies the color of the component's `"title"` slot.

Adds a Chromatic test and a demo page example. Also replaces broken image links in local demo.