### PR TITLE
ci(renovate): remove rate limiting on esri and stencil deps

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -10,8 +10,9 @@
   "platformCommit": true,
   "enabledManagers": ["npm"],
   "timezone": "America/Los_Angeles",
-  "schedule": ["before 5am on every weekday"],
+  "schedule": ["daily"],
   "labels": ["dependencies"],
+  "prConcurrentLimit": 0,
   "ignoreDeps": [
     "@types/jest",
     "@types/node",

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base",
     "npm:unpublishSafe",
+    "schedule:daily",
     "workarounds:typesNodeVersioning",
     ":pinAllExceptPeerDependencies",
     ":widenPeerDependencies"
@@ -10,9 +11,7 @@
   "platformCommit": true,
   "enabledManagers": ["npm"],
   "timezone": "America/Los_Angeles",
-  "schedule": ["daily"],
   "labels": ["dependencies"],
-  "prConcurrentLimit": 0,
   "ignoreDeps": [
     "@types/jest",
     "@types/node",
@@ -36,6 +35,11 @@
       "semanticCommitType": "build",
       "semanticCommitScope": "deps",
       "addLabels": ["chore"]
+    },
+    {
+      "matchPackagePatterns": ["^@(esri|stencil)/*"],
+      "schedule": ["8am", "12pm", "4pm"],
+      "extends": [":disableRateLimiting"]
     }
   ]
 }


### PR DESCRIPTION
**Related Issue:** #

## Summary

Removes the limit on the number of renovate pull requests than can be open concurrently. This came up on a Teams thread because the Calcite UI icons did not get updated in a timely manner.