### PR TITLE
feat(switch): add stateful component tokens

### DIFF
--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -19,23 +19,6 @@
  */
 
 :host {
-  --calcite-switch-handle-background-color: var(--calcite-color-foreground-1);
-  --calcite-switch-handle-border-color: var(--calcite-color-border-input);
-  --calcite-switch-track-background-color: var(--calcite-color-foreground-2);
-  --calcite-switch-track-border-color: var(--calcite-color-border-2);
-  --calcite-switch-corner-radius: var(--calcite-internal-switch-border-radius, --calcite-corner-radius-pill);
-  --calcite-switch-handle-shadow: none;
-
-  --calcite-switch-handle-border-color-hover: var(--calcite-color-brand);
-  --calcite-switch-handle-shadow-hover: inset 0 0 0 1px var(--calcite-color-brand);
-
-  --calcite-switch-handle-border-color-selected: var(--calcite-color-brand);
-  --calcite-switch-track-background-color-selected: var(--calcite-color-brand);
-  --calcite-switch-track-border-color-selected: var(--calcite-color-brand);
-
-  --calcite-switch-handle-border-color-selected-hover: var(--calcite-color-brand-hover);
-  --calcite-switch-handle-shadow-selected-hover: inset 0 0 0 1px var(--calcite-color-brand-hover);
-
   --calcite-internal-switch-border-radius: 9999px; // TODO: drop once --calcite-corner-radius is updated
 
   @apply relative
@@ -62,9 +45,12 @@
     pointer-events-none
     relative;
 
-  border-color: var(--calcite-switch-track-border-color);
-  background-color: var(--calcite-switch-track-background-color);
-  border-radius: var(--calcite-switch-corner-radius);
+  border-color: var(--calcite-switch-track-border-color, var(--calcite-color-border-2));
+  background-color: var(--calcite-switch-track-background-color, var(--calcite-color-foreground-2));
+  border-radius: var(
+    --calcite-switch-corner-radius,
+    var(--calcite-internal-switch-border-radius, var(--calcite-corner-radius-pill))
+  );
   block-size: var(--calcite-internal-switch-track-height);
   inline-size: var(--calcite-internal-switch-track-width);
 }
@@ -81,15 +67,17 @@
   inset-block-start: -1px;
   inset-inline: -1px theme("inset.auto");
 
-  border-color: var(--calcite-switch-handle-border-color);
-  background-color: var(--calcite-switch-handle-background-color);
-  border-radius: var(--calcite-switch-corner-radius);
-  box-shadow: var(--calcite-switch-handle-shadow);
+  border-color: var(--calcite-switch-handle-border-color, var(--calcite-color-border-input));
+  background-color: var(--calcite-switch-handle-background-color, var(--calcite-color-foreground-1));
+  border-radius: var(
+    --calcite-switch-corner-radius,
+    var(--calcite-internal-switch-border-radius, var(--calcite-corner-radius-pill))
+  );
+  box-shadow: var(--calcite-switch-handle-shadow, none);
   block-size: var(--calcite-internal-switch-handle-height);
   inline-size: var(--calcite-internal-switch-handle-width);
 }
 
-// sizes
 :host([scale="s"]) {
   --calcite-internal-switch-handle-height: var(--calcite-size-sm);
   --calcite-internal-switch-handle-width: var(--calcite-size-sm);
@@ -108,7 +96,7 @@
   --calcite-internal-switch-handle-height: var(--calcite-size-xl);
   --calcite-internal-switch-handle-width: var(--calcite-size-xl);
   --calcite-internal-switch-track-height: var(--calcite-size-xxl);
-  --calcite-internal-switch-track-width: #{$calcite-size-48}; // TODO: need new size token for this size
+  --calcite-internal-switch-track-width: #{$calcite-size-48};
 }
 
 :host(:focus) .track {
@@ -118,34 +106,33 @@
 :host(:hover),
 :host(:focus) {
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-hover);
-    box-shadow: var(--calcite-switch-handle-shadow-hover);
+    border-color: var(--calcite-switch-handle-border-color-hover, var(--calcite-color-brand));
+    box-shadow: var(--calcite-switch-handle-shadow-hover, inset 0 0 0 1px var(--calcite-color-brand));
   }
 }
 
 :host([checked]) {
   .track {
-    background-color: var(--calcite-switch-track-background-color-selected);
-    border-color: var(--calcite-switch-track-border-color-selected);
+    background-color: var(--calcite-switch-track-background-color-selected, var(--calcite-color-brand));
+    border-color: var(--calcite-switch-track-border-color-selected, var(--calcite-color-brand));
   }
 
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-selected);
-
+    border-color: var(--calcite-switch-handle-border-color-selected, var(--calcite-color-brand));
     inset-inline: theme("inset.auto") -1px;
   }
 }
 
 :host([checked]:hover) {
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-selected-hover);
-    box-shadow: var(--calcite-switch-handle-shadow-selected-hover);
+    border-color: var(--calcite-switch-handle-border-color-selected-hover, var(--calcite-color-brand-hover));
+    box-shadow: var(--calcite-switch-handle-shadow-selected-hover, inset 0 0 0 1px var(--calcite-color-brand-hover));
   }
 }
 
 @media (forced-colors: active) {
   :host([checked]) {
-    --calcite-switch-track-background-color: canvasText;
+    background-color: canvasText;
   }
 }
 

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -27,7 +27,6 @@
   cursor-pointer
   select-none
   align-middle;
