### PR TITLE
refactor(button): optimize for component tokens

### DIFF
--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -4,29 +4,11 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-button-background-color: Specifies the background color of the component.
- * @prop --calcite-button-background-color-hover: Specifies the background color of the component when in hover state.
- * @prop --calcite-button-background-color-focus: Specifies the background color of the component when in focus state.
- * @prop --calcite-button-background-color-active: Specifies the background color of the component when in active state.
  * @prop --calcite-button-text-color: Specifies the text color of the component.
- * @prop --calcite-button-text-color-hover: Specifies the text color of the component when in hover state.
- * @prop --calcite-button-text-color-focus: Specifies the text color of the component when in focus state.
- * @prop --calcite-button-text-color-active: Specifies the text color of the component when in active state.
  * @prop --calcite-button-icon-start-color: Specifies the color of the component's start position icon.
- * @prop --calcite-button-icon-start-color-hover: Specifies the color of the component's start position icon when in hover state.
- * @prop --calcite-button-icon-start-color-focus: Specifies the color of the component's start position icon when in focus state.
- * @prop --calcite-button-icon-start-color-active: Specifies the color of the component's start position icon when in active state.
  * @prop --calcite-button-icon-end-color: Specifies the color of the component's end position icon.
- * @prop --calcite-button-icon-end-color-hover: Specifies the color of the component's end position icon when in hover state.
- * @prop --calcite-button-icon-end-color-focus: Specifies the color of the component's end position icon when in focus state.
- * @prop --calcite-button-icon-end-color-active: Specifies the color of the component's end position icon when in active state.
  * @prop --calcite-button-box-shadow: Specifies the box shadow of the component.
- * @prop --calcite-button-box-shadow-hover: Specifies the box shadow of the component when in hover state.
- * @prop --calcite-button-box-shadow-focus: Specifies the box shadow of the component when in focus state.
- * @prop --calcite-button-box-shadow-active: Specifies the box shadow of the component when in active state.
  * @prop --calcite-button-border-color: Specifies border colors of the component.
- * @prop --calcite-button-border-color-hover: Specifies border colors of the component when in hover state.
- * @prop --calcite-button-border-color-focus: Specifies border colors of the component when in focus state.
- * @prop --calcite-button-border-color-active: Specifies border colors of the component when in active state.
  */
 
 :host {
@@ -34,92 +16,39 @@
   --calcite-button-text-color: var(--calcite-color-text-inverse);
   --calcite-button-box-shadow: var(--calcite-shadow-none);
   --calcite-button-border-color: var(--calcite-color-transparent);
-  --calcite-button-corner-radius: var(--calcite-corner-radius-sharp);
+  --calcite-button-corner-radius: var(--calcite-corner-radius);
   --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
   --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
-
-  /* hover */
-  --calcite-button-text-color-hover: var(--calcite-color-text-inverse-hover);
-  --calcite-button-background-color-hover: var(--calcite-color-background);
-  --calcite-button-border-color-hover: var(--calcite-color-transparent);
-  --calcite-button-box-shadow-hover: var(--calcite-shadow-none);
-  --calcite-button-icon-start-color-hover: var(--calcite-color-text-inverse-hover);
-  --calcite-button-icon-end-color-hover: var(--calcite-color-text-inverse-hover);
-
-  /* focus */
-  --calcite-button-text-color-focus: var(--calcite-color-text-inverse-hover);
-  --calcite-button-background-color-focus: var(--calcite-color-background);
-  --calcite-button-border-color-focus: var(--calcite-color-transparent);
-  --calcite-button-box-shadow-focus: var(--calcite-shadow-none);
-  --calcite-button-icon-start-color-focus: var(--calcite-color-text-inverse-focus);
-  --calcite-button-icon-end-color-focus: var(--calcite-color-text-inverse-focus);
-
-  /* active */
-  --calcite-button-text-color-active: var(--calcite-color-text-inverse-press);
-  --calcite-button-background-color-active: var(--calcite-color-background);
-  --calcite-button-border-color-active: var(--calcite-color-transparent);
-  --calcite-button-box-shadow-active: var(--calcite-shadow-none);
-  --calcite-button-icon-start-color-active: var(--calcite-color-text-inverse-active);
-  --calcite-button-icon-end-color-active: var(--calcite-color-text-inverse-active);
+  --calcite-button-box-shadow: inset 0 0 0 1px var(--calcite-button-box-shadow-color);
 
   @apply inline-block w-auto align-middle;
+  border-radius: var(--calcite-button-corner-radius);
 }
 
 /* fab variants */
 :host([round]) {
-  border-radius: 50px;
-  & a,
-  & button {
-    border-radius: 50px;
-  }
-}
-
-/* focus styles */
-:host button,
-:host a {
-  @apply focus-base;
-  &:focus {
-    @apply focus-outset;
-  }
+  --calcite-corner-radius: 50px;
 }
 
 .content {
-  margin-inline: var(--calcite-internal-button-content-margin);
+  margin-inline-start: var(--calcite-internal-button-content-margin-start);
+  margin-inline-end: var(--calcite-internal-button-content-margin-end);
 }
 
 .icon-start-empty {
-  .content {
-    margin-inline-start: unset;
-  }
+  --calcite-internal-button-content-margin-start: unset;
 }
 .icon-end-empty {
-  .content {
-    margin-inline-end: unset;
-  }
-}
-
-:host([scale="m"]) {
-  button,
-  a {
-    --calcite-internal-button-content-margin: theme("margin.3");
-  }
-}
-:host([scale="l"]) {
-  button,
-  a {
-    --calcite-internal-button-content-margin: theme("margin.4");
-  }
+  --calcite-internal-button-content-margin-end: unset;
 }
 
 /* button width */
 :host([width="auto"]) {
   @apply w-auto;
 }
-
 :host([width="half"]) {
   @apply w-2/4;
 }
-
 :host([width="full"]) {
   @apply w-full;
 }
