### PR TITLE
fix(list-item): always show hover and pointer styling

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -916,8 +916,6 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
     }
-    interface CalciteCode {
-    }
     interface CalciteColorPicker {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
@@ -1908,6 +1906,11 @@ export namespace Components {
          */
         "groupSeparator": boolean;
         /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden": boolean;
+        /**
           * When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
          */
         "icon": string | boolean;
@@ -2236,6 +2239,11 @@ export namespace Components {
          */
         "groupSeparator": boolean;
         /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden": boolean;
+        /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
          */
@@ -2396,6 +2404,11 @@ export namespace Components {
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
+        /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden": boolean;
         /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
@@ -3717,6 +3730,10 @@ export namespace Components {
          */
         "guid": string;
         /**
+          * When `true`, the component is not displayed and is not focusable or checkable.
+         */
+        "hidden": boolean;
+        /**
           * The hovered state of the component.
          */
         "hovered": boolean;
@@ -3750,6 +3767,10 @@ export namespace Components {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
+        /**
+          * When `true`, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable.
+         */
+        "hidden": boolean;
         /**
           * Defines the layout of the component.
          */
@@ -4938,6 +4959,10 @@ export namespace Components {
          */
         "heading": string;
         /**
+          * When `true`, the component is not displayed and is not focusable.
+         */
+        "hidden": boolean;
+        /**
           * When embed is `"false"`, the URL for the component.
          */
         "href": string;
@@ -4971,6 +4996,10 @@ export namespace Components {
           * The component header text, which displays between the icon and description.
          */
         "heading": string;
+        /**
+          * When `true`, the component is not displayed and is not focusable or checkable.
+         */
+        "hidden": boolean;
         /**
           * Specifies an icon to display.
          */
@@ -5888,12 +5917,6 @@ declare global {
     var HTMLCalciteChipGroupElement: {
         prototype: HTMLCalciteChipGroupElement;
         new (): HTMLCalciteChipGroupElement;
-    };
-    interface HTMLCalciteCodeElement extends Components.CalciteCode, HTMLStencilElement {
-    }
-    var HTMLCalciteCodeElement: {
-        prototype: HTMLCalciteCodeElement;
-        new (): HTMLCalciteCodeElement;
     };
     interface HTMLCalciteColorPickerElementEventMap {
         "calciteColorPickerChange": void;
@@ -7317,7 +7340,6 @@ declare global {
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
-        "calcite-code": HTMLCalciteCodeElement;
         "calcite-color-picker": HTMLCalciteColorPickerElement;
         "calcite-color-picker-hex-input": HTMLCalciteColorPickerHexInputElement;
         "calcite-color-picker-swatch": HTMLCalciteColorPickerSwatchElement;
@@ -8189,8 +8211,6 @@ declare namespace LocalJSX {
     "multiple" | "single" | "single-persist" | "none",
     SelectionMode
   >;
-    }
-    interface CalciteCode {
     }
     interface CalciteColorPicker {
         /**
@@ -9247,6 +9267,11 @@ declare namespace LocalJSX {
          */
         "groupSeparator"?: boolean;
         /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden"?: boolean;
+        /**
           * When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
          */
         "icon"?: string | boolean;
@@ -9588,6 +9613,11 @@ declare namespace LocalJSX {
          */
         "groupSeparator"?: boolean;
         /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden"?: boolean;
+        /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
          */
@@ -9750,6 +9780,11 @@ declare namespace LocalJSX {
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
+        /**
+          * When `true`, the component will not be visible.
+          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
+         */
+        "hidden"?: boolean;
         /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
@@ -11161,6 +11196,10 @@ declare namespace LocalJSX {
          */
         "guid"?: string;
         /**
+          * When `true`, the component is not displayed and is not focusable or checkable.
+         */
+        "hidden"?: boolean;
+        /**
           * The hovered state of the component.
          */
         "hovered"?: boolean;
@@ -11206,6 +11245,10 @@ declare namespace LocalJSX {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled"?: boolean;
+        /**
+          * When `true`, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable.
+         */
+        "hidden"?: boolean;
         /**
           * Defines the layout of the component.
          */
@@ -12419,6 +12462,10 @@ declare namespace LocalJSX {
          */
         "heading"?: string;
         /**
+          * When `true`, the component is not displayed and is not focusable.
+         */
+        "hidden"?: boolean;
+        /**
           * When embed is `"false"`, the URL for the component.
          */
         "href"?: string;
@@ -12452,6 +12499,10 @@ declare namespace LocalJSX {
           * The component header text, which displays between the icon and description.
          */
         "heading"?: string;
+        /**
+          * When `true`, the component is not displayed and is not focusable or checkable.
+         */
+        "hidden"?: boolean;
         /**
           * Specifies an icon to display.
          */
@@ -12858,7 +12909,6 @@ declare namespace LocalJSX {
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
-        "calcite-code": CalciteCode;
         "calcite-color-picker": CalciteColorPicker;
         "calcite-color-picker-hex-input": CalciteColorPickerHexInput;
         "calcite-color-picker-swatch": CalciteColorPickerSwatch;
@@ -12971,7 +13021,6 @@ declare module "@stencil/core" {
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;
-            "calcite-code": LocalJSX.CalciteCode & JSXBase.HTMLAttributes<HTMLCalciteCodeElement>;
             "calcite-color-picker": LocalJSX.CalciteColorPicker & JSXBase.HTMLAttributes<HTMLCalciteColorPickerElement>;
             "calcite-color-picker-hex-input": LocalJSX.CalciteColorPickerHexInput & JSXBase.HTMLAttributes<HTMLCalciteColorPickerHexInputElement>;
             "calcite-color-picker-swatch": LocalJSX.CalciteColorPickerSwatch & JSXBase.HTMLAttributes<HTMLCalciteColorPickerSwatchElement>;

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -916,6 +916,8 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
     }
+    interface CalciteCode {
+    }
     interface CalciteColorPicker {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
@@ -1906,11 +1908,6 @@ export namespace Components {
          */
         "groupSeparator": boolean;
         /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden": boolean;
-        /**
           * When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
          */
         "icon": string | boolean;
@@ -2239,11 +2236,6 @@ export namespace Components {
          */
         "groupSeparator": boolean;
         /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden": boolean;
-        /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
          */
@@ -2404,11 +2396,6 @@ export namespace Components {
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
-        /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden": boolean;
         /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
@@ -3730,10 +3717,6 @@ export namespace Components {
          */
         "guid": string;
         /**
-          * When `true`, the component is not displayed and is not focusable or checkable.
-         */
-        "hidden": boolean;
-        /**
           * The hovered state of the component.
          */
         "hovered": boolean;
@@ -3767,10 +3750,6 @@ export namespace Components {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
-        /**
-          * When `true`, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable.
-         */
-        "hidden": boolean;
         /**
           * Defines the layout of the component.
          */
@@ -4959,10 +4938,6 @@ export namespace Components {
          */
         "heading": string;
         /**
-          * When `true`, the component is not displayed and is not focusable.
-         */
-        "hidden": boolean;
-        /**
           * When embed is `"false"`, the URL for the component.
          */
         "href": string;
@@ -4996,10 +4971,6 @@ export namespace Components {
           * The component header text, which displays between the icon and description.
          */
         "heading": string;
-        /**
-          * When `true`, the component is not displayed and is not focusable or checkable.
-         */
-        "hidden": boolean;
         /**
           * Specifies an icon to display.
          */
@@ -5917,6 +5888,12 @@ declare global {
     var HTMLCalciteChipGroupElement: {
         prototype: HTMLCalciteChipGroupElement;
         new (): HTMLCalciteChipGroupElement;
+    };
+    interface HTMLCalciteCodeElement extends Components.CalciteCode, HTMLStencilElement {
+    }
+    var HTMLCalciteCodeElement: {
+        prototype: HTMLCalciteCodeElement;
+        new (): HTMLCalciteCodeElement;
     };
     interface HTMLCalciteColorPickerElementEventMap {
         "calciteColorPickerChange": void;
@@ -7340,6 +7317,7 @@ declare global {
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
+        "calcite-code": HTMLCalciteCodeElement;
         "calcite-color-picker": HTMLCalciteColorPickerElement;
         "calcite-color-picker-hex-input": HTMLCalciteColorPickerHexInputElement;
         "calcite-color-picker-swatch": HTMLCalciteColorPickerSwatchElement;
@@ -8211,6 +8189,8 @@ declare namespace LocalJSX {
     "multiple" | "single" | "single-persist" | "none",
     SelectionMode
   >;
+    }
+    interface CalciteCode {
     }
     interface CalciteColorPicker {
         /**
@@ -9267,11 +9247,6 @@ declare namespace LocalJSX {
          */
         "groupSeparator"?: boolean;
         /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden"?: boolean;
-        /**
           * When `true`, shows a default recommended icon. Alternatively, pass a Calcite UI Icon name to display a specific icon.
          */
         "icon"?: string | boolean;
@@ -9613,11 +9588,6 @@ declare namespace LocalJSX {
          */
         "groupSeparator"?: boolean;
         /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden"?: boolean;
-        /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
          */
@@ -9780,11 +9750,6 @@ declare namespace LocalJSX {
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
-        /**
-          * When `true`, the component will not be visible.
-          * @mdn [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden)
-         */
-        "hidden"?: boolean;
         /**
           * Specifies an icon to display.
           * @futureBreaking Remove boolean type as it is not supported.
@@ -11196,10 +11161,6 @@ declare namespace LocalJSX {
          */
         "guid"?: string;
         /**
-          * When `true`, the component is not displayed and is not focusable or checkable.
-         */
-        "hidden"?: boolean;
-        /**
           * The hovered state of the component.
          */
         "hovered"?: boolean;
@@ -11245,10 +11206,6 @@ declare namespace LocalJSX {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled"?: boolean;
-        /**
-          * When `true`, the component is not displayed and its `calcite-radio-button`s are not focusable or checkable.
-         */
-        "hidden"?: boolean;
         /**
           * Defines the layout of the component.
          */
@@ -12462,10 +12419,6 @@ declare namespace LocalJSX {
          */
         "heading"?: string;
         /**
-          * When `true`, the component is not displayed and is not focusable.
-         */
-        "hidden"?: boolean;
-        /**
           * When embed is `"false"`, the URL for the component.
          */
         "href"?: string;
@@ -12499,10 +12452,6 @@ declare namespace LocalJSX {
           * The component header text, which displays between the icon and description.
          */
         "heading"?: string;
-        /**
-          * When `true`, the component is not displayed and is not focusable or checkable.
-         */
-        "hidden"?: boolean;
         /**
           * Specifies an icon to display.
          */
@@ -12909,6 +12858,7 @@ declare namespace LocalJSX {
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
+        "calcite-code": CalciteCode;
         "calcite-color-picker": CalciteColorPicker;
         "calcite-color-picker-hex-input": CalciteColorPickerHexInput;
         "calcite-color-picker-swatch": CalciteColorPickerSwatch;
@@ -13021,6 +12971,7 @@ declare module "@stencil/core" {
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;
+            "calcite-code": LocalJSX.CalciteCode & JSXBase.HTMLAttributes<HTMLCalciteCodeElement>;
             "calcite-color-picker": LocalJSX.CalciteColorPicker & JSXBase.HTMLAttributes<HTMLCalciteColorPickerElement>;
             "calcite-color-picker-hex-input": LocalJSX.CalciteColorPickerHexInput & JSXBase.HTMLAttributes<HTMLCalciteColorPickerHexInputElement>;
             "calcite-color-picker-swatch": LocalJSX.CalciteColorPickerSwatch & JSXBase.HTMLAttributes<HTMLCalciteColorPickerSwatchElement>;

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -916,8 +916,6 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
     }
-    interface CalciteCode {
-    }
     interface CalciteColorPicker {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
@@ -5889,12 +5887,6 @@ declare global {
         prototype: HTMLCalciteChipGroupElement;
         new (): HTMLCalciteChipGroupElement;
     };
-    interface HTMLCalciteCodeElement extends Components.CalciteCode, HTMLStencilElement {
-    }
-    var HTMLCalciteCodeElement: {
-        prototype: HTMLCalciteCodeElement;
-        new (): HTMLCalciteCodeElement;
-    };
     interface HTMLCalciteColorPickerElementEventMap {
         "calciteColorPickerChange": void;
         "calciteColorPickerInput": void;
@@ -7317,7 +7309,6 @@ declare global {
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
-        "calcite-code": HTMLCalciteCodeElement;
         "calcite-color-picker": HTMLCalciteColorPickerElement;
         "calcite-color-picker-hex-input": HTMLCalciteColorPickerHexInputElement;
         "calcite-color-picker-swatch": HTMLCalciteColorPickerSwatchElement;
@@ -8189,8 +8180,6 @@ declare namespace LocalJSX {
     "multiple" | "single" | "single-persist" | "none",
     SelectionMode
   >;
-    }
-    interface CalciteCode {
     }
     interface CalciteColorPicker {
         /**
@@ -12858,7 +12847,6 @@ declare namespace LocalJSX {
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
-        "calcite-code": CalciteCode;
         "calcite-color-picker": CalciteColorPicker;
         "calcite-color-picker-hex-input": CalciteColorPickerHexInput;
         "calcite-color-picker-swatch": CalciteColorPickerSwatch;
@@ -12971,7 +12959,6 @@ declare module "@stencil/core" {
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;
-            "calcite-code": LocalJSX.CalciteCode & JSXBase.HTMLAttributes<HTMLCalciteCodeElement>;
             "calcite-color-picker": LocalJSX.CalciteColorPicker & JSXBase.HTMLAttributes<HTMLCalciteColorPickerElement>;
             "calcite-color-picker-hex-input": LocalJSX.CalciteColorPickerHexInput & JSXBase.HTMLAttributes<HTMLCalciteColorPickerHexInputElement>;
             "calcite-color-picker-swatch": LocalJSX.CalciteColorPickerSwatch & JSXBase.HTMLAttributes<HTMLCalciteColorPickerSwatchElement>;

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -67,6 +67,14 @@ describe("calcite-list-item", () => {
     disabled(`<calcite-list-item label="test" active></calcite-list-item>`);
   });
 
+  it("always displays hover class", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-list-item></calcite-list-item>`);
+    await page.waitForChanges();
+
+    expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).not.toBeNull();
+  });
+
   it("renders dragHandle when property is true", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-list-item></calcite-list-item>`);

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -67,14 +67,6 @@ describe("calcite-list-item", () => {
     disabled(`<calcite-list-item label="test" active></calcite-list-item>`);
   });
 
-  it("always displays hover class", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<calcite-list-item></calcite-list-item>`);
-    await page.waitForChanges();
-
-    expect(await page.find(`calcite-list-item >>> .${CSS.containerHover}`)).not.toBeNull();
-  });
-
   it("renders dragHandle when property is true", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-list-item></calcite-list-item>`);

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -671,7 +671,7 @@ export class ListItem
             aria-setsize={setSize}
             class={{
               [CSS.container]: true,
-              [CSS.containerHover]: selectionMode !== "none",
+              [CSS.containerHover]: true,
               [CSS.containerBorder]: showBorder,
               [CSS.containerBorderSelected]: borderSelected,
               [CSS.containerBorderUnselected]: borderUnselected,


### PR DESCRIPTION
**Related Issue:** #6700

## Summary

It was decided that the majority of cases use the layer list to perform some kind of action so the default should be to have hover and pointer styling by default. In the future, we may add another selectionMode to provide a better UX for "non interactive" lists.

Further information: https://github.com/Esri/calcite-design-system/issues/6123#issuecomment-1361770131

- Always has the hover and pointer styling on a list item regardless of selectionMode
- Add e2e test


