### PR TITLE
feat(tab): add `--calcite-tab-content-block-padding` to override built-in block-padding

### DIFF
--- a/packages/calcite-components/src/components/tab/tab.e2e.ts
+++ b/packages/calcite-components/src/components/tab/tab.e2e.ts
@@ -1,4 +1,20 @@
+import { newE2EPage } from "@stencil/core/testing";
 import { defaults, renders, hidden } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
+import { CSS } from "../tab-title/resources";
+
+const tabBlockPadding = html`
+  <calcite-tabs>
+    <calcite-tabs>
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab style="--calcite-block-padding: 0;">
+        <div>Chicken with Pesto</div>
+      </calcite-tab>
+    </calcite-tabs>
+  </calcite-tabs>
+`;
 
 describe("calcite-tab", () => {
   const tabHtml = "<calcite-tab>A tab</calcite-tab>";
@@ -19,5 +35,33 @@ describe("calcite-tab", () => {
       { propertyName: "selected", defaultValue: false },
       { propertyName: "scale", defaultValue: "m" },
     ]);
+  });
+
+  it("should allow the CSS custom property to be overridden when applied to :root", async () => {
+    const overrideStyle = "0px";
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <style>
+        :root {
+          --calcite-block-padding: ${overrideStyle};
+        }
+      </style>
+      ${tabBlockPadding}
+    `);
+    const content = await page.find(`calcite-tab >>> .${CSS.content}`);
+    const contentStyles = await content.getComputedStyle();
+    const contentPadding = contentStyles.getPropertyValue("padding");
+    expect(contentPadding).toEqual(overrideStyle);
+  });
+
+  it("should allow the CSS custom property to be overridden when applied to element", async () => {
+    const overrideStyle = "0px";
+    const page = await newE2EPage();
+    await page.setContent(tabBlockPadding);
+
+    const content = await page.find(`calcite-tab >>> .${CSS.content}`);
+    const contentStyles = await content.getComputedStyle();
+    const contentPadding = await contentStyles.getPropertyValue("padding");
+    expect(contentPadding).toEqual(overrideStyle);
   });
 });

--- a/packages/calcite-components/src/components/tab/tab.e2e.ts
+++ b/packages/calcite-components/src/components/tab/tab.e2e.ts
@@ -1,20 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
 import { defaults, renders, hidden } from "../../tests/commonTests";
-import { html } from "../../../support/formatting";
-import { CSS } from "../tab-title/resources";
-
-const tabBlockPadding = html`
-  <calcite-tabs>
-    <calcite-tabs>
-      <calcite-tab-nav slot="title-group">
-        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
-      </calcite-tab-nav>
-      <calcite-tab style="--calcite-block-padding: 0;">
-        <div>Chicken with Pesto</div>
-      </calcite-tab>
-    </calcite-tabs>
-  </calcite-tabs>
-`;
 
 describe("calcite-tab", () => {
   const tabHtml = "<calcite-tab>A tab</calcite-tab>";
@@ -35,33 +19,5 @@ describe("calcite-tab", () => {
       { propertyName: "selected", defaultValue: false },
       { propertyName: "scale", defaultValue: "m" },
     ]);
-  });
-
-  it("should allow the CSS custom property to be overridden when applied to :root", async () => {
-    const overrideStyle = "0px";
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <style>
-        :root {
-          --calcite-block-padding: ${overrideStyle};
-        }
-      </style>
-      ${tabBlockPadding}
-    `);
-    const content = await page.find(`calcite-tab >>> .${CSS.content}`);
-    const contentStyles = await content.getComputedStyle();
-    const contentPadding = contentStyles.getPropertyValue("padding");
-    expect(contentPadding).toEqual(overrideStyle);
-  });
-
-  it("should allow the CSS custom property to be overridden when applied to element", async () => {
-    const overrideStyle = "0px";
-    const page = await newE2EPage();
-    await page.setContent(tabBlockPadding);
-
-    const content = await page.find(`calcite-tab >>> .${CSS.content}`);
-    const contentStyles = await content.getComputedStyle();
-    const contentPadding = await contentStyles.getPropertyValue("padding");
-    expect(contentPadding).toEqual(overrideStyle);
   });
 });

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-content-space: Specifies the spacing of the component's content in the  `"default"` slot.
+ * @prop --calcite-tab-content-block-padding: Specifies the block padding of the component's content in the `default` slot.
  */
 
 :host([selected]) {
@@ -23,21 +23,22 @@
 
 .content {
   @apply box-border;
+  padding-block: var(--calcite-internal-tab-content-block-padding);
 }
 
 .scale-s .content {
+  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.1"));
   @apply text-n2h;
-  padding-block: var(--calcite-tab-content-space, theme("spacing.1"));
 }
 
 .scale-m .content {
+  --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.2"));
   @apply text-n1h;
-  padding-block: var(--calcite-tab-content-space, theme("spacing.2"));
 }
 
 .scale-l .content {
+  --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.[2.5]"));
   @apply text-0h;
-  padding-block: var(--calcite-tab-content-space, theme("spacing[2.5]"));
 }
 
 section,

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -26,17 +26,17 @@
   padding-block: var(--calcite-internal-tab-content-block-padding);
 }
 
