### PR TITLE
fix(preset): add back legacy token for calcite-ui-focus-color

### DIFF
--- a/packages/calcite-components/calcite-preset.ts
+++ b/packages/calcite-components/calcite-preset.ts
@@ -258,14 +258,17 @@ export default {
           "outline-color": "transparent",
         },
         ".focus-normal": {
-          outline: "2px solid var(--calcite-color-brand-hover, var(--calcite--color-brand))",
+          outline:
+            "2px solid var(--calcite-ui-focus-color, var(--calcite-color-brand-hover, var(--calcite--color-brand)))",
         },
         ".focus-outset": {
-          outline: "2px solid var(--calcite-color-brand)",
+          outline:
+            "2px solid var(--calcite-ui-focus-color, var(--calcite-color-brand-hover, var(--calcite--color-brand)))",
           "outline-offset": invert("2px", "--calcite-offset-invert-focus"),
         },
         ".focus-inset": {
-          outline: "2px solid var(--calcite-color-brand)",
+          outline:
+            "2px solid var(--calcite-ui-focus-color, var(--calcite-color-brand-hover, var(--calcite--color-brand)))",
           "outline-offset": invert("-2px", "--calcite-offset-invert-focus"),
         },
         ".focus-outset-danger": {


### PR DESCRIPTION
**Related Issue:** #8548

## Summary

Resolves issue with missing `--calcite-ui-focus-color`