### PR TITLE
feat(icon): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.scss
+++ b/packages/calcite-components/src/components/alert/alert.scss
@@ -19,6 +19,7 @@
  * @prop --calcite-alert-close-icon-color-hover: Specifies the color of the close button icon in the component when the close button is hovered.
  * @prop --calcite-alert-close-icon-color: Specifies the color of the close button icon in the component.
  * @prop --calcite-alert-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-alert-icon-color: Specifies the color of the icon in the component.
  * @prop --calcite-alert-shadow: Specifies the shadow of the component.
  * @prop --calcite-alert-width: Specifies the width of the component.
  */
@@ -85,11 +86,11 @@
 }
 
 .icon {
+  --calcite-icon-color: var(--calcite-alert-icon-color, var(--calcite-internal-alert-status-color));
   @apply flex flex-col items-center justify-center p-0;
   margin-block: auto;
   margin-inline-end: auto;
   padding-inline-start: var(--calcite-internal-alert-spacing-token-large);
-  color: var(--calcite-internal-alert-status-color);
 }
 
 .close {

--- a/packages/calcite-components/src/components/avatar/avatar.scss
+++ b/packages/calcite-components/src/components/avatar/avatar.scss
@@ -5,6 +5,7 @@
  *
  * @prop --calcite-avatar-corner-radius: defines the corner radius of the component.
  * @prop --calcite-avatar-text-color: defines the text color of the component.
+ * @prop --calcite-avatar-icon-color: defines the icon color of the component.
  *
  */
 
@@ -33,6 +34,10 @@
   @apply items-center justify-center;
 }
 
