### PR TITLE
refactor(card-group): Remove unused `scale` property

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -806,10 +806,6 @@ export namespace Components {
          */
         "label": string;
         /**
-          * Specifies the size of the component. Child `calcite-card`s inherit the component's value.
-         */
-        "scale": Scale;
-        /**
           * Specifies the component's selected items.
           * @readonly
          */
@@ -8191,10 +8187,6 @@ declare namespace LocalJSX {
           * Emits when the component's selection changes and the `selectionMode` is not `none`.
          */
         "onCalciteCardGroupSelect"?: (event: CalciteCardGroupCustomEvent<void>) => void;
-        /**
-          * Specifies the size of the component. Child `calcite-card`s inherit the component's value.
-         */
-        "scale"?: Scale;
         /**
           * Specifies the component's selected items.
           * @readonly

--- a/packages/calcite-components/src/components/card-group/card-group.tsx
+++ b/packages/calcite-components/src/components/card-group/card-group.tsx
@@ -19,7 +19,7 @@ import {
   InteractiveContainer,
   updateHostInteraction,
 } from "../../utils/interactive";
-import { Scale, SelectionMode } from "../interfaces";
+import { SelectionMode } from "../interfaces";
 import {
   LoadableComponent,
   componentLoaded,
@@ -56,9 +56,6 @@ export class CardGroup implements InteractiveComponent, LoadableComponent {
 
   /** Accessible name for the component. */
   @Prop() label!: string;
-
-  /** Specifies the size of the component. Child `calcite-card`s inherit the component's value. */
-  @Prop({ reflect: true }) scale: Scale = "m";
 
   /** Specifies the selection mode of the component. */
   @Prop({ reflect: true }) selectionMode: Extract<


### PR DESCRIPTION
**Related Issue:** #

## Summary
Removes this unused property that made it through review. 

Initially there was a plan to add scale to Card, but that change was removed and this property was not cleaned up. Should be safe to remove as it had no effect.