### PR TITLE
revert: fix(panel, flow-item): remove overflow rule

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -9,7 +9,7 @@
 
 :host {
   @extend %component-host;
-  @apply relative flex w-full flex-auto;
+  @apply relative flex w-full flex-auto overflow-hidden;
 }
 
 @include disabled();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -9,7 +9,7 @@
 
 :host {
   @extend %component-host;
-  @apply relative flex w-full h-full flex-auto;
+  @apply relative flex w-full h-full flex-auto overflow-hidden;
 
   --calcite-min-header-height: calc(var(--calcite-icon-size) * 3);
 }


### PR DESCRIPTION
**Related Issue:** #8028 #8611

## Summary

- Reverts previous pull request which removes `overflow:hidden` on the host of the `panel` and `flow-item` components.