+.icon {
+  --calcite-icon-color: var(--calcite-avatar-icon-color, var(--calcite-avatar-text-color, var(--calcite-color-text-2)));
+}
+
 .initials {
   @apply font-bold uppercase;
   color: var(--calcite-avatar-text-color, var(--calcite-color-text-2));
@@ -48,10 +53,6 @@
 
 :host([scale="l"]) {
   @apply text-0 h-11 w-11;
-}
-
-calcite-icon {
-  // TODO: component tokens
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -7,6 +7,7 @@
  * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
  * @prop --calcite-block-section-heading-text-color-hover: Specifies the component's heading text color on hover.
  * @prop --calcite-block-section-heading-text-color: Specifies the component's heading text color.
+ * @prop --calcite-block-section-status-icon-color: Specifies the status icon color of the component.
  * @prop --calcite-block-section-switch-corner-radius: Specifies the border radius of the switch.
  * @prop --calcite-block-section-switch-handle-background-color: Specifies the background color of the switch handle.
  * @prop --calcite-block-section-switch-handle-border-color-hover: Specifies the border color of the switch handle on hover.
@@ -17,6 +18,7 @@
  * @prop --calcite-block-section-switch-track-background-color: Specifies the background color of the switch track.
  * @prop --calcite-block-section-switch-track-border-color-checked: Specifies the border color of the switch track when checked.
  * @prop --calcite-block-section-switch-track-border-color: Specifies the border color of the switch track.
+ * @prop --calcite-block-section-toggle-icon-color: Specifies the icon color of the toggle.
  */
 
 :host {
@@ -46,10 +48,17 @@
     w-full;
 
   background-color: var(--calcite-color-transparent);
+
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-block-section-toggle-icon-color);
+  }
 }
 
 .status-icon {
-  color: var(--calcite-internal-block-section-icon-color);
+  --calcite-icon-color: var(
+    --calcite-block-section-status-icon-color,
+    var(--calcite-internal-block-section-icon-color)
+  );
 }
 
 .status-icon.valid {

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -27,6 +27,9 @@
  * @prop --calcite-block-padding: [Deprecated] use `--calcite-block-content-space` instead - Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color: Specifies the text color of the component.
  * @prop --calcite-block-toggle-icon-color: Specifies the color of the component's toggle icon.
+ * @prop --calcite-block-toggle-icon-color-hover: Specifies the color of the component's toggle icon on hover.
+ * @prop --calcite-block-status-icon-color-valid: Specifies the color of the component's status icon when valid.
+ * @prop --calcite-block-status-icon-color-invalid: Specifies the color of the component's status icon when invalid.
  */
 
 :host {
@@ -80,14 +83,14 @@
   background-color: var(--calcite-block-header-background-color, transparent);
 
   .toggle-icon {
-    color: var(--calcite-block-toggle-icon-color, var(--calcite-color-text-3));
+    --calcite-icon-color: var(--calcite-block-toggle-icon-color, var(--calcite-color-text-3));
   }
 
   &:hover {
     background-color: var(--calcite-block-header-background-color-hover, var(--calcite-color-foreground-2));
 
     .toggle-icon {
-      color: var(--calcite-block-toggle-icon-color, var(--calcite-color-text-1));
+      --calcite-icon-color: var(--calcite-block-toggle-icon-color-hover, var(--calcite-color-text-1));
     }
   }
   &:focus {
@@ -137,11 +140,11 @@ calcite-handle {
 
 .status-icon {
   &.valid {
-    color: var(--calcite-color-status-success);
+    --calcite-icon-color: var(--calcite-block-status-icon-color-valid, var(--calcite-color-status-success));
   }
 
   &.invalid {
-    color: var(--calcite-color-status-danger);
+    --calcite-icon-color: var(--calcite-block-status-icon-color-invalid, var(--calcite-color-status-danger));
   }
 }
 

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -108,6 +108,8 @@ a:hover {
 }
 
 .icon {
+  --calcite-icon-color: var(--calcite-button-icon-color);
+
   @apply relative
     m-0
     inline-flex
@@ -784,11 +786,6 @@ a:hover {
       outline-offset: -2px; // ensure focus outlines work in Safari
     }
   }
-}
-
-a,
-button {
-  --calcite-icon-color: var(--calcite-button-icon-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -15,6 +15,8 @@
  * @prop --calcite-chip-close-background-color-active: Specifies the active background color of the component's `closable` element when active.
  * @prop --calcite-chip-close-background-color-focus: Specifies the focus background color of the component's `closable` element when focused.
  * @prop --calcite-chip-close-focus-outline-color Specifies the focus outline color of the component's `closable` element.
+ * @prop --calcite-chip-select-icon-color: Specifies the color of the component's select icon
+ * @prop --calcite-chip-select-icon-color-active: Specifies the color of the component's select icon when active.
  *
  */
 
@@ -270,7 +272,8 @@
   &:active {
     background-color: var(--calcite-chip-close-background-color-active, var(--calcite-color-transparent-press));
   }
-  & calcite-icon {
+
+  calcite-icon {
     color: inherit;
   }
 }
@@ -293,6 +296,14 @@
     inline-size: var(--calcite-internal-chip-icon-size);
     visibility: visible;
     opacity: 0.5;
+
+    calcite-icon {
+      --calcite-icon-color: var(--calcite-chip-select-icon-color-active);
+    }
+  }
+
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-chip-select-icon-color);
   }
 }
 .container:not(.is-circle).image--slotted .select-icon.select-icon--active {

--- a/packages/calcite-components/src/components/icon/icon.scss
+++ b/packages/calcite-components/src/components/icon/icon.scss
@@ -14,10 +14,8 @@
  */
 
 :host {
-  --calcite-icon-color: var(--calcite-ui-icon-color, currentcolor);
-
   @apply inline-flex;
-  color: var(--calcite-icon-color);
+  color: var(--calcite-icon-color, var(--calcite-ui-icon-color, currentcolor));
   inline-size: var(--calcite-internal-icon-size);
   block-size: var(--calcite-internal-icon-size);
   min-inline-size: var(--calcite-internal-icon-size);

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.scss
@@ -5,16 +5,17 @@
  *
  * @prop --calcite-input-background-color: defines the background color of the component.
  * @prop --calcite-input-border-color: defines the border color of the component.
- * @prop --calcite-input-button-background-color: defines the background color of a button in the component.
  * @prop --calcite-input-button-background-color-hover: defines the background color of a button in the component when it's hovered.
+ * @prop --calcite-input-button-background-color: defines the background color of a button in the component.
  * @prop --calcite-input-button-border-color: defines the border color of a button in the component.
- * @prop --calcite-input-button-icon-color: defines the icon color of a button in the component.
  * @prop --calcite-input-button-icon-color-active: defines the icon color of a button in the component when it's active.
  * @prop --calcite-input-button-icon-color-hover: defines the icon color of a button in the component when it's hovered.
+ * @prop --calcite-input-button-icon-color: defines the icon color of a button in the component.
  * @prop --calcite-input-corner-radius: defines the corner radius of the component.
  * @prop --calcite-input-icon-color:  defines the icon color of the component.
  * @prop --calcite-input-placeholder-text-color: defines the color of placeholder text in the component.
  * @prop --calcite-input-text-color: defines the text color of the component.
+ * @prop --calcite-input-toggle-icon-color: defines the component's toggle icon color.
  *
  */
 
@@ -30,6 +31,26 @@
 
 @function get-trailing-text-input-padding($chevron-spacing) {
   @return calc(var(--calcite-toggle-spacing) + $chevron-spacing);
+}
+
+.horizontal-arrow-container,
+.vertical-arrow-container {
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-input-button-icon-color);
+  }
+
+  &:hover,
+  &:focus {
+    calcite-icon {
+      --calcite-icon-color: var(--calcite-input-button-icon-color-hover);
+    }
+  }
+
+  &:active {
+    calcite-icon {
+      --calcite-icon-color: var(--calcite-input-button-icon-color-active);
+    }
+  }
 }
 
 :host([scale="s"]) {
@@ -63,6 +84,10 @@
   inset-inline-end: 0;
   inset-block: 0;
   padding-inline: var(--calcite-toggle-spacing);
+
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-input-toggle-icon-color);
+  }
 }
 
 :host([range]) {

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -26,19 +26,19 @@ calcite-icon {
 }
 
 :host([status="invalid"]) calcite-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-danger));