@@ -169,12 +98,9 @@
 }
 
 /* only two icons */
-:host([alignment="center"]) {
-  a:not(.content--slotted),
-  button:not(.content--slotted) {
-    .icon--start + .icon--end {
-      margin-inline-start: var(--calcite-internal-button-content-margin);
-    }
+:host([alignment="center"]:not(:has(.content--slotted))) {
+  .icon + .icon {
+    margin-inline-start: var(--calcite-internal-button-content-margin-start);
   }
 }
 
@@ -224,40 +150,44 @@
     &.loading-in {
       animation-name: loader-in;
       animation-duration: var(--calcite-internal-animation-timing-slow);
+      animation-play-state: paused;
     }
     &.loading-out {
       animation-name: loader-out;
       animation-duration: var(--calcite-internal-animation-timing-slow);
+      animation-play-state: paused;
     }
   }
 }
 
 :host([loading]) {
   /* center loading spinner when button has text */
-  button.content--slotted,
-  a.content--slotted {
+  .content--slotted {
     .calcite-button--loader calcite-loader {
       margin-inline-end: var(--calcite-internal-button-content-margin);
+      animation-play-state: running;
     }
   }
   /* hide icons when loading with no text */
-  button:not(.content--slotted),
-  a:not(.content--slotted) {
-    .icon--start,
-    .icon--end {
-      @apply hidden;
+  button,
+  a {
+    &:not(.content--slotted) {
+      .icon--start,
+      .icon--end {
+        @apply hidden;
+      }
     }
   }
 }
 
 /* button base */
-:host button,
-:host a {
-  --calcite-internal-button-content-margin: theme("margin.2");
+button,
+a {
+  --calcite-internal-button-content-margin-start: theme("margin.2");
+  --calcite-internal-button-content-margin-end: theme("margin.2");
   --calcite-internal-button-padding-x: 7px;
   --calcite-internal-button-padding-y: 3px;
-  padding-block: var(--calcite-internal-button-padding-y);
-  padding-inline: var(--calcite-internal-button-padding-x);
+
   @apply font-inherit
     relative
     box-border
@@ -269,421 +199,270 @@
     appearance-none
     items-center
     justify-center
-    rounded-none
     border-none
     text-center
     font-normal
-    no-underline;
+    no-underline
+    focus-base;
+
+  padding-block: var(--calcite-internal-button-padding-y);
+  padding-inline: var(--calcite-internal-button-padding-x);
+  outline-color: transparent;
+  border-radius: var(--calcite-button-corner-radius);
+  box-shadow: var(--calcite-button-box-shadow);
+  color: var(--calcite-button-text-color);
+  background-color: var(--calcite-button-background-color);
+  border: var(--calcite-border-width-sm) solid var(--calcite-button-border-color);
   /* include transition from focus */
   transition:
     color var(--calcite-animation-timing) ease-in-out,
     background-color var(--calcite-animation-timing) ease-in-out,
     box-shadow var(--calcite-animation-timing) ease-in-out,
     outline-color var(--calcite-internal-animation-timing-fast) ease-in-out;
+
   &:hover {
     @apply no-underline;
   }
-  & span {
+  &:focus {
+    @apply focus-outset;
+  }
+
+  span {
     @apply truncate;
   }
 }
 
-/* assign component tokens as values to button properties */
-:host {
-  button,
-  a {
-    color: var(--calcite-button-text-color);
-    background-color: var(--calcite-button-background-color);
-    border: var(--calcite-border-width-sm) solid var(--calcite-button-border-color);
-    box-shadow: var(--calcite-button-box-shadow);
-
-    .icon--start {
-      color: var(--calcite-button-icon-start-color);
-    }
-    .icon--end {
-      color: var(--calcite-button-icon-end-color);
-    }
-
-    &:hover {
-      color: var(--calcite-button-text-color-hover);
-      background-color: var(--calcite-button-background-color-hover);
-      border-color: var(--calcite-button-border-color-hover);
-      box-shadow: var(--calcite-button-box-shadow-hover);
-
-      .icon--start {
-        color: var(--calcite-button-icon-start-color-hover);
-      }
-      .icon--end {
-        color: var(--calcite-button-icon-end-color-hover);
-      }
-    }
-    &:focus {
-      color: var(--calcite-button-text-color-focus);
-      background-color: var(--calcite-button-background-color-focus);
-      border-color: var(--calcite-button-border-color-focus);
-      box-shadow: var(--calcite-button-box-shadow-focus);
-
-      .icon--start {
-        color: var(--calcite-button-icon-start-color-focus);
-      }
-      .icon--end {
-        color: var(--calcite-button-icon-end-color-focus);
-      }
-    }
-    &:active {
-      color: var(--calcite-button-text-color-active);
-      background-color: var(--calcite-button-background-color-active);
-      border-color: var(--calcite-button-border-color-active);
-      box-shadow: var(--calcite-button-box-shadow-active);
-
-      .icon--start {
-        color: var(--calcite-button-icon-start-color-active);
-      }
-      .icon--end {
-        color: var(--calcite-button-icon-end-color-active);
-      }
-    }
-  }
+.icon--start {
+  color: var(--calcite-button-icon-start-color);
+}
+.icon--end {
+  color: var(--calcite-button-icon-end-color);
 }
 
 /* button styles */
 /* solid */
 :host([kind="brand"]) {
-  button,
-  a {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-hover: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-focus: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-active: var(--calcite-color-text-inverse);
-    --calcite-button-background-color: var(--calcite-color-brand);
-    --calcite-button-background-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-background-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-background-color-active: var(--calcite-color-brand-press);
-    --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
-    --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-  }
+  --calcite-button-text-color: var(--calcite-color-text-inverse);
+  --calcite-button-background-color: var(--calcite-color-brand);
+  --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
+  --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
+}
+:host([kind="brand"][appearance="solid"]:hover),
+:host([kind="brand"][appearance="solid"]:focus) {
+  --calcite-button-background-color: var(--calcite-color-brand-hover);
+  --calcite-button-border-color: var(--calcite-color-brand-hover);
+  --calcite-button-box-shadow-color: var(--calcite-color-brand-hover);
+}
+:host([kind="brand"]:active) {
+  --calcite-button-background-color: var(--calcite-color-brand-press);
 }
 
 :host([kind="danger"]) {
-  button,
-  a {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-hover: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-focus: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-active: var(--calcite-color-text-inverse);
-    --calcite-button-background-color: var(--calcite-color-status-danger);
-    --calcite-button-background-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-background-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-background-color-active: var(--calcite-color-status-danger-press);
-    --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
-    --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-  }
+  --calcite-button-text-color: var(--calcite-color-text-inverse);
+  --calcite-button-background-color: var(--calcite-color-status-danger);
+  --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
+  --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
+}
+:host([kind="danger"][appearance="solid"]:hover),
+:host([kind="danger"][appearance="solid"]:focus) {
+  --calcite-button-background-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-border-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-box-shadow-color: var(--calcite-color-status-danger-hover);
+}
+:host([kind="danger"]:active) {
+  --calcite-button-background-color: var(--calcite-color-status-danger-press);
 }
 
 :host([kind="neutral"]) {
-  button,
-  a {
-    --calcite-button-text-color: var(--calcite-color-text-1);
-    --calcite-button-text-color-hover: var(--calcite-color-text-1);
-    --calcite-button-text-color-focus: var(--calcite-color-text-1);
-    --calcite-button-text-color-active: var(--calcite-color-text-1);
-    --calcite-button-background-color: var(--calcite-color-foreground-3);
-    --calcite-button-background-color-hover: var(--calcite-color-foreground-2);
-    --calcite-button-background-color-focus: var(--calcite-color-foreground-2);
-    --calcite-button-background-color-active: var(--calcite-color-foreground-1);
-    --calcite-button-icon-start-color: var(--calcite-color-text-1);
-    --calcite-button-icon-end-color: var(--calcite-color-text-1);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-1);
-  }
+  --calcite-button-text-color: var(--calcite-color-text-1);
+  --calcite-button-background-color: var(--calcite-color-foreground-3);
+  --calcite-button-icon-start-color: var(--calcite-color-text-1);
+  --calcite-button-icon-end-color: var(--calcite-color-text-1);
+}
+:host([kind="neutral"][appearance="solid"]:hover),
+:host([kind="neutral"][appearance="solid"]:is(:hover, :focus)) {
+  --calcite-button-background-color: var(--calcite-color-foreground-2);
+  --calcite-button-border-color: var(--calcite-color-foreground-2);
+  --calcite-button-box-shadow-color: var(--calcite-color-foreground-2);
+}
+:host([kind="neutral"]:active) {
+  --calcite-button-background-color: var(--calcite-color-foreground-1);
 }
 
 :host([kind="inverse"]) {
-  button,
-  a {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-hover: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-focus: var(--calcite-color-text-inverse);
-    --calcite-button-text-color-active: var(--calcite-color-text-inverse);
-    --calcite-button-background-color: var(--calcite-color-inverse);
-    --calcite-button-background-color-hover: var(--calcite-color-inverse-hover);
-    --calcite-button-background-color-focus: var(--calcite-color-inverse-hover);
-    --calcite-button-background-color-active: var(--calcite-color-inverse-press);
-    --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
-    --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
-  }
+  --calcite-button-text-color: var(--calcite-color-text-inverse);
+  --calcite-button-background-color: var(--calcite-color-inverse);
+  --calcite-button-icon-start-color: var(--calcite-color-text-inverse);
+  --calcite-button-icon-end-color: var(--calcite-color-text-inverse);
+}
+:host([kind="inverse"][appearance="solid"]:is(:hover, :focus)) {
+  --calcite-button-background-color: var(--calcite-color-inverse-hover);
+  --calcite-button-border-color: var(--calcite-color-inverse-hover);
+  --calcite-button-box-shadow-color: var(--calcite-color-inverse-hover);
+}
+:host([kind="inverse"]:active) {
+  --calcite-button-background-color: var(--calcite-color-inverse-press);
 }
 
 /* outline background */
-:host([appearance="outline"]) {
-  button,
-  a {
-    --calcite-button-background-color: var(--calcite-color-transparent);
-    --calcite-button-background-color-hover: var(--calcite-color-transparent);
-    --calcite-button-background-color-focus: var(--calcite-color-transparent);
-    --calcite-button-background-color-active: var(--calcite-color-transparent);
-  }
+:host([appearance="outline"]),
+:host([appearance="outline"]:is(:hover, :focus, :active)) {
+  --calcite-button-background-color: var(--calcite-color-transparent);
+  --calcite-button-border-color: var(--calcite-color-transparent);
+  --calcite-button-box-shadow-color: var(--calcite-color-transparent);
 }
 
 /* outline-fill background */
-:host([appearance="outline-fill"]) {
-  button,
-  a {
-    --calcite-button-background-color: var(--calcite-color-foreground-1);
-    --calcite-button-background-color-hover: var(--calcite-color-foreground-1);
-    --calcite-button-background-color-focus: var(--calcite-color-foreground-1);
-    --calcite-button-background-color-active: var(--calcite-color-foreground-1);
-  }
+:host([appearance="outline-fill"]),
+:host([appearance="outline-fill"]:is(:hover, :focus, :active)) {
+  --calcite-button-background-color: var(--calcite-color-foreground-1);
 }
 
 /* outline and outline-fill text, border, icon, and box-shadow colors */
-:host([appearance="outline"][kind="brand"]),
-:host([appearance="outline-fill"][kind="brand"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-brand);
-    --calcite-button-text-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-text-color-focus: var(--calcite-color-brand);
-    --calcite-button-text-color-active: var(--calcite-color-brand-press);
-
-    /* border */
-    --calcite-button-border-color: var(--calcite-color-brand);
-    --calcite-button-border-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-border-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-border-color-active: var(--calcite-color-brand-press);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-brand);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-icon-start-color-active: var(--calcite-color-brand-press);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-brand);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-icon-end-color-active: var(--calcite-color-brand-press);
-
-    /* box shadow */
-    --calcite-button-box-shadow-hover: inset 0 0 0 1px var(--calcite-color-brand-hover);
-    --calcite-button-box-shadow-focus: inset 0 0 0 2px var(--calcite-color-brand);
-    --calcite-button-box-shadow-active: inset 0 0 0 2px var(--calcite-color-brand-press);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-brand);
-  }
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="brand"]) {
+  --calcite-button-text-color: var(--calcite-color-brand);
+  --calcite-button-border-color: var(--calcite-color-brand);
+  --calcite-button-icon-start-color: var(--calcite-color-brand);
+  --calcite-button-icon-end-color: var(--calcite-color-brand);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="brand"]:is(:hover, :focus)) {
+  --calcite-button-text-color: var(--calcite-color-brand-hover);
+  --calcite-button-border-color: var(--calcite-color-brand-hover);
+  --calcite-button-icon-start-color: var(--calcite-color-brand-hover);
+  --calcite-button-icon-end-color: var(--calcite-color-brand-hover);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="brand"]:hover) {
+  --calcite-button-box-shadow-color: var(--calcite-color-brand-hover);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="brand"]:focus) {
+  --calcite-button-box-shadow-color: var(--calcite-color-brand);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="brand"]:active) {
+  --calcite-button-text-color: var(--calcite-color-brand-press);
+  --calcite-button-border-color: var(--calcite-color-brand-press);
+  --calcite-button-icon-start-color: var(--calcite-color-brand-press);
+  --calcite-button-icon-end-color: var(--calcite-color-brand-press);
 }
 
