### PR TITLE
feat(flow-item): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -4,21 +4,29 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-flow-item-background-color: Specifies the background of the component.
- * @prop --calcite-flow-item-color: Specifies the color of the component.
- * @prop --calcite-flow-item-footer-padding: Specifies the padding of the component's footer.
- * @prop --calcite-flow-item-header-border-block-end: Specifies the component header's block end border.
+ * @prop --calcite-flow-item-footer-padding: [Deprecated] Use `--calcite-flow-item-footer-space` instead. Specifies the padding of the component's footer.
+ * @prop --calcite-flow-item-footer-space: Specifies the spacing of the component's footer.
+ * @prop --calcite-flow-item-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
  */
 
 :host {
   @include base-host();
+  --calcite-flow-item-border-color: var(--calcite-color-border-3);
+  --calcite-flow-item-description-text-color: var(--calcite-color-text-2);
+  --calcite-flow-item-fab-z-index: var(--calcite-z-index-sticky);
+  --calcite-flow-item-footer-background-color: var(--calcite-color-foreground-1);
+  --calcite-flow-item-footer-space: var(--calcite-flow-item-footer-padding, var(--calcite-spacing-xxs));
+  --calcite-flow-item-heading-text-color: var(--calcite-color-text-2);
+  --calcite-flow-item-header-background-color: var(--calcite-color-foreground-1);
+  --calcite-flow-item-header-z-index: var(--calcite-z-index-header);
+  --calcite-flow-item-header-border-width: var(--calcite-border-width-sm);
+  --calcite-flow-item-header-border-block-end: var(--calcite-border-width-sm) solid
+    var(--calcite-flow-item-border-color);
 
-  --calcite-flow-item-background-color: var(--calcite-color-foreground-1);
-  --calcite-flow-item-color: var(--calcite-color-text-2);
   --calcite-internal-flow-item-back-border-inline-end-width: var(--calcite-border-width-sm);
   --calcite-internal-flow-item-back-border-color: var(--calcite-color-border-3);
 
   background-color: var(--calcite-flow-item-background-color);
-  color: var(--calcite-flow-item-color);
   font-size: var(--calcite-font-size--1);
   position: relative;
   display: flex;
@@ -36,7 +44,16 @@
 }
 
 calcite-panel {
-  --calcite-panel-footer-padding: var(--calcite-flow-item-footer-padding);
+  --calcite-panel-background-color: var(--calcite-flow-item-background-color);
+  --calcite-panel-border-color: var(--calcite-flow-item-border-color);
+  --calcite-panel-description-text-color: var(--calcite-flow-item-description-text-color);
+  --calcite-panel-fab-z-index: var(--calcite-flow-item-fab-z-index);
+  --calcite-panel-footer-background-color: var(--calcite-flow-item-footer-background-color);
+  --calcite-panel-footer-space: var(--calcite-flow-item-footer-space);
+  --calcite-panel-heading-text-color: var(--calcite-flow-item-heading-text-color);
+  --calcite-panel-header-background-color: var(--calcite-flow-item-header-background-color);
+  --calcite-panel-header-z-index: var(--calcite-flow-item-header-z-index);
+  --calcite-panel-header-border-width: var(--calcite-flow-item-header-border-width);
   --calcite-panel-header-border-block-end: var(--calcite-flow-item-header-border-block-end);
 }
 

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -3,10 +3,17 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-flow-item-background-color: Specifies the background of the component.
+ * @prop --calcite-flow-item-background-color: Specifies the background color of the component.
+ * @prop --calcite-flow-item-border-color: Specifies the border color of the component.
+ * @prop --calcite-flow-item-description-text-color: Specifies the text color of the component's description.
+ * @prop --calcite-flow-item-fab-z-index: Specifies the component fab's z-index.
+ * @prop --calcite-flow-item-footer-background-color: Specifies the background color of the component's footer.
  * @prop --calcite-flow-item-footer-padding: [Deprecated] Use `--calcite-flow-item-footer-space` instead. Specifies the padding of the component's footer.
  * @prop --calcite-flow-item-footer-space: Specifies the spacing of the component's footer.
+ * @prop --calcite-flow-item-header-background-color: Specifies the component header's background color.
  * @prop --calcite-flow-item-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
