### PR TITLE
refactor: apply `transition-default` mixin

### DIFF
--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -105,6 +105,7 @@ $border-style: 1px solid var(--calcite-color-border-3);
 }
 
 .queue-count {
+  @include includes.transition-default();
   @apply cursor-default
   flex
   font-medium
@@ -116,8 +117,7 @@ $border-style: 1px solid var(--calcite-color-border-3);
   overflow-hidden
   self-stretch
   text-center
-  text-color-2
-  transition-default;
+  text-color-2;
   border-inline: 0 solid transparent;
   border-start-end-radius: 0;
 

--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -238,8 +238,8 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-item {
+  @include includes.transition-default();
   @apply focus-base
-    transition-default
     m-0
     h-8
     w-8

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -42,6 +42,7 @@
   -webkit-tap-highlight-color: transparent;
 
   .check-svg {
+    @include includes.transition-default();
     @apply bg-foreground-1
       pointer-events-none
       box-border
@@ -49,8 +50,7 @@
       overflow-hidden
       fill-current
       stroke-current
-      stroke-1
-      transition-default;
+      stroke-1;
     box-shadow: inset 0 0 0 1px var(--calcite-checkbox-border-color, var(--calcite-color-border-input));
     color: var(--calcite-checkbox-icon-color, theme("backgroundColor.background"));
   }

--- a/packages/components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/components/src/components/date-picker-day/date-picker-day.scss
@@ -24,12 +24,12 @@
 }
 
 .day {
+  @include includes.transition-default();
   @apply text-n2h
     flex
     items-center
     justify-center
     leading-none
-    transition-default
     w-full
     relative;
   line-height: var(--calcite-font-line-height-fixed-base);

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -64,6 +64,7 @@
 }
 
 .chevron {
+  @include includes.transition-default();
   @apply focus-base
     box-content
     flex
@@ -72,7 +73,6 @@
     items-center
     justify-center
     border-none
-    transition-default
     w-full
     h-full;
   --calcite-internal-action-padding-block: 0;

--- a/packages/components/src/components/inline-editable/inline-editable.scss
+++ b/packages/components/src/components/inline-editable/inline-editable.scss
@@ -41,8 +41,8 @@
 }
 
 .wrapper {
-  @apply transition-default
-    box-border
+  @include includes.transition-default();
+  @apply box-border
     flex
     justify-between;
 

--- a/packages/components/src/components/input-message/input-message.scss
+++ b/packages/components/src/components/input-message/input-message.scss
@@ -11,7 +11,8 @@
 @use "../../styles/includes";
 
 :host {
-  @apply text-color-1 transition-default box-border flex h-auto w-full items-center font-medium opacity-100;
+  @include includes.transition-default();
+  @apply text-color-1 box-border flex h-auto w-full items-center font-medium opacity-100;
 
   margin-block-start: var(
     --calcite-input-message-spacing,
@@ -20,7 +21,8 @@
 }
 
 .calcite-input-message-icon {
-  @apply transition-default pointer-events-none inline-flex flex-shrink-0;
+  @include includes.transition-default();
+  @apply pointer-events-none inline-flex flex-shrink-0;
   margin-inline-end: var(--calcite-spacing-sm);
 }
 

--- a/packages/components/src/components/input-number/input-number.scss
+++ b/packages/components/src/components/input-number/input-number.scss
@@ -441,8 +441,8 @@ input[readonly]:focus {
 }
 
 .number-button-wrapper {
-  @apply transition-default
-    pointer-events-none
+  @include includes.transition-default();
+  @apply pointer-events-none
     box-border
     flex
     flex-col;
@@ -580,7 +580,7 @@ input[readonly]:focus {
 // input needed for higher specificity of these overrides
 input {
   &.inline-child {
-    @apply transition-default;
+    @include includes.transition-default();
 
     // `calcite-inline-editable` deprecated in v5.2.0, removal target v7.0.0 (remove &.inline-editable-child)
     &.inline-editable-child {
@@ -619,7 +619,7 @@ input {
       input,
       .inline-editable,
       .action-wrapper {
-        @apply transition-default;
+        @include includes.transition-default();
         background-color: var(
           --calcite-input-number-inline-editable-background-color-hover,
           var(--calcite-color-foreground-2)
@@ -633,7 +633,7 @@ input {
   input,
   .inline-editable,
   .action-wrapper {
-    @apply transition-default;
+    @include includes.transition-default();
     background-color: var(--calcite-input-number-background-color, var(--calcite-color-foreground-1));
   }
 }

--- a/packages/components/src/components/input-text/input-text.scss
+++ b/packages/components/src/components/input-text/input-text.scss
@@ -431,7 +431,7 @@ input[type="text"]::-ms-reveal {
 // input needed for higher specificity of these overrides
 input {
   &.inline-child {
-    @apply transition-default;
+    @include includes.transition-default();
 
     // `calcite-inline-editable` deprecated in v5.2.0, removal target v7.0.0 (remove &.inline-editable-child)
     &.inline-editable-child {
@@ -469,7 +469,7 @@ input {
       input,
       .inline-editable,
       .action-wrapper {
-        @apply transition-default;
+        @include includes.transition-default();
         background-color: var(
           --calcite-input-text-inline-editable-background-color-hover,
           var(--calcite-color-foreground-2)
@@ -483,7 +483,7 @@ input {
   input,
   .inline-editable,
   .action-wrapper {
-    @apply transition-default;
+    @include includes.transition-default();
     background-color: var(--calcite-input-text-background-color, var(--calcite-color-foreground-1));
   }
 }

--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -474,8 +474,8 @@ input[type="number"] {
 }
 
 .number-button-wrapper {
-  @apply transition-default
-    pointer-events-none
+  @include includes.transition-default();
+  @apply pointer-events-none
     box-border
     flex
     flex-col;
@@ -649,7 +649,7 @@ input[type="date"]::-webkit-input-placeholder {
 // input needed for higher specificity of these overrides
 input {
   &.inline-child {
-    @apply transition-default;
+    @include includes.transition-default();
 
     // `calcite-inline-editable` deprecated in v5.2.0, removal target v7.0.0 (remove &.inline-editable-child)
     &.inline-editable-child {
@@ -688,7 +688,7 @@ input {
       input,
       .inline-editable,
       .action-wrapper {
-        @apply transition-default;
+        @include includes.transition-default();
         background-color: var(
           --calcite-input-inline-editable-background-color-hover,
           var(--calcite-color-foreground-2)
@@ -701,7 +701,7 @@ input {
 :host([inline-editable]) {
   .inline-editable,
   .action-wrapper {
-    @apply transition-default;
+    @include includes.transition-default();
     background-color: var(--calcite-input-background-color, var(--calcite-color-foreground-1));
   }
 }

--- a/packages/components/src/components/notice/notice.scss
+++ b/packages/components/src/components/notice/notice.scss
@@ -147,7 +147,8 @@
 }
 
 @mixin notice-element-base() {
-  @apply transition-default box-border;
+  @include includes.transition-default();
+  @apply box-border;
   padding-block: var(--calcite-notice-spacing-token-small);
   padding-inline: var(--calcite-notice-spacing-token-large);
   flex: 0 0 auto;
@@ -176,7 +177,8 @@
 }
 
 .notice-close {
-  @apply flex cursor-pointer items-center transition-default box-border;
+  @include includes.transition-default();
+  @apply flex cursor-pointer items-center box-border;
   flex: 0 0 auto;
   margin-inline-end: var(--calcite-spacing-xs);
   --calcite-action-background-color: var(--calcite-notice-close-background-color);

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -100,7 +100,7 @@
   border-block: 2px solid transparent;
 
   &:hover {
-    @apply transition-default;
+    @include includes.transition-default();
 
     color: var(--calcite-pagination-color-hover, var(--calcite-color-text-1));
   }

--- a/packages/components/src/components/radio-button/radio-button.scss
+++ b/packages/components/src/components/radio-button/radio-button.scss
@@ -28,9 +28,9 @@
   }
 
   .radio {
+    @include includes.transition-default();
     @apply cursor-pointer
-    focus-base
-    transition-default;
+    focus-base;
     border-radius: var(--calcite-radio-button-corner-radius, var(--calcite-corner-radius-pill));
     background-color: var(--calcite-radio-button-background-color, var(--calcite-color-foreground-1));
     box-shadow: inset 0 0 0 var(--calcite-border-width-sm)

--- a/packages/components/src/components/rating/rating.scss
+++ b/packages/components/src/components/rating/rating.scss
@@ -60,7 +60,7 @@
 }
 
 .star {
-  @apply transition-default;
+  @include includes.transition-default();
   position: relative;
   display: flex;
   flex-direction: column;
@@ -88,7 +88,7 @@
 }
 
 .fraction {
-  @apply transition-default;
+  @include includes.transition-default();
   position: absolute;
   pointer-events: none;
   inset-block-start: 0;

--- a/packages/components/src/components/split-button/split-button.scss
+++ b/packages/components/src/components/split-button/split-button.scss
@@ -122,7 +122,8 @@
 }
 
 .divider-container {
-  @apply transition-default flex w-px items-stretch;
+  @include includes.transition-default();
+  @apply flex w-px items-stretch;
   background-color: var(
     --calcite-split-button-divider-color,
     var(--calcite-internal-split-button-divider-border-color)

--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -98,6 +98,7 @@
 }
 
 .container {
+  @include includes.transition-default();
   @apply relative
   box-border
   content-center
@@ -108,7 +109,6 @@
   justify-between
   px-0
   text-n1h
-  transition-default
   w-full;
 
   color: var(--calcite-tab-text-color, var(--calcite-color-text-3));
@@ -116,11 +116,11 @@
 }
 
 .selected-indicator {
+  @include includes.transition-default();
   @apply absolute
     block
     w-full
-    h-0.5
-    transition-default;
+    h-0.5;
   inset-block-end: 0;
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -128,11 +128,11 @@
 }
 
 :host([bordered][selected]) .container::after {
+  @include includes.transition-default();
   @apply absolute
     block
     w-full
-    h-0.5
-    transition-default;
+    h-0.5;
   inset-block-end: -1px;
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -177,7 +177,7 @@
     inline-flex
     self-center;
   & svg {
-    @apply transition-default;
+    @include includes.transition-default();
   }
 }
 

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -86,8 +86,8 @@
 
 :host([lines]) {
   .children-container::after {
-    @apply transition-default
-        absolute
+    @include includes.transition-default();
+    @apply absolute
         top-0
         w-px
         transition-colors
@@ -187,7 +187,8 @@
 .node-container {
   @apply relative flex grow items-center min-w-0;
   .selection-icon {
-    @apply transition-default opacity-0;
+    @include includes.transition-default();
+    @apply opacity-0;
     color: var(--calcite-color-border-1);
   }
 }
@@ -225,8 +226,8 @@
 }
 
 .chevron {
-  @apply transition-default
-    text-color-3
+  @include includes.transition-default();
+  @apply text-color-3
     relative
     self-center;
   flex: 0 0 auto;


### PR DESCRIPTION
**Related Issue:** #12080

## Summary

Replaces Tailwind's `transition-default` with the Sass mixin equivalent.