-:host([appearance="outline"][kind="danger"]),
-:host([appearance="outline-fill"][kind="danger"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-status-danger);
-    --calcite-button-text-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-text-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-text-color-active: var(--calcite-color-status-danger-press);
-
-    /* border */
-    --calcite-button-border-color: var(--calcite-color-status-danger);
-    --calcite-button-border-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-border-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-border-color-active: var(--calcite-color-status-danger-press);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-status-danger);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-start-color-active: var(--calcite-color-status-danger-press);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-status-danger);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-end-color-active: var(--calcite-color-status-danger-press);
-
-    /* box shadow */
-    --calcite-button-box-shadow-hover: inset 0 0 0 1px var(--calcite-color-status-danger-hover);
-    --calcite-button-box-shadow-focus: inset 0 0 0 2px var(--calcite-color-status-danger);
-    --calcite-button-box-shadow-active: inset 0 0 0 2px var(--calcite-color-status-danger-press);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-status-danger);
-  }
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="danger"]) {
+  --calcite-button-text-color: var(--calcite-color-status-danger);
+  --calcite-button-border-color: var(--calcite-color-status-danger);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="danger"]:is(:hover, :focus)) {
+  --calcite-button-text-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-border-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger-hover);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="danger"]:hover) {
+  --calcite-button-box-shadow-color: var(--calcite-color-status-danger-hover);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="danger"]:focus) {
+  --calcite-button-box-shadow-color: var(--calcite-color-status-danger);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="danger"]:active) {
+  --calcite-button-text-color: var(--calcite-color-status-danger-press);
+  --calcite-button-border-color: var(--calcite-color-status-danger-press);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger-press);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger-press);
 }
 