+ * @prop --calcite-flow-item-heading-text-color: Specifies the component's heading text color.
+ * @prop --calcite-flow-item-header-z-index: Specifies the component header's z-index.
  */
 
 :host {

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -3,22 +3,36 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-flow-item-background-color: Specifies the background of the component.
+ * @prop --calcite-flow-item-color: Specifies the color of the component.
  * @prop --calcite-flow-item-footer-padding: Specifies the padding of the component's footer.
  * @prop --calcite-flow-item-header-border-block-end: Specifies the component header's block end border.
  */
 
 :host {
-  @extend %component-host;
-  @apply relative flex w-full flex-auto;
+  @include base-host();
+
+  --calcite-flow-item-background-color: var(--calcite-color-foreground-1);
+  --calcite-flow-item-color: var(--calcite-color-text-2);
+  --calcite-internal-flow-item-back-border-inline-end-width: var(--calcite-border-width-sm);
+  --calcite-internal-flow-item-back-border-color: var(--calcite-color-border-3);
+
+  background-color: var(--calcite-flow-item-background-color);
+  color: var(--calcite-flow-item-color);
+  font-size: var(--calcite-font-size--1);
+  position: relative;
+  display: flex;
+  inline-size: 100%;
+  flex: 1 1 auto;
 }
 
 @include disabled();
 
 .back-button {
-  @apply border-color-3
-  border-0
-  border-solid;
-  border-inline-end-width: theme("borderWidth.DEFAULT");
+  border-color: var(--calcite-internal-flow-item-back-border-color);
+  border-width: 0px;
+  border-style: solid;
+  border-inline-end-width: var(--calcite-internal-flow-item-back-border-inline-end-width);
 }
 
 calcite-panel {

--- a/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
@@ -297,3 +297,15 @@ export const withNoHeaderBorderBlockEnd_TestOnly = (): string =>
   html`<calcite-flow-item style="--calcite-flow-item-header-border-block-end:none;" height-scale="s" heading="My Panel"
     >Slotted content!</calcite-flow-item
   >`;
+
+const themeStyles = `
+  --calcite-flow-item-color: blue;
+  --calcite-flow-item-background-color: red;
+`;
+
+export const themed_TestOnly = (): string =>
+  html`<calcite-flow-item style="${themeStyles}" heading="Example" collapsible closable description="description">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sapien lectus, ultricies a molestie nec,
+    sollicitudin ac nulla. Pellentesque tincidunt malesuada arcu et placerat. In malesuada neque lectus, at congue est
+    malesuada quis.
+  </calcite-flow-item>`;

--- a/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
@@ -309,3 +309,46 @@ export const themed_TestOnly = (): string =>
     sollicitudin ac nulla. Pellentesque tincidunt malesuada arcu et placerat. In malesuada neque lectus, at congue est
     malesuada quis.
   </calcite-flow-item>`;
+
+export const theming_TestOnly = (): string => html`
+  <style>
+    .container {
+      max-height: 300px;
+      width: 300px;
+    }
+  </style>
+  <div class="container">
+    <calcite-flow-item
+      heading="My Flow Item"
+      description="My description"
+      style="
+      --calcite-flow-item-background-color: lightblue;
+      --calcite-flow-item-border-color: red;
+      --calcite-flow-item-description-color: purple;
+      --calcite-flow-item-footer-background-color: lightgreen;
+      --calcite-flow-item-footer-space: 24px;
+      --calcite-flow-item-header-background-color: yellow;
+      --calcite-flow-item-header-border-width: 1px;
+      --calcite-flow-item-heading-text-color: orange;
+      --calcite-flow-item-header-z-index: 999;
+      --calcite-flow-item-fab-z-index: 998;
+    "
+    >
+      <calcite-list>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+        <calcite-list-item label="My list item" description="My description"></calcite-list-item>
+      </calcite-list>
+      <calcite-fab slot="fab"></calcite-fab>
+      ${footerHTML}
+    </calcite-flow-item>
+  </div>
+`;

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -12,7 +12,6 @@
  * @prop --calcite-panel-footer-space: Specifies the spacing of the component's footer.
  * @prop --calcite-panel-header-background-color: Specifies the component header's background color.
  * @prop --calcite-panel-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
- * @prop --calcite-panel-header-color: [Deprecated] Use `--calcite-panel-heading-text-color` instead. Specifies the component header's  color.
  * @prop --calcite-panel-heading-text-color: Specifies the component's heading text color.
  * @prop --calcite-panel-header-z-index: Specifies the component header's z-index.
  */
@@ -33,7 +32,7 @@
   --calcite-panel-fab-z-index: var(--calcite-z-index-sticky);
   --calcite-panel-footer-background-color: var(--calcite-color-foreground-1);
   --calcite-panel-footer-space: var(--calcite-panel-footer-padding, var(--calcite-spacing-xxs));
-  --calcite-panel-heading-text-color: var(--calcite-panel-header-color, var(--calcite-color-text-2));
+  --calcite-panel-heading-text-color: var(--calcite-color-text-2);
   --calcite-panel-header-background-color: var(--calcite-color-foreground-1);
   --calcite-panel-header-z-index: var(--calcite-z-index-header);
   --calcite-panel-header-border-width: var(--calcite-border-width-sm);


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

- Add component tokens for `calcite-flow-item`
- Add story

Adds the following component tokens:

 * @prop --calcite-flow-item-background-color: Specifies the background color of the component.
 * @prop --calcite-flow-item-border-color: Specifies the border color of the component.
 * @prop --calcite-flow-item-description-text-color: Specifies the text color of the component's description.
 * @prop --calcite-flow-item-fab-z-index: Specifies the component fab's z-index.
 * @prop --calcite-flow-item-footer-background-color: Specifies the background color of the component's footer.
 * @prop --calcite-flow-item-footer-padding: [Deprecated] Use `--calcite-flow-item-footer-space` instead. Specifies the padding of the component's footer.
 * @prop --calcite-flow-item-footer-space: Specifies the spacing of the component's footer.
 * @prop --calcite-flow-item-header-background-color: Specifies the component header's background color.
 * @prop --calcite-flow-item-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
 * @prop --calcite-flow-item-heading-text-color: Specifies the component's heading text color.
 * @prop --calcite-flow-item-header-z-index: Specifies the component header's z-index.

Deprecates the following component tokens:

* @prop --calcite-flow-item-footer-padding: [Deprecated] Use `--calcite-flow-item-footer-space` instead. Specifies the padding of the component's footer.
 * @prop --calcite-flow-item-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
