### PR TITLE
fix: fix styling when dragging items on a mobile device

### DIFF
--- a/packages/calcite-components/src/assets/styles/_sortable.scss
+++ b/packages/calcite-components/src/assets/styles/_sortable.scss
@@ -1,7 +1,9 @@
 @mixin sortable-helper-classes() {
   .calcite-sortable--chosen,
   .calcite-sortable--ghost,
-  .calcite-sortable--drag {
+  .calcite-sortable--drag,
+  .calcite-sortable--fallback {
+    position: relative;
     overflow: hidden;
   }
 

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -13,6 +13,7 @@ export const CSS = {
   ghostClass: "calcite-sortable--ghost",
   chosenClass: "calcite-sortable--chosen",
   dragClass: "calcite-sortable--drag",
+  fallbackClass: "calcite-sortable--fallback",
 };
 
 /**


### PR DESCRIPTION
**Related Issue:** #8728

## Summary

- Fixes fallback ghost element styling to not overflow its container.
- adds fallback class for sortable items.