### PR TITLE
feat(rating): Add component tokens

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -777,6 +777,36 @@ export namespace Components {
          */
         "thumbnailPosition": LogicalFlowPosition;
     }
+    interface CalciteCardGroup {
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled": boolean;
+        /**
+          * Accessible name for the component.
+         */
+        "label": string;
+        /**
+          * Specifies the size of the component. Child `calcite-card`s inherit the component's value.
+         */
+        "scale": Scale;
+        /**
+          * Specifies the component's selected items.
+          * @readonly
+         */
+        "selectedItems": HTMLCalciteCardElement[];
+        /**
+          * Specifies the selection mode of the component.
+         */
+        "selectionMode": Extract<
+    "multiple" | "single" | "single-persist" | "none",
+    SelectionMode
+  >;
+        /**
+          * Sets focus on the component's first focusable element.
+         */
+        "setFocus": () => Promise<void>;
+    }
     interface CalciteCheckbox {
         /**
           * When `true`, the component is checked.
@@ -5403,6 +5433,10 @@ export interface CalciteCardCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCardElement;
 }
+export interface CalciteCardGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLCalciteCardGroupElement;
+}
 export interface CalciteCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCheckboxElement;
@@ -5862,6 +5896,23 @@ declare global {
     var HTMLCalciteCardElement: {
         prototype: HTMLCalciteCardElement;
         new (): HTMLCalciteCardElement;
+    };
+    interface HTMLCalciteCardGroupElementEventMap {
+        "calciteCardGroupSelect": void;
+    }
+    interface HTMLCalciteCardGroupElement extends Components.CalciteCardGroup, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLCalciteCardGroupElementEventMap>(type: K, listener: (this: HTMLCalciteCardGroupElement, ev: CalciteCardGroupCustomEvent<HTMLCalciteCardGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLCalciteCardGroupElementEventMap>(type: K, listener: (this: HTMLCalciteCardGroupElement, ev: CalciteCardGroupCustomEvent<HTMLCalciteCardGroupElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLCalciteCardGroupElement: {
+        prototype: HTMLCalciteCardGroupElement;
+        new (): HTMLCalciteCardGroupElement;
     };
     interface HTMLCalciteCheckboxElementEventMap {
         "calciteInternalCheckboxBlur": boolean;
@@ -7337,6 +7388,7 @@ declare global {
         "calcite-block-section": HTMLCalciteBlockSectionElement;
         "calcite-button": HTMLCalciteButtonElement;
         "calcite-card": HTMLCalciteCardElement;
+        "calcite-card-group": HTMLCalciteCardGroupElement;
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
@@ -8059,6 +8111,36 @@ declare namespace LocalJSX {
           * Sets the placement of the thumbnail defined in the `thumbnail` slot.
          */
         "thumbnailPosition"?: LogicalFlowPosition;
+    }
+    interface CalciteCardGroup {
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled"?: boolean;
+        /**
+          * Accessible name for the component.
+         */
+        "label": string;
+        /**
+          * Emits when the component's selection changes and the selectionMode is not `none`.
+         */
+        "onCalciteCardGroupSelect"?: (event: CalciteCardGroupCustomEvent<void>) => void;
+        /**
+          * Specifies the size of the component. Child `calcite-card`s inherit the component's value.
+         */
+        "scale"?: Scale;
+        /**
+          * Specifies the component's selected items.
+          * @readonly
+         */
+        "selectedItems"?: HTMLCalciteCardElement[];
+        /**
+          * Specifies the selection mode of the component.
+         */
+        "selectionMode"?: Extract<
+    "multiple" | "single" | "single-persist" | "none",
+    SelectionMode
+  >;
     }
     interface CalciteCheckbox {
         /**
@@ -12906,6 +12988,7 @@ declare namespace LocalJSX {
         "calcite-block-section": CalciteBlockSection;
         "calcite-button": CalciteButton;
         "calcite-card": CalciteCard;
+        "calcite-card-group": CalciteCardGroup;
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
@@ -13018,6 +13101,7 @@ declare module "@stencil/core" {
             "calcite-block-section": LocalJSX.CalciteBlockSection & JSXBase.HTMLAttributes<HTMLCalciteBlockSectionElement>;
             "calcite-button": LocalJSX.CalciteButton & JSXBase.HTMLAttributes<HTMLCalciteButtonElement>;
             "calcite-card": LocalJSX.CalciteCard & JSXBase.HTMLAttributes<HTMLCalciteCardElement>;
+            "calcite-card-group": LocalJSX.CalciteCardGroup & JSXBase.HTMLAttributes<HTMLCalciteCardGroupElement>;
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;

--- a/packages/calcite-components/src/components/meter/meter.scss
+++ b/packages/calcite-components/src/components/meter/meter.scss
@@ -19,9 +19,9 @@
   *
   * --calcite-internal-meter-fill-color
   * --calcite-internal-meter-background-color
-  * --calcite-internal-meter-space: var(--calcite-spacing-base);
-  * --calcite-internal-meter-height: var(--calcite-size-lg);
-  * --calcite-internal-meter-font-size: var(--calcite-font-size--1);
+  * --calcite-internal-meter-space
+  * --calcite-internal-meter-height
+  * --calcite-internal-meter-font-size
 */
 
 @include base-component();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -16,14 +16,6 @@
  *
  */
 
-/**
-  * Local props
-  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
-  *
-  * --calcite-internal-meter-fill-color
-  * --calcite-internal-meter-background-color
-*/
-
 :host {
   @apply relative flex items-center;
   inline-size: fit-content;

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -24,8 +24,7 @@
   * --calcite-internal-rating-chip-text-spacing
   * --calcite-internal-rating-spacing
   * --calcite-internal-rating-block-size
-
-
+  *
 */
 
 :host {

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -27,7 +27,7 @@
   --calcite-rating-chip-border-color: var(--calcite-color-foreground-2);
   --calcite-rating-chip-shadow: var(--calcite-shadow-none);
   --calcite-rating-chip-corner-radius: 9999px;
-  --calcite-rating-chip-text-color: var(--calcite-color-text-1);
+  --calcite-rating-chip-text-color: var(--calcite-color-text-3);
 }
 
 @include disabled();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -3,12 +3,39 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating star.
+ * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating item.
+ * @prop --calcite-rating-outline-color: Specifies the outline color for a rating item.
+ * @prop --calcite-rating-outline-color-hover: Specifies the outline color for a rating item while hovered.
+ * @prop --calcite-rating-value-fill-color: Specifies the fill color for for value of the component.
+ * @prop --calcite-rating-average-fill-color: Specifies the fill color for average of the component.
+ * @prop --calcite-rating-chip-background-color: Specifies the background color of the component.
+ * @prop --calcite-rating-chip-border-color: Specifies the border color of the component.
+ * @prop --calcite-rating-chip-shadow: Specifies the box shadow of the component.
+ * @prop --calcite-rating-chip-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-rating-chip-text-color: Specifies the color of the component's `"default"` slot.
+ *
  */
+
+/**
+  * Local props
+  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
+  *
+  * --calcite-internal-meter-fill-color
+  * --calcite-internal-meter-background-color
+*/
 
 :host {
   @apply relative flex items-center;
   inline-size: fit-content;
+  --calcite-rating-outline-color: var(--calcite-color-border-input);
+  --calcite-rating-outline-color-hover: var(--calcite-color-brand);
+  --calcite-rating-value-fill-color: var(--calcite-color-brand);
+  --calcite-rating-average-fill-color: var(--calcite-color-status-warning);
+  --calcite-rating-chip-background-color: var(--calcite-color-foreground-2);
+  --calcite-rating-chip-border-color: var(--calcite-color-foreground-2);
+  --calcite-rating-chip-shadow: var(--calcite-shadow-none);
+  --calcite-rating-chip-corner-radius: 9999px;
+  --calcite-rating-chip-text-color: var(--calcite-color-text-1);
 }
 
 @include disabled();
@@ -37,7 +64,7 @@
   display: flex;
   border-width: 0;
   padding: 0;
-  align-items: center;
+  aligns: center;
   gap: var(--calcite-rating-spacing-unit);
 }
 
@@ -50,8 +77,10 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  align-self: center;
   cursor: pointer;
-  color: theme("borderColor.color.input");
+  box-shadow: var(--calcite-rating-shadow);
+  color: var(--calcite-rating-outline-color);
   &:focus {
     @apply focus-outset;
   }
@@ -59,12 +88,12 @@
 
 .average,
 .fraction {
-  color: theme("colors.warning");
+  color: var(--calcite-rating-average-fill-color);
 }
 
 .hovered,
 .selected {
-  color: theme("colors.brand");
+  color: var(--calcite-rating-value-fill-color);
 }
 
 .fraction {
@@ -80,14 +109,19 @@
 calcite-chip {
   pointer-events: none;
   cursor: default;
+  --calcite-chip-background-color: var(--calcite-rating-chip-background-color);
+  --calcite-chip-border-color: var(--calcite-rating-chip-border-color);
+  --calcite-chip-shadow: var(--calcite-rating-chip-shadow);
+  --calcite-chip-corner-radius: var(--calcite-rating-chip-corner-radius);
+  --calcite-chip-text-color: var(--calcite-rating-chip-text-color);
 }
 
 .number--average {
   font-weight: bold;
+  color: var(--calcite-rating-chip-text-color, var(--calcite-color-text-1));
 }
 
 .number--count {
-  color: var(--calcite-color-text-2);
   font-style: italic;
   &:not(:first-child) {
     margin-inline-start: var(--calcite-rating-spacing-unit);

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -3,16 +3,16 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: The amount of left and right margin spacing between each rating item.
+ * @prop --calcite-rating-spacing-unit: The amount spacing between rating items.
  * @prop --calcite-rating-outline-color: Specifies the outline color for a rating item.
  * @prop --calcite-rating-outline-color-hover: Specifies the outline color for a rating item while hovered.
- * @prop --calcite-rating-value-fill-color: Specifies the fill color for for value of the component.
- * @prop --calcite-rating-average-fill-color: Specifies the fill color for average of the component.
- * @prop --calcite-rating-chip-background-color: Specifies the background color of the component.
- * @prop --calcite-rating-chip-border-color: Specifies the border color of the component.
- * @prop --calcite-rating-chip-shadow: Specifies the box shadow of the component.
- * @prop --calcite-rating-chip-corner-radius: Specifies the corner radius of the component.
- * @prop --calcite-rating-chip-text-color: Specifies the color of the component's `"default"` slot.
+ * @prop --calcite-rating-value-fill-color: Specifies the fill color for a rating item with value.
+ * @prop --calcite-rating-average-fill-color: Specifies the fill color for a rating item with average.
+ * @prop --calcite-rating-chip-background-color: Specifies the background color of the component's `show-chip` display.
+ * @prop --calcite-rating-chip-border-color: Specifies the border color of the component's `show-chip` display.
+ * @prop --calcite-rating-chip-shadow: Specifies the box shadow of the component's `show-chip` display.
+ * @prop --calcite-rating-chip-corner-radius: Specifies the corner radius of the component's `show-chip` display.
+ * @prop --calcite-rating-chip-text-color: Specifies the color of the component's `show-chip` display.
  *
  */
 

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -34,11 +34,11 @@
 }
 
 :host([scale="m"]) {
-  --calcite-rating-spacing-unit: var(--calcite-size-xs);
+  --calcite-rating-spacing-unit: var(--calcite-size-sm);
 }
 
 :host([scale="l"]) {
-  --calcite-rating-spacing-unit: var(--calcite-size-sm);
+  --calcite-rating-spacing-unit: var(--calcite-size-md);
 }
 
 :host([read-only]) {
@@ -50,6 +50,7 @@
   display: flex;
   border-width: 0;
   padding: 0;
+  align-items: center;
   gap: var(--calcite-rating-spacing-unit);
 }
 
@@ -103,12 +104,12 @@ calcite-chip {
 }
 
 .number--average {
-  font-weight: bold;
+  font-weight: var(--calcite-font-weight-bold);
   color: var(--calcite-rating-chip-text-color, var(--calcite-color-text-1));
 }
 
 .number--count {
-  font-style: italic;
+  font-style: var(--calcite-font-style-emphasis);
   &:not(:first-child) {
     margin-inline-start: var(--calcite-rating-spacing-unit);
   }

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -3,7 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: The amount spacing between rating items.
+ * @prop --calcite-rating-spacing-unit: [Deprecated] Use the `--calcite-rating-spacing` property instead.  The amount of spacing between rating items.
+ * @prop --calcite-rating-spacing: Specifies the amount of spacing between rating items.
  * @prop --calcite-rating-outline-color: Specifies the outline color for a rating item.
  * @prop --calcite-rating-outline-color-hover: Specifies the outline color for a rating item while hovered.
  * @prop --calcite-rating-value-fill-color: Specifies the fill color for a rating item with value.
@@ -15,6 +16,15 @@
  * @prop --calcite-rating-chip-text-color: Specifies the color of the component's `show-chip` display.
  *
  */
+
+/**
+  * Local props
+  * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
+  *
+  * --calcite-internal-rating-chip-text-spacing
+  * --calcite-internal-rating-spacing
+
+*/
 
 :host {
   @apply relative flex items-center;
@@ -30,15 +40,27 @@
 }
 
 :host([scale="s"]) {
-  --calcite-rating-spacing-unit: var(--calcite-size-xxs);
+  --calcite-internal-rating-spacing: var(
+    --calcite-rating-spacing-unit,
+    var(--calcite-rating-spacing, var(--calcite-size-xxs))
+  );
+  --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
 }
 
 :host([scale="m"]) {
-  --calcite-rating-spacing-unit: var(--calcite-size-sm);
+  --calcite-internal-rating-spacing: var(
+    --calcite-rating-spacing-unit,
+    var(--calcite-rating-spacing, var(--calcite-size-sm))
+  );
+  --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
 }
 
 :host([scale="l"]) {
-  --calcite-rating-spacing-unit: var(--calcite-size-md);
+  --calcite-internal-rating-spacing: var(
+    --calcite-rating-spacing-unit,
+    var(--calcite-rating-spacing, var(--calcite-size-md))
+  );
+  --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
 }
 
 :host([read-only]) {
@@ -51,7 +73,7 @@
   border-width: 0;
   padding: 0;
   align-items: center;
-  gap: var(--calcite-rating-spacing-unit);
+  gap: var(--calcite-internal-rating-spacing);
 }
 
 .wrapper {
@@ -111,7 +133,7 @@ calcite-chip {
 .number--count {
   font-style: var(--calcite-font-style-emphasis);
   &:not(:first-child) {
-    margin-inline-start: var(--calcite-rating-spacing-unit);
+    margin-inline-start: var(--calcite-internal-rating-chip-text-spacing);
   }
 }
 

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -29,21 +29,16 @@
   --calcite-rating-chip-corner-radius: 9999px;
 }
 
-@include disabled();
-
 :host([scale="s"]) {
-  @apply h-6;
-  --calcite-rating-spacing-unit: theme("spacing.1");
+  --calcite-rating-spacing-unit: var(--calcite-size-xxs);
 }
 
 :host([scale="m"]) {
-  @apply h-8;
-  --calcite-rating-spacing-unit: theme("spacing.2");
+  --calcite-rating-spacing-unit: var(--calcite-size-xs);
 }
 
 :host([scale="l"]) {
-  @apply h-11;
-  --calcite-rating-spacing-unit: theme("spacing.3");
+  --calcite-rating-spacing-unit: var(--calcite-size-sm);
 }
 
 :host([read-only]) {
@@ -55,7 +50,6 @@
   display: flex;
   border-width: 0;
   padding: 0;
-  aligns: center;
   gap: var(--calcite-rating-spacing-unit);
 }
 
@@ -125,3 +119,4 @@ calcite-chip {
 
 @include hidden-form-input();
 @include base-component();
+@include disabled();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -23,6 +23,8 @@
   *
   * --calcite-internal-rating-chip-text-spacing
   * --calcite-internal-rating-spacing
+  * --calcite-internal-rating-block-size
+
 
 */
 
@@ -45,6 +47,7 @@
     var(--calcite-rating-spacing, var(--calcite-size-xxs))
   );
   --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
+  --calcite-internal-rating-block-size: var(--calcite-size-xxl);
 }
 
 :host([scale="m"]) {
@@ -53,6 +56,7 @@
     var(--calcite-rating-spacing, var(--calcite-size-sm))
   );
   --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
+  --calcite-internal-rating-block-size: var(--calcite-size-xxxl);
 }
 
 :host([scale="l"]) {
@@ -61,6 +65,7 @@
     var(--calcite-rating-spacing, var(--calcite-size-md))
   );
   --calcite-internal-rating-chip-text-spacing: var(--calcite-size-sm);
+  --calcite-internal-rating-block-size: 44px;
 }
 
 :host([read-only]) {
@@ -74,6 +79,7 @@
   padding: 0;
   align-items: center;
   gap: var(--calcite-internal-rating-spacing);
+  block-size: var(--calcite-internal-rating-block-size);
 }
 
 .wrapper {

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -27,7 +27,6 @@
   --calcite-rating-chip-border-color: var(--calcite-color-foreground-2);
   --calcite-rating-chip-shadow: var(--calcite-shadow-none);
   --calcite-rating-chip-corner-radius: 9999px;
-  --calcite-rating-chip-text-color: var(--calcite-color-text-2);
 }
 
 @include disabled();

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -99,6 +99,7 @@ calcite-chip {
   --calcite-chip-shadow: var(--calcite-rating-chip-shadow);
   --calcite-chip-corner-radius: var(--calcite-rating-chip-corner-radius);
   --calcite-chip-text-color: var(--calcite-rating-chip-text-color);
+  color: var(--calcite-color-text-3);
 }
 
 .number--average {

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -27,7 +27,7 @@
   --calcite-rating-chip-border-color: var(--calcite-color-foreground-2);
   --calcite-rating-chip-shadow: var(--calcite-shadow-none);
   --calcite-rating-chip-corner-radius: 9999px;
-  --calcite-rating-chip-text-color: var(--calcite-color-text-3);
+  --calcite-rating-chip-text-color: var(--calcite-color-text-2);
 }
 
 @include disabled();

--- a/packages/calcite-components/src/components/rating/rating.stories.ts
+++ b/packages/calcite-components/src/components/rating/rating.stories.ts
@@ -54,3 +54,41 @@ export const Focus_TestOnly = (): string =>
 Focus_TestOnly.parameters = {
   chromatic: { delay: 500 },
 };
+
+export const theming_TestOnly = (): string => html`
+  <calcite-rating
+    average="2.4"
+    count="10"
+    style="--calcite-rating-spacing-unit: 16px;
+        --calcite-rating-outline-color: lightgreen;
+        --calcite-rating-outline-color-hover: darkgreen;
+        --calcite-rating-value-fill-color: green;
+        --calcite-rating-average-fill-color: purple;
+        --calcite-rating-chip-background-color: green;
+        --calcite-rating-chip-border-color: darkgreen;
+        --calcite-rating-chip-shadow: var(--calcite-shadow-md);
+        --calcite-rating-chip-corner-radius: 12px;
+        --calcite-rating-chip-text-color: lightgreen;
+        --calcite-ui-focus-color: red;"
+  ></calcite-rating>
+`;
+
+export const themingTwo_TestOnly = (): string => html`
+  <calcite-rating
+    value="4"
+    show-chip
+    average="2.4"
+    count="10"
+    style="--calcite-rating-spacing-unit: 16px;
+        --calcite-rating-outline-color: lightgreen;
+        --calcite-rating-outline-color-hover: darkgreen;
+        --calcite-rating-value-fill-color: green;
+        --calcite-rating-average-fill-color: purple;
+        --calcite-rating-chip-background-color: green;
+        --calcite-rating-chip-border-color: darkgreen;
+        --calcite-rating-chip-shadow: var(--calcite-shadow-md);
+        --calcite-rating-chip-corner-radius: 12px;
+        --calcite-rating-chip-text-color: lightgreen;
+        --calcite-ui-focus-color: red;"
+  ></calcite-rating>
+`;

--- a/packages/calcite-components/src/components/rating/rating.stories.ts
+++ b/packages/calcite-components/src/components/rating/rating.stories.ts
@@ -59,6 +59,24 @@ export const theming_TestOnly = (): string => html`
   <calcite-rating
     average="2.4"
     count="10"
+    style="--calcite-rating-spacing: 16px;
+        --calcite-rating-outline-color: lightgreen;
+        --calcite-rating-outline-color-hover: darkgreen;
+        --calcite-rating-value-fill-color: green;
+        --calcite-rating-average-fill-color: purple;
+        --calcite-rating-chip-background-color: green;
+        --calcite-rating-chip-border-color: darkgreen;
+        --calcite-rating-chip-shadow: var(--calcite-shadow-md);
+        --calcite-rating-chip-corner-radius: 12px;
+        --calcite-rating-chip-text-color: lightgreen;
+        --calcite-ui-focus-color: red;"
+  ></calcite-rating>
+`;
+
+export const themingDeprecatedCssProp_TestOnly = (): string => html`
+  <calcite-rating
+    average="2.4"
+    count="10"
     style="--calcite-rating-spacing-unit: 16px;
         --calcite-rating-outline-color: lightgreen;
         --calcite-rating-outline-color-hover: darkgreen;
@@ -79,7 +97,7 @@ export const themingTwo_TestOnly = (): string => html`
     show-chip
     average="2.4"
     count="10"
-    style="--calcite-rating-spacing-unit: 16px;
+    style="--calcite-rating-spacing: 16px;
         --calcite-rating-outline-color: lightgreen;
         --calcite-rating-outline-color-hover: darkgreen;
         --calcite-rating-value-fill-color: green;

--- a/packages/calcite-components/src/demos/rating.html
+++ b/packages/calcite-components/src/demos/rating.html
@@ -31,6 +31,20 @@
         margin: 25px 0;
         border-top: 1px solid var(--calcite-color-border-2);
       }
+
+      .theme-example {
+        --calcite-rating-spacing-unit: 16px;
+        --calcite-rating-outline-color: lightgreen;
+        --calcite-rating-outline-color-hover: darkgreen;
+        --calcite-rating-value-fill-color: green;
+        --calcite-rating-average-fill-color: purple;
+        --calcite-rating-chip-background-color: green;
+        --calcite-rating-chip-border-color: darkgreen;
+        --calcite-rating-chip-shadow: var(--calcite-shadow-md);
+        --calcite-rating-chip-corner-radius: 12px;
+        --calcite-rating-chip-text-color: lightgreen;
+        --calcite-ui-focus-color: red;
+      }
     </style>
     <script src="./_assets/head.js"></script>
   </head>
@@ -52,6 +66,23 @@
       * DEFAULT
       **************************************************
     -->
+
+      <!-- Default -->
+      <div class="parent">
+        <div class="child right-aligned-text">Themed</div>
+
+        <div class="child">
+          <calcite-rating class="theme-example" scale="s" show-chip></calcite-rating>
+        </div>
+
+        <div class="child">
+          <calcite-rating class="theme-example" average="3.65" count="136" show-chip></calcite-rating>
+        </div>
+
+        <div class="child">
+          <calcite-rating class="theme-example" value="2" show-chip></calcite-rating>
+        </div>
+      </div>
 
       <!-- Default -->
       <div class="parent">

--- a/packages/calcite-components/src/demos/rating.html
+++ b/packages/calcite-components/src/demos/rating.html
@@ -33,7 +33,7 @@
       }
 
       .theme-example {
-        --calcite-rating-spacing-unit: 16px;
+        --calcite-rating-spacing: 16px;
         --calcite-rating-outline-color: lightgreen;
         --calcite-rating-outline-color-hover: darkgreen;
         --calcite-rating-value-fill-color: green;
@@ -84,6 +84,27 @@
         </div>
       </div>
 
+      <!-- Default -->
+      <div class="parent">
+        <div class="child right-aligned-text">deprecated css spacing property test</div>
+
+        <div class="child">
+          <calcite-rating style="--calcite-rating-spacing-unit: 12px" scale="s" show-chip></calcite-rating>
+        </div>
+
+        <div class="child">
+          <calcite-rating
+            style="--calcite-rating-spacing-unit: 12px"
+            average="3.65"
+            count="136"
+            show-chip
+          ></calcite-rating>
+        </div>
+
+        <div class="child">
+          <calcite-rating style="--calcite-rating-spacing-unit: 12px" value="2" show-chip></calcite-rating>
+        </div>
+      </div>
       <!-- Default -->
       <div class="parent">
         <div class="child right-aligned-text">Default</div>


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary
Adds the following component tokens:

`--calcite-rating-spacing-unit`: The amount spacing between rating items.
`--calcite-rating-outline-color`: Specifies the outline color for a rating item.
`--calcite-rating-outline-color-hover`: Specifies the outline color for a rating item while hovered.
`--calcite-rating-value-fill-color`: Specifies the fill color for a rating item with value.
`--calcite-rating-average-fill-color`: Specifies the fill color for a rating item with average.
`--calcite-rating-chip-background-color`: Specifies the background color of the component's `show-chip` display.
`--calcite-rating-chip-border-color`: Specifies the border color of the component's `show-chip` display.
`--calcite-rating-chip-shadow`: Specifies the box shadow of the component's `show-chip` display.
`--calcite-rating-chip-corner-radius`: Specifies the corner radius of the component's `show-chip` display.
`--calcite-rating-chip-text-color`: Specifies the color of the component's `show-chip` display.

We need to offer the `outline-color-hover` because users do not have the ability to target the individually rendered rating stars with css.

Adds theming example to the local doc pages as well as a Chromatic story.