### PR TITLE
fix(combobox): ensure supporting components are auto-defined

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1221,7 +1221,7 @@ export class Combobox
       if (!this.isMulti()) {
         this.toggleSelection(this.selectedItems[this.selectedItems.length - 1], false);
       }
-      const item = document.createElement(ComboboxItem) as HTMLCalciteComboboxItemElement;
+      const item = document.createElement("calcite-combobox-item");
       item.value = value;
       item.textLabel = value;
       item.selected = true;


### PR DESCRIPTION
**Related Issue:** #8495 

## Summary

This fixes an issue that prevented the Stencil build from including supporting components from being auto-defined in the components output target. 

This probably wasn't noticeable since in `combobox` and `combobox-item`s are expected to be used together.