-:host([appearance="outline"][kind="neutral"]),
-:host([appearance="outline-fill"][kind="neutral"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-text-1);
-    --calcite-button-text-color-hover: var(--calcite-color-text-1);
-    --calcite-button-text-color-focus: var(--calcite-color-text-1);
-    --calcite-button-text-color-active: var(--calcite-color-text-1);
-
-    /* border */
-    --calcite-button-border-color: var(--calcite-color-border-1);
-    --calcite-button-border-color-hover: var(--calcite-color-border-1);
-    --calcite-button-border-color-focus: var(--calcite-color-border-1);
-    --calcite-button-border-color-active: var(--calcite-color-border-1);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-text-1);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-text-1);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-text-1);
-    --calcite-button-icon-start-color-active: var(--calcite-color-text-1);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-text-1);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-text-1);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-text-1);
-    --calcite-button-icon-end-color-active: var(--calcite-color-text-1);
-
-    /* box shadow */
-    --calcite-button-box-shadow-hover: inset 0 0 0 1px var(--calcite-color-foreground-3);
-    --calcite-button-box-shadow-focus: inset 0 0 0 2px var(--calcite-color-foreground-3);
-    --calcite-button-box-shadow-active: inset 0 0 0 2px var(--calcite-color-foreground-3);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-1);
-  }
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="neutral"]),
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="neutral"]:is(:hover, :focus, :active)) {
+  --calcite-button-text-color: var(--calcite-color-text-1);
+  --calcite-button-border-color: var(--calcite-color-border-1);
+  --calcite-button-icon-start-color: var(--calcite-color-text-1);
+  --calcite-button-icon-end-color: var(--calcite-color-text-1);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="neutral"]:is(:hover, :focus, :active)) {
+  --calcite-button-box-shadow-color: var(--calcite-color-foreground-3);
 }
 
