### PR TITLE
test(color-picker): added clearable logic alongside allowEmpty

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -974,9 +974,6 @@ export namespace Components {
         "setFocus": () => Promise<void>;
     }
     interface CalciteColorPicker {
-        /**
-          * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
-         */
         "allowEmpty": boolean;
         /**
           * When `true`, the component will allow updates to the color's alpha value.
@@ -986,6 +983,10 @@ export namespace Components {
           * When `true`, hides the RGB/HSV channel inputs.
          */
         "channelsDisabled": boolean;
+        /**
+          * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+         */
+        "clearable": boolean;
         /**
           * Internal prop for advanced use-cases.
          */
@@ -8365,9 +8366,6 @@ declare namespace LocalJSX {
   >;
     }
     interface CalciteColorPicker {
-        /**
-          * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
-         */
         "allowEmpty"?: boolean;
         /**
           * When `true`, the component will allow updates to the color's alpha value.
@@ -8377,6 +8375,10 @@ declare namespace LocalJSX {
           * When `true`, hides the RGB/HSV channel inputs.
          */
         "channelsDisabled"?: boolean;
+        /**
+          * When `true`, an empty color (`null`) will be allowed as a `value`.  When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+         */
+        "clearable"?: boolean;
         /**
           * Internal prop for advanced use-cases.
          */

--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -50,7 +50,7 @@ describe("calcite-color-picker", () => {
 
   describe("accessible", () => {
     accessible("calcite-color-picker");
-    accessible("<calcite-color-picker allow-empty value=''></calcite-color-picker>");
+    accessible("<calcite-color-picker clearable value=''></calcite-color-picker>");
   });
 
   describe("honors hidden attribute", () => {
@@ -82,6 +82,10 @@ describe("calcite-color-picker", () => {
       },
       {
         propertyName: "channelsDisabled",
+        defaultValue: false,
+      },
+      {
+        propertyName: "clearable",
         defaultValue: false,
       },
       {
@@ -1094,7 +1098,7 @@ describe("calcite-color-picker", () => {
         describe("when no-color", () => {
           it("color gets propagated to hex, RGB & HSV inputs", async () => {
             const page = await newE2EPage();
-            await page.setContent(html`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
+            await page.setContent(html`<calcite-color-picker clearable value=""></calcite-color-picker>`);
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
@@ -1125,9 +1129,7 @@ describe("calcite-color-picker", () => {
 
             beforeEach(async () => {
               page = await newE2EPage();
-              await page.setContent(
-                `<calcite-color-picker allow-empty value='${initialValue}'></calcite-color-picker>`,
-              );
+              await page.setContent(`<calcite-color-picker clearable value='${initialValue}'></calcite-color-picker>`);
             });
 
             it("restores previous color to RGB inputs", async () => {
@@ -1185,9 +1187,7 @@ describe("calcite-color-picker", () => {
 
           it("changes the value to the specified format after being empty", async () => {
             const page = await newE2EPage();
-            await page.setContent(
-              html`<calcite-color-picker allow-empty value="" format="rgb"></calcite-color-picker>`,
-            );
+            await page.setContent(html`<calcite-color-picker clearable value="" format="rgb"></calcite-color-picker>`);
             const color = await page.find("calcite-color-picker");
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
@@ -1199,7 +1199,7 @@ describe("calcite-color-picker", () => {
           describe("clearing color via supporting inputs", () => {
             it("clears color via hex input", async () => {
               const page = await newE2EPage();
-              await page.setContent(html`<calcite-color-picker allow-empty value="#c0ff33"></calcite-color-picker>`);
+              await page.setContent(html`<calcite-color-picker clearable value="#c0ff33"></calcite-color-picker>`);
               const picker = await page.find("calcite-color-picker");
               const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
@@ -1210,7 +1210,7 @@ describe("calcite-color-picker", () => {
 
             it("clears color via RGB channel inputs", async () => {
               const page = await newE2EPage();
-              await page.setContent(html`<calcite-color-picker allow-empty value="#c0ff33"></calcite-color-picker>`);
+              await page.setContent(html`<calcite-color-picker clearable value="#c0ff33"></calcite-color-picker>`);
               const picker = await page.find("calcite-color-picker");
 
               const [rgbModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
@@ -1229,7 +1229,7 @@ describe("calcite-color-picker", () => {
 
             it("clears color via HSV channel inputs", async () => {
               const page = await newE2EPage();
-              await page.setContent(html`<calcite-color-picker allow-empty value="#c0ff33"></calcite-color-picker>`);
+              await page.setContent(html`<calcite-color-picker clearable value="#c0ff33"></calcite-color-picker>`);
               const picker = await page.find("calcite-color-picker");
 
               const [, hsvModeButton] = await page.findAll(`calcite-color-picker >>> .${CSS.colorMode}`);
@@ -1647,9 +1647,7 @@ describe("calcite-color-picker", () => {
         describe("when no-color", () => {
           it("color gets propagated to hex, RGB, HSV & opacity inputs", async () => {
             const page = await newE2EPage();
-            await page.setContent(
-              html`<calcite-color-picker alpha-channel allow-empty value=""></calcite-color-picker>`,
-            );
+            await page.setContent(html`<calcite-color-picker alpha-channel clearable value=""></calcite-color-picker>`);
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
@@ -1683,7 +1681,7 @@ describe("calcite-color-picker", () => {
             beforeEach(async () => {
               page = await newE2EPage();
               await page.setContent(
-                `<calcite-color-picker alpha-channel allow-empty value='${initialValue}'></calcite-color-picker>`,
+                `<calcite-color-picker alpha-channel clearable value='${initialValue}'></calcite-color-picker>`,
               );
             });
 
@@ -1776,7 +1774,7 @@ describe("calcite-color-picker", () => {
           it("changes the value to the specified format after being empty", async () => {
             const page = await newE2EPage();
             await page.setContent(
-              "<calcite-color-picker alpha-channel allow-empty value='' format='rgba'></calcite-color-picker>",
+              "<calcite-color-picker alpha-channel clearable value='' format='rgba'></calcite-color-picker>",
             );
             const color = await page.find("calcite-color-picker");
 
@@ -1790,7 +1788,7 @@ describe("calcite-color-picker", () => {
             it("clears color via hex input", async () => {
               const page = await newE2EPage();
               await page.setContent(
-                "<calcite-color-picker alpha-channel allow-empty value='#c0ff3333'></calcite-color-picker>",
+                "<calcite-color-picker alpha-channel clearable value='#c0ff3333'></calcite-color-picker>",
               );
               const picker = await page.find("calcite-color-picker");
 
@@ -1803,7 +1801,7 @@ describe("calcite-color-picker", () => {
             it("clears color via RGB channel inputs", async () => {
               const page = await newE2EPage();
               await page.setContent(
-                "<calcite-color-picker alpha-channel allow-empty value='#c0ff3333'></calcite-color-picker>",
+                "<calcite-color-picker alpha-channel clearable value='#c0ff3333'></calcite-color-picker>",
               );
               const picker = await page.find("calcite-color-picker");
 
@@ -1827,7 +1825,7 @@ describe("calcite-color-picker", () => {
             it("clears color via HSV channel inputs", async () => {
               const page = await newE2EPage();
               await page.setContent(
-                "<calcite-color-picker alpha-channel allow-empty value='#c0ff3333'></calcite-color-picker>",
+                "<calcite-color-picker alpha-channel clearable value='#c0ff3333'></calcite-color-picker>",
               );
               const picker = await page.find("calcite-color-picker");
 
@@ -1963,7 +1961,7 @@ describe("calcite-color-picker", () => {
 
       it("does not allow saving/removing when no-color is set", async () => {
         const page = await newE2EPage();
-        await page.setContent(`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
+        await page.setContent(`<calcite-color-picker clearable value=""></calcite-color-picker>`);
 
         const saveColor = await page.find(`calcite-color-picker >>> .${CSS.saveColor}`);
         const removeColor = await page.find(`calcite-color-picker >>> .${CSS.deleteColor}`);
@@ -2063,7 +2061,7 @@ describe("calcite-color-picker", () => {
 
       it("does not allow saving/removing when no-color is set", async () => {
         const page = await newE2EPage();
-        await page.setContent(`<calcite-color-picker alpha-channel allow-empty value=""></calcite-color-picker>`);
+        await page.setContent(`<calcite-color-picker alpha-channel clearable value=""></calcite-color-picker>`);
 
         const saveColor = await page.find(`calcite-color-picker >>> .${CSS.saveColor}`);
         const removeColor = await page.find(`calcite-color-picker >>> .${CSS.deleteColor}`);
@@ -2076,7 +2074,7 @@ describe("calcite-color-picker", () => {
 
   it("allows setting no-color", async () => {
     const page = await newE2EPage();
-    await page.setContent(`<calcite-color-picker allow-empty></calcite-color-picker>`);
+    await page.setContent(`<calcite-color-picker clearable></calcite-color-picker>`);
 
     const color = await page.find("calcite-color-picker");
 
@@ -2152,7 +2150,7 @@ describe("calcite-color-picker", () => {
     describe("keyboard", () => {
       it("allows editing color field via keyboard", async () => {
         const page = await newE2EPage();
-        await page.setContent(`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
+        await page.setContent(`<calcite-color-picker clearable value=""></calcite-color-picker>`);
 
         const picker = await page.find("calcite-color-picker");
         const scope = await page.find(`calcite-color-picker >>> .${CSS.colorFieldScope}`);
@@ -2232,7 +2230,7 @@ describe("calcite-color-picker", () => {
 
       it("allows editing hue slider via keyboard", async () => {
         const page = await newE2EPage();
-        await page.setContent(`<calcite-color-picker allow-empty value=""></calcite-color-picker>`);
+        await page.setContent(`<calcite-color-picker clearable value=""></calcite-color-picker>`);
 
         const picker = await page.find("calcite-color-picker");
         const hueScope = await page.find(`calcite-color-picker >>> .${CSS.hueScope}`);

--- a/packages/calcite-components/src/components/color-picker/color-picker.stories.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.stories.ts
@@ -69,6 +69,10 @@ export const simple = (): string =>
       name: "allow-empty",
       value: boolean("allow-empty", false),
     },
+    {
+      name: "clearable",
+      value: boolean("clearable", false),
+    },
     ...createColorAttributes(),
     {
       name: "value",

--- a/packages/calcite-components/src/demos/color-picker.html
+++ b/packages/calcite-components/src/demos/color-picker.html
@@ -49,7 +49,7 @@
       <div class="parent">
         <div class="child right-aligned-text">Default</div>
         <div class="child">
-          <calcite-color-picker scale="s"></calcite-color-picker>
+          <calcite-color-picker clearable scale="s"></calcite-color-picker>
         </div>
 
         <div class="child">


### PR DESCRIPTION
**Related Issue:** #6880

## Summary
Added clearable to contribute to continuity within the codebase - the logic allows for allowEmpty & clearable to be utilized to allow null values in the color picker.