### PR TITLE
fix(combobox): prevent toggling items when combobox is closed

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -674,7 +674,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Specifies the optional new name of the file after it is downloaded.
+          * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download.
          */
         "download": string | boolean;
         /**
@@ -8059,7 +8059,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Specifies the optional new name of the file after it is downloaded.
+          * Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download.
          */
         "download"?: string | boolean;
         /**

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1918,4 +1918,42 @@ describe("calcite-combobox", () => {
       });
     });
   });
+  it("prevents toggling items when combobox is closed", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-combobox label="test" placeholder="placeholder" max-items="10" scale="m">
+        <calcite-combobox-item-group label="Pokemon">
+          <calcite-combobox-item value="Pikachu" text-label="Pikachu"></calcite-combobox-item>
+          <calcite-combobox-item value="Venusaur" text-label="Venusaur"></calcite-combobox-item>
+          <calcite-combobox-item value="Charizard" text-label="Charizard"></calcite-combobox-item>
+          <calcite-combobox-item-group label="Cutest Pokemon">
+            <calcite-combobox-item value="Bulbasaur" text-label="Bulbasaur"></calcite-combobox-item>
+            <calcite-combobox-item value="Squirtle1" text-label="Squirtle1">
+              <calcite-combobox-item value="Squirtle2" text-label="Squirtle2"> </calcite-combobox-item>
+            </calcite-combobox-item>
+          </calcite-combobox-item-group>
+        </calcite-combobox-item-group>
+      </calcite-combobox>
+    `);
+
+    const combobox = await page.find("calcite-combobox");
+    await combobox.click();
+    expect(await page.find("calcite-combobox")).toHaveAttribute("open");
+
+    const item1 = await combobox.find("calcite-combobox-item[value=Pikachu]");
+    await item1.click();
+    const item2 = await combobox.find("calcite-combobox-item[value=Charizard]");
+    await item2.click();
+
+    const chips = await page.findAll("calcite-combobox >>> calcite-chip");
+    expect(chips.length).toBe(2);
+
+    await combobox.click();
+    expect(await page.find("calcite-combobox")).not.toHaveAttribute("open");
+
+    await combobox.press("Enter");
+    expect(chips.length).toBe(2);
+    await combobox.press("Enter");
+    expect(chips.length).toBe(2);
+  });
 });

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1941,10 +1941,8 @@ describe("calcite-combobox", () => {
     await combobox.click();
     expect(await page.find("calcite-combobox")).toHaveAttribute("open");
 
-    const item1 = await combobox.find("calcite-combobox-item[value=Pikachu]");
-    await item1.click();
-    const item2 = await combobox.find("calcite-combobox-item[value=Charizard]");
-    await item2.click();
+    await (await combobox.find("calcite-combobox-item[value=Pikachu]")).click();
+    await (await combobox.find("calcite-combobox-item[value=Charizard]")).click();
 
     const chips = await page.findAll("calcite-combobox >>> calcite-chip");
     expect(chips.length).toBe(2);

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1918,6 +1918,7 @@ describe("calcite-combobox", () => {
       });
     });
   });
+
   it("prevents toggling items when combobox is closed", async () => {
     const page = await newE2EPage();
     await page.setContent(html`

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -725,7 +725,7 @@ export class Combobox
         event.preventDefault();
         break;
       case "Enter":
-        if (this.activeItemIndex > -1) {
+        if (this.open && this.activeItemIndex > -1) {
           this.toggleSelection(this.filteredItems[this.activeItemIndex]);
           event.preventDefault();
         } else if (this.activeChipIndex > -1) {


### PR DESCRIPTION
**Related Issue:** #8919

## Summary
Prevent combobox from allowing to select and deselect the "last focused item" with the Enter key when it's closed. 