-  tap-highlight-color: transparent;
 }
 
 .container {

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -5,17 +5,16 @@
  *
  * @prop --calcite-switch-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-switch-handle-background-color: Specifies the background color of the component handle.
- * @prop --calcite-switch-handle-border-color: Specifies the border color of the component handle.
- * @prop --calcite-switch-track-background-color: Specifies the background color of the component track.
- * @prop --calcite-switch-track-border-color: Specifies the border color of the component track.
- * @prop --calcite-switch-handle-shadow: Specifies the shadow of the component handle.
+ * @prop --calcite-switch-handle-border-color-checked-hover: Specifies the border color of the component handle when checked and hovered.
+ * @prop --calcite-switch-handle-border-color-checked: Specifies the border color of the component handle when checked.
  * @prop --calcite-switch-handle-border-color-hover: Specifies the border color of the component handle when hovered.
- * @prop --calcite-switch-shadow-hover: Specifies the shadow of the component handle when hovered.
- * @prop --calcite-switch-handle-border-color-selected: Specifies the border color of the component handle when selected.
- * @prop --calcite-switch-track-background-color-selected: Specifies the background color of the component track when selected.
- * @prop --calcite-switch-track-border-color-selected: Specifies the border color of the component track when selected.
- * @prop --calcite-switch-handle-border-color-selected-hover: Specifies the border color of the component handle when selected and hovered.
- * @prop --calcite-switch-shadow-selected-hover: Specifies the shadow of the component handle when selected and hovered.
+ * @prop --calcite-switch-handle-border-color: Specifies the border color of the component handle.
+ * @prop --calcite-switch-handle-shadow-checked-hover: Specifies the shadow of the component handle when checked and hovered.
+ * @prop --calcite-switch-handle-shadow: Specifies the shadow of the component handle.
+ * @prop --calcite-switch-track-background-color-checked: Specifies the background color of the component track when checked.
+ * @prop --calcite-switch-track-background-color: Specifies the background color of the component track.
+ * @prop --calcite-switch-track-border-color-checked: Specifies the border color of the component track when checked.
+ * @prop --calcite-switch-track-border-color: Specifies the border color of the component track.
  */
 
 :host {
@@ -112,20 +111,20 @@
 
 :host([checked]) {
   .track {
-    background-color: var(--calcite-switch-track-background-color-selected, var(--calcite-color-brand));
-    border-color: var(--calcite-switch-track-border-color-selected, var(--calcite-color-brand));
+    background-color: var(--calcite-switch-track-background-color-checked, var(--calcite-color-brand));
+    border-color: var(--calcite-switch-track-border-color-checked, var(--calcite-color-brand));
   }
 
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-selected, var(--calcite-color-brand));
+    border-color: var(--calcite-switch-handle-border-color-checked, var(--calcite-color-brand));
     inset-inline: theme("inset.auto") -1px;
   }
 }
 
 :host([checked]:hover) {
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-selected-hover, var(--calcite-color-brand-hover));
-    box-shadow: var(--calcite-switch-handle-shadow-selected-hover, inset 0 0 0 1px var(--calcite-color-brand-hover));
+    border-color: var(--calcite-switch-handle-border-color-checked-hover, var(--calcite-color-brand-hover));
+    box-shadow: var(--calcite-switch-handle-shadow-checked-hover, inset 0 0 0 1px var(--calcite-color-brand-hover));
   }
 }
 

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -5,15 +5,9 @@
  *
  * @prop --calcite-switch-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-switch-handle-background-color: Specifies the background color of the component handle.
- * @prop --calcite-switch-handle-border-color-checked-hover: Specifies the border color of the component handle when the component is checked and hovered.
- * @prop --calcite-switch-handle-border-color-checked: Specifies the border color of the component handle when the component is checked.
- * @prop --calcite-switch-handle-border-color-hover: Specifies the border color of the component handle when the component is hovered.
  * @prop --calcite-switch-handle-border-color: Specifies the border color of the component handle.