-:host([appearance="outline"][kind="inverse"]),
-:host([appearance="outline-fill"][kind="inverse"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-text-1);
-    --calcite-button-text-color-hover: var(--calcite-color-text-1);
-    --calcite-button-text-color-focus: var(--calcite-color-text-1);
-    --calcite-button-text-color-active: var(--calcite-color-text-1);
-
-    /* border */
-    --calcite-button-border-color: var(--calcite-color-inverse);
-    --calcite-button-border-color-hover: var(--calcite-color-inverse-hover);
-    --calcite-button-border-color-focus: var(--calcite-color-inverse-hover);
-    --calcite-button-border-color-active: var(--calcite-color-inverse-press);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-text-1);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-inverse-hover);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-inverse-hover);
-    --calcite-button-icon-start-color-active: var(--calcite-color-inverse-press);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-text-1);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-inverse-hover);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-inverse-hover);
-    --calcite-button-icon-end-color-active: var(--calcite-color-inverse-press);
-
-    /* box shadow */
-    --calcite-button-box-shadow-hover: inset 0 0 0 1px var(--calcite-color-inverse-hover);
-    --calcite-button-box-shadow-focus: inset 0 0 0 2px var(--calcite-color-inverse-hover);
-    --calcite-button-box-shadow-active: inset 0 0 0 2px var(--calcite-color-inverse-press);
-  }
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-1);
-  }
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="inverse"]),
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="inverse"]:is(:hover, :focus)) {
+  --calcite-button-text-color: var(--calcite-color-text-1);
+  --calcite-button-border-color: var(--calcite-color-inverse-hover);
+  --calcite-button-icon-start-color: var(--calcite-color-inverse-hover);
+  --calcite-button-icon-end-color: var(--calcite-color-inverse-hover);
+}
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="inverse"]:is(:hover, :focus)) {
+  --calcite-button-box-shadow-color: var(--calcite-color-inverse-hover);
 }
 
-:host([appearance="outline-fill"][split-child="primary"]) button,
-:host([appearance="outline"][split-child="primary"]) button {
-  border-inline-end-width: 0;
-  border-inline-start-width: theme("borderWidth.DEFAULT");
+:host(:is([appearance="outline-fill"], [appearance="outline"])[kind="inverse"]:press) {
+  --calcite-button-border-color: var(--calcite-color-inverse-press);
+  --calcite-button-box-shadow-color: var(--calcite-color-inverse-press);
+  --calcite-button-icon-start-color: var(--calcite-color-inverse-press);
+  --calcite-button-icon-end-color: var(--calcite-color-inverse-press);
 }
 
-:host([appearance="outline-fill"][split-child="secondary"]) button,
-:host([appearance="outline"][split-child="secondary"]) button {
-  border-inline-start-width: 0;
-  border-inline-end-width: theme("borderWidth.DEFAULT");
+:host(:is([appearance="outline-fill"], [appearance="outline"])[split-child="primary"]) button {
+  border-inline-end-width: var(--calcite-border-width-none);
+  border-inline-start-width: var(--calcite-border-width-sm);
+}
+
+:host(:is([appearance="outline-fill"], [appearance="outline"])[split-child="secondary"]) button {
+  border-inline-start-width: var(--calcite-border-width-none);
+  border-inline-end-width: var(--calcite-border-width-sm);
 }
 
 /* transparent */
+:host([appearance="transparent"]) {
+  --calcite-button-border-color: var(--calcite-color-transparent);
+  --calcite-button-box-shadow-color: var(--calcite-color-transparent);
+}
+
 :host([appearance="transparent"]:not(.enable-editing-button)) {
-  button,
-  a {
-    --calcite-button-background-color: var(--calcite-color-transparent);
-    --calcite-button-background-color-hover: var(--calcite-color-transparent-hover);
-    --calcite-button-background-color-focus: var(--calcite-color-transparent-hover);
-    --calcite-button-background-color-active: var(--calcite-color-transparent-press);
-  }
+  --calcite-button-background-color: var(--calcite-color-transparent);
+}
+:host([appearance="transparent"]:not(.enable-editing-button):is(:hover, :focus)) {
+  --calcite-button-background-color: var(--calcite-color-transparent-hover);
+}
+:host([appearance="transparent"]:not(.enable-editing-button):active) {
+  --calcite-button-background-color: var(--calcite-color-transparent-press);
 }
 
 :host([appearance="transparent"][kind="brand"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-brand);
-    --calcite-button-text-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-text-color-focus: var(--calcite-color-brand);
-    --calcite-button-text-color-active: var(--calcite-color-brand-press);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-brand);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-icon-start-color-active: var(--calcite-color-brand-press);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-brand);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-brand-hover);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-brand-hover);
-    --calcite-button-icon-end-color-active: var(--calcite-color-brand-press);
-
-    calcite-loader {
-      --calcite-button-text-color: var(--calcite-color-brand);
-    }
-  }
+  --calcite-button-text-color: var(--calcite-color-brand);
+  --calcite-button-icon-start-color: var(--calcite-color-brand);
+  --calcite-button-icon-end-color: var(--calcite-color-brand);
+}
+:host([appearance="transparent"][kind="brand"]:is(:hover, :focus)) {
+  --calcite-button-text-color: var(--calcite-color-brand-hover);
+  --calcite-button-icon-start-color: var(--calcite-color-brand-hover);
+  --calcite-button-icon-end-color: var(--calcite-color-brand-hover);
+}
+:host([appearance="transparent"][kind="brand"]:active) {
+  --calcite-button-text-color: var(--calcite-color-brand-press);
+  --calcite-button-icon-start-color: var(--calcite-color-brand-press);
+  --calcite-button-icon-end-color: var(--calcite-color-brand-press);
 }
 
 :host([appearance="transparent"][kind="danger"]) {
-  button,
-  a {
-    /* text */
-    --calcite-button-text-color: var(--calcite-color-status-danger);
-    --calcite-button-text-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-text-color-focus: var(--calcite-color-status-danger);
-    --calcite-button-text-color-active: var(--calcite-color-status-danger-press);
-
-    /* start icon */
-    --calcite-button-icon-start-color: var(--calcite-color-status-danger);
-    --calcite-button-icon-start-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-start-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-start-color-active: var(--calcite-color-status-danger-press);
-
-    /* end icon */
-    --calcite-button-icon-end-color: var(--calcite-color-status-danger);
-    --calcite-button-icon-end-color-hover: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-end-color-focus: var(--calcite-color-status-danger-hover);
-    --calcite-button-icon-end-color-active: var(--calcite-color-status-danger-press);
-    calcite-loader {
-      --calcite-button-text-color: var(--calcite-color-status-danger);
-    }
-  }
+  --calcite-button-text-color: var(--calcite-color-status-danger);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger);
+}
+:host([appearance="transparent"][kind="danger"]:is(:hover, :focus)) {
+  --calcite-button-text-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger-hover);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger-hover);
+}
+:host([appearance="transparent"][kind="danger"]:active) {
+  --calcite-button-text-color: var(--calcite-color-status-danger-press);
+  --calcite-button-icon-start-color: var(--calcite-color-status-danger-press);
+  --calcite-button-icon-end-color: var(--calcite-color-status-danger-press);
 }
 
 :host([appearance="transparent"][kind="neutral"]:not(.cancel-editing-button)) {
-  button,
-  a,
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-1);
-  }
+  --calcite-button-text-color: var(--calcite-color-text-1);
 }
 
 :host([appearance="transparent"][kind="neutral"].cancel-editing-button) {
+  --calcite-button-text-color: var(--calcite-color-text-3);
+
   button {
     @apply border-t-color-input
     border-b-color-input
@@ -691,19 +470,19 @@
     border-b;
     border-block-style: solid;
 
-    --calcite-button-text-color: var(--calcite-color-text-3);
-    --calcite-button-text-color-hover: var(--calcite-color-text-1);
-
     &:not(.content--slotted) {
       --calcite-internal-button-padding-y: 0;
     }
   }
 }
