### PR TITLE
feat(time-picker): add component tokens to time picker

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -15,7 +15,17 @@
  * @prop --calcite-input-icon-color:  defines the icon color of the component.
  * @prop --calcite-input-placeholder-text-color: defines the color of placeholder text in the component.
  * @prop --calcite-input-text-color: defines the text color of the component.
- *
+ * @prop --calcite-input-time-picker-background-color: defines the background color of the time picker sub component.
+ * @prop --calcite-input-time-picker-background-color-hover: defines the background color of the time picker sub component when hovered.
+ * @prop --calcite-input-time-picker-background-color-active: defines the background color of the time picker sub component when active.
+ * @prop --calcite-input-time-picker-text-color: defines the text color of the time picker sub component.
+ * @prop --calcite-input-time-picker-icon-color: defines the icon color of the time picker sub component.
+ * @prop --calcite-input-time-picker-box-shadow: defines the box shadow around the numbers inside the open component.
+ * @prop --calcite-input-time-picker-box-shadow-focus: defines the box shadow around the numbers inside the open component when focused.
+ * @prop --calcite-input-popover-background-color: defines the background color of the popover sub component.
+ * @prop --calcite-input-popover-border-color: defines the border color of the popover sub component.
+ * @prop --calcite-input-popover-text-color: defines the text color of the popover sub component.
+ * @prop --calcite-input-popover-background-color: defines the background color of the popover sub component.
  */
 
 :host {
@@ -57,15 +67,24 @@
 }
 
 calcite-popover {
-  // TODO: sub-component tokens go here
+  --calcite-popover-background-color: var(--calcite-input-popover-background-color);
+  --calcite-popover-border-color: var(--calcite-input-popover-border-color);
+  --calcite-popover-text-color: var(--calcite-input-popover-text-color);
+  --calcite-popover-shadow: var(--calcite-input-popover-shadow);
 }
 
 calcite-time-picker {
-  // TODO: sub-component tokens go here
+  --calcite-time-picker-text-color: var(--calcite-input-time-picker-text-color);
+  --calcite-time-picker-background-color: var(--calcite-input-time-picker-background-color);
+  --calcite-time-picker-background-color-hover: var(--calcite-input-time-picker-background-color-hover);
+  --calcite-time-picker-background-color-active: var(--calcite-input-time-picker-background-color-active);
+  --calcite-time-picker-icon-color: var(--calcite-input-time-picker-icon-color);
+  --calcite-time-picker-input-box-shadow: var(--calcite-input-time-picker-box-shadow);
+  --calcite-time-picker-input-box-shadow-focus: var(--calcite-input-time-picker-box-shadow-focus);
 }
 
 calcite-icon {
-  // TODO: sub-component tokens go here
+  --calcite-icon-color: var(--calcite-input-icon-color);
 }
 
 @include form-validation-message();

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -8,7 +8,8 @@
  * @prop --calcite-time-picker-background-color-hover: Specifies the background color of the component when hovered.
  * @prop --calcite-time-picker-background-color-active: Specifies the background color of the component when active.
  * @prop --calcite-time-picker-icon-color: Specifies the color of the component's icons.
- * @prop --calcite-time-picker-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-time-picker-input-box-shadow: Specifies the box shadow around the numbers inside the open component.
+ * @prop --calcite-time-picker-input-box-shadow-focus: Specifies the box shadow around the numbers inside the open component when focused.
  */
 time-picker :host {
   @apply inline-block;
@@ -66,14 +67,16 @@ time-picker :host {
   }
 
   .input {
-    @apply bg-foreground-1
-      inline-flex
+    @apply inline-flex
       cursor-pointer
       items-center
       justify-center
       font-medium;
+
+    background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
+
     &:hover {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-foreground-2);
+      box-shadow: var(--calcite-time-picker-input-box-shadow, inset 0 0 0 2px var(--calcite-color-foreground-2));
       z-index: theme("zIndex.header");
     }
     &:focus,
@@ -83,7 +86,7 @@ time-picker :host {
     }
     &.inputFocus,
     &:hover.inputFocus {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-brand);
+      box-shadow: var(--calcite-time-picker-input-box-shadow-focus, inset 0 0 0 2px var(--calcite-color-brand));
       z-index: theme("zIndex.header");
     }
   }