- * @prop --calcite-switch-handle-shadow-checked-hover: Specifies the shadow of the component handle when the component is checked and hovered.
  * @prop --calcite-switch-handle-shadow: Specifies the shadow of the component handle.
- * @prop --calcite-switch-track-background-color-checked: Specifies the background color of the component track when the component is checked.
  * @prop --calcite-switch-track-background-color: Specifies the background color of the component track.
- * @prop --calcite-switch-track-border-color-checked: Specifies the border color of the component track when the component is checked.
  * @prop --calcite-switch-track-border-color: Specifies the border color of the component track.
  */
 
@@ -104,27 +98,27 @@
 :host(:hover),
 :host(:focus) {
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-hover, var(--calcite-color-brand));
-    box-shadow: var(--calcite-switch-handle-shadow-hover, inset 0 0 0 1px var(--calcite-color-brand));
+    border-color: var(--calcite-switch-handle-border-color, var(--calcite-color-brand));
+    box-shadow: var(--calcite-switch-handle-shadow, inset 0 0 0 1px var(--calcite-color-brand));
   }
 }
 
 :host([checked]) {
   .track {
-    background-color: var(--calcite-switch-track-background-color-checked, var(--calcite-color-brand));
-    border-color: var(--calcite-switch-track-border-color-checked, var(--calcite-color-brand));
+    background-color: var(--calcite-switch-track-background-color, var(--calcite-color-brand));
+    border-color: var(--calcite-switch-track-border-color, var(--calcite-color-brand));
   }
 
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-checked, var(--calcite-color-brand));
+    border-color: var(--calcite-switch-handle-border-color, var(--calcite-color-brand));
     inset-inline: theme("inset.auto") -1px;
   }
 }
 
 :host([checked]:hover) {
   .handle {
-    border-color: var(--calcite-switch-handle-border-color-checked-hover, var(--calcite-color-brand-hover));
-    box-shadow: var(--calcite-switch-handle-shadow-checked-hover, inset 0 0 0 1px var(--calcite-color-brand-hover));
+    border-color: var(--calcite-switch-handle-border-color, var(--calcite-color-brand-hover));
+    box-shadow: var(--calcite-switch-handle-shadow, inset 0 0 0 1px var(--calcite-color-brand-hover));
   }
 }
 

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -3,15 +3,20 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-switch-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-switch-handle-background-color: Specifies the background color of the component handle.
  * @prop --calcite-switch-handle-border-color: Specifies the border color of the component handle.
  * @prop --calcite-switch-track-background-color: Specifies the background color of the component track.
  * @prop --calcite-switch-track-border-color: Specifies the border color of the component track.
- * @prop --calcite-switch-corner-radius: Specifies the corner radius of the component.
- * @prop --calcite-switch-shadow: Specifies the shadow of the component.
+ * @prop --calcite-switch-handle-shadow: Specifies the shadow of the component handle.
+ * @prop --calcite-switch-handle-border-color-hover: Specifies the border color of the component handle when hovered.
+ * @prop --calcite-switch-shadow-hover: Specifies the shadow of the component handle when hovered.
+ * @prop --calcite-switch-handle-border-color-selected: Specifies the border color of the component handle when selected.
+ * @prop --calcite-switch-track-background-color-selected: Specifies the background color of the component track when selected.
+ * @prop --calcite-switch-track-border-color-selected: Specifies the border color of the component track when selected.
+ * @prop --calcite-switch-handle-border-color-selected-hover: Specifies the border color of the component handle when selected and hovered.
+ * @prop --calcite-switch-shadow-selected-hover: Specifies the shadow of the component handle when selected and hovered.
  */
