### PR TITLE
build(deps): update dependency @esri/calcite-ui-icons to v3.26.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7301,15 +7301,6 @@
       "resolved": "packages/calcite-design-tokens",
       "link": true
     },
-    "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.25.6",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.25.6.tgz",
-      "integrity": "sha512-zWHrNykjVNHSMRNv7nV6QhDRQ89WWv+4cAJyUPjCxfNWCJvGUdFdqt+OQWOj4jpYMMponoWRleY9bkNCrh4i5w==",
-      "dev": true,
-      "bin": {
-        "spriter": "bin/spriter.js"
-      }
-    },
     "node_modules/@esri/eslint-plugin-calcite-components": {
       "resolved": "packages/eslint-plugin-calcite-components",
       "link": true
@@ -47026,7 +47017,7 @@
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "^2.1.2-next.0",
-        "@esri/calcite-ui-icons": "3.25.6",
+        "@esri/calcite-ui-icons": "3.26.4",
         "@esri/eslint-plugin-calcite-components": "^1.1.1-next.0",
         "@stencil-community/eslint-plugin": "0.7.1",
         "@stencil-community/postcss": "2.2.0",
@@ -47081,6 +47072,15 @@
       "peerDependencies": {
         "react": ">=16.7",
         "react-dom": ">=16.7"
+      }
+    },
+    "packages/calcite-components/node_modules/@esri/calcite-ui-icons": {
+      "version": "3.26.4",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.26.4.tgz",
+      "integrity": "sha512-VRdm6tAJzxS0NkyYQtDgE57ANMEL/oz6Xh4mww6Bhq9mz0UXGeq1+Nb+QgBorsa1Jye1N79unTmLcPW9uN747Q==",
+      "dev": true,
+      "bin": {
+        "spriter": "bin/spriter.js"
       }
     },
     "packages/calcite-design-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47017,7 +47017,7 @@
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "^2.1.2-next.0",
-        "@esri/calcite-ui-icons": "3.26.4",
+        "@esri/calcite-ui-icons": "3.26.3",
         "@esri/eslint-plugin-calcite-components": "^1.1.1-next.0",
         "@stencil-community/eslint-plugin": "0.7.1",
         "@stencil-community/postcss": "2.2.0",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "^2.1.2-next.0",
-    "@esri/calcite-ui-icons": "3.25.6",
+    "@esri/calcite-ui-icons": "3.26.4",
     "@esri/eslint-plugin-calcite-components": "^1.1.1-next.0",
     "@stencil-community/eslint-plugin": "0.7.1",
     "@stencil-community/postcss": "2.2.0",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "^2.1.2-next.0",
-    "@esri/calcite-ui-icons": "3.26.4",
+    "@esri/calcite-ui-icons": "3.26.3",
     "@esri/eslint-plugin-calcite-components": "^1.1.1-next.0",
     "@stencil-community/eslint-plugin": "0.7.1",
     "@stencil-community/postcss": "2.2.0",


### PR DESCRIPTION
**Related Issue:** #

## Summary
Update to latest icon library version.