+  --calcite-icon-color: var(--calcite-input-message-icon-color, var(--calcite-color-status-danger));
 }
 
 :host([status="warning"]) calcite-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-warning));
+  --calcite-icon-color: var(--calcite-input-message-icon-color, var(--calcite-color-status-warning));
 }
 
 :host([status="valid"]) calcite-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-success));
+  --calcite-icon-color: var(--calcite-input-message-icon-color, var(--calcite-color-status-success));
 }
 
 :host([status="idle"]) calcite-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-brand));
+  --calcite-icon-color: var(--calcite-input-message-icon-color, var(--calcite-color-brand));
 }
 
 :host([scale="s"]) {

--- a/packages/calcite-components/src/components/link/link.scss
+++ b/packages/calcite-components/src/components/link/link.scss
@@ -74,6 +74,7 @@ a {
 }
 
 calcite-icon {
+  --calcite-icon-color: var(--calcite-link-icon-color, currentColor);
   @apply transition-default align-middle;
 
   inline-size: 1em;
@@ -85,11 +86,9 @@ calcite-icon {
   // icon positioning and styles
   &.icon-start {
     margin-inline-end: theme("margin.2");
-    color: var(--calcite-link-icon-color, currentColor);
   }
   &.icon-end {
     margin-inline-start: theme("margin.2");
-    color: var(--calcite-link-icon-color, currentColor);
   }
 }
 

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.scss
@@ -5,6 +5,7 @@
 * @prop --calcite-navigation-logo-border-color: Specifies the border color of the component.
 * @prop --calcite-navigation-logo-description-text-color: Specifies text color of description of component.
 * @prop --calcite-navigation-logo-heading-text-color: Specifies the text color of heading of component.
+* @prop --calcite-navigation-logo-icon-color: Specifies the icon color of the component.
 * @prop --calcite-navigation-logo-text-color: Specifies the text color of the component.
 *
 */
@@ -61,10 +62,14 @@
   @apply ps-0;
 }
 
+.icon {
+  --calcite-icon-color: var(--calcite-navigation-logo-icon-color, var(--calcite-internal-navigation-logo-icon-color));
+}
+
 :host([active]) .anchor {
   --calcite-internal-navigation-logo-text-color: var(--calcite-color-text-1);
   --calcite-internal-navigation-logo-border-color: var(--calcite-color-brand);
-  --calcite-icon-color: var(--calcite-color-brand);
+  --calcite-internal-navigation-logo-icon-color: var(--calcite-color-brand);
 }
 
 .container {

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -14,6 +14,9 @@
 * @prop --calcite-popover-corner-radius: defines the corner radius of the component.
 * @prop --calcite-popover-shadow: defines the shadow of the component.
 * @prop --calcite-popover-text-color: defines the text color of the component.
+* @prop --calcite-popover-close-icon-color: defines the component's close icon color.
+* @prop --calcite-popover-close-icon-color-hover: defines the component's close icon color on hover.
+* @prop --calcite-popover-close-icon-color-active: defines the component's close icon color when active.
 *
 */
 
@@ -112,6 +115,19 @@
   flex: 0 0 auto;
   border-start-end-radius: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-round));
   border-end-end-radius: var(--calcite-popover-corner-radius, var(--calcite-corner-radius-round));
