### PR TITLE
feat(tab): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -3,7 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-content-block-padding: Specifies the block padding of the component's content in the `default` slot.
+ * @prop --calcite-tab-content-block-padding: [Deprecated] Use `--calcite-tab-content-space` instead. Specifies the block padding of the component's content in the `default` slot.
+ * @prop --calcite-tab-content-space: Specifies the space of the component's content in the `default` slot.
  */
 
 :host([selected]) {
@@ -23,22 +24,33 @@
 
 .content {
   @apply box-border;
-  padding-block: var(--calcite-internal-tab-content-block-padding);
 }
 
 .scale-s {
-  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.1"));
-  @apply text-n2h;
+  font-size: var(--calcite-font-size-sm);
+  line-height: 1rem; //TODO: replace with token
+
+  .content {
+    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.1")));
+  }
 }
 
 .scale-m {
-  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.2"));
-  @apply text-n1h;
+  font-size: var(--calcite-font-size);
+  line-height: 1rem; //TODO: replace with token
+
+  .content {
+    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.2")));
+  }
 }
 
 .scale-l {
-  --calcite-internal-tab-content-block-padding: var(--calcite-tab-content-block-padding, theme("spacing.[2.5]"));
-  @apply text-0h;
+  font-size: var(--calcite-font-size-md);
+  line-height: 1.25rem; //TODO: replace with token
+
+  .content {
+    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.[2.5]")));
+  }
 }
 
 section,

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -3,8 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-content-block-padding: [Deprecated] Use `--calcite-tab-content-space` instead. Specifies the block padding of the component's content in the `default` slot.
- * @prop --calcite-tab-content-space: Specifies the space of the component's content in the `default` slot.
+ * @prop --calcite-tab-content-block-padding: [Deprecated] Use `--calcite-tab-content-space-y` instead. Specifies the block padding of the component's content in the `default` slot.
+ * @prop --calcite-tab-content-space-y: Specifies the vertical space of the component's content in the `default` slot.
  */
 
 :host([selected]) {
@@ -31,7 +31,7 @@
   line-height: 1rem;
 
   .content {
-    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.1")));
+    padding-block: var(--calcite-tab-content-space-y, var(--calcite-tab-content-block-padding, theme("spacing.1")));
   }
 }
 
@@ -40,7 +40,7 @@
   line-height: 1rem;
 
   .content {
-    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.2")));
+    padding-block: var(--calcite-tab-content-space-y, var(--calcite-tab-content-block-padding, theme("spacing.2")));
   }
 }
 
@@ -49,7 +49,7 @@
   line-height: 1.25rem;
 
   .content {
-    padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.[2.5]")));
+    padding-block: var(--calcite-tab-content-space-y, var(--calcite-tab-content-block-padding, theme("spacing.[2.5]")));
   }
 }
 

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -28,7 +28,7 @@
 
 .scale-s {
   font-size: var(--calcite-font-size-sm);
-  line-height: 1rem; //TODO: replace with token
+  line-height: 1rem;
 
   .content {
     padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.1")));
@@ -37,7 +37,7 @@
 
 .scale-m {
   font-size: var(--calcite-font-size);
-  line-height: 1rem; //TODO: replace with token
+  line-height: 1rem;
 
   .content {
     padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.2")));
@@ -46,7 +46,7 @@
 
 .scale-l {
   font-size: var(--calcite-font-size-md);
-  line-height: 1.25rem; //TODO: replace with token
+  line-height: 1.25rem;
 
   .content {
     padding-block: var(--calcite-tab-content-space, var(--calcite-tab-content-block-padding, theme("spacing.[2.5]")));


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following component tokens (CSS props):

* `--calcite-tab-content-space-y`

Deprecates the following:

* `--calcite-tab-content-block-padding`