-
+:host([appearance="transparent"][kind="neutral"].cancel-editing-button:hover) {
+  --calcite-button-text-color: var(--calcite-color-text-1);
+}
 :host([appearance="transparent"][kind="neutral"].enable-editing-button) {
-  button {
-    --calcite-button-background-color: var(--calcite-color-transparent);
-  }
+  --calcite-button-background-color: var(--calcite-color-transparent);
+}
+:host([appearance="transparent"][kind="inverse"]) {
+  --calcite-button-text-color: var(--calcite-color-text-inverse);
 }
 
 :host(.confirm-changes-button),
@@ -716,54 +495,113 @@
   }
 }
 
-:host([appearance="transparent"][kind="inverse"]) {
-  button,
+/* generate button scales (scenario: text exists) */
+:host([scale="s"]) {
   a,
-  calcite-loader {
-    --calcite-button-text-color: var(--calcite-color-text-inverse);
+  button {
+    --calcite-internal-button-padding-y: 3px;
+
+    &.content--slotted {
+      @apply text-n2h;
+    }
+
+    /* generate fab scales (scenario: 1 icon, ie., should be square) */
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding[0.5]");
+      --calcite-internal-button-padding-y: 3px;
+      @apply text-0h w-6;
+
+      min-block-size: theme("height.6");
+    }
+  }
+}
+/* accommodate for transparent buttons not having borders */
+:host([scale="s"][appearance="transparent"]) {
+  button,
+  a {
+    &.content--slotted {
+      --calcite-internal-button-padding-x: theme("padding.2");
+    }
+  }
+}
+/* generate fab scales (scenario: 2 icons, ie., should not be square) */
+:host([scale="s"][icon-start][icon-end]) {
+  button,
+  a {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: 23px;
+      @apply text-0h h-6;
+    }
+  }
+}
+/* accommodate for transparent buttons not having borders */
+:host([scale="s"][icon-start][icon-end][appearance="transparent"]) {
+  button,
+  a {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding.6");
+    }
   }
 }
 
-/* generate button scales (scenario: text exists) */
-:host([scale="s"]) button.content--slotted,
-:host([scale="s"]) a.content--slotted {
-  @apply text-n2h;
-}
+:host([scale="m"]) {
+  button,
+  a {
+    --calcite-internal-button-content-margin-start: theme("margin.3");
+    --calcite-internal-button-content-margin-end: theme("margin.3");
 
-/* accommodate for transparent buttons not having borders */
-:host([scale="s"][appearance="transparent"]) button.content--slotted,
-:host([scale="s"][appearance="transparent"]) a.content--slotted {
-  --calcite-internal-button-padding-x: theme("padding.2");
-}
-
-:host([scale="s"]) button,
-:host([scale="s"]) a {
-  --calcite-internal-button-padding-y: 3px;
-}
-
-:host([scale="m"]) button.content--slotted,
-:host([scale="m"]) a.content--slotted {
-  --calcite-internal-button-padding-x: 11px;
-  @apply text-n1h;
-}
-
-:host([scale="m"]) button,
-:host([scale="m"]) a {
-  --calcite-internal-button-padding-y: 7px;
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding[0.5]");
+      --calcite-internal-button-padding-y: 7px;
+      @apply text-0h w-8;
+      min-block-size: theme("height.8");
+    }
+  }
 }
 /* accommodate for transparent buttons not having borders */
