### PR TITLE
docs(tile): deprecate embed property

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -4958,6 +4958,7 @@ export namespace Components {
         "disabled": boolean;
         /**
           * The component's embed mode.  When `true`, renders without a border and padding for use by other components.
+          * @deprecated
          */
         "embed": boolean;
         /**
@@ -12484,6 +12485,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         /**
           * The component's embed mode.  When `true`, renders without a border and padding for use by other components.
+          * @deprecated
          */
         "embed"?: boolean;
         /**

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -4958,7 +4958,7 @@ export namespace Components {
         "disabled": boolean;
         /**
           * The component's embed mode.  When `true`, renders without a border and padding for use by other components.
-          * @deprecated
+          * @deprecated No longer necessary.
          */
         "embed": boolean;
         /**
@@ -12485,7 +12485,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         /**
           * The component's embed mode.  When `true`, renders without a border and padding for use by other components.
-          * @deprecated
+          * @deprecated No longer necessary.
          */
         "embed"?: boolean;
         /**

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -51,7 +51,7 @@ export class Tile implements InteractiveComponent {
    *
    * When `true`, renders without a border and padding for use by other components.
    *
-   * @deprecated
+   * @deprecated No longer necessary.
    */
   @Prop({ reflect: true }) embed = false;
 

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -50,6 +50,8 @@ export class Tile implements InteractiveComponent {
    * The component's embed mode.
    *
    * When `true`, renders without a border and padding for use by other components.
+   *
+   * @deprecated
    */
   @Prop({ reflect: true }) embed = false;
 


### PR DESCRIPTION
**Related Issues:** #6662 #8351

## Summary

Tile Select no longer uses Tile, and thus its internal `embed` property, so this PR marks it as deprecated.