### PR TITLE
feat(action menu): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -3,11 +3,11 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-action-group-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-action-group-action-menu-text-color: The text color of the sub-component.
  * @prop --calcite-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-gap: Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-padding: Sets the padding when the `layout` property is `"grid"`.
- * @prop --calcite-action-group-action-menu-border-color: The border color of the sub-component.
- * @prop --calcite-action-group-action-menu-text-color: The text color of the sub-component.
  */
 
 :host {

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -6,6 +6,8 @@
  * @prop --calcite-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-gap: Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-padding: Sets the padding when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-action-group-action-menu-text-color: The text color of the sub-component.
  */
 
 :host {
@@ -63,6 +65,11 @@
   gap: var(--calcite-action-group-gap);
   padding: var(--calcite-action-group-gap);
   grid-template-columns: repeat(var(--calcite-action-group-columns), auto);
+}
+
+calcite-action-menu {
+  --calcite-action-menu-border-color: var(--calcite-action-group-action-menu-border-color);
+  --calcite-action-menu-text-color: var(--calcite-action-group-action-menu-text-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import {
   accessible,
@@ -524,6 +524,52 @@ describe("calcite-action-menu", () => {
 
       expect(await actionMenu.getProperty("open")).toBe(false);
       expect(clickSpy).toHaveReceivedEventTimes(1);
+    });
+  });
+
+  describe("Theme-ing", () => {
+    let page: E2EPage;
+    const customTheme = {
+      "--calcite-action-menu-group-separator-border-color": "rgb(192, 255, 238)",
+    };
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        html: `
+        <calcite-action-menu open>
+          <calcite-action slot="trigger" text="Add" icon="banana"></calcite-action>
+          <calcite-action-group>
+            <calcite-action text="Plus" icon="plus" text-enabled></calcite-action
+            ><calcite-action text="Minus" icon="minus" text-enabled></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Table" icon="table" text-enabled></calcite-action
+          ></calcite-action-group>
+          <calcite-action-group>
+            <calcite-action text="Save" icon="save" text-enabled></calcite-action>
+          </calcite-action-group>
+        </calcite-action-menu>
+      `,
+      });
+      await page.waitForChanges();
+    });
+
+    it("should allow theme-ing of the border-color", async () => {
+      const actionMenu = await page.find("calcite-action-menu");
+      const slottedActionGroup = await page.find("calcite-action-group");
+      const defaultStyle = await slottedActionGroup.getComputedStyle();
+
+      await actionMenu.setAttribute(
+        "style",
+        `--calcite-action-menu-group-separator-border-color: ${customTheme["--calcite-action-menu-group-separator-border-color"]}`,
+      );
+      await page.waitForChanges();
+
+      const styles = await slottedActionGroup.getComputedStyle();
+      expect(defaultStyle.borderBlockEndColor).not.toBe(
+        customTheme["--calcite-action-menu-group-separator-border-color"],
+      );
+      expect(styles.borderBlockEndColor).toBe(customTheme["--calcite-action-menu-group-separator-border-color"]);
     });
   });
 });

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -3,22 +3,21 @@
 *
 * These properties can be overridden using the component's tag as selector.
 *