@@ -92,8 +95,8 @@ time-picker :host {
     @apply text-n1;
     .button,
     .input {
-      @apply px-3
-        py-1;
+      padding-block: var(--calcite-spacing-xxs);
+      padding-inline: var(--calcite-spacing-md);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
@@ -106,8 +109,8 @@ time-picker :host {
     @apply text-0;
     .button,
     .input {
-      @apply px-4
-        py-2;
+      padding-block: var(--calcite-spacing-sm);
+      padding-inline: var(--calcite-spacing-xl);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
@@ -120,8 +123,8 @@ time-picker :host {
     @apply text-1;
     .button,
     .input {
-      @apply px-5
-        py-3;
+      padding-block: var(--calcite-spacing-md);
+      padding-inline: var(--calcite-spacing-xxl);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
@@ -132,7 +135,7 @@ time-picker :host {
 }
 
 calcite-icon {
-  --calcite-icon-color: var(--calcite-time-picker-icon-color);
+  --calcite-icon-color: var(--calcite-time-picker-icon-color, var(--calcite-color-text-3));
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -1,17 +1,28 @@
-:host {
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-time-picker-text-color: Specifies the text color of the component.
+ * @prop --calcite-time-picker-background-color: Specifies the background color of the component.
+ * @prop --calcite-time-picker-background-color-hover: Specifies the background color of the component when hovered.
+ * @prop --calcite-time-picker-background-color-active: Specifies the background color of the component when active.
+ * @prop --calcite-time-picker-icon-color: Specifies the color of the component's icons.
+ * @prop --calcite-time-picker-corner-radius: Specifies the corner radius of the component.
+ */
+time-picker :host {
   @apply inline-block;
 }
 
 .time-picker {
-  @apply bg-foreground-1
-    shadow-2
-    text-color-1
-    flex
+  @apply flex
     select-none
     items-center
     font-medium;
 
-  border-radius: var(--calcite-border-radius);
+  background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
+  color: var(--calcite-time-picker-text-color, var(--calcite-color-text-1));
+  box-shadow: var(--calcite-time-picker-shadow, var(--calcite-shadow-none));
 
   .column {
     @apply flex
@@ -23,20 +34,22 @@
   }
 
   .button {
-    @apply bg-foreground-1
-      inline-flex
+    @apply inline-flex
       cursor-pointer
       items-center
       justify-center;
+
+    background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
+
     &:hover,
     &:focus {
-      @apply bg-foreground-2
-        outline-none;
+      @apply outline-none;
+      background-color: var(--calcite-time-picker-background-color-hover, var(--calcite-color-foreground-2));
       z-index: theme("zIndex.header");
       outline-offset: 0;
     }
     &:active {
-      @apply bg-foreground-3;
+      background-color: var(--calcite-time-picker-background-color-active, var(--calcite-color-foreground-3));
     }
     &.top-left {
       border-start-start-radius: var(--calcite-border-radius);
@@ -49,9 +62,6 @@
     }
     &.bottom-right {
       border-end-end-radius: var(--calcite-border-radius);
-    }
-    calcite-icon {
-      @apply text-color-3;
     }
   }
 
@@ -119,6 +129,10 @@
       }
     }
   }
+}
+
+calcite-icon {
+  --calcite-icon-color: var(--calcite-time-picker-icon-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/demos/input-time-picker.html
+++ b/packages/calcite-components/src/demos/input-time-picker.html
@@ -35,13 +35,18 @@
         gap: 1em;
       }
       .themed-example {
-        --calcite-time-picker-background-color: lightblue;
-        --calcite-time-picker-background-color-hover: green;
-        --calcite-time-picker-background-color-active: pink;
-        --calcite-time-picker-icon-color: yellow;
-        --calcite-time-picker-text-color: red;
-        --calcite-time-picker-input-box-shadow: inset 0 0 0 2px yellow;
-        --calcite-time-picker-input-box-shadow-focus: inset 0 0 0 2px green;
+        --calcite-input-background-color: lightblue;
+        --calcite-input-text-color: white;
+        --calcite-input-icon-color: white;
+        --calcite-input-corner-radius: 10px;
+        --calcite-input-popover-background-color: lightblue;
+        --calcite-input-time-picker-background-color: lightblue;
+        --calcite-input-time-picker-background-color-hover: navy;
+        --calcite-input-time-picker-background-color-active: yellow;
+        --calcite-input-time-picker-text-color: white;
+        --calcite-input-time-picker-icon-color: white;
+        --calcite-input-time-picker-box-shadow: inset 0 0 0 2px yellow;
+        --calcite-input-time-picker-box-shadow-focus: inset 0 0 0 2px navy;
       }
     </style>
   </head>

--- a/packages/calcite-components/src/demos/input-time-picker.html
+++ b/packages/calcite-components/src/demos/input-time-picker.html
@@ -34,12 +34,32 @@
         flex-direction: column;
         gap: 1em;
       }
+      .themed-example {
+        --calcite-time-picker-background-color: red;
+        --calcite-time-picker-background-color-hover: green;
+        --calcite-time-picker-background-color-active: pink;
+        --calcite-time-picker-icon-color: yellow;
+        --calcite-time-picker-text-color: blue;
+        --calcite-time-picker-corner-radius: 100%;
+      }
     </style>
   </head>
   <body>
     <demo-dom-swapper>
       <div id="main-container">
         <main>
+          <h3>Themed</h3>
+          <div class="grid">
+            <calcite-label
+              >Themed example
+              <calcite-input-time-picker
+                class="themed-example"
+                lang="en"
+                value="10:00:00"
+                open
+              ></calcite-input-time-picker>
+            </calcite-label>
+          </div>
           <h3>12-Hour Locales</h3>
           <div id="h12" class="grid"></div>
           <h3>24-Hour Locales</h3>

--- a/packages/calcite-components/src/demos/input-time-picker.html
+++ b/packages/calcite-components/src/demos/input-time-picker.html
@@ -35,12 +35,13 @@
         gap: 1em;
       }
       .themed-example {
-        --calcite-time-picker-background-color: red;
+        --calcite-time-picker-background-color: lightblue;
         --calcite-time-picker-background-color-hover: green;
         --calcite-time-picker-background-color-active: pink;
         --calcite-time-picker-icon-color: yellow;
-        --calcite-time-picker-text-color: blue;
-        --calcite-time-picker-corner-radius: 100%;
+        --calcite-time-picker-text-color: red;
+        --calcite-time-picker-input-box-shadow: inset 0 0 0 2px yellow;
+        --calcite-time-picker-input-box-shadow-focus: inset 0 0 0 2px green;
       }
     </style>
   </head>
@@ -48,10 +49,10 @@
     <demo-dom-swapper>
       <div id="main-container">
         <main>
-          <h3>Themed</h3>
+          <h3>Themed time picker</h3>
           <div class="grid">
             <calcite-label
-              >Themed example
+              >English(en)
               <calcite-input-time-picker
                 class="themed-example"
                 lang="en"


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary
Add the following component tokens to the time-picker component:

`--calcite-time-picker-text-color`: Specifies the text color of the component.
`--calcite-time-picker-background-color`: Specifies the background color of the component.
`--calcite-time-picker-background-color-hover`: Specifies the background color of the component when in hovered.
`--calcite-time-picker-background-color-active`: Specifies the background color of the component when in active.
`--calcite-time-picker-icon-color`: Specifies the color of the component's icons.
`--calcite-time-picker-input-box-shadow`: Specifies the box shadow around the numbers inside the open component.
`--calcite-time-picker-input-box-shadow-focus`: Specifies the box shadow around the numbers inside the open component when focused.