### PR TITLE
docs: update copyright to 2024

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 
@@ -10,4 +10,4 @@ See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
 For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
-email: contracts@esri.com
+email: <contracts@esri.com>

--- a/packages/calcite-components-angular/projects/component-library/LICENSE.md
+++ b/packages/calcite-components-angular/projects/component-library/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components-angular/projects/component-library/README.md
+++ b/packages/calcite-components-angular/projects/component-library/README.md
@@ -74,7 +74,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](https://github.c
 
 ## License
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components-react/LICENSE.md
+++ b/packages/calcite-components-react/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components/LICENSE.md
+++ b/packages/calcite-components/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components/readme.md
+++ b/packages/calcite-components/readme.md
@@ -154,7 +154,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/eslint-plugin-calcite-components/LICENSE.md
+++ b/packages/eslint-plugin-calcite-components/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/eslint-plugin-calcite-components/README.md
+++ b/packages/eslint-plugin-calcite-components/README.md
@@ -78,7 +78,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2023 Esri
+COPYRIGHT © 2024 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates all copyright years to 2024 in our licensing and readme markdown files across the monorepo.