### PR TITLE
feat(navigation-user): adds component tokens

### DIFF
--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -3,16 +3,17 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-navigation-user-background-color: Specifies the background color of the component.
- * @prop --calcite-navigation-user-border-color: Specifies the border color of the component.
- * @prop --calcite-navigation-user-background-color-hover: Specifies the background color of the component when hovered.
- * @prop --calcite-navigation-user-background-color-active: Specifies the background color of the component when active.
- * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
+ * @prop --calcite-navigation-user-active-border-color: Specifies the border color of component when active property is true.
  * @prop --calcite-navigation-user-active-text-color: Specifies the text color of the component when active property is true.
- * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
- * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
  * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of avatar of the component.
  * @prop --calcite-navigation-user-avatar-text-color: Specifies the text color of avatar of the component.
+ * @prop --calcite-navigation-user-background-color-active: Specifies the background color of the component when active.
+ * @prop --calcite-navigation-user-background-color-hover: Specifies the background color of the component when hovered.
+ * @prop --calcite-navigation-user-background-color: Specifies the background color of the component.
+ * @prop --calcite-navigation-user-border-color: Specifies the border color of the component.
+ * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
+ * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
+ * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
  *
  */
 
@@ -62,6 +63,7 @@ calcite-avatar ~ .text-container {
 :host([active]) .button {
   --calcite-ui-icon-color: var(--calcite-color-brand);
   color: var(--calcite-navigation-user-active-text-color, var(--calcite-color-text-1));
+  border-color: var(--calcite-navigation-user-active-border-color, var(--calcite-color-brand));
 }
 
 .text-container {

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -8,6 +8,7 @@
  * @prop --calcite-navigation-user-background-color-hover: Specifies the background color of the component when hovered.
  * @prop --calcite-navigation-user-background-color-active: Specifies the background color of the component when active.
  * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
+ * @prop --calcite-navigation-user-active-text-color: Specifies the text color of the component when active property is true.
  * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
  * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
  * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of avatar of the component.
@@ -60,8 +61,7 @@ calcite-avatar ~ .text-container {
 
 :host([active]) .button {
   --calcite-ui-icon-color: var(--calcite-color-brand);
-  background-color: var(--calcite-navigation-user-background-color-active, var(--calcite-color-brand));
-  color: var(--calcite-navigation-user-text-color-active, var(--calcite-color-text-1));
+  color: var(--calcite-navigation-user-active-text-color, var(--calcite-color-text-1));
 }
 
 .text-container {

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -3,17 +3,13 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-navigation-user-active-border-color: Specifies the border color of component when active property is true.
- * @prop --calcite-navigation-user-active-text-color: Specifies the text color of the component when active property is true.
  * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of avatar of the component.
  * @prop --calcite-navigation-user-avatar-text-color: Specifies the text color of avatar of the component.
- * @prop --calcite-navigation-user-background-color-active: Specifies the background color of the component when active.
- * @prop --calcite-navigation-user-background-color-hover: Specifies the background color of the component when hovered.
  * @prop --calcite-navigation-user-background-color: Specifies the background color of the component.
  * @prop --calcite-navigation-user-border-color: Specifies the border color of the component.
  * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
  * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
- * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
+ * @prop --calcite-navigation-user-text-color: Specifies the text color of the component.
  *
  */
 
@@ -30,9 +26,9 @@
       font-sans;
     background-color: var(--calcite-navigation-user-background-color, transparent);
     border: none;
-    border-block-end-width: 2px;
+    border-block-end-width: var(--calcite-spacing-base);
     border-block-end-style: solid;
-    border-block-end-color: var(--calcite-navigation-user-border-color, transparent);
+    border-color: var(--calcite-navigation-user-border-color, transparent);
     font-size: var(--calcite-font-size-md);
     line-height: var(--calcite-font-line-height-fixed-lg);
   }
@@ -40,7 +36,7 @@
 
 :host(:hover) .button,
 :host(:focus) .button {
-  background-color: var(--calcite-navigation-user-background-color-hover, var(--calcite-color-foreground-2));
+  --calcite-navigation-user-background-color: var(--calcite-color-foreground-2);
 }
 
 :host(:focus) .button {
@@ -48,8 +44,8 @@
 }
 
 :host(:active) .button {
-  background-color: var(--calcite-navigation-user-background-color-active, var(--calcite-color-foreground-3));
-  color: var(--calcite-navigation-user-text-color-active, var(--calcite-color-text-1));
+  --calcite-navigation-user-background-color: var(--calcite-color-foreground-3);
+  --calcite-navigation-user-text-color: var(--calcite-color-text-1);
 }
 
 calcite-avatar {
@@ -62,8 +58,8 @@ calcite-avatar ~ .text-container {
 
 :host([active]) .button {
   --calcite-ui-icon-color: var(--calcite-color-brand);
-  color: var(--calcite-navigation-user-active-text-color, var(--calcite-color-text-1));
-  border-color: var(--calcite-navigation-user-active-border-color, var(--calcite-color-brand));
+  --calcite-navigation-user-text-color: var(--calcite-color-text-1);
+  --calcite-navigation-user-border-color: var(--calcite-color-brand);
 }
 
 .text-container {

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -3,16 +3,21 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-navigation-user-avatar-corner-radius: defines the corner radius of the component.
- * @prop --calcite-navigation-user-avatar-text-color: defines the text color of the component.
+ * @prop --calcite-navigation-user-background-color: Specifies the background color of the component.
+ * @prop --calcite-navigation-user-border-color: Specifies the border color of the component.
+ * @prop --calcite-navigation-user-background-color-hover: Specifies the background color of the component when hovered.
+ * @prop --calcite-navigation-user-background-color-active: Specifies the background color of the component when active.
+ * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
+ * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
+ * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
+ * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-navigation-user-avatar-text-color: Specifies the text color of the component.
  *
  */
 
 :host {
   @apply inline-flex outline-none;
   & .button {
-    background-color: transparent;
-    border: none;
     @apply flex
       m-0
       items-center
@@ -20,15 +25,20 @@
       cursor-pointer
       transition-default
       focus-base
-      font-sans
-      text-0h;
-    border-block-end: 2px solid transparent;
+      font-sans;
+    background-color: var(--calcite-navigation-user-background-color, transparent);
+    border: none;
+    border-block-end-width: 2px;
+    border-block-end-style: solid;
+    border-block-end-color: var(--calcite-navigation-user-border-color, transparent);
+    font-size: var(--calcite-font-size-md);
+    line-height: var(--calcite-font-line-height-fixed-lg);
   }
 }
 
 :host(:hover) .button,
 :host(:focus) .button {
-  @apply bg-foreground-2;
+  background-color: var(--calcite-navigation-user-background-color-hover, var(--calcite-color-foreground-2));
 }
 
 :host(:focus) .button {
@@ -36,11 +46,12 @@
 }
 
 :host(:active) .button {
-  @apply bg-foreground-3 text-color-1;
+  background-color: var(--calcite-navigation-user-background-color-active, var(--calcite-color-foreground-3));
+  color: var(--calcite-navigation-user-text-color-active, var(--calcite-color-text-1));
 }
 
 calcite-avatar {
-  @apply px-4;
+  padding-inline: var(--calcite-spacing-xl);
 }
 
 calcite-avatar ~ .text-container {
@@ -48,28 +59,29 @@ calcite-avatar ~ .text-container {
 }
 
 :host([active]) .button {
-  @apply text-color-1 border-color-brand;
   --calcite-ui-icon-color: var(--calcite-color-brand);
+  background-color: var(--calcite-navigation-user-background-color-active, var(--calcite-color-brand));
+  color: var(--calcite-navigation-user-text-color-active, var(--calcite-color-text-1));
 }
 
 .text-container {
   @apply flex
   flex-col
-  text-start
-  px-4
-  mt-0.5;
+  text-start;
+  padding-inline: var(--calcite-spacing-xl);
+  margin-block-start: var(--calcite-spacing-base);
 }
 
 .full-name {
-  @apply text-0
-  ms-0
-  text-color-1
-  font-medium;
+  @apply ms-0;
+  font-size: var(--calcite-font-size-md);
+  font-weight: var(--calcite-font-weight-medium);
+  color: var(--calcite-navigation-user-full-name-text-color, var(--calcite-color-text-1));
 }
 
 .username {
-  @apply text-color-2;
-  font-size: var(--calcite-font-size--1);
+  font-size: var(--calcite-font-size);
+  color: var(--calcite-navigation-user-name-text-color, var(--calcite-color-text-2));
 }
 
 calcite-avatar {

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.scss
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.scss
@@ -10,8 +10,8 @@
  * @prop --calcite-navigation-user-text-color-active: Specifies the text color of the component when active.
  * @prop --calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
  * @prop --calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
- * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of the component.
- * @prop --calcite-navigation-user-avatar-text-color: Specifies the text color of the component.
+ * @prop --calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of avatar of the component.
+ * @prop --calcite-navigation-user-avatar-text-color: Specifies the text color of avatar of the component.
  *
  */
 


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary


Adds following tokens for `calcite-navigation-user`

``` 
--calcite-navigation-user-avatar-corner-radius: Specifies the corner radius of avatar of the component.
--calcite-navigation-user-avatar-text-color: Specifies the text color of avatar of the component.
--calcite-navigation-user-background-color: Specifies the background color of the component.
--calcite-navigation-user-border-color: Specifies the border color of the component.
--calcite-navigation-user-full-name-text-color: Specifies the text color of full name of the component.
--calcite-navigation-user-name-text-color: Specifies the text color of user name of the component.
--calcite-navigation-user-text-color: Specifies the text color of the component.