### PR TITLE
build(storybook): lint component readmes after building docs

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -40,7 +40,7 @@
     "test": "stencil test --no-docs --no-build --spec --e2e",
     "test:prerender": "npm run build -- --prerender",
     "test:watch": "npm run build && npm run test -- -- --watchAll",
-    "util:build-docs": "npm run util:prep-build-reqs && stencil build --docs --config stencil.storybook.config.ts",
+    "util:build-docs": "npm run util:prep-build-reqs && stencil build --docs --config stencil.storybook.config.ts && npm run lint:md",
     "util:clean-tested-build": "npm ci && npm test && npm run build",
     "util:copy-assets": "npm run util:copy-icons",
     "util:copy-icons": "cpy \"../../node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",


### PR DESCRIPTION
## Summary

Lint the component readmes after they are generated by the storybook build to reduce the diffs. The readmes are linted in the action that updates them:

https://github.com/Esri/calcite-design-system/blob/2d111761f756689942775174fdc8b1217aca16c1/.github/workflows/update-doc.yml#L19-L20