### PR TITLE
docs(input-number): deprecate `minLength`/`maxLength` props as they have no effect

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -2287,7 +2287,7 @@ export namespace Components {
         /**
           * Specifies the maximum length of text for the component's value.
           * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
-          * @deprecated
+          * @deprecated This property has no effect on the component.
          */
         "maxLength": number;
         /**
@@ -2306,7 +2306,7 @@ export namespace Components {
         /**
           * Specifies the minimum length of text for the component's value.
           * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
-          * @deprecated
+          * @deprecated This property has no effect on the component.
          */
         "minLength": number;
         /**
@@ -9668,7 +9668,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the maximum length of text for the component's value.
           * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
-          * @deprecated
+          * @deprecated This property has no effect on the component.
          */
         "maxLength"?: number;
         /**
@@ -9687,7 +9687,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the minimum length of text for the component's value.
           * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
-          * @deprecated
+          * @deprecated This property has no effect on the component.
          */
         "minLength"?: number;
         /**

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -2287,6 +2287,7 @@ export namespace Components {
         /**
           * Specifies the maximum length of text for the component's value.
           * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
+          * @deprecated
          */
         "maxLength": number;
         /**
@@ -2305,6 +2306,7 @@ export namespace Components {
         /**
           * Specifies the minimum length of text for the component's value.
           * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
+          * @deprecated
          */
         "minLength": number;
         /**
@@ -9666,6 +9668,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the maximum length of text for the component's value.
           * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
+          * @deprecated
          */
         "maxLength"?: number;
         /**
@@ -9684,6 +9687,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the minimum length of text for the component's value.
           * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
+          * @deprecated
          */
         "minLength"?: number;
         /**

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -202,6 +202,8 @@ export class InputNumber
    * Specifies the maximum length of text for the component's value.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
+   *
+   * @deprecated
    */
   @Prop({ reflect: true }) maxLength: number;
 
@@ -209,6 +211,8 @@ export class InputNumber
    * Specifies the minimum length of text for the component's value.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
+   *
+   * @deprecated
    */
   @Prop({ reflect: true }) minLength: number;
 

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -203,7 +203,7 @@ export class InputNumber
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
    *
-   * @deprecated
+   * @deprecated This property has no effect on the component.
    */
   @Prop({ reflect: true }) maxLength: number;
 
@@ -212,7 +212,7 @@ export class InputNumber
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
    *
-   * @deprecated
+   * @deprecated This property has no effect on the component.
    */
   @Prop({ reflect: true }) minLength: number;
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Deprecates `minLength`/`maxLength` since they have no effect on numeric inputs. We can remove them at a future breaking change release.

This stems from https://github.com/Esri/calcite-design-system/pull/8655#discussion_r1468938091.