### PR TITLE
test(combobox): fix form-associated test

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1632,7 +1632,7 @@ export class Combobox
 
     return (
       this.showingInlineIcon && (
-        <span class="icon-start">
+        <span class="icon-start" key="selected-placeholder-icon">
           <calcite-icon
             class="selected-icon"
             flipRtl={this.open && selectedItem ? selectedItem.iconFlipRtl : placeholderIconFlipRtl}
@@ -1647,7 +1647,7 @@ export class Combobox
   renderChevronIcon(): VNode {
     const { open } = this;
     return (
-      <span class="icon-end">
+      <span class="icon-end" key="chevron">
         <calcite-icon
           icon={open ? "chevron-up" : "chevron-down"}
           scale={getIconScale(this.scale)}
@@ -1692,6 +1692,7 @@ export class Combobox
                 [CSS.selectionDisplayFit]: fitSelectionDisplay,
                 [CSS.selectionDisplaySingle]: singleSelectionDisplay,
               }}
+              key="grid"
               ref={this.setChipContainerEl}
             >
               {!singleSelectionMode && !singleSelectionDisplay && this.renderChips()}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes a test failure caused by conditional rendering of nodes. 

**Note**: the `grid` key can be removed once we bump Stencil to v4.12.0 or greater as it introduced [automatic `key` insertion](https://github.com/ionic-team/stencil/releases/tag/v4.12.0). 
