### PR TITLE
feat(tab-nav): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -4,18 +4,18 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-tab-nav-indicator-color: Specifies the color of the active tab indicator.
- * @prop --calcite-tab-nav-scroll-button-background-color: Specifies the background color of the scroll buttons.
- * @prop --calcite-tab-nav-scroll-button-background-color-active: Specifies the background color of the scroll buttons when active.
- * @prop --calcite-tab-nav-scroll-button-background-color-focus: Specifies the background color of the scroll buttons when focused.
- * @prop --calcite-tab-nav-scroll-button-background-color-hover: Specifies the background color of the scroll buttons when hovered.
- * @prop --calcite-tab-nav-scroll-button-border-color: Specifies the border color of the scroll buttons.
- * @prop --calcite-tab-nav-scroll-button-border-color-active: Specifies the border color of the scroll buttons when active.
- * @prop --calcite-tab-nav-scroll-button-border-color-focus: Specifies the border color of the scroll buttons when focused.
- * @prop --calcite-tab-nav-scroll-button-border-color-hover: Specifies the border color of the scroll buttons when hovered.
- * @prop --calcite-tab-nav-scroll-button-icon-color: Specifies the color of the scroll buttons' icon.
- * @prop --calcite-tab-nav-scroll-button-icon-color-active: Specifies the color of the scroll buttons' icon when active.
- * @prop --calcite-tab-nav-scroll-button-icon-color-focus: Specifies the color of the scroll buttons' icon when focused.
- * @prop --calcite-tab-nav-scroll-button-icon-color-hover: Specifies the color of the scroll buttons' icon when hovered.
+ * @prop --calcite-tab-nav-button-background-color: Specifies the background color of the scroll buttons.
+ * @prop --calcite-tab-nav-button-background-color-active: Specifies the background color of the scroll buttons when active.
+ * @prop --calcite-tab-nav-button-background-color-focus: Specifies the background color of the scroll buttons when focused.
+ * @prop --calcite-tab-nav-button-background-color-hover: Specifies the background color of the scroll buttons when hovered.
+ * @prop --calcite-tab-nav-button-border-color: Specifies the border color of the scroll buttons.
+ * @prop --calcite-tab-nav-button-border-color-active: Specifies the border color of the scroll buttons when active.
+ * @prop --calcite-tab-nav-button-border-color-focus: Specifies the border color of the scroll buttons when focused.
+ * @prop --calcite-tab-nav-button-border-color-hover: Specifies the border color of the scroll buttons when hovered.
+ * @prop --calcite-tab-nav-button-icon-color: Specifies the color of the scroll buttons' icon.
+ * @prop --calcite-tab-nav-button-icon-color-active: Specifies the color of the scroll buttons' icon when active.
+ * @prop --calcite-tab-nav-button-icon-color-focus: Specifies the color of the scroll buttons' icon when focused.
+ * @prop --calcite-tab-nav-button-icon-color-hover: Specifies the color of the scroll buttons' icon when hovered.
  */
 
 :host {

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.scss
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.scss
@@ -1,3 +1,23 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-tab-nav-indicator-color: Specifies the color of the active tab indicator.
+ * @prop --calcite-tab-nav-scroll-button-background-color: Specifies the background color of the scroll buttons.
+ * @prop --calcite-tab-nav-scroll-button-background-color-active: Specifies the background color of the scroll buttons when active.
+ * @prop --calcite-tab-nav-scroll-button-background-color-focus: Specifies the background color of the scroll buttons when focused.
+ * @prop --calcite-tab-nav-scroll-button-background-color-hover: Specifies the background color of the scroll buttons when hovered.
+ * @prop --calcite-tab-nav-scroll-button-border-color: Specifies the border color of the scroll buttons.
+ * @prop --calcite-tab-nav-scroll-button-border-color-active: Specifies the border color of the scroll buttons when active.
+ * @prop --calcite-tab-nav-scroll-button-border-color-focus: Specifies the border color of the scroll buttons when focused.
+ * @prop --calcite-tab-nav-scroll-button-border-color-hover: Specifies the border color of the scroll buttons when hovered.
+ * @prop --calcite-tab-nav-scroll-button-icon-color: Specifies the color of the scroll buttons' icon.
+ * @prop --calcite-tab-nav-scroll-button-icon-color-active: Specifies the color of the scroll buttons' icon when active.
+ * @prop --calcite-tab-nav-scroll-button-icon-color-focus: Specifies the color of the scroll buttons' icon when focused.
+ * @prop --calcite-tab-nav-scroll-button-icon-color-hover: Specifies the color of the scroll buttons' icon when hovered.
+ */
+
 :host {
   --calcite-internal-tab-nav-gradient-start-side: left;
   --calcite-internal-tab-nav-gradient-end-side: right;
@@ -138,18 +158,21 @@ $last-mask-color-stop-position: 51%; // we go beyond the half point to ensure th
 
 .tab-nav-active-indicator {
   @apply absolute
-    bg-brand
     bottom-0
     block
     h-0.5
     ease-out
     transition-all;
+
+  background-color: var(--calcite-tab-nav-indicator-color, var(--calcite-color-brand));
 }
 
 .scroll-button-container {
   @apply absolute bottom-0 top-0;
 
   calcite-button {
+    // TODO: replace with updated sub-component tokens (see prop doc for reference)
+
     --calcite-offset-invert-focus: 1;
     --calcite-color-text-1: var(--calcite-color-text-3);
 


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following component tokens (CSS props):

* `--calcite-tab-nav-indicator-color`
* `--calcite-tab-nav-button-background-color`
* `--calcite-tab-nav-button-background-color-active`
* `--calcite-tab-nav-button-background-color-focus`
* `--calcite-tab-nav-button-background-color-hover`
* `--calcite-tab-nav-button-border-color`
* `--calcite-tab-nav-button-border-color-active`
* `--calcite-tab-nav-button-border-color-focus`
* `--calcite-tab-nav-button-border-color-hover`
* `--calcite-tab-nav-button-icon-color`
* `--calcite-tab-nav-button-icon-color-active`
* `--calcite-tab-nav-button-icon-color-focus`
* `--calcite-tab-nav-button-icon-color-hover`

**Note:** scroll button prop assignment is depends on button refactor.