-.scale-s .content {
+.scale-s {
   --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.1"));
   @apply text-n2h;
 }
 
-.scale-m .content {
+.scale-m {
   --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.2"));
   @apply text-n1h;
 }
 
-.scale-l .content {
+.scale-l {
   --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.[2.5]"));
   @apply text-0h;
 }

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -32,12 +32,12 @@
 }
 
 .scale-m {
-  --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.2"));
+  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.2"));
   @apply text-n1h;
 }
 
 .scale-l {
-  --calcite-internal-tab-content-padding: var(--calcite-tab-content-block-padding, theme("spacing.[2.5]"));
+  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.[2.5]"));
   @apply text-0h;
 }
 

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -1,3 +1,11 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
+ */
+
 :host([selected]) {
   section,
   .container {
@@ -18,15 +26,18 @@
 }
 
 .scale-s .content {
-  @apply text-n2h py-1;
+  @apply text-n2h;
+  padding-block: var(--calcite-block-padding, theme("spacing.1"));
 }
 
 .scale-m .content {
-  @apply text-n1h py-2;
+  @apply text-n1h;
+  padding-block: var(--calcite-block-padding, theme("spacing.2"));
 }
 
 .scale-l .content {
-  @apply text-0h py-2.5;
+  @apply text-0h;
+  padding-block: var(--calcite-block-padding, theme("spacing[2.5]"));
 }
 
 section,

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
+ * @prop --calcite-tab-content-space: Specifies the padding of the block `default` slot.
  */
 
 :host([selected]) {
@@ -27,17 +27,17 @@
 
 .scale-s .content {
   @apply text-n2h;
-  padding-block: var(--calcite-block-padding, theme("spacing.1"));
+  padding-block: var(--calcite-tab-content-space, theme("spacing.1"));
 }
 
 .scale-m .content {
   @apply text-n1h;
-  padding-block: var(--calcite-block-padding, theme("spacing.2"));
+  padding-block: var(--calcite-tab-content-space, theme("spacing.2"));
 }
 
 .scale-l .content {
   @apply text-0h;
-  padding-block: var(--calcite-block-padding, theme("spacing[2.5]"));
+  padding-block: var(--calcite-tab-content-space, theme("spacing[2.5]"));
 }
 
 section,

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-content-space: Specifies the padding of the block `default` slot.
+ * @prop --calcite-tab-content-space: Specifies the spacing of the component's content in the  `"default"` slot.
  */
 
 :host([selected]) {

--- a/packages/calcite-components/src/components/tabs/tabs.stories.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.stories.ts
@@ -461,3 +461,16 @@ export const noVerticalScrollbarInsideShellPanel_TestOnly = (): string => html`
     </calcite-shell-panel>
   </calcite-shell>
 `;
+
+export const paddingDisabled_TestOnly = (): string => html`
+  <calcite-panel heading="Properties">
+    <calcite-tabs>
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab style="--calcite-block-padding: 0;">
+        <div>Chicken with Pesto</div>
+      </calcite-tab>
+    </calcite-tabs>
+  </calcite-panel>
+`;

--- a/packages/calcite-components/src/components/tabs/tabs.stories.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.stories.ts
@@ -462,19 +462,6 @@ export const noVerticalScrollbarInsideShellPanel_TestOnly = (): string => html`
   </calcite-shell>
 `;
 
-export const paddingDisabled_TestOnly = (): string => html`
-  <calcite-panel heading="Properties">
-    <calcite-tabs>
-      <calcite-tab-nav slot="title-group">
-        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
-      </calcite-tab-nav>
-      <calcite-tab style="--calcite-block-padding: 0;">
-        <div>Chicken with Pesto</div>
-      </calcite-tab>
-    </calcite-tabs>
-  </calcite-panel>
-`;
-
 export const paddingPropOverrideAtRootLevel = (): string => html`
   <style>
     :root {
@@ -484,10 +471,10 @@ export const paddingPropOverrideAtRootLevel = (): string => html`
   <calcite-tabs>
     <calcite-tabs>
       <calcite-tab-nav slot="title-group">
-        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+        <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       </calcite-tab-nav>
       <calcite-tab>
-        <div>Chicken with Pesto</div>
+        <div>Tab 1 Content</div>
       </calcite-tab>
     </calcite-tabs>
   </calcite-tabs>
@@ -497,10 +484,10 @@ export const paddingPropOverrideAtElementLevel = (): string => html`
   <calcite-tabs>
     <calcite-tabs>
       <calcite-tab-nav slot="title-group">
-        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+        <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       </calcite-tab-nav>
       <calcite-tab style="--calcite-block-padding: 0;">
-        <div>Chicken with Pesto</div>
+        <div>Tab 1 Content</div>
       </calcite-tab>
     </calcite-tabs>
   </calcite-tabs>

--- a/packages/calcite-components/src/components/tabs/tabs.stories.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.stories.ts
@@ -474,3 +474,34 @@ export const paddingDisabled_TestOnly = (): string => html`
     </calcite-tabs>
   </calcite-panel>
 `;
+
+export const paddingPropOverrideAtRootLevel = (): string => html`
+  <style>
+    :root {
+      --calcite-block-padding: 0;
+    }
+  </style>
+  <calcite-tabs>
+    <calcite-tabs>
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab>
+        <div>Chicken with Pesto</div>
+      </calcite-tab>
+    </calcite-tabs>
+  </calcite-tabs>
+`;
+
+export const paddingPropOverrideAtElementLevel = (): string => html`
+  <calcite-tabs>
+    <calcite-tabs>
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title selected>Sandwiches</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab style="--calcite-block-padding: 0;">
+        <div>Chicken with Pesto</div>
+      </calcite-tab>
+    </calcite-tabs>
+  </calcite-tabs>
+`;

--- a/packages/calcite-components/src/components/tabs/tabs.stories.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.stories.ts
@@ -465,7 +465,7 @@ export const noVerticalScrollbarInsideShellPanel_TestOnly = (): string => html`
 export const paddingPropOverrideAtRootLevel = (): string => html`
   <style>
     :root {
-      --calcite-block-padding: 0;
+      --calcite-tab-content-block-padding: 0;
     }
   </style>
   <calcite-tabs>
@@ -486,7 +486,7 @@ export const paddingPropOverrideAtElementLevel = (): string => html`
       <calcite-tab-nav slot="title-group">
         <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
       </calcite-tab-nav>
-      <calcite-tab style="--calcite-block-padding: 0;">
+      <calcite-tab style="--calcite-tab-content-block-padding: 0;">
         <div>Tab 1 Content</div>
       </calcite-tab>
     </calcite-tabs>


### PR DESCRIPTION
**Related Issue:** #8413

## Summary
Introduces a CSS custom property `--calcite-tab-content-block-padding` to align with other components that have built-in padding. 

Currently, the Tab component has a built-in `block-padding` that cannot be overridden in a supported way, leading to a bug with scrollbars when tabs are housed inside a panel. 

The introduction of the custom property allows for more flexibility in the component, as users can achieve their desired layout and padding by adding it to their slotted content. (https://github.com/Esri/calcite-design-system/issues/8139#issuecomment-1830397218)