### PR TITLE
refactor(color-picker): add `clearable` property and deprecate `allowEmpty`

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1066,12 +1066,17 @@ export namespace Components {
     interface CalciteColorPickerHexInput {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+          * @deprecated Use `clearable` instead.
          */
         "allowEmpty": boolean;
         /**
           * When `true`, the component will allow updates to the color's alpha value.
          */
         "alphaChannel": boolean;
+        /**
+          * When `true`, a clear button is displayed when the component has a value.
+         */
+        "clearable": boolean;
         /**
           * Specifies accessible label for the input field.
           * @deprecated use `messages` instead
@@ -8470,12 +8475,17 @@ declare namespace LocalJSX {
     interface CalciteColorPickerHexInput {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+          * @deprecated Use `clearable` instead.
          */
         "allowEmpty"?: boolean;
         /**
           * When `true`, the component will allow updates to the color's alpha value.
          */
         "alphaChannel"?: boolean;
+        /**
+          * When `true`, a clear button is displayed when the component has a value.
+         */
+        "clearable"?: boolean;
         /**
           * Specifies accessible label for the input field.
           * @deprecated use `messages` instead

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -674,7 +674,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Specifies the optional new name of the file after it is downloaded.
+          * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download.
          */
         "download": string | boolean;
         /**
@@ -980,6 +980,7 @@ export namespace Components {
     interface CalciteColorPicker {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+          * @deprecated Use `clearable` instead.
          */
         "allowEmpty": boolean;
         /**
@@ -990,6 +991,10 @@ export namespace Components {
           * When `true`, hides the RGB/HSV channel inputs.
          */
         "channelsDisabled": boolean;
+        /**
+          * When `true`, a clear button is displayed when the component has a value.
+         */
+        "clearable": boolean;
         /**
           * Internal prop for advanced use-cases.
          */
@@ -8059,7 +8064,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Specifies the optional new name of the file after it is downloaded.
+          * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download.
          */
         "download"?: string | boolean;
         /**
@@ -8375,6 +8380,7 @@ declare namespace LocalJSX {
     interface CalciteColorPicker {
         /**
           * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+          * @deprecated Use `clearable` instead.
          */
         "allowEmpty"?: boolean;
         /**
@@ -8385,6 +8391,10 @@ declare namespace LocalJSX {
           * When `true`, hides the RGB/HSV channel inputs.
          */
         "channelsDisabled"?: boolean;
+        /**
+          * When `true`, a clear button is displayed when the component has a value.
+         */
+        "clearable"?: boolean;
         /**
           * Internal prop for advanced use-cases.
          */

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -878,9 +878,9 @@ export class ColorPicker
                 {noHex ? null : (
                   <div class={CSS.hexOptions}>
                     <calcite-color-picker-hex-input
-                      allowEmpty={isClearable}
                       alphaChannel={alphaChannel}
                       class={CSS.control}
+                      clearable={isClearable}
                       messages={messages}
                       numberingSystem={this.numberingSystem}
                       onCalciteColorPickerHexInputChange={this.handleHexInputChange}


### PR DESCRIPTION
**Related Issue:** #6880

## Summary
Add `clearable` property and deprecate `allowEmpty`.