### PR TITLE
ci(pr-semantic): remove no longer needed validateSingleCommit

### DIFF
--- a/.github/workflows/pr-semantic.yml
+++ b/.github/workflows/pr-semantic.yml
@@ -5,7 +5,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5.0.2
-        with:
-          validateSingleCommit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Per the action's documentation (https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#legacy-configuration-for-validating-single-commits) and our latest squash merging settings (use PR title + description), validating on single commits is no longer necessary.