### PR TITLE
fix(list-item): Do not focus on item cells on focusIn

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -717,19 +717,19 @@ export class ListItem
   };
 
   private focusCellHandle = (): void => {
-    this.focusCell(this.handleGridEl);
+    this.handleCellFocusIn(this.handleGridEl);
   };
 
   private focusCellActionsStart = (): void => {
-    this.focusCell(this.actionsStartEl);
+    this.handleCellFocusIn(this.actionsStartEl);
   };
 
   private focusCellContent = (): void => {
-    this.focusCell(this.contentEl);
+    this.handleCellFocusIn(this.contentEl);
   };
 
   private focusCellActionsEnd = (): void => {
-    this.focusCell(this.actionsEndEl);
+    this.handleCellFocusIn(this.actionsEndEl);
   };
 
   private emitCalciteInternalListItemChange(): void {
@@ -894,8 +894,19 @@ export class ListItem
     this.focusCell(null);
   };
 
-  private focusCell = (focusEl: HTMLTableCellElement, saveFocusIndex = true): void => {
+  private handleCellFocusIn = (focusEl: HTMLTableCellElement): void => {
+    this.setFocusCell(focusEl, getFirstTabbable(focusEl), true);
+  };
+
+  // Only one cell within a list-item should be focusable at a time. Ensures the active cell is focusable.
+  private setFocusCell = (
+    focusEl: HTMLTableCellElement,
+    focusedEl: HTMLElement,
+    saveFocusIndex: boolean,
+  ): void => {
     const { parentListEl } = this;
+
+    focusEl.tabIndex = focusEl === focusedEl ? 0 : -1;
 
     if (saveFocusIndex) {
       focusMap.set(parentListEl, null);
@@ -908,13 +919,19 @@ export class ListItem
       tableCell.removeAttribute(activeCellTestAttribute);
     });
 
+    focusEl.setAttribute(activeCellTestAttribute, "");
+
+    if (saveFocusIndex) {
+      focusMap.set(parentListEl, gridCells.indexOf(focusEl));
+    }
+  };
+
+  private focusCell = (focusEl: HTMLTableCellElement | null, saveFocusIndex = true): void => {
     const focusedEl = getFirstTabbable(focusEl);
 
-    // Only one cell within a list-item should be focusable at a time. Ensures the active cell is focusable.
     if (focusEl) {
       focusEl.tabIndex = focusEl === focusedEl ? 0 : -1;
-      saveFocusIndex && focusMap.set(parentListEl, gridCells.indexOf(focusEl));
-      focusEl.setAttribute(activeCellTestAttribute, "");
+      this.setFocusCell(focusEl, focusedEl, saveFocusIndex);
     }
 
     focusedEl?.focus();

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -900,13 +900,11 @@ export class ListItem
 
   // Only one cell within a list-item should be focusable at a time. Ensures the active cell is focusable.
   private setFocusCell = (
-    focusEl: HTMLTableCellElement,
+    focusEl: HTMLTableCellElement | null,
     focusedEl: HTMLElement,
     saveFocusIndex: boolean,
   ): void => {
     const { parentListEl } = this;
-
-    focusEl.tabIndex = focusEl === focusedEl ? 0 : -1;
 
     if (saveFocusIndex) {
       focusMap.set(parentListEl, null);
@@ -919,6 +917,11 @@ export class ListItem
       tableCell.removeAttribute(activeCellTestAttribute);
     });
 
+    if (!focusEl) {
+      return;
+    }
+
+    focusEl.tabIndex = focusEl === focusedEl ? 0 : -1;
     focusEl.setAttribute(activeCellTestAttribute, "");
 
     if (saveFocusIndex) {
@@ -928,12 +931,7 @@ export class ListItem
 
   private focusCell = (focusEl: HTMLTableCellElement | null, saveFocusIndex = true): void => {
     const focusedEl = getFirstTabbable(focusEl);
-
-    if (focusEl) {
-      focusEl.tabIndex = focusEl === focusedEl ? 0 : -1;
-      this.setFocusCell(focusEl, focusedEl, saveFocusIndex);
-    }
-
+    this.setFocusCell(focusEl, focusedEl, saveFocusIndex);
     focusedEl?.focus();
   };
 }

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -857,22 +857,27 @@ describe("calcite-list", () => {
       await page.waitForChanges();
 
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toBe("item1");
 
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toBe("action1");
 
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toBe("action2");
 
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toBe("action3");
 
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toBe("action4");
     });

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -822,6 +822,61 @@ describe("calcite-list", () => {
       expect(await one.getProperty("open")).toBe(false);
     });
 
+    it("should allow tabbing through slotted actions within a cell", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-list>
+          <calcite-list-item
+            id="item1"
+            label="Hiking trails"
+            description="Designated routes for hikers to use."
+            value="hiking-trails"
+          >
+            <calcite-action
+              id="action1"
+              slot="actions-start"
+              icon="gear"
+              text="Setup the trails layer"
+            ></calcite-action>
+            <calcite-action
+              id="action2"
+              slot="actions-start"
+              icon="hammer"
+              text="Troubleshoot the trails layer"
+            ></calcite-action>
+            <calcite-action
+              id="action3"
+              slot="actions-end"
+              icon="bookmark"
+              text="Bookmark trails layer"
+            ></calcite-action>
+            <calcite-action id="action4" slot="actions-end" icon="plus" text="Add trails layer"></calcite-action>
+          </calcite-list-item>
+        </calcite-list> `,
+      );
+      await page.waitForChanges();
+
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedElementProp(page, "id")).toBe("item1");
+
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedElementProp(page, "id")).toBe("action1");
+
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedElementProp(page, "id")).toBe("action2");
+
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedElementProp(page, "id")).toBe("action3");
+
+      await page.keyboard.press("Tab");
+
+      expect(await getFocusedElementProp(page, "id")).toBe("action4");
+    });
+
     it("should navigate after focusing within a cell", async () => {
       const page = await newE2EPage();
       await page.setContent(html`


### PR DESCRIPTION
**Related Issue:** #8664

## Summary

- Fixes tabbing through slotted elements within the list-item.
- When focusin occurs, do not focus the element, instead just save the cell index.