### PR TITLE
ci(e2e): manually setup chrome to fix puppeteer errrors

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -24,9 +24,17 @@ jobs:
             echo "run e2e"
             echo "SKIP=false" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/setup-node@v3
+      - if: steps.markdown-check.outputs.SKIP == 'false'
+        uses: actions/setup-node@v3
         with:
           node-version-file: package.json
-      - run: npm install
       - if: steps.markdown-check.outputs.SKIP == 'false'
-        run: npm run build && npm run test
+        uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: stable
+      - if: steps.markdown-check.outputs.SKIP == 'false'
+        run: npm install && npm run build && npm run test
+        env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+          PUPPETEER_SKIP_DOWNLOAD: true

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1376,7 +1376,7 @@ describe("calcite-input", () => {
           expect(await input.getProperty("value")).toBe(localizedValue);
         });
 
-        it(`displays correct formatted value when using exponential numbers for ${locale} locale`, async () => {
+        it(`displays correct formatted value when using exponential numbers for locale`, async () => {
           numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1376,7 +1376,7 @@ describe("calcite-input", () => {
           expect(await input.getProperty("value")).toBe(localizedValue);
         });
 
-        it(`displays correct formatted value when using exponential numbers for locale`, async () => {
+        it(`displays correct formatted value when using exponential numbers for ${locale} locale`, async () => {
           numberStringFormatter.numberFormatOptions = {
             locale,
             numberingSystem: "latn",


### PR DESCRIPTION
Manually install Chrome using an action to prevent errors with Puppeteer trying to install Chrome from a broken URL.

```
npm ERR! code 1
npm ERR! path /home/runner/work/calcite-design-system/calcite-design-system/node_modules/puppeteer
npm ERR! command failed
npm ERR! command sh -c node install.mjs
npm ERR! ERROR: Failed to set up Chrome r119.0.6045.105! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
npm ERR! Error: Download failed: server returned code 500. URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/119.0.6045.105/linux64/chrome-linux64.zip
npm ERR!     at file:///home/runner/work/calcite-design-system/calcite-design-system/node_modules/@puppeteer/browsers/lib/esm/httpUtil.js:74:31
npm ERR!     at ClientRequest.requestCallback (file:///home/runner/work/calcite-design-system/calcite-design-system/node_modules/@puppeteer/browsers/lib/esm/httpUtil.js:52:13)
npm ERR!     at Object.onceWrapper (node:events:629:26)
npm ERR!     at ClientRequest.emit (node:events:514:28)
npm ERR!     at HTTPParser.parserOnIncomingClient (node:_http_client:693:27)
npm ERR!     at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
npm ERR!     at TLSSocket.socketOnData (node:_http_client:535:22)
npm ERR!     at TLSSocket.emit (node:events:514:28)
npm ERR!     at addChunk (node:internal/streams/readable:545:12)
npm ERR!     at readableAddChunkPushByteMode (node:internal/streams/readable:495:3)
```

error: https://github.com/Esri/calcite-design-system/actions/runs/8009736114/job/21879085441#step:4:62
related issue: https://github.com/GoogleChromeLabs/chrome-for-testing/issues/109