-:host([scale="m"][appearance="transparent"]) button.content--slotted,
-:host([scale="m"][appearance="transparent"]) a.content--slotted {
-  --calcite-internal-button-padding-x: theme("padding.3");
+:host([scale="m"][appearance="transparent"]) {
+  a,
+  button {
+    &.content--slotted {
+      --calcite-internal-button-padding-x: theme("padding.3");
+    }
+  }
 }
-
-:host([scale="l"]) button.content--slotted,
-:host([scale="l"]) a.content--slotted {
-  --calcite-internal-button-padding-x: 15px;
-  @apply text-0h;
+:host([scale="m"][icon-start][icon-end]) {
+  a,
+  button {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding.8");
+      @apply text-0h h-8;
+    }
+  }
+}
+/* accommodate for transparent buttons not having borders */
+:host([scale="m"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
+:host([scale="m"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
+  --calcite-internal-button-padding-x: 33px;
 }
 
 :host([scale="l"]) {
+  button,
+  a {
+    --calcite-internal-button-content-margin-start: theme("margin.4");
+    --calcite-internal-button-content-margin-end: theme("margin.4");
+    --calcite-internal-button-padding-y: 7px;
+
+    &.content--slotted {
+      --calcite-internal-button-padding-x: 15px;
+      @apply text-0h;
+    }
+
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding[0.5]");
+      --calcite-internal-button-padding-y: 9px;
+      @apply text-0h w-11;
+      min-block-size: theme("height.11");
+    }
+  }
+
   .button-padding {
     --calcite-internal-button-padding-x: theme("padding.4");
     --calcite-internal-button-padding-y: 11px;
@@ -773,70 +611,37 @@
     --calcite-internal-button-padding-y: 9px;
   }
 }
-
-/* generate fab scales (scenario: 1 icon, ie., should be square) */
-:host([scale="s"]) button:not(.content--slotted),
-:host([scale="s"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding[0.5]");
-  --calcite-internal-button-padding-y: 3px;
-  @apply text-0h w-6;
-  min-block-size: theme("height.6");
-}
-
-:host([scale="m"]) button:not(.content--slotted),
-:host([scale="m"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding[0.5]");
-  --calcite-internal-button-padding-y: 7px;
-  @apply text-0h w-8;
-  min-block-size: theme("height.8");
-}
-:host([scale="l"]) button:not(.content--slotted),
-:host([scale="l"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding[0.5]");
-  --calcite-internal-button-padding-y: 9px;
-  @apply text-0h w-11;
-  min-block-size: theme("height.11");
-}
 /* accommodate for transparent buttons not having borders */
-:host([scale="l"][appearance="transparent"]) button:not(.content--slotted),
-:host([scale="l"][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-y: theme("padding[2.5]");
+:host([scale="l"][appearance="transparent"]) {
+  a,
+  button {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-y: theme("padding[2.5]");
+    }
+  }
 }
+:host([scale="l"][icon-start][icon-end]) {
+  a,
+  button {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: 43px;
+      @apply text-0h h-11;
 
-/* generate fab scales (scenario: 2 icons, ie., should not be square) */
-:host([scale="s"][icon-start][icon-end]) button:not(.content--slotted),
-:host([scale="s"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: 23px;
-  @apply text-0h h-6;
-}
-/* accommodate for transparent buttons not having borders */
-:host([scale="s"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
-:host([scale="s"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding.6");
-}
-:host([scale="m"][icon-start][icon-end]) button:not(.content--slotted),
-:host([scale="m"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding.8");
-  @apply text-0h h-8;
-}
-/* accommodate for transparent buttons not having borders */
-:host([scale="m"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
-:host([scale="m"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: 33px;
-}
-:host([scale="l"][icon-start][icon-end]) button:not(.content--slotted),
-:host([scale="l"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: 43px;
-  @apply text-0h h-11;
-  /* add space between when only 2 icons */
-  .icon--start + .icon--end {
-    margin-inline-start: theme("margin.4");
+      /* add space between when only 2 icons */
+      .icon--start + .icon--end {
+        margin-inline-start: theme("margin.4");
+      }
+    }
   }
 }
 /* accommodate for transparent buttons not having borders */
-:host([scale="l"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
-:host([scale="l"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-internal-button-padding-x: theme("padding.11");
+:host([scale="l"][icon-start][icon-end][appearance="transparent"]) {
+  a,
+  button {
+    &:not(.content--slotted) {
+      --calcite-internal-button-padding-x: theme("padding.11");
+    }
+  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -150,12 +150,10 @@
     &.loading-in {
       animation-name: loader-in;
       animation-duration: var(--calcite-internal-animation-timing-slow);
-      animation-play-state: paused;
     }
     &.loading-out {
       animation-name: loader-out;
       animation-duration: var(--calcite-internal-animation-timing-slow);
-      animation-play-state: paused;
     }
   }
 }
@@ -165,7 +163,6 @@
   .content--slotted {
     .calcite-button--loader calcite-loader {
       margin-inline-end: var(--calcite-internal-button-content-margin);
-      animation-play-state: running;
     }
   }
   /* hide icons when loading with no text */

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -84,7 +84,7 @@
 }
 
 .content {
-  margin-inline: var(--calcite-button-content-margin-internal);
+  margin-inline: var(--calcite-internal-button-content-margin);
 }
 
 .icon-start-empty {
@@ -101,13 +101,13 @@
 :host([scale="m"]) {
   button,
   a {
-    --calcite-button-content-margin-internal: theme("margin.3");
+    --calcite-internal-button-content-margin: theme("margin.3");
   }
 }
 :host([scale="l"]) {
   button,
   a {
-    --calcite-button-content-margin-internal: theme("margin.4");
+    --calcite-internal-button-content-margin: theme("margin.4");
   }
 }
 
@@ -173,7 +173,7 @@
   a:not(.content--slotted),
   button:not(.content--slotted) {
     .icon--start + .icon--end {
-      margin-inline-start: var(--calcite-button-content-margin-internal);
+      margin-inline-start: var(--calcite-internal-button-content-margin);
     }
   }
 }
@@ -237,7 +237,7 @@
   button.content--slotted,
   a.content--slotted {
     .calcite-button--loader calcite-loader {
-      margin-inline-end: var(--calcite-button-content-margin-internal);
+      margin-inline-end: var(--calcite-internal-button-content-margin);
     }
   }
   /* hide icons when loading with no text */
@@ -253,11 +253,11 @@
 /* button base */
 :host button,
 :host a {
-  --calcite-button-content-margin-internal: theme("margin.2");
-  --calcite-button-padding-x-internal: 7px;
-  --calcite-button-padding-y-internal: 3px;
-  padding-block: var(--calcite-button-padding-y-internal);
-  padding-inline: var(--calcite-button-padding-x-internal);
+  --calcite-internal-button-content-margin: theme("margin.2");
+  --calcite-internal-button-padding-x: 7px;
+  --calcite-internal-button-padding-y: 3px;
+  padding-block: var(--calcite-internal-button-padding-y);
+  padding-inline: var(--calcite-internal-button-padding-x);
   @apply font-inherit
     relative
     box-border
@@ -695,7 +695,7 @@
     --calcite-button-text-color-hover: var(--calcite-color-text-1);
 
     &:not(.content--slotted) {
-      --calcite-button-padding-y-internal: 0;
+      --calcite-internal-button-padding-y: 0;
     }
   }
 }
@@ -733,100 +733,100 @@
 /* accommodate for transparent buttons not having borders */
 :host([scale="s"][appearance="transparent"]) button.content--slotted,
 :host([scale="s"][appearance="transparent"]) a.content--slotted {
-  --calcite-button-padding-x-internal: theme("padding.2");
+  --calcite-internal-button-padding-x: theme("padding.2");
 }
 
 :host([scale="s"]) button,
 :host([scale="s"]) a {
-  --calcite-button-padding-y-internal: 3px;
+  --calcite-internal-button-padding-y: 3px;
 }
 
 :host([scale="m"]) button.content--slotted,
 :host([scale="m"]) a.content--slotted {
-  --calcite-button-padding-x-internal: 11px;
+  --calcite-internal-button-padding-x: 11px;
   @apply text-n1h;
 }
 
 :host([scale="m"]) button,
 :host([scale="m"]) a {
-  --calcite-button-padding-y-internal: 7px;
+  --calcite-internal-button-padding-y: 7px;
 }
 /* accommodate for transparent buttons not having borders */
 :host([scale="m"][appearance="transparent"]) button.content--slotted,
 :host([scale="m"][appearance="transparent"]) a.content--slotted {
-  --calcite-button-padding-x-internal: theme("padding.3");
+  --calcite-internal-button-padding-x: theme("padding.3");
 }
 
 :host([scale="l"]) button.content--slotted,
 :host([scale="l"]) a.content--slotted {
-  --calcite-button-padding-x-internal: 15px;
+  --calcite-internal-button-padding-x: 15px;
   @apply text-0h;
 }
 
 :host([scale="l"]) {
   .button-padding {
-    --calcite-button-padding-x-internal: theme("padding.4");
-    --calcite-button-padding-y-internal: 11px;
+    --calcite-internal-button-padding-x: theme("padding.4");
+    --calcite-internal-button-padding-y: 11px;
   }
   /* shrink the padding if an icon is present to preserve the height */
   .button-padding--shrunk {
-    --calcite-button-padding-y-internal: 9px;
+    --calcite-internal-button-padding-y: 9px;
   }
 }
 
 /* generate fab scales (scenario: 1 icon, ie., should be square) */
 :host([scale="s"]) button:not(.content--slotted),
 :host([scale="s"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding[0.5]");
-  --calcite-button-padding-y-internal: 3px;
+  --calcite-internal-button-padding-x: theme("padding[0.5]");
+  --calcite-internal-button-padding-y: 3px;
   @apply text-0h w-6;
   min-block-size: theme("height.6");
 }
 
 :host([scale="m"]) button:not(.content--slotted),
 :host([scale="m"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding[0.5]");
-  --calcite-button-padding-y-internal: 7px;
+  --calcite-internal-button-padding-x: theme("padding[0.5]");
+  --calcite-internal-button-padding-y: 7px;
   @apply text-0h w-8;
   min-block-size: theme("height.8");
 }
 :host([scale="l"]) button:not(.content--slotted),
 :host([scale="l"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding[0.5]");
-  --calcite-button-padding-y-internal: 9px;
+  --calcite-internal-button-padding-x: theme("padding[0.5]");
+  --calcite-internal-button-padding-y: 9px;
   @apply text-0h w-11;
   min-block-size: theme("height.11");
 }
 /* accommodate for transparent buttons not having borders */
 :host([scale="l"][appearance="transparent"]) button:not(.content--slotted),
 :host([scale="l"][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-button-padding-y-internal: theme("padding[2.5]");
+  --calcite-internal-button-padding-y: theme("padding[2.5]");
 }
 
 /* generate fab scales (scenario: 2 icons, ie., should not be square) */
 :host([scale="s"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="s"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: 23px;
+  --calcite-internal-button-padding-x: 23px;
   @apply text-0h h-6;
 }
 /* accommodate for transparent buttons not having borders */
 :host([scale="s"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
 :host([scale="s"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding.6");
+  --calcite-internal-button-padding-x: theme("padding.6");
 }
 :host([scale="m"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="m"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding.8");
+  --calcite-internal-button-padding-x: theme("padding.8");
   @apply text-0h h-8;
 }
 /* accommodate for transparent buttons not having borders */
 :host([scale="m"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
 :host([scale="m"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: 33px;
+  --calcite-internal-button-padding-x: 33px;
 }
 :host([scale="l"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="l"][icon-start][icon-end]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: 43px;
+  --calcite-internal-button-padding-x: 43px;
   @apply text-0h h-11;
   /* add space between when only 2 icons */
   .icon--start + .icon--end {
@@ -836,7 +836,7 @@
 /* accommodate for transparent buttons not having borders */
 :host([scale="l"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
 :host([scale="l"][icon-start][icon-end][appearance="transparent"]) a:not(.content--slotted) {
-  --calcite-button-padding-x-internal: theme("padding.11");
+  --calcite-internal-button-padding-x: theme("padding.11");
 }
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Reduce file size from 842 lines to 648
Saves around 40ms on the test page (more once loader is refactored to reduce CLS)

- Lift component tokens up to `:host`
- Utilize `:is`, `:has`, and `:not` to limit necessary selector rules
- Only apply a style prop rule once then rely on resetting the value of CSS variables base on classes and state.


