### PR TITLE
feat(action-bar, action-pad, action-group, action-menu): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -3,16 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-bar-action-background-color: defines the background color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-indicator-color: defines the indicator color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-text-color: defines the text color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-background-color-active: defines the background color of an action sub-component when active inside the component.
- * @prop --calcite-action-bar-action-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
- * @prop --calcite-action-bar-action-text-color-active: defines the text color of an action sub-component when active inside the component.
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
+ * @prop --calcite-action-bar-background-color: defines the background color of the component.
  *
  */
 
@@ -51,16 +43,28 @@
 }
 
 ::slotted(calcite-action-group) {
-  border-block-end: 1px solid var(--calcite-color-border-3);
+  --calcite-action-group-background-color: var(--calcite-action-bar-background-color, var(--calcite-color-border-3));
+  border-style: solid;
 }
 
-:host([layout="horizontal"]) ::slotted(calcite-action-group) {
-  border-block-end: 0;
-  border-inline-end: 1px solid var(--calcite-color-border-3);
+:host([layout="vertical"]) {
+  ::slotted(calcite-action-group) {
+    border-inline-end: 0;
+    border-block-end-width: var(--calcite-border-width-sm);
+  }
 }
 
-:host([layout="horizontal"][expand-disabled]) ::slotted(calcite-action-group:last-of-type) {
-  border-inline-end: 0;
+:host([layout="horizontal"]) {
+  ::slotted(calcite-action-group) {
+    border-block-end: 0;
+    border-inline-end-width: var(--calcite-border-width-sm);
+  }
+}
+
+:host([layout="horizontal"][expand-disabled]) {
+  ::slotted(calcite-action-group:last-of-type) {
+    border-inline-end: 0;
+  }
 }
 
 ::slotted(calcite-action-group:last-child) {
@@ -70,25 +74,6 @@
 
 .action-group--end {
   @apply justify-end;
-}
-
-calcite-action {
-  --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color);
-  --calcite-action-background-color: var(--calcite-action-bar-action-background-color);
-  --calcite-action-text-color: var(--calcite-action-bar-action-text-color);
-
-  &:hover,
-  &:focus {
-    --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color-hover);
-    --calcite-action-background-color: var(--calcite-action-bar-action-background-color-hover);
-    --calcite-action-text-color: var(--calcite-action-bar-action-text-color-hover);
-  }
-
-  &:active {
-    --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color-active);
-    --calcite-action-background-color: var(--calcite-action-bar-action-background-color-active);
-    --calcite-action-text-color: var(--calcite-action-bar-action-text-color-active);
-  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -4,6 +4,8 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
+ * @prop --calcite-action-pad-corner-radius: defines the corner radius of the component.
+ * @prop --calcite-action-pad-shadow: defines the box shadow of the component.
  */
 
 :host {
@@ -18,20 +20,25 @@
 }
 
 ::slotted(calcite-action-group) {
-  @apply border-color-3
-  border-0
-  border-b
-  border-solid
-  pb-0 pt-0;
+  border-width: var(--calcite-border-width-none);
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-style: solid;
+  padding-block: 0px;
+  border-color: var(--calcite-action-group-border-color, var(--calcite-color-border-3));
 }
 
 .container {
-  @apply bg-background
-  shadow-2
-  inline-flex
+  @apply inline-flex
   flex-col
-  overflow-y-auto
-  rounded;
+  overflow-y-auto;
+  box-shadow: var(
+    --calcite-action-pad-shadow,
+    var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000),
+    0 6px 20px -4px rgba(0, 0, 0, 0.1),
+    0 4px 12px -2px rgba(0, 0, 0, 0.08)
+  );
+  border-radius: var(--calcite-action-pad-corner-radius, var(--calcite-corner-radius-round));
 }
 
 .action-group--bottom {

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -31,17 +31,6 @@
 
 :host {
   @apply inline-flex;
-  --calcite-chip-background-color: var(--calcite-color-foreground-2);
-  --calcite-chip-border-color: var(--calcite-color-border-3);
-  --calcite-chip-shadow: var(--calcite-shadow-none);
-  --calcite-chip-corner-radius: 9999px;
-  --calcite-chip-close-icon-color: var(--calcite-color-text-3);
-  --calcite-chip-icon-color: var(--calcite-color-text-1);
-  --calcite-chip-close-background-color: var(--calcite-color-transparent);
-  --calcite-chip-close-background-color-hover: var(--calcite-color-transparent-hover);
-  --calcite-chip-close-background-color-focus: var(--calcite-color-transparent-hover);
-  --calcite-chip-close-background-color-active: var(--calcite-color-transparent-press);
-  --calcite-chip-close-focus-outline-color: var(--calcite-color-brand);
 }
 
 :host([scale="s"]) {
@@ -71,85 +60,20 @@
   --calcite-internal-chip-container-size: 44px;
 }
 
-:host([appearance="outline-fill"]) {
-  --calcite-chip-background-color: var(--calcite-color-foreground-1);
-}
-
-:host([appearance="outline"]) {
-  --calcite-chip-background-color: transparent;
-}
-
-:host([kind="neutral"]) {
-  --calcite-chip-text-color: var(--calcite-color-text-1);
-  --calcite-chip-close-icon-color: var(--calcite-color-text-3);
-  --calcite-chip-icon-color: var(--calcite-color-text-1);
-}
-
-:host([kind="neutral"][appearance="solid"]) {
-  --calcite-chip-border-color: transparent;
-}
-
-:host([kind="neutral"][appearance="outline-fill"]),
-:host([kind="neutral"][appearance="outline"]) {
-  --calcite-chip-border-color: var(--calcite-color-border-1);
-}
-
-:host([kind="inverse"]) {
-  --calcite-chip-icon-color: var(--calcite-color-text-inverse);
-}
-
-:host([kind="inverse"][appearance="solid"]) {
-  --calcite-chip-background-color: var(--calcite-color-inverse);
-  --calcite-chip-border-color: transparent;
-  --calcite-chip-text-color: var(--calcite-color-text-inverse);
-  --calcite-chip-close-icon-color: var(--calcite-color-text-inverse);
-}
-
-:host([kind="inverse"][appearance="outline-fill"]),
-:host([kind="inverse"][appearance="outline"]) {
-  --calcite-chip-border-color: var(--calcite-color-inverse);
-  --calcite-chip-text-color: var(--calcite-color-text-1);
-  --calcite-chip-icon-color: var(--calcite-color-inverse);
-}
-
-:host([kind="brand"]) {
-  --calcite-chip-icon-color: var(--calcite-color-text-inverse);
-}
-
-:host([kind="brand"][appearance="solid"]) {
-  --calcite-chip-close-icon-color: var(--calcite-color-text-inverse);
-  --calcite-chip-background-color: var(--calcite-color-brand);
-  --calcite-chip-border-color: transparent;
-  --calcite-chip-text-color: var(--calcite-color-text-inverse);
-}
-
-:host([kind="brand"][appearance="outline-fill"]),
-:host([kind="brand"][appearance="outline"]) {
-  --calcite-chip-border-color: var(--calcite-color-brand);
-  --calcite-chip-text-color: var(--calcite-color-text-1);
-  --calcite-chip-icon-color: var(--calcite-color-inverse);
-}
-
-:host([kind="brand"][appearance="solid"]),
-:host([kind="inverse"][appearance="solid"]) {
-  --calcite-chip-close-focus-outline-color: var(--calcite-color-text-inverse);
-}
-
 .container {
   @apply inline-flex
-  h-full
-  max-w-full
   items-center
   focus-base
   justify-center
   cursor-default
   box-border
   font-medium;
-  border: var(--calcite-border-width-sm) solid var(--calcite-chip-border-color);
-  color: var(--calcite-chip-text-color);
-  border-radius: var(--calcite-chip-corner-radius);
-  background-color: var(--calcite-chip-background-color);
-  box-shadow: var(--calcite-chip-shadow);
+  max-inline-size: var(--calcite-container-size-content-fluid);
+  border: var(--calcite-border-width-sm) solid var(--calcite-chip-border-color, var(--calcite-color-border-3));
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  border-radius: var(--calcite-chip-corner-radius, 9999px);
+  background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-2));
+  box-shadow: var(--calcite-chip-shadow, var(--calcite-shadow-none));
   block-size: var(--calcite-internal-chip-container-size);
   &.is-circle {
     inline-size: var(--calcite-internal-chip-container-size);
@@ -162,6 +86,84 @@
   }
   &:not(.non-interactive):focus {
     @apply focus-outset;
+  }
+}
+
+:host([appearance="outline-fill"]) .container {
+  background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-1));
+}
+
+:host([appearance="outline"]) .container {
+  background-color: var(--calcite-chip-background-color, transparent);
+}
+
+:host([kind="neutral"]) .container {
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  .close {
+    color: var(--calcite-chip-close-icon-color, var(--calcite-color-text-3));
+  }
+  .chip-icon {
+    color: var(--calcite-chip-icon-color, var(--calcite-color-text-1));
+  }
+}
+
+:host([kind="neutral"][appearance="solid"]) .container {
+  border-color: var(--calcite-chip-border-color, transparent);
+}
+
+:host([kind="neutral"][appearance="outline-fill"]) .container,
+:host([kind="neutral"][appearance="outline"]) .container {
+  border-color: var(--calcite-chip-border-color, var(--calcite-color-border-1));
+}
+
+:host([kind="inverse"]) .container .chip-icon {
+  color: var(--calcite-chip-icon-color, var(--calcite-color-text-inverse));
+}
+
+:host([kind="inverse"][appearance="solid"]) .container {
+  background-color: var(--calcite-chip-background-color, var(--calcite-color-inverse));
+  border-color: var(--calcite-chip-border-color, transparent);
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-inverse));
+  .close {
+    color: var(--calcite-chip-close-icon-color, var(--calcite-color-text-inverse));
+  }
+}
+
+:host([kind="inverse"][appearance="outline-fill"]) .container,
+:host([kind="inverse"][appearance="outline"]) .container {
+  border-color: var(--calcite-chip-border-color, var(--calcite-color-inverse));
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  .chip-icon {
+    color: var(--calcite-chip-icon-color, var(--calcite-color-inverse));
+  }
+}
+
+:host([kind="brand"]) .container .chip-icon {
+  color: var(--calcite-chip-icon-color, var(--calcite-color-text-inverse));
+}
+
+:host([kind="brand"][appearance="solid"]) .container {
+  background-color: var(--calcite-chip-background-color, var(--calcite-color-brand));
+  border-color: var(--calcite-chip-border-color, transparent);
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-inverse));
+  .close {
+    color: var(--calcite-chip-close-icon-color, var(--calcite-color-text-inverse));
+  }
+}
+
+:host([kind="brand"][appearance="outline-fill"]) .container,
+:host([kind="brand"][appearance="outline"]) .container {
+  border-color: var(--calcite-chip-border-color, var(--calcite-color-brand));
+  color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  .chip-icon {
+    color: var(--calcite-chip-icon-color, var(--calcite-color-inverse));
+  }
+}
+
+:host([kind="brand"][appearance="solid"]) .container,
+:host([kind="inverse"][appearance="solid"]) .container {
+  .close:focus {
+    outline-color: var(--calcite-chip-close-focus-outline-color, var(--calcite-color-text-inverse));
   }
 }
 