-* @prop --calcite-action-menu-border-color: The border color of the component.
-* @prop --calcite-action-menu-text-color: The text color of the component.
+* @prop --calcite-action-menu-group-separator-border-color: The border color of the component.
+*
 */
 
 :host {
-  @apply text-color-2
-  text-1
+  @apply text-1
   box-border
   flex
   flex-col;
-
-  color: var(--calcite-action-menu-text-color, --calcite-color-text-2);
 }
 
 ::slotted(calcite-action-group) {
-  border-block-end: 1px solid var(--calcite-action-menu-border-color, --calcite-color-border-3);
+  border-block-end-style: solid;
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-block-end-color: var(--calcite-action-menu-group-separator-border-color, --calcite-color-border-3);
 }
 
 ::slotted(calcite-action-group:last-child) {

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -21,21 +21,21 @@
 }
 
 ::slotted(calcite-action-group:last-child) {
-  border-block-end: 0;
+  border-block-end: var(--calcite-border-width-none);
 }
 
 .default-trigger {
   @apply relative
-  h-full
   flex-initial
   self-stretch;
+  block-size: var(--calcite-container-size-content-fluid);
 }
 
 @include slotted("trigger", "calcite-action") {
   @apply relative
-  h-full
   flex-initial
   self-stretch;
+  block-size: var(--calcite-container-size-content-fluid);
 }
 
 .menu {

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -17,7 +17,7 @@
 ::slotted(calcite-action-group) {
   border-block-end-style: solid;
   border-block-end-width: var(--calcite-border-width-sm);
-  border-block-end-color: var(--calcite-action-menu-group-separator-border-color, --calcite-color-border-3);
+  border-block-end-color: var(--calcite-action-menu-group-separator-border-color, var(--calcite-color-border-3));
 }
 
 ::slotted(calcite-action-group:last-child) {

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -1,13 +1,24 @@
+/**
+* CSS Custom Properties
+*
+* These properties can be overridden using the component's tag as selector.
+*
+* @prop --calcite-action-menu-border-color: The border color of the component.
+* @prop --calcite-action-menu-text-color: The text color of the component.
+*/
+
 :host {
   @apply text-color-2
   text-1
   box-border
   flex
   flex-col;
+
+  color: var(--calcite-action-menu-text-color, --calcite-color-text-2);
 }
 
 ::slotted(calcite-action-group) {
-  border-block-end: 1px solid var(--calcite-color-border-3);
+  border-block-end: 1px solid var(--calcite-action-menu-border-color, --calcite-color-border-3);
 }
 
 ::slotted(calcite-action-group:last-child) {
@@ -35,6 +46,10 @@
   overflow-y-auto
   overflow-x-hidden
   max-h-menu;
+}
+
+calcite-popover {
+  // TODO: add sub-component tokens
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -4,6 +4,8 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
+ * @prop --calcite-block-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-block-action-menu-text-color: The text color of the sub-component.
  */
 
 :host {
@@ -159,6 +161,11 @@ calcite-action-menu {
   .header .title .heading {
     @apply text-color-1;
   }
+}
+
+calcite-action-menu {
+  --calcite-action-menu-border-color: var(--calcite-block-action-menu-border-color);
+  --calcite-action-menu-text-color: var(--calcite-block-action-menu-text-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -3,9 +3,9 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
  * @prop --calcite-block-action-menu-border-color: The border color of the sub-component.
  * @prop --calcite-block-action-menu-text-color: The text color of the sub-component.
+ * @prop --calcite-block-padding: Specifies the padding of the block `default` slot.
  */
 
 :host {

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -1,3 +1,12 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-menu-item-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-menu-item-action-menu-text-color: The text color of the sub-component.
+ */
+
 :host {
   @apply flex
   items-center
@@ -204,6 +213,11 @@ calcite-action {
 .content:focus .hover-href-icon,
 .content:hover .hover-href-icon {
   @apply opacity-100 -end-1;
+}
+
+calcite-action-menu {
+  --calcite-action-menu-border-color: var(--calcite-menu-item-action-menu-border-color);
+  --calcite-action-menu-text-color: var(--calcite-menu-item-action-menu-text-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -3,6 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-panel-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-panel-action-menu-text-color: The text color of the sub-component.
  * @prop --calcite-panel-background-color: Specifies the background color of the component.
  * @prop --calcite-panel-border-color: Specifies the border color of the component.
  * @prop --calcite-panel-description-text-color: Specifies the text color of the component's description.
@@ -12,10 +14,8 @@
  * @prop --calcite-panel-footer-space: Specifies the spacing of the component's footer.
  * @prop --calcite-panel-header-background-color: Specifies the component header's background color.
  * @prop --calcite-panel-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
- * @prop --calcite-panel-heading-text-color: Specifies the component's heading text color.
  * @prop --calcite-panel-header-z-index: Specifies the component header's z-index.
- * @prop --calcite-panel-action-menu-border-color: The border color of the sub-component.
- * @prop --calcite-panel-action-menu-text-color: The text color of the sub-component.
+ * @prop --calcite-panel-heading-text-color: Specifies the component's heading text color.
  */
 
 :host {

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -14,6 +14,8 @@
  * @prop --calcite-panel-header-border-block-end: [Deprecated] No longer necessary. Specifies the component header's block end border.
  * @prop --calcite-panel-heading-text-color: Specifies the component's heading text color.
  * @prop --calcite-panel-header-z-index: Specifies the component header's z-index.
+ * @prop --calcite-panel-action-menu-border-color: The border color of the sub-component.
+ * @prop --calcite-panel-action-menu-text-color: The text color of the sub-component.
  */
 
 :host {
@@ -185,6 +187,11 @@
   padding: var(--calcite-spacing-xxs);
   inset-inline: 0;
   inline-size: fit-content;
+}
+
+calcite-action-menu {
+  --calcite-action-menu-border-color: var(--calcite-panel-action-menu-border-color);
+  --calcite-action-menu-text-color: var(--calcite-panel-action-menu-text-color);
 }
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds Action-Menu component tokens and sub-component tokens to Calcite Components

### Action Group
--calcite-action-group-action-menu-border-color: The border color of the sub-component.
--calcite-action-group-action-menu-text-color: The text color of the sub-component.

### Action Menu
--calcite-action-menu-border-color: The border color of the component.
--calcite-action-menu-text-color: The text color of the component.

### Block

--calcite-block-action-menu-border-color: The border color of the sub-component.
--calcite-block-action-menu-text-color: The text color of the sub-component.

### Menu Item
--calcite-menu-item-action-menu-border-color: The border color of the sub-component.
--calcite-menu-item-action-menu-text-color: The text color of the sub-component.

### Panel
--calcite-panel-action-menu-border-color: The border color of the sub-component.
--calcite-panel-action-menu-text-color: The text color of the sub-component.

