### PR TITLE
feat(tooltip): add component tokens.

### DIFF
--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -14,7 +14,7 @@ $floating-ui-transform-right: translateX(-5px);
     transition: var(--calcite-floating-ui-transition);
     transition-property: transform, visibility, opacity;
     opacity: 0;
-    box-shadow: $shadow-2;
+    box-shadow: var(--calcite-shadow-2);
     border-radius: var(--calcite-border-radius-round);
     z-index: var(--calcite-z-index);
   }

--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -5,7 +5,7 @@ $floating-ui-transform-right: translateX(-5px);
 
 @mixin floating-ui-base {
   --calcite-floating-ui-transition: var(--calcite-animation-timing);
-  --calcite-floating-ui-z-index: theme("zIndex.dropdown");
+  --calcite-floating-ui-z-index: var(--calcite-z-index-dropdown);
 }
 
 @mixin floatingUIAnim {
@@ -15,7 +15,8 @@ $floating-ui-transform-right: translateX(-5px);
     transition-property: transform, visibility, opacity;
     opacity: 0;
     box-shadow: $shadow-2;
-    @apply rounded z-default;
+    border-radius: var(--calcite-border-radius-round);
+    z-index: var(--calcite-z-index);
   }
 }
 
@@ -100,13 +101,13 @@ $floating-ui-transform-right: translateX(-5px);
 
 @mixin floatingUIArrow {
   .calcite-floating-ui-arrow {
-    @apply -z-default
-    absolute
-    pointer-events-none
-    fill-background-foreground-1;
+    z-index: var(--calcite-z-index-default);
+    position: absolute;
+    pointer-events: none;
+    fill: var(--calcite-color-foreground-1);
   }
 
   .calcite-floating-ui-arrow__stroke {
-    stroke: theme("borderColor.color.3");
+    stroke: var(--calcite-color-border-3);
   }
 }

--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -3,20 +3,19 @@ $floating-ui-transform-top: translateY(5px);
 $floating-ui-transform-left: translateX(5px);
 $floating-ui-transform-right: translateX(-5px);
 
