### PR TITLE
fix(tab): style focus outline of tab content

### DIFF
--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -46,4 +46,12 @@ section,
   @apply hidden h-full w-full;
 }
 
+.container {
+  @apply focus-base;
+
+  &:focus {
+    @apply focus-inset;
+  }
+}
+
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #8799 

## Summary

Applies focus outline styling to `tab`'s content container.

<img width="366" alt="Screenshot 2024-02-21 at 10 58 57 AM" src="https://github.com/Esri/calcite-design-system/assets/197440/b8dc6408-4135-4a4f-84e4-70c8fb6e84b3">

<img width="359" alt="Screenshot 2024-02-21 at 10 58 53 AM" src="https://github.com/Esri/calcite-design-system/assets/197440/58c6cae1-6f70-4d4f-bbad-00a789ce2344">