### PR TITLE
chore(pr-e2e): add workflow_dispatch option for e2e tests

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,5 +1,6 @@
 name: E2E
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main, rc]
 jobs:


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Allows anyone with GH Actions permission on the repo to manually go to https://github.com/Esri/calcite-design-system/actions/workflows/pr-e2e.yml and select their current branch, even if it's base is not `main` or `rc` and trigger an `npm run build && npm run test`

<img width="315" alt="Screenshot 2024-02-22 at 9 36 48 AM" src="https://github.com/Esri/calcite-design-system/assets/3362490/4d8634db-67d5-417b-b23a-6238ed195fb8">