-
-@import "~@esri/calcite-design-tokens/dist/scss/core";
 
 :host {
   --calcite-switch-handle-background-color: var(--calcite-color-foreground-1);
@@ -19,7 +24,17 @@
   --calcite-switch-track-background-color: var(--calcite-color-foreground-2);
   --calcite-switch-track-border-color: var(--calcite-color-border-2);
   --calcite-switch-corner-radius: var(--calcite-internal-switch-border-radius, --calcite-corner-radius-pill);
-  --calcite-switch-shadow: none;
+  --calcite-switch-handle-shadow: none;
+
+  --calcite-switch-handle-border-color-hover: var(--calcite-color-brand);
+  --calcite-switch-handle-shadow-hover: inset 0 0 0 1px var(--calcite-color-brand);
+
+  --calcite-switch-handle-border-color-selected: var(--calcite-color-brand);
+  --calcite-switch-track-background-color-selected: var(--calcite-color-brand);
+  --calcite-switch-track-border-color-selected: var(--calcite-color-brand);
+
+  --calcite-switch-handle-border-color-selected-hover: var(--calcite-color-brand-hover);
+  --calcite-switch-handle-shadow-selected-hover: inset 0 0 0 1px var(--calcite-color-brand-hover);
 
   --calcite-internal-switch-border-radius: 9999px; // TODO: drop once --calcite-corner-radius is updated
 
@@ -69,7 +84,7 @@
   border-color: var(--calcite-switch-handle-border-color);
   background-color: var(--calcite-switch-handle-background-color);
   border-radius: var(--calcite-switch-corner-radius);
-  box-shadow: inset 0 0 0 1px var(--calcite-switch-shadow);
+  box-shadow: var(--calcite-switch-handle-shadow);
   block-size: var(--calcite-internal-switch-handle-height);
   inline-size: var(--calcite-internal-switch-handle-width);
 }
@@ -102,23 +117,30 @@
 
 :host(:hover),
 :host(:focus) {
-  --calcite-switch-handle-border-color: var(--calcite-color-brand);
-  --calcite-switch-shadow: var(--calcite-color-brand);
+  .handle {
+    border-color: var(--calcite-switch-handle-border-color-hover);
+    box-shadow: var(--calcite-switch-handle-shadow-hover);
+  }
 }
 
 :host([checked]) {
-  --calcite-switch-handle-border-color: var(--calcite-color-brand);
-  --calcite-switch-track-background-color: var(--calcite-color-brand);
-  --calcite-switch-track-border-color: var(--calcite-color-brand-hover);
+  .track {
+    background-color: var(--calcite-switch-track-background-color-selected);
+    border-color: var(--calcite-switch-track-border-color-selected);
+  }
 
   .handle {
+    border-color: var(--calcite-switch-handle-border-color-selected);
+
     inset-inline: theme("inset.auto") -1px;
   }
 }
 
 :host([checked]:hover) {
-  --calcite-switch-handle-border-color: var(--calcite-color-brand-hover);
-  --calcite-switch-shadow: var(--calcite-color-brand-hover);
+  .handle {
+    border-color: var(--calcite-switch-handle-border-color-selected-hover);
+    box-shadow: var(--calcite-switch-handle-shadow-selected-hover);
+  }
 }
 
 @media (forced-colors: active) {

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -5,15 +5,15 @@
  *
  * @prop --calcite-switch-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-switch-handle-background-color: Specifies the background color of the component handle.
- * @prop --calcite-switch-handle-border-color-checked-hover: Specifies the border color of the component handle when checked and hovered.
- * @prop --calcite-switch-handle-border-color-checked: Specifies the border color of the component handle when checked.
- * @prop --calcite-switch-handle-border-color-hover: Specifies the border color of the component handle when hovered.
+ * @prop --calcite-switch-handle-border-color-checked-hover: Specifies the border color of the component handle when the component is checked and hovered.
+ * @prop --calcite-switch-handle-border-color-checked: Specifies the border color of the component handle when the component is checked.
+ * @prop --calcite-switch-handle-border-color-hover: Specifies the border color of the component handle when the component is hovered.
  * @prop --calcite-switch-handle-border-color: Specifies the border color of the component handle.
- * @prop --calcite-switch-handle-shadow-checked-hover: Specifies the shadow of the component handle when checked and hovered.
+ * @prop --calcite-switch-handle-shadow-checked-hover: Specifies the shadow of the component handle when the component is checked and hovered.
  * @prop --calcite-switch-handle-shadow: Specifies the shadow of the component handle.
- * @prop --calcite-switch-track-background-color-checked: Specifies the background color of the component track when checked.
+ * @prop --calcite-switch-track-background-color-checked: Specifies the background color of the component track when the component is checked.
  * @prop --calcite-switch-track-background-color: Specifies the background color of the component track.
- * @prop --calcite-switch-track-border-color-checked: Specifies the border color of the component track when checked.
+ * @prop --calcite-switch-track-border-color-checked: Specifies the border color of the component track when the component is checked.
  * @prop --calcite-switch-track-border-color: Specifies the border color of the component track.
  */
 


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Updates component tokens to the following (CSS props):

* `--calcite-switch-corner-radius`
* `--calcite-switch-handle-background-color`
* `--calcite-switch-handle-border-color`
* `--calcite-switch-handle-shadow`
* `--calcite-switch-shadow-hover`
* `--calcite-switch-track-background-color`
* `--calcite-switch-track-border-color`