### PR TITLE
fix: prevent package patching on install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47161,7 +47161,6 @@
     "packages/calcite-components": {
       "name": "@esri/calcite-components",
       "version": "2.5.1-next.0",
-      "hasInstallScript": true,
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@floating-ui/dom": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "version:next": "npm run util:is-in-sync-with-origin-main && npm run util:is-working-tree-clean && lerna version --conventional-prerelease --preid next --no-git-tag-version --no-push --yes && npm run util:sync-linked-package-versions -- next",
     "version:rc": "npm run util:is-in-sync-with-origin-rc && npm run util:is-working-tree-clean && lerna version --conventional-prerelease --preid rc --no-git-tag-version --no-push --yes && npm run util:sync-linked-package-versions -- rc",
     "version:latest": "npm run util:is-in-sync-with-origin-main && npm run util:is-working-tree-clean && lerna version --conventional-commits --create-release github --no-git-tag-version --no-push --yes && npm run util:sync-linked-package-versions -- latest",
-    "util:patch:calcite-components": "patch-package",
     "prepare": "husky install",
     "start": "turbo run start --log-order=stream",
     "test": "turbo run test --log-order=stream",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -34,7 +34,6 @@
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path .gitignore",
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\" >/dev/null",
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
-    "postinstall": "cd ../ && npm run util:patch:calcite-components",
     "posttest": "npm run test:prerender",
     "release:docs": "npm run docs && storybook-to-ghpages --existing-output-dir=docs",
     "start": "npm run util:clean-js-files && concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\"",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Cleans up package-patching scripts (introduced in https://github.com/Esri/calcite-design-system/pull/8751) to prevent them from running on `calcite-components` installs.

