### PR TITLE
fix(navigation-logo): no longer changes icon color when `href` is parsed

### DIFF
--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -1,11 +1,3 @@
-/**
- * CSS Custom Properties
- *
- * These properties can be overridden using the component's tag as selector.
- *
- * @prop --calcite-navigation-logo-text-color: Specifies the text color of the component. Defaults to `var(--calcite-color-text-1)`
- */
-
 :host {
   @apply inline-flex outline-none;
 }

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -12,6 +12,7 @@
     focus-base
     no-underline
     text-0h;
+  color: inherit;
   border-block-end: 2px solid transparent;
 }
 

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -20,7 +20,7 @@
     focus-base
     no-underline
     text-0h;
-  color: var(--calcite-navigation-logo-text-color, var(--calcite-color-text-1));
+  color: inherit;
   border-block-end: 2px solid transparent;
 }
 

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -1,3 +1,11 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-navigation-logo-text-color: Specifies the text color of the component. Defaults to `var(--calcite-color-text-1)`
+ */
+
 :host {
   @apply inline-flex outline-none;
 }
@@ -12,7 +20,7 @@
     focus-base
     no-underline
     text-0h;
-  color: inherit;
+  color: var(--calcite-navigation-logo-text-color, var(--calcite-color-text-1));
   border-block-end: 2px solid transparent;
 }
 

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.stories.ts
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.stories.ts
@@ -61,3 +61,17 @@ export const slottedInNav_TestOnly = (): string => html`
     />
   </calcite-navigation>
 `;
+
+export const withHref_TestOnly = (): string => html`
+  <calcite-navigation>
+    <calcite-navigation-logo
+      slot="logo"
+      heading="A view of the estuary"
+      icon="globe"
+      href="https://www.esri.com"
+      target="_blank"
+      description="20 years of change where the river meets the sea"
+    >
+    </calcite-navigation-logo>
+  </calcite-navigation>
+`;


### PR DESCRIPTION
**Related Issue:** #8482 

## Summary

Fixes change of icon color in `navigation-logo` when `href` attribute is parsed.