### PR TITLE
docs(changelog): specify components group name

### DIFF
--- a/packages/calcite-components-angular/projects/component-library/CHANGELOG.md
+++ b/packages/calcite-components-angular/projects/component-library/CHANGELOG.md
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-angular:** Synchronize undefined versions
+- **@esri/calcite-components-angular:** Synchronize components versions
 
 ### Dependencies
 
@@ -23,7 +23,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-angular:** Synchronize undefined versions
+- **@esri/calcite-components-angular:** Synchronize components versions
 
 ### Dependencies
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-angular:** Synchronize undefined versions
+- **@esri/calcite-components-angular:** Synchronize components versions
 
 ### Dependencies
 
@@ -47,7 +47,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-angular:** Synchronize undefined versions
+- **@esri/calcite-components-angular:** Synchronize components versions
 
 ### Dependencies
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-angular:** Synchronize undefined versions
+- **@esri/calcite-components-angular:** Synchronize components versions
 
 ### Dependencies
 

--- a/packages/calcite-components-react/CHANGELOG.md
+++ b/packages/calcite-components-react/CHANGELOG.md
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -23,7 +23,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -47,7 +47,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -100,7 +100,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -112,7 +112,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -124,7 +124,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -136,7 +136,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -172,7 +172,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -196,7 +196,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 
@@ -220,7 +220,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Miscellaneous Chores
 
-- **@esri/calcite-components-react:** Synchronize undefined versions
+- **@esri/calcite-components-react:** Synchronize components versions
 
 ### Dependencies
 


### PR DESCRIPTION
**Related Issue:** #8763

## Summary

#8762 fixed the synced version group name in the latest release-please pull request. This updates the group name in the changelogs for previous versions.