### PR TITLE
feat(input-text): add component tokens

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -73,13 +73,13 @@ import { DisplayMode } from "./components/sheet/interfaces";
 import { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 import { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
 import { DragDetail } from "./utils/sortableComponent";
-import { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
 import { StepperMessages } from "./components/stepper/assets/stepper/t9n";
+import { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail } from "./components/stepper/interfaces";
 import { StepperItemMessages } from "./components/stepper-item/assets/stepper-item/t9n";
 import { TabID, TabLayout, TabPosition } from "./components/tabs/interfaces";
 import { TabChangeEventDetail, TabCloseEventDetail } from "./components/tab/interfaces";
 import { TabTitleMessages } from "./components/tab-title/assets/tab-title/t9n";
-import { RowType, TableInteractionMode, TableLayout, TableRowFocusEvent } from "./components/table/interfaces";
+import { RowType, TableLayout, TableRowFocusEvent } from "./components/table/interfaces";
 import { TableMessages } from "./components/table/assets/table/t9n";
 import { TableCellMessages } from "./components/table-cell/assets/table-cell/t9n";
 import { TableHeaderMessages } from "./components/table-header/assets/table-header/t9n";
@@ -159,13 +159,13 @@ export { DisplayMode } from "./components/sheet/interfaces";
 export { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 export { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
 export { DragDetail } from "./utils/sortableComponent";
-export { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
 export { StepperMessages } from "./components/stepper/assets/stepper/t9n";
+export { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail } from "./components/stepper/interfaces";
 export { StepperItemMessages } from "./components/stepper-item/assets/stepper-item/t9n";
 export { TabID, TabLayout, TabPosition } from "./components/tabs/interfaces";
 export { TabChangeEventDetail, TabCloseEventDetail } from "./components/tab/interfaces";
 export { TabTitleMessages } from "./components/tab-title/assets/tab-title/t9n";
-export { RowType, TableInteractionMode, TableLayout, TableRowFocusEvent } from "./components/table/interfaces";
+export { RowType, TableLayout, TableRowFocusEvent } from "./components/table/interfaces";
 export { TableMessages } from "./components/table/assets/table/t9n";
 export { TableCellMessages } from "./components/table-cell/assets/table-cell/t9n";
 export { TableHeaderMessages } from "./components/table-header/assets/table-header/t9n";
@@ -4382,7 +4382,7 @@ export namespace Components {
         /**
           * Defines the layout of the component.
          */
-        "layout": StepperLayout;
+        "layout": Extract<"horizontal" | "vertical", Layout>;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -4453,7 +4453,7 @@ export namespace Components {
         /**
           * Specifies the layout of the `calcite-stepper-item` inherited from parent `calcite-stepper`, defaults to `horizontal`.
          */
-        "layout": StepperLayout;
+        "layout": Extract<"horizontal" | "vertical", Layout>;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -4462,6 +4462,10 @@ export namespace Components {
           * Made into a prop for testing purposes only
          */
         "messages": StepperItemMessages;
+        /**
+          * Specifies if the user is viewing one `stepper-item` at a time. Helps in determining if header region is tabbable.
+         */
+        "multipleViewMode": boolean;
         /**
           * When `true`, displays the step number in the `calcite-stepper-item` heading inherited from parent `calcite-stepper`.
          */
@@ -4645,10 +4649,6 @@ export namespace Components {
          */
         "groupSeparator": boolean;
         /**
-          * When `"interactive"`, allows focus and keyboard navigation of `table-header`s and `table-cell`s.  When `"static"`, prevents focus and keyboard navigation of `table-header`s and `table-cell`s when assistive technologies are not active. Selection affordances and slotted content within `table-cell`s remain focusable.
-         */
-        "interactionMode": TableInteractionMode;
-        /**
           * Specifies the layout of the component.
          */
         "layout": TableLayout;
@@ -4708,7 +4708,6 @@ export namespace Components {
           * When true, prevents user interaction.  Notes:  This prop should use the
          */
         "disabled": boolean;
-        "interactionMode": TableInteractionMode;
         "lastCell": boolean;
         /**
           * Use this property to override individual strings used by the component.
@@ -4753,7 +4752,6 @@ export namespace Components {
           * A heading to display above description content.
          */
         "heading": string;
-        "interactionMode": TableInteractionMode;
         "lastCell": boolean;
         /**
           * Use this property to override individual strings used by the component.
@@ -4765,6 +4763,7 @@ export namespace Components {
         "messages": TableHeaderMessages;
         "numberCell": boolean;
         "parentRowIsSelected": boolean;
+        "parentRowPosition": number;
         "parentRowType": RowType;
         "positionInRow": number;
         /**
@@ -4788,7 +4787,6 @@ export namespace Components {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
-        "interactionMode": TableInteractionMode;
         "lastVisibleRow": boolean;
         "numbered": boolean;
         "positionAll": number;
@@ -4865,11 +4863,6 @@ export namespace Components {
          */
         "messages": TextAreaMessages;
         /**
-          * Specifies the minimum number of characters allowed.
-          * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength)
-         */
-        "minLength": number;
-        /**
           * Specifies the name of the component.
           * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-name)
          */
@@ -4942,10 +4935,6 @@ export namespace Components {
           * When `true`, the component is active.
          */
         "active": boolean;
-        /**
-          * Specifies the alignment of the Tile's content.
-         */
-        "alignment": Exclude<Alignment, "end">;
         /**
           * A description for the component, which displays below the heading.
          */
@@ -11877,7 +11866,7 @@ declare namespace LocalJSX {
         /**
           * Defines the layout of the component.
          */
-        "layout"?: StepperLayout;
+        "layout"?: Extract<"horizontal" | "vertical", Layout>;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -11944,7 +11933,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the layout of the `calcite-stepper-item` inherited from parent `calcite-stepper`, defaults to `horizontal`.
          */
-        "layout"?: StepperLayout;
+        "layout"?: Extract<"horizontal" | "vertical", Layout>;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -11953,6 +11942,10 @@ declare namespace LocalJSX {
           * Made into a prop for testing purposes only
          */
         "messages"?: StepperItemMessages;
+        /**
+          * Specifies if the user is viewing one `stepper-item` at a time. Helps in determining if header region is tabbable.
+         */
+        "multipleViewMode"?: boolean;
         /**
           * When `true`, displays the step number in the `calcite-stepper-item` heading inherited from parent `calcite-stepper`.
          */
@@ -12142,10 +12135,6 @@ declare namespace LocalJSX {
          */
         "groupSeparator"?: boolean;
         /**
-          * When `"interactive"`, allows focus and keyboard navigation of `table-header`s and `table-cell`s.  When `"static"`, prevents focus and keyboard navigation of `table-header`s and `table-cell`s when assistive technologies are not active. Selection affordances and slotted content within `table-cell`s remain focusable.
-         */
-        "interactionMode"?: TableInteractionMode;
-        /**
           * Specifies the layout of the component.
          */
         "layout"?: TableLayout;
@@ -12214,7 +12203,6 @@ declare namespace LocalJSX {
           * When true, prevents user interaction.  Notes:  This prop should use the
          */
         "disabled"?: boolean;
-        "interactionMode"?: TableInteractionMode;
         "lastCell"?: boolean;
         /**
           * Use this property to override individual strings used by the component.
@@ -12255,7 +12243,6 @@ declare namespace LocalJSX {
           * A heading to display above description content.
          */
         "heading"?: string;
-        "interactionMode"?: TableInteractionMode;
         "lastCell"?: boolean;
         /**
           * Use this property to override individual strings used by the component.
@@ -12267,6 +12254,7 @@ declare namespace LocalJSX {
         "messages"?: TableHeaderMessages;
         "numberCell"?: boolean;
         "parentRowIsSelected"?: boolean;
+        "parentRowPosition"?: number;
         "parentRowType"?: RowType;
         "positionInRow"?: number;
         /**
@@ -12286,7 +12274,6 @@ declare namespace LocalJSX {
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled"?: boolean;
-        "interactionMode"?: TableInteractionMode;
         "lastVisibleRow"?: boolean;
         "numbered"?: boolean;
         "onCalciteInternalTableRowFocusRequest"?: (event: CalciteTableRowCustomEvent<TableRowFocusEvent>) => void;
@@ -12368,11 +12355,6 @@ declare namespace LocalJSX {
          */
         "messages"?: TextAreaMessages;
         /**
-          * Specifies the minimum number of characters allowed.
-          * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength)
-         */
-        "minLength"?: number;
-        /**
           * Specifies the name of the component.
           * @mdn [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-name)
          */
@@ -12445,10 +12427,6 @@ declare namespace LocalJSX {
           * When `true`, the component is active.
          */
         "active"?: boolean;
-        /**
-          * Specifies the alignment of the Tile's content.
-         */
-        "alignment"?: Exclude<Alignment, "end">;
         /**
           * A description for the component, which displays below the heading.
          */

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -7,19 +7,26 @@
  * @prop --calcite-input-text-text-color: defines the text color of the component.
  * @prop --calcite-input-text-border-color: defines the border color of the component.
  * @prop --calcite-input-text-background-color: defines the background color of the component.
+ * @prop --calcite-input-text-button-background-color: defines the background color of a button element in the component.
+ * @prop --calcite-input-text-button-background-color-hover: defines the background color of a :hover-ed button element in the component.
+ * @prop --calcite-input-text-button-background-color-active: defines the background color of an :active button element in the component.
  * @prop --calcite-input-text-icon-color: defines the color of an icon element in the component.
- * @prop --calcite-input-text-icon-color-hover: defines the color of an icon element when it's parent is hovered in the component.
- * @prop --calcite-input-text-prefixsuffix-text-color: defines the text color of a prefix/suffix element in the component.
- * @prop --calcite-input-text-prefixsuffix-background-color: defines the background color of a prefix/suffix element in the component.
+ * @prop --calcite-input-text-button-icon-color-hover: defines the color of an icon element when it's parent is hovered in the component.
+ * @prop --calcite-input-text-prefix-text-color: defines the prefix text color in the component.
+ * @prop --calcite-input-text-prefix-background-color: defines the prefix background color in the component.
+ * @prop --calcite-input-text-suffix-text-color: defines the suffix text color in the component.
+ * @prop --calcite-input-text-suffix-background-color: defines the suffix background color in the component.
  * @prop --calcite-input-text-placeholder-text-color: defines the color of placeholder text in the component.
+ * @prop --calcite-input-text-shadow: defines the box-shadow of the component.
  *
  */
+
 :host {
-  --calcite-input-text-corner-radius: var(--calcite-border-radius-sharp);
+  --calcite-input-text-corner-radius: var(--calcite-corner-radius);
   --calcite-input-text-text-color: var(--calcite-color-text-1);
   --calcite-input-text-border-color: var(--calcite-color-border-input);
   --calcite-input-text-background-color: var(--calcite-color-foreground-1);
-
+  --calcite-input-text-shadow: none;
   // Button
   --calcite-input-text-button-background-color: var(--calcite-color-foreground-1);
   --calcite-input-text-button-background-color-hover: var(--calcite-color-foreground-2);
@@ -27,43 +34,39 @@
 
   // Icon
   --calcite-input-text-icon-color: var(--calcite-color-text-3);
-  --calcite-input-text-icon-color-hover: var(--calcite-color-text-1);
+  --calcite-input-text-button-icon-color-hover: var(--calcite-color-text-1);
 
   // Prefix/Suffix
-  --calcite-input-text-prefixsuffix-text-color: var(--calcite-color-text-2);
-  --calcite-input-text-prefixsuffix-background-color: var(--calcite-color-background);
+  --calcite-input-text-prefix-text-color: var(--calcite-color-text-2);
+  --calcite-input-text-prefix-background-color: var(--calcite-color-background);
+  --calcite-input-text-suffix-text-color: var(--calcite-color-text-2);
+  --calcite-input-text-suffix-background-color: var(--calcite-color-background);
 
   // Placeholder
   --calcite-input-text-placeholder-text-color: var(--calcite-color-text-3);
 
   // For props that should follow the initial border-color but not change on statechange.
-  --calcite-internal-input-text-border-color-base: var(--calcite-input-text-border-color);
+  --calcite-internal-input-text-border-color-base: var(--calcite-color-border-input);
+
   @apply block;
+  box-shadow: var(--calcite-input-text-shadow);
 }
 
 // scales
 :host([scale="s"]) {
-  & input {
-    padding-inline-start: theme("spacing.2");
-    padding-inline-end: var(--calcite-internal-input-text-input-padding-inline-end, theme("spacing.2"));
-  }
-
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n2h h-6;
+    @apply text-n2h h-6 px-2;
   }
-
-  & .prefix,
-  & .suffix {
-    @apply px-2;
-  }
-
+  & .number-button-wrapper,
   & .action-wrapper calcite-button,
   & .action-wrapper calcite-button button {
     @apply h-6;
   }
-
+  & input[type="file"] {
+    @apply h-6;
+  }
   & .clear-button {
     min-block-size: theme("spacing.6");
     min-inline-size: theme("spacing.6");
@@ -71,27 +74,16 @@
 }
 
 :host([scale="m"]) {
-  & input {
-    padding-inline-start: theme("spacing.3");
-    padding-inline-end: var(--calcite-internal-input-text-input-padding-inline-end, theme("spacing.3"));
-  }
-
   & input,
   & .prefix,
   & .suffix {
-    @apply text-n1h h-8;
-  }
-
-  & .prefix,
-  & .suffix {
-    @apply px-3;
+    @apply text-n1h h-8 px-3;
   }
 
   & .action-wrapper calcite-button,
   & .action-wrapper calcite-button button {
     @apply h-8;
   }
-
   & .clear-button {
     min-block-size: theme("spacing.8");
     min-inline-size: theme("spacing.8");
@@ -99,93 +91,63 @@
 }
 
 :host([scale="l"]) {
-  & input {
-    padding-inline-start: theme("spacing.4");
-    padding-inline-end: var(--calcite-internal-input-text-input-padding-inline-end, theme("spacing.4"));
-  }
-
   & input,
   & .prefix,
   & .suffix {
-    @apply text-0h h-11;
+    @apply text-0h h-11 px-4;
   }
-
-  & .prefix,
-  & .suffix {
-    @apply px-4;
-  }
-
   & .action-wrapper calcite-button,
   & .action-wrapper calcite-button button {
     @apply h-11;
   }
-
   & .clear-button {
     min-block-size: theme("spacing.11");
     min-inline-size: theme("spacing.11");
   }
 }
 
-@include disabled();
-
 input {
+  @apply border font-inherit relative m-0
+    box-border flex max-h-full w-full max-w-full flex-1 font-normal;
+
   transition:
     var(--calcite-animation-timing),
     block-size 0,
     outline-offset 0s;
   -webkit-appearance: none;
-  background-color: var(--calcite-input-text-background-color, var(--calcite-color-foreground-1));
-  color: var(--calcite-input-text-text-color, var(--calcite-color-text-1));
-  border-color: var(--calcite-input-text-border-color, var(--calcite-color-border-input));
-  inline-size: var(--calcite-container-size-content-fluid);
-  max-inline-size: var(--calcite-container-size-content-fluid);
-  max-block-size: var(--calcite-container-size-content-fluid);
-  border-radius: var(--calcite-input-text-corner-radius, var(--calcite-corner-radius-sharp));
-
-  @apply box-border
-    flex
-    flex-1
-    font-inherit
-    font-normal
-    m-0
-    relative
-    text-ellipsis;
-
-  &:placeholder-shown {
-    @apply text-ellipsis;
-  }
+  border-radius: var(--calcite-input-text-corner-radius);
+  color: var(--calcite-input-text-text-color);
+  border-color: var(--calcite-input-text-border-color);
+  background-color: var(--calcite-input-text-background-color);
 }
 
 // states
-:host(:focus:not([read-only])) {
-  --calcite-input-text-border-color: var(--calcite-color-brand);
-}
-:host(:focus) {
-  --calcite-input-text-text-color: var(--calcite-color-text-1);
-}
-:host([read-only]) {
-  --calcite-input-text-background-color: var(--calcite-color-background);
-}
 input {
-  @apply border
-    border-solid;
+  @apply border-spacing-1
+    border-solid
+    text-ellipsis;
   &::placeholder,
-  &:-ms-input-placeholder,
-  &::-ms-input-placeholder {
-    color: var(--calcite-input-text-placeholder-text-color, var(--calcite-color-text-3));
+  &:-ms-input-text-placeholder,
+  &::-ms-input-text-placeholder {
     @apply font-normal;
+    color: var(--calcite-input-text-placeholder-text-color);
+  }
+  &:placeholder-shown {
+    @apply text-ellipsis;
   }
 }
 input[readonly] {
   @apply font-medium;
 }
-
 calcite-icon {
-  color: var(--calcite-input-text-icon-color, var(--calcite-color-text-3));
+  color: var(--calcite-input-text-icon-color);
+}
+button:hover,
+button:active {
+  --calcite-input-text-icon-color: var(--calcite-input-text-button-icon-color-hover);
 }
 
 //focus
-
 input {
   @apply focus-base;
 }
@@ -245,9 +207,12 @@ input:focus {
   @apply transition-default
     pointer-events-none
     absolute
-    block
+    block;
+}
 
-    z-default; // needed for firefox to display the icon properly
+.icon,
+.resize-icon-wrapper {
+  @apply z-default; // needed for firefox to display the icon properly
 }
 
 // hide browser default clear
@@ -279,8 +244,9 @@ input[type="text"]::-ms-reveal {
   border-inline-start-width: theme("borderWidth.0");
 
   &:hover {
-    --calcite-input-text-button-background-color: var(--calcite-input-text-button-background-color-hover);
     @apply transition-default;
+    --calcite-input-text-button-background-color: var(--calcite-input-text-button-background-color-hover);
+
     calcite-icon {
       @apply transition-default;
     }
@@ -310,14 +276,6 @@ input[type="text"]::-ms-reveal {
   @apply order-7 flex;
 }
 
-.prefix {
-  @apply order-2;
-  border-inline-end-width: theme("borderWidth.0");
-}
-.suffix {
-  @apply order-5;
-  border-inline-start-width: theme("borderWidth.0");
-}
 // prefix and suffix
 .prefix,
 .suffix {
@@ -333,10 +291,24 @@ input[type="text"]::-ms-reveal {
     border-solid
     font-medium
     leading-none;
-
-  color: var(--calcite-input-text-prefixsuffix-text-color);
-  background-color: var(--calcite-input-text-prefixsuffix-background-color);
   border-color: var(--calcite-internal-input-text-border-color-base);
+}
+.prefix {
+  color: var(--calcite-input-text-prefix-text-color);
+  background-color: var(--calcite-input-text-prefix-background-color);
+}
+.suffix {
+  color: var(--calcite-input-text-suffix-text-color);
+  background-color: var(--calcite-input-text-suffix-background-color);
+}
+
+.prefix {
+  @apply order-2;
+  border-inline-end-width: theme("borderWidth.0");
+}
+.suffix {
+  @apply order-5;
+  border-inline-start-width: theme("borderWidth.0");
 }
 
 // alignment type
@@ -378,11 +350,24 @@ input {
 
   &.inline-child:not(.editing-enabled) {
     @apply border-color-transparent
-    flex
-    cursor-pointer text-ellipsis;
+      flex
+      cursor-pointer text-ellipsis;
     padding-inline-start: 0;
   }
 }
+
+@include form-validation-message();
+@include hidden-form-input();
+@include base-component();
+
+:host(:focus) {
+  --calcite-input-text-border-color: var(--calcite-color-brand);
+}
+
+:host([read-only]) {
+  --calcite-input-text-background-color: var(--calcite-color-background);
+}
+
 :host([prefix-text]) {
   input,
   textarea {
@@ -397,13 +382,20 @@ input {
     border-end-end-radius: 0;
   }
 }
-:host(:not(:empty)) {
-  input {
+:host([suffix-text]) {
+  .suffix {
     border-start-end-radius: 0;
     border-end-end-radius: 0;
   }
 }
-:host(:not([suffix-text])) {
+
+:host([scale="l"]) {
+  .resize-icon-wrapper {
+    block-size: 18px;
+    inline-size: 18px;
+  }
+}
+:host(:not([clearable], [suffix-text])) {
   .wrapper:has(+ .validation-container) {
     input {
       border-start-end-radius: var(--calcite-input-text-corner-radius);
@@ -411,6 +403,17 @@ input {
     }
   }
 }
+:host(:not([suffix-text])) {
+  input:has(+ .clear-button) {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+  .clear-button {
+    border-start-end-radius: var(--calcite-input-text-corner-radius);
+    border-end-end-radius: var(--calcite-input-text-corner-radius);
+  }
+}
+
 .prefix {
   border-start-start-radius: var(--calcite-input-text-corner-radius);
   border-end-start-radius: var(--calcite-input-text-corner-radius);
@@ -419,7 +422,16 @@ input {
   border-start-end-radius: var(--calcite-input-text-corner-radius);
   border-end-end-radius: var(--calcite-input-text-corner-radius);
 }
-
-@include form-validation-message();
-@include hidden-form-input();
-@include base-component();
+:host(:not(:empty)) {
+  input,
+  .clear-button {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+}
+::slotted(*) {
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  border-start-end-radius: var(--calcite-input-text-corner-radius);
+  border-end-end-radius: var(--calcite-input-text-corner-radius);
+}

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -1,4 +1,43 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-input-text-corner-radius: defines the border radius of the component.
+ * @prop --calcite-input-text-text-color: defines the text color of the component.
+ * @prop --calcite-input-text-border-color: defines the border color of the component.
+ * @prop --calcite-input-text-background-color: defines the background color of the component.
+ * @prop --calcite-input-text-icon-color: defines the color of an icon element in the component.
+ * @prop --calcite-input-text-icon-color-hover: defines the color of an icon element when it's parent is hovered in the component.
+ * @prop --calcite-input-text-prefixsuffix-text-color: defines the text color of a prefix/suffix element in the component.
+ * @prop --calcite-input-text-prefixsuffix-background-color: defines the background color of a prefix/suffix element in the component.
+ * @prop --calcite-input-text-placeholder-text-color: defines the color of placeholder text in the component.
+ *
+ */
 :host {
+  --calcite-input-text-corner-radius: var(--calcite-border-radius-sharp);
+  --calcite-input-text-text-color: var(--calcite-color-text-1);
+  --calcite-input-text-border-color: var(--calcite-color-border-input);
+  --calcite-input-text-background-color: var(--calcite-color-foreground-1);
+
+  // Button
+  --calcite-input-text-button-background-color: var(--calcite-color-foreground-1);
+  --calcite-input-text-button-background-color-hover: var(--calcite-color-foreground-2);
+  --calcite-input-text-button-background-color-active: var(--calcite-color-foreground-3);
+
+  // Icon
+  --calcite-input-text-icon-color: var(--calcite-color-text-3);
+  --calcite-input-text-icon-color-hover: var(--calcite-color-text-1);
+
+  // Prefix/Suffix
+  --calcite-input-text-prefixsuffix-text-color: var(--calcite-color-text-2);
+  --calcite-input-text-prefixsuffix-background-color: var(--calcite-color-background);
+
+  // Placeholder
+  --calcite-input-text-placeholder-text-color: var(--calcite-color-text-3);
+
+  // For props that should follow the initial border-color but not change on statechange.
+  --calcite-internal-input-text-border-color-base: var(--calcite-input-text-border-color);
   @apply block;
 }
 
@@ -95,20 +134,22 @@ input {
     block-size 0,
     outline-offset 0s;
   -webkit-appearance: none;
-  @apply bg-foreground-1
-    box-border
+  background-color: var(--calcite-input-text-background-color, var(--calcite-color-foreground-1));
+  color: var(--calcite-input-text-text-color, var(--calcite-color-text-1));
+  border-color: var(--calcite-input-text-border-color, var(--calcite-color-border-input));
+  inline-size: var(--calcite-container-size-content-fluid);
+  max-inline-size: var(--calcite-container-size-content-fluid);
+  max-block-size: var(--calcite-container-size-content-fluid);
+  border-radius: var(--calcite-input-text-corner-radius, var(--calcite-corner-radius-sharp));
+
+  @apply box-border
     flex
     flex-1
     font-inherit
     font-normal
     m-0
-    max-h-full
-    max-w-full
     relative
-    rounded-none
-    text-color-1
-    text-ellipsis
-    w-full;
+    text-ellipsis;
 
   &:placeholder-shown {
     @apply text-ellipsis;
@@ -116,28 +157,31 @@ input {
 }
 
 // states
+:host(:focus:not([read-only])) {
+  --calcite-input-text-border-color: var(--calcite-color-brand);
+}
+:host(:focus) {
+  --calcite-input-text-text-color: var(--calcite-color-text-1);
+}
+:host([read-only]) {
+  --calcite-input-text-background-color: var(--calcite-color-background);
+}
 input {
-  @apply text-color-1
-    border-color-input
-    border
+  @apply border
     border-solid;
   &::placeholder,
   &:-ms-input-placeholder,
   &::-ms-input-placeholder {
-    @apply text-color-3 font-normal;
+    color: var(--calcite-input-text-placeholder-text-color, var(--calcite-color-text-3));
+    @apply font-normal;
   }
 }
-input:focus {
-  @apply border-color-brand text-color-1;
-}
 input[readonly] {
-  @apply bg-background font-medium;
+  @apply font-medium;
 }
-input[readonly]:focus {
-  @apply text-color-1;
-}
+
 calcite-icon {
-  @apply text-color-3;
+  color: var(--calcite-input-text-icon-color, var(--calcite-color-text-3));
 }
 
 //focus
@@ -150,9 +194,8 @@ input:focus {
 }
 
 :host([status="invalid"]) {
-  & input {
-    @apply border-color-danger;
-  }
+  --calcite-input-text-border-color: var(--calcite-color-status-danger);
+
   & input:focus {
     @apply focus-inset-danger;
   }
@@ -219,8 +262,6 @@ input[type="text"]::-ms-reveal {
 .clear-button {
   pointer-events: initial;
   @apply focus-base
-    border-color-input
-    bg-foreground-1
     order-4
     m-0
     box-border
@@ -233,19 +274,19 @@ input[type="text"]::-ms-reveal {
     border
     border-solid;
 
+  background-color: var(--calcite-input-text-button-background-color);
+  border-color: var(--calcite-internal-input-text-border-color-base);
   border-inline-start-width: theme("borderWidth.0");
 
   &:hover {
-    @apply bg-foreground-2 transition-default;
+    --calcite-input-text-button-background-color: var(--calcite-input-text-button-background-color-hover);
+    @apply transition-default;
     calcite-icon {
-      @apply text-color-1 transition-default;
+      @apply transition-default;
     }
   }
   &:active {
-    @apply bg-foreground-3;
-    calcite-icon {
-      @apply text-color-1;
-    }
+    --calcite-input-text-button-background-color: var(--calcite-input-text-button-background-color-active);
   }
   &:focus {
     @apply focus-inset;
@@ -269,13 +310,18 @@ input[type="text"]::-ms-reveal {
   @apply order-7 flex;
 }
 
+.prefix {
+  @apply order-2;
+  border-inline-end-width: theme("borderWidth.0");
+}
+.suffix {
+  @apply order-5;
+  border-inline-start-width: theme("borderWidth.0");
+}
 // prefix and suffix
 .prefix,
 .suffix {
-  @apply border-color-input
-    bg-background
-    text-color-2
-    box-border
+  @apply box-border
     flex
     h-auto
     min-h-full
@@ -287,15 +333,10 @@ input[type="text"]::-ms-reveal {
     border-solid
     font-medium
     leading-none;
-}
 
-.prefix {
-  @apply order-2;
-  border-inline-end-width: theme("borderWidth.0");
-}
-.suffix {
-  @apply order-5;
-  border-inline-start-width: theme("borderWidth.0");
+  color: var(--calcite-input-text-prefixsuffix-text-color);
+  background-color: var(--calcite-input-text-prefixsuffix-background-color);
+  border-color: var(--calcite-internal-input-text-border-color-base);
 }
 
 // alignment type
@@ -341,6 +382,42 @@ input {
     cursor-pointer text-ellipsis;
     padding-inline-start: 0;
   }
+}
+:host([prefix-text]) {
+  input,
+  textarea {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+}
+:host([suffix-text]) {
+  input,
+  textarea {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+}
+:host(:not(:empty)) {
+  input {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+}
+:host(:not([suffix-text])) {
+  .wrapper:has(+ .validation-container) {
+    input {
+      border-start-end-radius: var(--calcite-input-text-corner-radius);
+      border-end-end-radius: var(--calcite-input-text-corner-radius);
+    }
+  }
+}
+.prefix {
+  border-start-start-radius: var(--calcite-input-text-corner-radius);
+  border-end-start-radius: var(--calcite-input-text-corner-radius);
+}
+.suffix {
+  border-start-end-radius: var(--calcite-input-text-corner-radius);
+  border-end-end-radius: var(--calcite-input-text-corner-radius);
 }
 
 @include form-validation-message();


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds the following component tokens to the input-text component

```
--calcite-input-text-corner-radius: defines the border radius of the component.
--calcite-input-text-text-color: defines the text color of the component.
--calcite-input-text-border-color: defines the border color of the component.
--calcite-input-text-background-color: defines the background color of the component.
--calcite-input-text-icon-color: defines the color of an icon element in the component.
--calcite-input-text-icon-color-hover: defines the color of an icon element when it's parent is hovered in the component.
--calcite-input-text-prefixsuffix-text-color: defines the text color of a prefix/suffix element in the component.
--calcite-input-text-prefixsuffix-background-color: defines the background color of a prefix/suffix element in the component.
--calcite-input-text-placeholder-text-color: defines the color of placeholder text in the component.
```