### PR TITLE
docs(list): add filter-no-results slot

### DIFF
--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -63,6 +63,7 @@ import { ListDragDetail } from "./interfaces";
  * @slot - A slot for adding `calcite-list-item` elements.
  * @slot filter-actions-start - A slot for adding actionable `calcite-action` elements before the filter component.
  * @slot filter-actions-end - A slot for adding actionable `calcite-action` elements after the filter component.
+ * @slot filter-no-results - When `filterEnabled` is `true`, a slot for adding content to display when no results are found.
  */
 @Component({
   tag: "calcite-list",


### PR DESCRIPTION
**Related Issue:** #8892

## Summary
Adds the `filter-no-results` slot to the `list` component's doc.