@@ -230,7 +232,6 @@
 .chip-icon {
   @apply relative my-0 inline-flex duration-150 ease-in-out;
   margin-inline: var(--calcite-internal-chip-spacing-s);
-  color: var(--calcite-chip-icon-color);
 }
 
 .image-container {
@@ -250,24 +251,24 @@
     border-none;
   -webkit-appearance: none;
   display: flex;
-  border-radius: var(--calcite-chip-corner-radius);
+  border-radius: var(--calcite-chip-corner-radius, 9999px);
   align-content: center;
   justify-content: center;
   margin: 0;
-  color: var(--calcite-chip-close-icon-color);
+  color: var(--calcite-chip-close-icon-color, var(--calcite-color-text-3));
   block-size: var(--calcite-internal-chip-icon-size);
   inline-size: var(--calcite-internal-chip-icon-size);
-  background-color: var(--calcite-chip-close-background-color);
+  background-color: var(--calcite-chip-close-background-color, var(--calcite-color-transparent));
   &:hover {
-    background-color: var(--calcite-chip-close-background-color-focus);
+    background-color: var(--calcite-chip-close-background-color-hover, var(--calcite-color-transparent-hover));
   }
   &:focus {
-    background-color: var(--calcite-chip-close-background-color-focus);
+    background-color: var(--calcite-chip-close-background-color-focus, var(--calcite-color-transparent-hover));
     @apply focus-inset;
-    outline-color: var(--calcite-chip-close-focus-outline-color);
+    outline-color: var(--calcite-chip-close-focus-outline-color, var(--calcite-color-brand));
   }
   &:active {
-    background-color: var(--calcite-chip-close-background-color-active);
+    background-color: var(--calcite-chip-close-background-color-active, var(--calcite-color-transparent-press));
   }
   & calcite-icon {
     color: inherit;

--- a/packages/calcite-components/src/components/meter/meter.scss
+++ b/packages/calcite-components/src/components/meter/meter.scss
@@ -17,8 +17,6 @@
   * Local props
   * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
   *
-  * --calcite-internal-meter-fill-color
-  * --calcite-internal-meter-background-color
   * --calcite-internal-meter-space
   * --calcite-internal-meter-height
   * --calcite-internal-meter-font-size
@@ -32,14 +30,6 @@
   --calcite-internal-meter-space: var(--calcite-spacing-base);
   --calcite-internal-meter-height: var(--calcite-size-lg);
   --calcite-internal-meter-font-size: var(--calcite-font-size--1);
-  --calcite-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-brand));
-  --calcite-meter-background-color: var(--calcite-color-foreground-2);
-  --calcite-meter-border-color: var(--calcite-color-border-3);
-  --calcite-meter-shadow: var(--calcite-shadow-none);
-  --calcite-meter-range-text-color: var(--calcite-color-text-3);
-  --calcite-meter-value-text-color: var(--calcite-color-text-1);
-  --calcite-meter-shadow: var(--calcite-shadow-none);
-  --calcite-meter-corner-radius: 9999px;
 }
 
 :host([scale="s"]) {
@@ -52,40 +42,67 @@
   --calcite-internal-meter-font-size: var(--calcite-font-size-0);
 }
 
