### PR TITLE
fix(tile-select): ensure supporting components are auto-defined

### DIFF
--- a/packages/calcite-components/src/components/tile-select/tile-select.tsx
+++ b/packages/calcite-components/src/components/tile-select/tile-select.tsx
@@ -275,9 +275,11 @@ export class TileSelect implements InteractiveComponent, LoadableComponent {
   // --------------------------------------------------------------------------
 
   private renderInput(): void {
-    this.input = document.createElement(
-      this.type === "radio" ? "calcite-radio-button" : "calcite-checkbox",
-    );
+    this.input =
+      this.type === "radio"
+        ? /* we need to call createElement(x) separately to ensure supporting components are properly bundled */
+          document.createElement("calcite-radio-button")
+        : document.createElement("calcite-checkbox");
     this.input.checked = this.checked;
     this.input.disabled = this.disabled;
     this.input.hidden = this.el.hidden;


### PR DESCRIPTION
**Related Issue:** #8495 

## Summary

This fixes an issue that prevented the Stencil build from including supporting components from being auto-defined in the `components` output target.