### PR TITLE
test(shell-center-row): fix test

### DIFF
--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.e2e.ts
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.e2e.ts
@@ -56,11 +56,10 @@ describe("calcite-shell-center-row", () => {
     `;
     await page.setContent(pageContent);
 
-    const element = await page.find("calcite-shell-center-row");
+    const element = await page.find("calcite-shell-center-row >>> div:first-of-type");
 
     await page.waitForChanges();
-
-    expect(element.shadowRoot.firstElementChild).toHaveClass(CSS.actionBarContainer);
+    expect(element).toHaveClass(CSS.actionBarContainer);
   });
 
   it("should render action bar container last when action bar has end position", async () => {


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

This selects the correct component within the shadow dom. The previous selector included the components <style> tag.