-:host([appearance="solid"]) {
-  --calcite-meter-border-color: var(--calcite-color-foreground-3);
-  --calcite-meter-background-color: var(--calcite-color-foreground-3);
-}
-
-:host([appearance="outline"]) {
-  --calcite-meter-background-color: transparent;
-}
-
-.fill {
-  --calcite-internal-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-brand));
-}
-
-.fill-danger {
-  --calcite-internal-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-status-danger));
-}
-
-.fill-success {
-  --calcite-internal-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-status-success));
-}
-
-.fill-warning {
-  --calcite-internal-meter-fill-color: var(--calcite-meter-fill-color, var(--calcite-color-status-warning));
-}
-
 .container {
   @apply flex relative items-center;
   margin: 0;
   inline-size: var(--calcite-container-size-content-fluid);
   block-size: var(--calcite-internal-meter-height);
-  background-color: var(--calcite-meter-background-color);
-  border: var(--calcite-border-width-sm) solid var(--calcite-meter-border-color);
-  border-radius: var(--calcite-meter-corner-radius);
-  box-shadow: var(--calcite-meter-shadow);
+  background-color: var(--calcite-meter-background-color, var(--calcite-color-foreground-2));
+  border: var(--calcite-border-width-sm) solid var(--calcite-meter-border-color, var(--calcite-color-border-3));
+  border-radius: var(--calcite-meter-corner-radius, 9999px);
+  box-shadow: var(--calcite-meter-shadow, var(--calcite-shadow-none));
+}
+
+.container.solid {
+  background-color: var(--calcite-meter-background-color, var(--calcite-color-foreground-3));
+  border-color: var(--calcite-meter-border-color, var(--calcite-color-foreground-3));
+}
+
+.container.outline {
+  background-color: var(--calcite-meter-background-color, transparent);
+}
+
+.fill {
+  @apply block absolute duration-150 ease-in-out z-default;
+  inset-inline-start: var(--calcite-internal-meter-space);
+  inset-block: var(--calcite-internal-meter-space);
+  border-radius: var(--calcite-meter-corner-radius, 9999px);
+  max-inline-size: calc(100% - (var(--calcite-internal-meter-space) * 2));
+  min-inline-size: calc(var(--calcite-internal-meter-height) - (var(--calcite-internal-meter-space) * 2));
+  background-color: var(--calcite-meter-fill-color, var(--calcite-color-brand));
+  transition-property: inline-size, background-color, box-shadow;
+}
+
+.solid .fill {
+  inset-block: 0;
+  inset-inline-start: 0;
+  max-inline-size: 100%;
+  min-inline-size: calc(var(--calcite-internal-meter-height));
+  box-shadow: 0 0 0 1px var(--calcite-meter-fill-color, var(--calcite-color-brand));
+}
+
+.fill-danger {
+  background-color: var(--calcite-meter-fill-color, var(--calcite-color-status-danger));
+}
+
+.fill-success {
+  background-color: var(--calcite-meter-fill-color, var(--calcite-color-status-success));
+}
+
+.fill-warning {
+  background-color: var(--calcite-meter-fill-color, var(--calcite-color-status-warning));
+}
+
+.solid .fill-danger {
+  box-shadow: 0 0 0 1px var(--calcite-meter-fill-color, var(--calcite-color-status-danger));
+}
+
+.solid .fill-success {
+  box-shadow: 0 0 0 1px var(--calcite-meter-fill-color, var(--calcite-color-status-success));
+}
+
+.solid .fill-warning {
+  box-shadow: 0 0 0 1px var(--calcite-meter-fill-color, var(--calcite-color-status-warning));
 }
 
 .value-visible {
@@ -99,7 +116,7 @@
 .step-line {
   @apply block absolute inset-y-0;
   inline-size: var(--calcite-internal-meter-space);
-  background-color: var(--calcite-meter-border-color);
+  background-color: var(--calcite-meter-border-color, var(--calcite-color-border-3));
 }
 
 .label {
@@ -114,33 +131,14 @@
 .label-value {
   inset-block-end: calc(100% + 0.5em);
   font-weight: var(--calcite-font-weight-bold);
-  color: var(--calcite-meter-value-text-color);
+  color: var(--calcite-meter-value-text-color, var(--calcite-color-text-1));
 }
 
 .label-range {
-  color: var(--calcite-meter-range-text-color);
+  color: var(--calcite-meter-range-text-color, var(--calcite-color-text-3));
   inset-block-start: calc(100% + 0.5em);
 }
 
 .label-range .unit-label {
   font-weight: var(--calcite-font-weight-medium);
-}
-
-.fill {
-  @apply block absolute duration-150 ease-in-out z-default;
-  inset-inline-start: var(--calcite-internal-meter-space);
-  inset-block: var(--calcite-internal-meter-space);
-  border-radius: var(--calcite-meter-corner-radius);
-  max-inline-size: calc(100% - (var(--calcite-internal-meter-space) * 2));
-  min-inline-size: calc(var(--calcite-internal-meter-height) - (var(--calcite-internal-meter-space) * 2));
-  background-color: var(--calcite-internal-meter-fill-color);
-  transition-property: inline-size, background-color, box-shadow;
-}
-
-.solid .fill {
-  inset-block: 0;
-  inset-inline-start: 0;
-  max-inline-size: 100%;
-  min-inline-size: calc(var(--calcite-internal-meter-height));
-  box-shadow: 0 0 0 1px var(--calcite-internal-meter-fill-color);
 }


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

### Action Bar
--calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
--calcite-action-bar-background-color: defines the background color of the component.

### Action Group
--calcite-action-group-background-color-active: defines the background color of an action sub-component when active inside the component.
--calcite-action-group-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
--calcite-action-group-background-color: defines the background color of an action sub-component inside the component.
--calcite-action-group-background-color: defines the background color of the component.
--calcite-action-group-border-color: The border color of the sub-component.
--calcite-action-group-columns: [Deprecated]  Sets number of grid-template-columns when the `layout` property is `"grid"`.
--calcite-action-group-gap: [Deprecated]  Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
--calcite-action-group-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
--calcite-action-group-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
--calcite-action-group-indicator-color: defines the indicator color of an action sub-component inside the component.
--calcite-action-group-padding: [Deprecated]  Sets the padding when the `layout` property is `"grid"`.
--calcite-action-group-text-color-active: defines the text color of an action sub-component when active inside the component.
--calcite-action-group-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
--calcite-action-group-text-color: The text color of the sub-component.
--calcite-internal-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
--calcite-internal-action-group-gap, var(te-internal-action-group-gap: Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`).

### Action Menu

--calcite-action-menu-background-color: defines the background color of an action sub-component inside the component.
--calcite-action-menu-indicator-color: defines the indicator color of an action sub-component inside the component.
--calcite-action-menu-text-color: defines the text color of an action sub-component inside the component.
--calcite-action-menu-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
--calcite-action-menu-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
--calcite-action-menu-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
--calcite-action-menu-background-color-active: defines the background color of an action sub-component when active inside the component.
--calcite-action-menu-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
--calcite-action-menu-text-color-active: defines the text color of an action sub-component when active inside the component.
--calcite-action-menu-group-separator-border-color: The border color of the component.

### Action Pad
--calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
--calcite-action-pad-corner-radius: defines the corner radius of the component.
--calcite-action-pad-shadow: defines the box shadow of the component.
 