-@mixin floating-ui-base {
-  --calcite-floating-ui-transition: var(--calcite-animation-timing);
-  --calcite-floating-ui-z-index: var(--calcite-z-index-dropdown);
-}
-
-@mixin floatingUIAnim {
+@mixin floatingUIAnim($boxShadow, $borderRadius, $borderWidth, $borderColor, $backgroundColor) {
   .calcite-floating-ui-anim {
     position: relative;
-    transition: var(--calcite-floating-ui-transition);
+    transition: var(--calcite-animation-timing);
     transition-property: transform, visibility, opacity;
     opacity: 0;
-    box-shadow: var(--calcite-shadow-2);
-    border-radius: var(--calcite-border-radius-round);
+    border-style: solid;
+    border-width: var(#{$borderWidth});
+    box-shadow: var(#{$boxShadow});
+    border-radius: var(#{$borderRadius});
     z-index: var(--calcite-z-index);
+    background-color: var(#{$backgroundColor});
+    border-color: var(#{$borderColor});
   }
 }
 
@@ -25,9 +24,16 @@ $floating-ui-transform-right: translateX(-5px);
   transform: translate(0);
 }
 
-@mixin floatingUIElemAnim($selector) {
+@mixin floatingUIElemAnim(
+  $selector,
+  $boxShadow: "--calcite-shadow-md",
+  $borderRadius: "--calcite-corner-radius-0",
+  $borderWidth: "--calcite-border-width-none",
+  $borderColor: "--calcite-color-border-3",
+  $backgroundColor: "--calcite-color-foreground-1"
+) {
   #{$selector} {
-    @include floatingUIAnim();
+    @include floatingUIAnim($boxShadow, $borderRadius, $borderWidth, $borderColor, $backgroundColor);
 
     &[data-placement^="bottom"] .calcite-floating-ui-anim {
       transform: $floating-ui-transform-bottom;
@@ -51,8 +57,8 @@ $floating-ui-transform-right: translateX(-5px);
   }
 }
 
-@mixin floatingUIHostAnim {
-  @include floatingUIAnim();
+@mixin floatingUIHostAnim($boxShadow, $borderRadius, $borderWidth, $borderColor, $backgroundColor) {
+  @include floatingUIAnim($boxShadow, $borderRadius, $borderWidth, $borderColor, $backgroundColor);
 
   :host([data-placement^="bottom"]) .calcite-floating-ui-anim {
     transform: $floating-ui-transform-bottom;
@@ -75,10 +81,10 @@ $floating-ui-transform-right: translateX(-5px);
   }
 }
 
-@mixin floatingUIContainer() {
+@mixin floatingUIContainer($zIndex: "--calcite-z-index-dropdown") {
   display: block;
   position: absolute;
-  z-index: var(--calcite-floating-ui-z-index);
+  z-index: var(#{$zIndex});
 }
 
 @mixin floatingUIWrapper {
@@ -89,25 +95,34 @@ $floating-ui-transform-right: translateX(-5px);
   visibility: visible;
 }
 
-@mixin floatingUIHost() {
+@mixin floatingUIHost(
+  $zIndex: "--calcite-z-index-dropdown",
+  $boxShadow: "--calcite-shadow-md",
+  $borderRadius: "--calcite-corner-radius-0",
+  $borderWidth: "--calcite-border-width-none",
+  $borderColor: "--calcite-color-border-3",
+  $backgroundColor: "--calcite-color-foreground-1"
+) {
   :host {
-    @include floatingUIContainer();
+    @include floatingUIContainer($zIndex);
   }
 
-  @include floatingUIHostAnim();
+  @include floatingUIHostAnim($boxShadow, $borderRadius, $borderWidth, $borderColor, $backgroundColor);
 
   @include calciteHydratedHidden();
+
+  @include floatingUIArrow($backgroundColor, $borderColor);
 }
 
-@mixin floatingUIArrow {
+@mixin floatingUIArrow($backgroundColor: "--calcite-color-foreground-1", $borderColor: "--calcite-color-border-3") {
   .calcite-floating-ui-arrow {
     z-index: var(--calcite-z-index-default);
     position: absolute;
     pointer-events: none;
-    fill: var(--calcite-color-foreground-1);
+    fill: var(#{$backgroundColor});
   }
 
   .calcite-floating-ui-arrow__stroke {
-    stroke: var(--calcite-color-border-3);
+    stroke: var(#{$borderColor});
   }
 }

--- a/packages/calcite-components/src/assets/styles/global.scss
+++ b/packages/calcite-components/src/assets/styles/global.scss
@@ -13,13 +13,11 @@
 
 :root {
   @extend %type-vars;
-  @include floating-ui-base();
   @include animation-base();
 
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --calcite-popover-z-index: var(--calcite-z-index-popup);
   --calcite-border-radius: var(--calcite-border-radius-round, 4px);
   --calcite-border-radius-base: 0;
   --calcite-offset-invert-focus: 0; // should be 0 or 1

--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -179,8 +179,7 @@
 }
 
 .floating-ui-container {
-  --calcite-floating-ui-z-index: theme("zIndex.dropdown");
-  @include floatingUIContainer();
+  @include floatingUIContainer("--calcite-z-index-dropdown");
   @include floatingUIWrapper();
 }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.scss
+++ b/packages/calcite-components/src/components/dropdown/dropdown.scss
@@ -13,8 +13,7 @@
 @include disabled();
 
 :host .calcite-dropdown-wrapper {
-  --calcite-floating-ui-z-index: theme("zIndex.dropdown");
-  @include floatingUIContainer();
+  @include floatingUIContainer("--calcite-z-index-dropdown");
   @include floatingUIWrapper();
 }
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -95,8 +95,7 @@
 }
 
 .menu-container {
-  --calcite-floating-ui-z-index: theme("zIndex.dropdown");
-  @include floatingUIContainer();
+  @include floatingUIContainer("--calcite-z-index-dropdown");
   @include floatingUIWrapper();
   @apply invisible;
 }

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -10,6 +10,7 @@
 */
 
 :host {
+  @apply pointer-events-none;
   --calcite-floating-ui-z-index: var(--calcite-popover-z-index, var(--calcite-z-index-popup));
   --calcite-popover-background-color: var(--calcite-color-foreground-1);
   --calcite-popover-border-color: var(--calcite-color-border-3);
@@ -19,6 +20,18 @@
 
 @include floatingUIHost();
 @include floatingUIArrow();
+
+.heading {
+  @apply word-break
+  m-0
+  block
+  flex-auto
+  self-center
+  whitespace-normal
+  font-medium;
+
+  color: var(--calcite-popover-text-color);
+}
 
 :host([scale="s"]) {
   .heading {
@@ -42,10 +55,6 @@
     px-5
     py-4;
   }
-}
-
-:host {
-  @apply pointer-events-none;
 }
 
 :host([open]) {
@@ -75,18 +84,6 @@
     border-solid;
 
   border-block-end-color: var(--calcite-popover-border-color);
-}
-
-.heading {
-  @apply word-break
-  m-0
-  block
-  flex-auto
-  self-center
-  whitespace-normal
-  font-medium;
-
-  color: var(--calcite-popover-text-color);
 }
 
 .container {
@@ -124,6 +121,14 @@
 ::slotted(calcite-panel),
 ::slotted(calcite-flow) {
   @apply h-full;
+}
+
+.calcite-floating-ui-arrow {
+  fill: var(--calcite-popover-background-color);
+}
+
+.calcite-floating-ui-arrow__stroke {
+  stroke: var(--calcite-popover-border-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -5,6 +5,7 @@
 *
 * @prop --calcite-popover-background-color: Specifies the background color of the component.
 * @prop --calcite-popover-border-color: The border color of the component.
+* @prop --calcite-popover-shadow: The shadow of the component.
 * @prop --calcite-popover-corner-radius: The corner radius of the component.
 * @prop --calcite-popover-text-color: The text color of the component.
 */
@@ -14,6 +15,7 @@
   --calcite-floating-ui-z-index: var(--calcite-popover-z-index, var(--calcite-z-index-popup));
   --calcite-popover-background-color: var(--calcite-color-foreground-1);
   --calcite-popover-border-color: var(--calcite-color-border-3);
+  --calcite-popover-shadow: var(--calcite-shadow-2);
   --calcite-popover-text-color: var(--calcite-color-text-1);
   --calcite-popover-corner-radius: var(--calcite-border-radius-round);
 }
@@ -68,6 +70,7 @@
   background-color: var(--calcite-popover-background-color);
   border-color: var(--calcite-popover-border-color);
   border-radius: var(--calcite-popover-corner-radius);
+  box-shadow: var(--calcite-popover-shadow);
 }
 
 .arrow::before {

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -12,16 +12,22 @@
 
 :host {
   @apply pointer-events-none;
-  --calcite-floating-ui-z-index: var(--calcite-popover-z-index, var(--calcite-z-index-popup));
   --calcite-popover-background-color: var(--calcite-color-foreground-1);
   --calcite-popover-border-color: var(--calcite-color-border-3);
-  --calcite-popover-shadow: var(--calcite-shadow-2);
+  --calcite-popover-shadow: var(--calcite-shadow-md);
   --calcite-popover-text-color: var(--calcite-color-text-1);
-  --calcite-popover-corner-radius: var(--calcite-border-radius-round);
+  --calcite-popover-corner-radius: var(--calcite-corner-radius-round);
+  --calcite-popover-z-index: var(--calcite-z-index-popup);
 }
 
-@include floatingUIHost();
-@include floatingUIArrow();
+@include floatingUIHost(
+  "--calcite-popover-z-index",
+  "--calcite-popover-shadow",
+  "--calcite-popover-corner-radius",
+  "--calcite-border-width-sm",
+  "--calcite-popover-border-color",
+  "--calcite-popover-background-color"
+);
 
 .heading {
   @apply word-break
@@ -61,20 +67,6 @@
 
 :host([open]) {
   pointer-events: initial;
-}
-
-.calcite-floating-ui-anim {
-  @apply border
-    border-solid;
-
-  background-color: var(--calcite-popover-background-color);
-  border-color: var(--calcite-popover-border-color);
-  border-radius: var(--calcite-popover-corner-radius);
-  box-shadow: var(--calcite-popover-shadow);
-}
-
-.arrow::before {
-  outline: 1px solid var(--calcite-popover-border-color);
 }
 
 .header {
@@ -124,14 +116,6 @@
 ::slotted(calcite-panel),
 ::slotted(calcite-flow) {
   @apply h-full;
-}
-
-.calcite-floating-ui-arrow {
-  fill: var(--calcite-popover-background-color);
-}
-
-.calcite-floating-ui-arrow__stroke {
-  stroke: var(--calcite-popover-border-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/popover/popover.stories.ts
+++ b/packages/calcite-components/src/components/popover/popover.stories.ts
@@ -195,3 +195,25 @@ export const transparentBG_TestOnly = (): string => html`
     </calcite-popover>
   </div>
 `;
+
+export const theming_TestOnly = (): string => html`
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-popover
+      style="
+      --calcite-popover-background-color: lightblue;
+      --calcite-popover-border-color: green;
+      --calcite-popover-text-color: purple;
+      --calcite-popover-corner-radius: 20px;
+      --calcite-floating-ui-z-index: 100;
+    "
+      heading="these 🥨s are making me thirsty"
+      reference-element="reference-element"
+      placement="auto"
+      open
+      closable
+    >
+      ${contentHTML}
+    </calcite-popover>
+  </div>
+`;

--- a/packages/calcite-components/src/components/popover/popover.stories.ts
+++ b/packages/calcite-components/src/components/popover/popover.stories.ts
@@ -203,6 +203,7 @@ export const theming_TestOnly = (): string => html`
       style="
       --calcite-popover-background-color: lightblue;
       --calcite-popover-border-color: green;
+      --calcite-popover-shadow: 10px 5px 5px red;
       --calcite-popover-text-color: purple;
       --calcite-popover-corner-radius: 20px;
       --calcite-floating-ui-z-index: 100;

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -3,40 +3,58 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+
+ * @prop --calcite-tooltip-background-color: Specifies the background color of the component.
+ * @prop --calcite-tooltip-border-color: The border color of the component.
+ * @prop --calcite-tooltip-corner-radius: The corner radius of the component.
+ * @prop --calcite-tooltip-text-color: The text color of the component.
  * @prop --calcite-tooltip-z-index: Sets the z-index value for the component.
  */
 
 :host {
-  --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, theme("zIndex.tooltip"));
+  --calcite-tooltip-background-color: var(--calcite-color-foreground-1);
+  --calcite-tooltip-border-color: var(--calcite-color-border-3);
+  --calcite-tooltip-text-color: var(--calcite-color-text-1);
+  --calcite-tooltip-corner-radius: var(--calcite-border-radius-round);
+  --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, var(--calcite-z-index-tooltip));
 }
 
 @include floatingUIHost();
 @include floatingUIArrow();
 
 .container {
-  @apply text-color-1
-    text-n2-wrap
-    relative
-    overflow-hidden
-    rounded
-    py-3
-    px-4
-    font-medium;
+  position: relative;
+  overflow: hidden;
+  font-weight: var(--calcite-font-weight-medium);
+  font-size: var(--calcite-font-size--2);
+  line-height: 1.375;
+  padding-block: var(--calcite-spacing-md);
+  padding-inline: var(--calcite-spacing-sm);
   max-inline-size: 20rem;
   max-block-size: 20rem;
   text-align: start;
+  color: var(--calcite-tooltip-text-color);
+  border-radius: var(--calcite-tooltip-corner-radius);
 }
 
 .calcite-floating-ui-anim {
-  @apply bg-foreground-1
-    border-color-3
-    rounded
-    border
-    border-solid;
+  border-style: solid;
+  border-width: var(--calcite-border-width-sm);
+  background-color: var(--calcite-tooltip-background-color);
+  border-color: var(--calcite-tooltip-border-color);
+  border-radius: var(--calcite-tooltip-corner-radius);
 }
 
 .arrow::before {
-  outline: 1px solid var(--calcite-color-border-3);
+  outline: var(--calcite-border-width-sm) solid var(--calcite-tooltip-border-color);
+}
+
+.calcite-floating-ui-arrow {
+  fill: var(--calcite-tooltip-background-color);
+}
+
+.calcite-floating-ui-arrow__stroke {
+  stroke: var(--calcite-tooltip-border-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -15,14 +15,20 @@
 :host {
   --calcite-tooltip-background-color: var(--calcite-color-foreground-1);
   --calcite-tooltip-border-color: var(--calcite-color-border-3);
-  --calcite-tooltip-shadow: var(--calcite-shadow-2);
+  --calcite-tooltip-shadow: var(--calcite-shadow-md);
   --calcite-tooltip-text-color: var(--calcite-color-text-1);
-  --calcite-tooltip-corner-radius: var(--calcite-border-radius-round);
-  --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, var(--calcite-z-index-tooltip));
+  --calcite-tooltip-corner-radius: var(--calcite-corner-radius-round);
+  --calcite-tooltip-z-index: var(--calcite-z-index-tooltip);
 }
 
-@include floatingUIHost();
-@include floatingUIArrow();
+@include floatingUIHost(
+  "--calcite-tooltip-z-index",
+  "--calcite-tooltip-shadow",
+  "--calcite-tooltip-corner-radius",
+  "--calcite-border-width-sm",
+  "--calcite-tooltip-border-color",
+  "--calcite-tooltip-background-color"
+);
 
 .container {
   position: relative;
@@ -37,27 +43,6 @@
   text-align: start;
   color: var(--calcite-tooltip-text-color);
   border-radius: var(--calcite-tooltip-corner-radius);
-}
-
-.calcite-floating-ui-anim {
-  border-style: solid;
-  border-width: var(--calcite-border-width-sm);
-  background-color: var(--calcite-tooltip-background-color);
-  border-color: var(--calcite-tooltip-border-color);
-  border-radius: var(--calcite-tooltip-corner-radius);
-  box-shadow: var(--calcite-tooltip-shadow);
-}
-
-.arrow::before {
-  outline: var(--calcite-border-width-sm) solid var(--calcite-tooltip-border-color);
-}
-
-.calcite-floating-ui-arrow {
-  fill: var(--calcite-tooltip-background-color);
-}
-
-.calcite-floating-ui-arrow__stroke {
-  stroke: var(--calcite-tooltip-border-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -7,6 +7,7 @@
  * @prop --calcite-tooltip-background-color: Specifies the background color of the component.
  * @prop --calcite-tooltip-border-color: The border color of the component.
  * @prop --calcite-tooltip-corner-radius: The corner radius of the component.
+ * @prop --calcite-tooltip-shadow: The shadow of the component.
  * @prop --calcite-tooltip-text-color: The text color of the component.
  * @prop --calcite-tooltip-z-index: Sets the z-index value for the component.
  */
@@ -14,6 +15,7 @@
 :host {
   --calcite-tooltip-background-color: var(--calcite-color-foreground-1);
   --calcite-tooltip-border-color: var(--calcite-color-border-3);
+  --calcite-tooltip-shadow: var(--calcite-shadow-2);
   --calcite-tooltip-text-color: var(--calcite-color-text-1);
   --calcite-tooltip-corner-radius: var(--calcite-border-radius-round);
   --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, var(--calcite-z-index-tooltip));
@@ -43,6 +45,7 @@
   background-color: var(--calcite-tooltip-background-color);
   border-color: var(--calcite-tooltip-border-color);
   border-radius: var(--calcite-tooltip-corner-radius);
+  box-shadow: var(--calcite-tooltip-shadow);
 }
 
 .arrow::before {

--- a/packages/calcite-components/src/components/tooltip/tooltip.stories.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.stories.ts
@@ -86,3 +86,23 @@ export const transparentBG_TestOnly = (): string => html`
     <calcite-tooltip reference-element="reference-element" placement="auto" open> ${contentHTML} </calcite-tooltip>
   </div>
 `;
+
+export const theming_TestOnly = (): string => html`
+  <div style="width: 400px;">
+    ${referenceElementHTML}
+    <calcite-tooltip
+      style="
+      --calcite-tooltip-background-color: lightblue;
+      --calcite-tooltip-border-color: green;
+      --calcite-tooltip-text-color: purple;
+      --calcite-tooltip-corner-radius: 20px;
+      --calcite-floating-ui-z-index: 100;
+    "
+      reference-element="reference-element"
+      placement="auto"
+      open
+    >
+      ${contentHTML}
+    </calcite-tooltip>
+  </div>
+`;

--- a/packages/calcite-components/src/components/tooltip/tooltip.stories.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.stories.ts
@@ -94,6 +94,7 @@ export const theming_TestOnly = (): string => html`
       style="
       --calcite-tooltip-background-color: lightblue;
       --calcite-tooltip-border-color: green;
+      --calcite-tooltip-shadow: 10px 5px 5px red;
       --calcite-tooltip-text-color: purple;
       --calcite-tooltip-corner-radius: 20px;
       --calcite-floating-ui-z-index: 100;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

 * @prop --calcite-tooltip-background-color: Specifies the background color of the component.
 * @prop --calcite-tooltip-border-color: The border color of the component.
 * @prop --calcite-tooltip-corner-radius: The corner radius of the component.
 * @prop --calcite-tooltip-shadow: The shadow of the component.
 * @prop --calcite-tooltip-text-color: The text color of the component.

<img width="569" alt="image" src="https://github.com/Esri/calcite-design-system/assets/1231455/4e7c740a-9a22-41a0-9f1f-fe503ba3d6e9">

<img width="584" alt="image" src="https://github.com/Esri/calcite-design-system/assets/1231455/17f9e3dc-c6ce-493a-a2ef-e132a0f66bd1">