### PR TITLE
feat(action-bar, action-pad, block, flow-item, panel): add `overlayPositioning` prop for built-in menus

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -9,8 +9,8 @@ import { Alignment, Appearance, Columns, FlipContext, Kind, Layout, LogicalFlowP
 import { RequestedItem } from "./components/accordion/interfaces";
 import { RequestedItem as RequestedItem1 } from "./components/accordion-item/interfaces";
 import { ActionMessages } from "./components/action/assets/action/t9n";
-import { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n";
 import { EffectivePlacement, LogicalPlacement, MenuPlacement, OverlayPositioning, ReferenceElement } from "./utils/floating-ui";
+import { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n";
 import { ActionGroupMessages } from "./components/action-group/assets/action-group/t9n";
 import { ActionPadMessages } from "./components/action-pad/assets/action-pad/t9n";
 import { AlertDuration, Sync } from "./components/alert/interfaces";
@@ -95,8 +95,8 @@ export { Alignment, Appearance, Columns, FlipContext, Kind, Layout, LogicalFlowP
 export { RequestedItem } from "./components/accordion/interfaces";
 export { RequestedItem as RequestedItem1 } from "./components/accordion-item/interfaces";
 export { ActionMessages } from "./components/action/assets/action/t9n";
-export { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n";
 export { EffectivePlacement, LogicalPlacement, MenuPlacement, OverlayPositioning, ReferenceElement } from "./utils/floating-ui";
+export { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n";
 export { ActionGroupMessages } from "./components/action-group/assets/action-group/t9n";
 export { ActionPadMessages } from "./components/action-pad/assets/action-pad/t9n";
 export { AlertDuration, Sync } from "./components/alert/interfaces";
@@ -345,6 +345,10 @@ export namespace Components {
          */
         "overflowActionsDisabled": boolean;
         /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning": OverlayPositioning;
+        /**
           * Arranges the component depending on the element's `dir` property.
          */
         "position": Position;
@@ -463,6 +467,10 @@ export namespace Components {
           * Made into a prop for testing purposes only
          */
         "messages": ActionPadMessages;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning": OverlayPositioning;
         /**
           * Arranges the component depending on the element's `dir` property.
          */
@@ -604,6 +612,10 @@ export namespace Components {
           * When `true`, expands the component and its contents.
          */
         "open": boolean;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning": OverlayPositioning;
         /**
           * Sets focus on the component's first tabbable element.
          */
@@ -1724,6 +1736,10 @@ export namespace Components {
           * Made into a prop for testing purposes only
          */
         "messages": FlowItemMessages;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning": OverlayPositioning;
         /**
           * Scrolls the component's content to a specified set of coordinates.
           * @example myCalciteFlowItem.scrollContentTo({   left: 0, // Specifies the number of pixels along the X axis to scroll the window or element.   top: 0, // Specifies the number of pixels along the Y axis to scroll the window or element   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value). });
@@ -3433,6 +3449,10 @@ export namespace Components {
           * Made into a prop for testing purposes only
          */
         "messages": PanelMessages;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning": OverlayPositioning;
         /**
           * Scrolls the component's content to a specified set of coordinates.
           * @example myCalciteFlowItem.scrollContentTo({   left: 0, // Specifies the number of pixels along the X axis to scroll the window or element.   top: 0, // Specifies the number of pixels along the Y axis to scroll the window or element   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value). });
@@ -7568,6 +7588,10 @@ declare namespace LocalJSX {
          */
         "overflowActionsDisabled"?: boolean;
         /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning"?: OverlayPositioning;
+        /**
           * Arranges the component depending on the element's `dir` property.
          */
         "position"?: Position;
@@ -7682,6 +7706,10 @@ declare namespace LocalJSX {
           * Fires when the `expanded` property is toggled.
          */
         "onCalciteActionPadToggle"?: (event: CalciteActionPadCustomEvent<void>) => void;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning"?: OverlayPositioning;
         /**
           * Arranges the component depending on the element's `dir` property.
          */
@@ -7860,6 +7888,10 @@ declare namespace LocalJSX {
           * When `true`, expands the component and its contents.
          */
         "open"?: boolean;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning"?: OverlayPositioning;
         /**
           * Displays a status-related indicator icon.
          */
@@ -9053,6 +9085,10 @@ declare namespace LocalJSX {
           * Fires when the collapse button is clicked.
          */
         "onCalciteFlowItemToggle"?: (event: CalciteFlowItemCustomEvent<void>) => void;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning"?: OverlayPositioning;
         /**
           * When `true`, displays a back button in the component's header.
          */
@@ -10863,6 +10899,10 @@ declare namespace LocalJSX {
           * Fires when the collapse button is clicked.
          */
         "onCalcitePanelToggle"?: (event: CalcitePanelCustomEvent<void>) => void;
+        /**
+          * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+         */
+        "overlayPositioning"?: OverlayPositioning;
     }
     /**
      * @deprecated Use the `list` component instead.

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -1,6 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, focusable, hidden, reflects, renders, slots, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+  t9n,
+} from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { overflowActionsDebounceInMs } from "./utils";
 import { getFocusedElementProp } from "../../tests/utils";
@@ -32,6 +42,10 @@ describe("calcite-action-bar", () => {
         propertyName: "layout",
         defaultValue: "vertical",
       },
+      {
+        propertyName: "overlayPositioning",
+        defaultValue: "absolute",
+      },
     ]);
   });
 
@@ -45,7 +59,15 @@ describe("calcite-action-bar", () => {
         propertyName: "expanded",
         value: true,
       },
+      {
+        propertyName: "overlayPositioning",
+        value: "fixed",
+      },
     ]);
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-bar", "calcite-action-group");
   });
 
   describe("expand functionality", () => {

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -67,7 +67,12 @@ describe("calcite-action-bar", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-bar", "calcite-action-group");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-action-bar>
+        <calcite-action id="plus" slot="menu-actions" text="Add" icon="plus"></calcite-action>
+      </calcite-action-bar>`,
+      "calcite-action-group",
+    );
   });
 
   describe("expand functionality", () => {

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -48,6 +48,7 @@ import {
   overflowActionsDebounceInMs,
   queryActions,
 } from "./utils";
+import { OverlayPositioning } from "../../utils/floating-ui";
 
 /**
  * @slot - A slot for adding `calcite-action`s that will appear at the top of the component.
@@ -122,6 +123,16 @@ export class ActionBar
     this.resizeObserver?.observe(this.el);
     this.overflowActions();
   }
+
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   *
+   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   *
+   */
+  @Prop({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   /**
    * Arranges the component depending on the element's `dir` property.
@@ -391,6 +402,7 @@ export class ActionBar
       layout,
       messages,
       actionsEndGroupLabel,
+      overlayPositioning,
     } = this;
 
     const expandToggleNode = !expandDisabled ? (
@@ -414,6 +426,7 @@ export class ActionBar
         hidden={this.expandDisabled && !(this.hasActionsEnd || this.hasBottomActions)}
         label={actionsEndGroupLabel}
         layout={layout}
+        overlayPositioning={overlayPositioning}
         scale={scale}
       >
         <slot name={SLOTS.actionsEnd} onSlotchange={this.handleActionsEndSlotChange} />

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -1,6 +1,15 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, focusable, hidden, reflects, renders, slots } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+} from "../../tests/commonTests";
 import { TOOLTIP_OPEN_DELAY_MS } from "../tooltip/resources";
 import { CSS, SLOTS, activeAttr } from "./resources";
 
@@ -82,6 +91,10 @@ describe("calcite-action-menu", () => {
         value: "auto",
       },
     ]);
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-action-menu", "calcite-popover");
   });
 
   it("should emit 'calciteActionMenuOpen' event", async () => {

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -94,7 +94,12 @@ describe("calcite-action-menu", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-action-menu", "calcite-popover");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-action-menu>
+        <calcite-action text="Plus" icon="plus" text-enabled></calcite-action>
+      </calcite-action-menu>`,
+      "calcite-popover",
+    );
   });
 
   it("should emit 'calciteActionMenuOpen' event", async () => {

--- a/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
+++ b/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
@@ -1,5 +1,15 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, focusable, hidden, reflects, renders, slots, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+  t9n,
+} from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { html } from "../../../support/formatting";
 
@@ -27,6 +37,10 @@ describe("calcite-action-pad", () => {
         defaultValue: "vertical",
       },
       {
+        propertyName: "overlayPositioning",
+        defaultValue: "absolute",
+      },
+      {
         propertyName: "scale",
         defaultValue: undefined,
       },
@@ -47,7 +61,15 @@ describe("calcite-action-pad", () => {
         propertyName: "layout",
         value: "horizontal",
       },
+      {
+        propertyName: "overlayPositioning",
+        value: "fixed",
+      },
     ]);
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-pad", "calcite-action-group");
   });
 
   describe("expand functionality", () => {

--- a/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
+++ b/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
@@ -69,7 +69,12 @@ describe("calcite-action-pad", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-pad", "calcite-action-group");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-action-pad>
+        <calcite-action id="plus" slot="menu-actions" text="Add" icon="plus"></calcite-action>
+      </calcite-action-pad>`,
+      "calcite-action-group",
+    );
   });
 
   describe("expand functionality", () => {

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -36,6 +36,7 @@ import { Layout, Position, Scale } from "../interfaces";
 import { ActionPadMessages } from "./assets/action-pad/t9n";
 import { CSS, SLOTS } from "./resources";
 import { createObserver } from "../../utils/observers";
+import { OverlayPositioning } from "../../utils/floating-ui";
 
 /**
  * @slot - A slot for adding `calcite-action`s to the component.
@@ -116,6 +117,16 @@ export class ActionPad
   onMessagesChange(): void {
     /* wired up by t9n util */
   }
+
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   *
+   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   *
+   */
+  @Prop({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   // --------------------------------------------------------------------------
   //
@@ -265,6 +276,7 @@ export class ActionPad
       scale,
       layout,
       actionsEndGroupLabel,
+      overlayPositioning,
     } = this;
 
     const expandToggleNode = !expandDisabled ? (
@@ -287,6 +299,7 @@ export class ActionPad
         class={CSS.actionGroupEnd}
         label={actionsEndGroupLabel}
         layout={layout}
+        overlayPositioning={overlayPositioning}
         scale={scale}
       >
         <slot name={SLOTS.expandTooltip} onSlotchange={this.handleTooltipSlotChange} />

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -1,6 +1,17 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { CSS, SLOTS } from "./resources";
-import { accessible, defaults, disabled, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  disabled,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+  t9n,
+} from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { openClose } from "../../tests/commonTests";
 
@@ -26,6 +37,31 @@ describe("calcite-block", () => {
       {
         propertyName: "open",
         defaultValue: false,
+      },
+      {
+        propertyName: "overlayPositioning",
+        defaultValue: "absolute",
+      },
+    ]);
+  });
+
+  describe("reflects", () => {
+    reflects("calcite-block", [
+      {
+        propertyName: "collapsible",
+        value: true,
+      },
+      {
+        propertyName: "headingLevel",
+        value: 2,
+      },
+      {
+        propertyName: "open",
+        value: true,
+      },
+      {
+        propertyName: "overlayPositioning",
+        value: "fixed",
       },
     ]);
   });
@@ -85,6 +121,10 @@ describe("calcite-block", () => {
 
   describe("disabled", () => {
     disabled(html`<calcite-block heading="heading" description="description" collapsible></calcite-block>`);
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-block", "calcite-action-menu");
   });
 
   it("has a loading state", async () => {

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -124,7 +124,12 @@ describe("calcite-block", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-block", "calcite-action-menu");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-block>
+        <calcite-action label="Add" icon="plus" slot="header-menu-actions"></calcite-action>
+      </calcite-block>`,
+      "calcite-action-menu",
+    );
   });
 
   it("has a loading state", async () => {

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -43,6 +43,7 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
+import { OverlayPositioning } from "../../utils/floating-ui";
 
 /**
  * @slot - A slot for adding custom content.
@@ -139,6 +140,16 @@ export class Block
   onMessagesChange(): void {
     /* wired up by t9n util */
   }
+
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   *
+   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   *
+   */
+  @Prop({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   //--------------------------------------------------------------------------
   //
@@ -364,7 +375,10 @@ export class Block
           </div>
         ) : null}
         {hasMenuActions ? (
-          <calcite-action-menu label={messages.options}>
+          <calcite-action-menu
+            label={messages.options}
+            overlayPositioning={this.overlayPositioning}
+          >
             <slot name={SLOTS.headerMenuActions} />
           </calcite-action-menu>
         ) : null}

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -156,7 +156,12 @@ describe("calcite-flow-item", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-flow-item", "calcite-panel");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-flow-item>
+        <calcite-action text="measure" text-enabled icon="measure" slot="header-menu-actions"></calcite-action>
+      </calcite-flow-item>`,
+      "calcite-panel",
+    );
   });
 
   it("showBackButton", async () => {

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -1,5 +1,16 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, disabled, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  disabled,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+  t9n,
+} from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 import { html } from "../../../support/formatting";
 
@@ -47,8 +58,57 @@ describe("calcite-flow-item", () => {
         defaultValue: false,
       },
       {
+        propertyName: "overlayPositioning",
+        defaultValue: "absolute",
+      },
+      {
         propertyName: "showBackButton",
         defaultValue: false,
+      },
+    ]);
+  });
+
+  describe("reflects", () => {
+    reflects("calcite-flow-item", [
+      {
+        propertyName: "closable",
+        value: true,
+      },
+      {
+        propertyName: "closed",
+        value: true,
+      },
+      {
+        propertyName: "collapsible",
+        value: true,
+      },
+      {
+        propertyName: "collapseDirection",
+        value: "up",
+      },
+      {
+        propertyName: "collapsed",
+        value: true,
+      },
+      {
+        propertyName: "disabled",
+        value: true,
+      },
+      {
+        propertyName: "loading",
+        value: true,
+      },
+      {
+        propertyName: "menuOpen",
+        value: true,
+      },
+      {
+        propertyName: "overlayPositioning",
+        value: "fixed",
+      },
+      {
+        propertyName: "showBackButton",
+        value: true,
       },
     ]);
   });
@@ -93,6 +153,10 @@ describe("calcite-flow-item", () => {
 
   describe("translation support", () => {
     t9n("calcite-flow-item");
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-flow-item", "calcite-panel");
   });
 
   it("showBackButton", async () => {

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -83,10 +83,6 @@ describe("calcite-flow-item", () => {
         value: true,
       },
       {
-        propertyName: "collapseDirection",
-        value: "up",
-      },
-      {
         propertyName: "collapsed",
         value: true,
       },
@@ -105,10 +101,6 @@ describe("calcite-flow-item", () => {
       {
         propertyName: "overlayPositioning",
         value: "fixed",
-      },
-      {
-        propertyName: "showBackButton",
-        value: true,
       },
     ]);
   });

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -37,6 +37,7 @@ import { HeadingLevel } from "../functional/Heading";
 import { SLOTS as PANEL_SLOTS } from "../panel/resources";
 import { FlowItemMessages } from "./assets/flow-item/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
+import { OverlayPositioning } from "../../utils/floating-ui";
 
 /**
  * @slot - A slot for adding custom content.
@@ -138,6 +139,16 @@ export class FlowItem
    */
   // eslint-disable-next-line @stencil-community/strict-mutable -- updated by t9n module
   @Prop({ mutable: true }) messages: FlowItemMessages;
+
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   *
+   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   *
+   */
+  @Prop({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   /**
    * When `true`, displays a back button in the component's header.
@@ -344,6 +355,7 @@ export class FlowItem
       loading,
       menuOpen,
       messages,
+      overlayPositioning,
     } = this;
     return (
       <Host>
@@ -364,6 +376,7 @@ export class FlowItem
             onCalcitePanelClose={this.handlePanelClose}
             onCalcitePanelScroll={this.handlePanelScroll}
             onCalcitePanelToggle={this.handlePanelToggle}
+            overlayPositioning={overlayPositioning}
             // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
             ref={this.setContainerRef}
           >

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -1,6 +1,17 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, disabled, focusable, hidden, renders, slots, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  delegatesToFloatingUiOwningComponent,
+  disabled,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  slots,
+  t9n,
+} from "../../tests/commonTests";
 import { CSS, SLOTS } from "./resources";
 
 const panelTemplate = (scrollable = false) =>
@@ -44,6 +55,39 @@ describe("calcite-panel", () => {
         propertyName: "collapsed",
         defaultValue: false,
       },
+      {
+        propertyName: "overlayPositioning",
+        defaultValue: "absolute",
+      },
+    ]);
+  });
+
+  describe("reflects", () => {
+    reflects("calcite-panel", [
+      {
+        propertyName: "widthScale",
+        value: "s",
+      },
+      {
+        propertyName: "headingLevel",
+        value: 2,
+      },
+      {
+        propertyName: "collapsible",
+        value: true,
+      },
+      {
+        propertyName: "collapseDirection",
+        value: "end",
+      },
+      {
+        propertyName: "collapsed",
+        value: true,
+      },
+      {
+        propertyName: "overlayPositioning",
+        value: "fixed",
+      },
     ]);
   });
 
@@ -57,6 +101,10 @@ describe("calcite-panel", () => {
 
   describe("translation support", () => {
     t9n("calcite-panel");
+  });
+
+  describe("delegates to floating-ui-owner component", () => {
+    delegatesToFloatingUiOwningComponent("calcite-panel", "calcite-flow-item");
   });
 
   it("honors closed prop", async () => {

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -65,20 +65,12 @@ describe("calcite-panel", () => {
   describe("reflects", () => {
     reflects("calcite-panel", [
       {
-        propertyName: "widthScale",
-        value: "s",
-      },
-      {
         propertyName: "headingLevel",
         value: 2,
       },
       {
         propertyName: "collapsible",
         value: true,
-      },
-      {
-        propertyName: "collapseDirection",
-        value: "end",
       },
       {
         propertyName: "collapsed",
@@ -108,7 +100,7 @@ describe("calcite-panel", () => {
       html`<calcite-panel>
         <calcite-action text="measure" text-enabled icon="measure" slot="header-menu-actions"></calcite-action>
       </calcite-panel>`,
-      "calcite-flow-item",
+      "calcite-action-menu",
     );
   });
 

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -104,7 +104,12 @@ describe("calcite-panel", () => {
   });
 
   describe("delegates to floating-ui-owner component", () => {
-    delegatesToFloatingUiOwningComponent("calcite-panel", "calcite-flow-item");
+    delegatesToFloatingUiOwningComponent(
+      html`<calcite-panel>
+        <calcite-action text="measure" text-enabled icon="measure" slot="header-menu-actions"></calcite-action>
+      </calcite-panel>`,
+      "calcite-flow-item",
+    );
   });
 
   it("honors closed prop", async () => {

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -43,6 +43,7 @@ import {
   updateMessages,
 } from "../../utils/t9n";
 import { PanelMessages } from "./assets/panel/t9n";
+import { OverlayPositioning } from "../../utils/floating-ui";
 
 /**
  * @slot - A slot for adding custom content.
@@ -139,6 +140,16 @@ export class Panel
   onMessagesChange(): void {
     /* wired up by t9n util */
   }
+
+  /**
+   * Determines the type of positioning to use for the overlaid content.
+   *
+   * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
+   *
+   * `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
+   *
+   */
+  @Prop({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   //--------------------------------------------------------------------------
   //
@@ -477,6 +488,7 @@ export class Panel
         key="menu"
         label={messages.options}
         open={menuOpen}
+        overlayPositioning={this.overlayPositioning}
         placement="bottom-end"
       >
         <calcite-action

--- a/packages/calcite-components/src/tests/commonTests.ts
+++ b/packages/calcite-components/src/tests/commonTests.ts
@@ -1377,6 +1377,40 @@ export function floatingUIOwner(
 }
 
 /**
+ * Helper to test if a component has a floating-UI-owning component wired up.
+ *
+ * Note: this performs a shallow test and assumes the underlying component has floating-ui properly configured.
+ *
+ * @example
+ * describe("delegates to floating-ui-owner component", () => {
+ *   delegatesToFloatingUiOwningComponent("calcite-pad", "calcite-action-group");
+ * });
+ *
+ * @param componentTagOrHTML
+ * @param floatingUiOwnerComponentTag
+ */
+export async function delegatesToFloatingUiOwningComponent(
+  componentTagOrHTML: TagOrHTML,
+  floatingUiOwnerComponentTag: ComponentTag,
+): Promise<void> {
+  it("delegates to floating-ui owning component", async () => {
+    const page = await simplePageSetup(componentTagOrHTML);
+    const tag = getTag(componentTagOrHTML);
+
+    // we assume if `overlay-positioning` is used by an internal component that it is a floating-ui component
+
+    const floatingUiOwningComponent = await page.find(`${tag} >>> ${floatingUiOwnerComponentTag}`);
+    expect(await floatingUiOwningComponent.getProperty("overlayPositioning")).toBe("absolute");
+
+    const component = await page.find(tag);
+    await component.setProperty("overlayPositioning", "fixed");
+    await page.waitForChanges();
+
+    expect(await floatingUiOwningComponent.getProperty("overlayPositioning")).toBe("fixed");
+  });
+}
+
+/**
  * Helper to test t9n component setup.
  *
  * Note that this helper should be used within a describe block.


### PR DESCRIPTION
**Related Issue:** #8620

## Summary

This allows users to specify `overlayPositioning` to help escape scrolling containers for underlying menus.

**Note**: this adds a new helper (`delegatesToFloatingUiOwningComponent`) to shallowly test if a component has a floating-ui-owning component wired up.