+}
+
+.close-button {
+  color: var(--calcite-popover-close-icon-color);
+
+  &:hover,
+  &:focus {
+    color: var(--calcite-popover-close-icon-color-hover);
+  }
+
+  &:active {
+    color: var(--calcite-popover-close-icon-color-active);
+  }
 }
 
 ::slotted(calcite-panel),

--- a/packages/calcite-components/src/components/select/select.scss
+++ b/packages/calcite-components/src/components/select/select.scss
@@ -8,6 +8,8 @@
  * @prop --calcite-select-font-size: [Deprecated] The font size of `calcite-option`s in the component.
  * @prop --calcite-select-spacing: [Deprecated] The padding around the selected option text.
  * @prop --calcite-select-text-color: The text color of the component.
+ * @prop --calcite-select-icon-color: The icon color of the component.
+ *
  */
 
 :host {
@@ -92,8 +94,15 @@
 
 .select,
 .icon-container {
-  color: var(--calcite-select-text-color, var(--calcite-color-text-2));
   border-color: var(--calcite-select-border-color, var(--calcite-color-border-input));
+}
+
+.select {
+  color: var(--calcite-select-text-color, var(--calcite-color-text-2));
+}
+
+.icon-container {
+  color: var(--calcite-select-icon-color, var(--calcite-color-text-2));
 }
 
 .icon-container {

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -1,3 +1,12 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-stepper-item-icon-color: Specifies the component's icon color.
+ *
+ */
+
 :host([scale="s"]) {
   --calcite-stepper-item-spacing-unit-s: theme("spacing.1");
   --calcite-stepper-item-spacing-unit-m: theme("spacing.3");
@@ -96,10 +105,11 @@
 }
 
 // stepper item icon
-:host .stepper-item-icon {
+.stepper-item-icon {
+  --calcite-icon-color: var(--calcite-stepper-item-icon-color, var(--calcite-color-text-3));
+
   margin-inline-end: var(--calcite-stepper-item-spacing-unit-m);
-  @apply text-color-3
-    opacity-disabled
+  @apply opacity-disabled
     mt-px
     inline-flex
     h-3

--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -4,15 +4,17 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-tab-title-background-color: Specifies the background color of the component.
- * @prop --calcite-tab-title-text-color: Specifies the text color of the component.
- * @prop --calcite-tab-title-close-button-background-color: Specifies the background color of the close button.
  * @prop --calcite-tab-title-close-button-background-color-active: Specifies the background color of the close button when active.
  * @prop --calcite-tab-title-close-button-background-color-focus: Specifies the background color of the close button when focused.
  * @prop --calcite-tab-title-close-button-background-color-hover: Specifies the background color of the close button when hovered.
- * @prop --calcite-tab-title-close-button-icon-color: Specifies the icon color of the close button.
+ * @prop --calcite-tab-title-close-button-background-color: Specifies the background color of the close button.
  * @prop --calcite-tab-title-close-button-icon-color-active: Specifies the icon color of the close button when active.
  * @prop --calcite-tab-title-close-button-icon-color-focus: Specifies the icon color of the close button when focused.
  * @prop --calcite-tab-title-close-button-icon-color-hover: Specifies the icon color of the close button when hovered.
+ * @prop --calcite-tab-title-close-button-icon-color: Specifies the icon color of the close button.
+ * @prop --calcite-tab-title-icon-color: Specifies the icon color of the component.
+ * @prop --calcite-tab-title-text-color: Specifies the text color of the component.
+ *
  */
 
 :host {
@@ -121,6 +123,8 @@
 }
 
 .calcite-tab-title--icon {
+  --calcite-icon-color: var(--calcite-tab-title-icon-color, currentcolor);
+
   @apply relative
     m-0
     inline-flex

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -127,8 +127,10 @@
   }
 }
 
-calcite-icon {
-  --calcite-icon-color: var(--calcite-tile-icon-color, var(--calcite-color-text-3));
+:host(:not([href])) {
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-tile-icon-color, var(--calcite-color-text-3));
+  }
 }
 
 :host([href]),

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -7,6 +7,7 @@
  * @prop --calcite-tile-border-color: Specifies the border color of the component.
  * @prop --calcite-tile-description-text-color: Specifies the description text color of the component.
  * @prop --calcite-tile-heading-text-color: Specifies the heading text color of the component.
+ * @prop --calcite-tile-icon-color: Specifies the icon color of the component.
  */
 
 :host {
@@ -123,8 +124,8 @@
   }
 }
 
-:host(:not([href])) {
-  --calcite-ui-icon-color: var(--calcite-color-text-3);
+calcite-icon {
+  --calcite-icon-color: var(--calcite-tile-icon-color, var(--calcite-color-text-3));
 }
 
 :host([href]),

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -5,19 +5,22 @@
 *
 * These properties can be overridden using the component's tag as selector.
 *
-* @prop --calcite-tip-max-width: [Deprecated] in favor of setting `max-width` on tips directly - Specifies the maximum width of a slotted `calcite-tip` within the component.
-* @prop --calcite-tip-manager-height: [Deprecated] use `--calcite-tip-manager-content-height` instead - Specifies the maximum height of a slotted `calcite-tip` within the component.
-* @prop --calcite-tip-manager-background-color: The background color of the component.
-* @prop --calcite-tip-manager-heading-text-color: The heading text color of the component.
-* @prop --calcite-tip-manager-text-color: The text color of the component.
-* @prop --calcite-tip-manager-border-color: The border color of the component.
-*
-* @prop --calcite-tip-manager-action-background-color: defines the background color of an action sub-component inside the component.
-* @prop --calcite-tip-manager-action-text-color: defines the text color of an action sub-component inside the component.
-* @prop --calcite-tip-manager-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
-* @prop --calcite-tip-manager-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
 * @prop --calcite-tip-manager-action-background-color-active: defines the background color of an action sub-component when active inside the component.
+* @prop --calcite-tip-manager-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
+* @prop --calcite-tip-manager-action-background-color: defines the background color of an action sub-component inside the component.
 * @prop --calcite-tip-manager-action-text-color-active: defines the text color of an action sub-component when active inside the component.
+* @prop --calcite-tip-manager-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
+* @prop --calcite-tip-manager-action-text-color: defines the text color of an action sub-component inside the component.
+* @prop --calcite-tip-manager-background-color: The background color of the component.
+* @prop --calcite-tip-manager-border-color: The border color of the component.
+* @prop --calcite-tip-manager-heading-text-color: The heading text color of the component.
+* @prop --calcite-tip-manager-height: [Deprecated] use `--calcite-tip-manager-content-height` instead - Specifies the maximum height of a slotted `calcite-tip` within the component.
+* @prop --calcite-tip-manager-text-color: The text color of the component.
+* @prop --calcite-tip-max-width: [Deprecated] in favor of setting `max-width` on tips directly - Specifies the maximum width of a slotted `calcite-tip` within the component.
+* @prop --calcite-tip-manager-close-icon-color: The color of the component's close icon.
+* @prop --calcite-tip-manager-close-icon-color-hover: The color of the component's close icon when hovered.
+* @prop --calcite-tip-manager-close-icon-color-active: The color of the component's close icon when active.
+*
 */
 
 :host {
@@ -108,6 +111,24 @@
 
 .page-position {
   @apply text-n2h my-0 mx-2;
+}
+
+.close {
+  calcite-icon {
+    --calcite-icon-color: var(--calcite-tip-manager-close-icon-color);
+  }
+
+  &:hover,
+  &:focus {
+    calcite-icon {
+      --calcite-icon-color: var(--calcite-tip-manager-close-icon-color-hover);
+    }
+  }
+  &:active {
+    calcite-icon {
+      --calcite-icon-color: var(--calcite-tip-manager-close-icon-color-active);
+    }
+  }
 }
 
 /* @keyframes*/

--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -3,12 +3,17 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tree-item-checkbox-background-color: defines the background-color of the sub-component.
  * @prop --calcite-tree-item-checkbox-background-color-checked: defines the background-color of the sub-component when checked.
+ * @prop --calcite-tree-item-checkbox-background-color: defines the background-color of the sub-component.
  * @prop --calcite-tree-item-checkbox-icon-color: defines the checkmark color of the sub-component.
- * @prop --calcite-tree-item-checkbox-shadow: defines the shadow of the sub-component.
  * @prop --calcite-tree-item-checkbox-shadow-checked: defines the shadow of the sub-component when checked.
  * @prop --calcite-tree-item-checkbox-shadow-hover: defines the shadow of the sub-component when hovered.
+ * @prop --calcite-tree-item-checkbox-shadow: defines the shadow of the sub-component.
+ * @prop --calcite-tree-item-chevron-color-active: defines the color of the component's chevron when active.
+ * @prop --calcite-tree-item-chevron-color-hover: defines the color of the component's chevron on hover.
+ * @prop --calcite-tree-item-chevron-color: defines the color of the component's chevron.
+ * @prop --calcite-tree-item-icon-color: defines the icon color of the component.
+ * @prop --calcite-tree-item-selection-icon-color: defines the color of the component's selection icon.
  */
 
 :host {
@@ -268,6 +273,27 @@ calcite-checkbox {
   --calcite-checkbox-shadow: var(--calcite-tree-item-checkbox-shadow);
   --calcite-checkbox-shadow-checked: var(--calcite-tree-item-checkbox-shadow-checked);
   --calcite-checkbox-shadow-hover: var(--calcite-tree-item-checkbox-shadow-hover);
+}
+
+calcite-icon {
+  &.chevron {
+    --calcite-icon-color: var(--calcite-tree-item-chevron-color);
+
+    &:hover,
+    &:focus {
+      --calcite-icon-color: var(--calcite-tree-item-chevron-color-hover);
+    }
+    &:active {
+      --calcite-icon-color: var(--calcite-tree-item-chevron-color-active);
+    }
+  }
+  &.checkmark,
+  &.bullet-point {
+    --calcite-icon-color: var(--calcite-tree-item-selection-icon-color);
+  }
+  &.icon-start {
+    --calcite-icon-color: var(--calcite-tree-item-icon-color);
+  }
 }
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following component tokens.

### Icon
--calcite-icon-color: defines the color of the component. Defaults to `currentColor`.

### Alert

--calcite-alert-icon-color: Specifies the color of the icon in the component.

### Avatar

--calcite-avatar-icon-color: defines the icon color of the component.

### Block Section

--calcite-block-section-status-icon-color: Specifies the status icon color of the component.
--calcite-block-section-toggle-icon-color: Specifies the icon color of the toggle.

### Block

--calcite-block-toggle-icon-color-hover: Specifies the color of the component's toggle icon on hover.
--calcite-block-status-icon-color-valid: Specifies the color of the component's status icon when valid.
--calcite-block-status-icon-color-invalid: Specifies the color of the component's status icon when invalid.

### Chip

--calcite-chip-select-icon-color: Specifies the color of the component's select icon
--calcite-chip-select-icon-color-active: Specifies the color of the component's select icon when active.

### Input Date Picker

--calcite-input-toggle-icon-color: defines the component's toggle icon color.

### Navigation Logo

--calcite-navigation-logo-icon-color: Specifies the icon color of the component.

### Popover

--calcite-popover-close-icon-color: defines the component's close icon color.
--calcite-popover-close-icon-color-hover: defines the component's close icon color on hover.
--calcite-popover-close-icon-color-active: defines the component's close icon color when active.

### Select

--calcite-select-icon-color: The icon color of the component.

### Tab Title

--calcite-tab-title-icon-color: Specifies the icon color of the component.

### Tip Manager

--calcite-tip-manager-close-icon-color: The color of the component's close icon.
--calcite-tip-manager-close-icon-color-hover: The color of the component's close icon when hovered.
--calcite-tip-manager-close-icon-color-active: The color of the component's close icon when active.

### Tree Item

--calcite-tree-item-chevron-color-active: defines the color of the component's chevron when active.
--calcite-tree-item-chevron-color-hover: defines the color of the component's chevron on hover.
--calcite-tree-item-chevron-color: defines the color of the component's chevron.
--calcite-tree-item-icon-color: defines the icon color of the component.
--calcite-tree-item-selection-icon-color: defines the color of the component's selection icon.
