### PR TITLE
build(changelog): fix synced version group name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,7 +29,7 @@
     },
     {
       "type": "linked-versions",
-      "group-name": "components",
+      "groupName": "components",
       "components": ["@esri/calcite-components", "@esri/calcite-components-react", "@esri/calcite-components-angular"]
     },
     {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This updates the `release-please` config to use [`groupName`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#linked-versions) vs [`group-name`](https://github.com/Esri/calcite-design-system/blob/main/release-please-config.json#L32) to fix synced version changelog entries (notice `undefined` below):

> ## [2.2.0](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@2.1.0...@esri/calcite-components-react@2.2.0) (2024-01-17)
> 
> ### Miscellaneous Chores
> 
> - **@esri/calcite-components-react:** Synchronize undefined versions