### PR TITLE
feat(block-section): add subcomponent CSS props

### DIFF
--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -7,7 +7,7 @@
  * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
  * @prop --calcite-block-section-heading-text-color-hover: Specifies the component's heading text color on hover.
  * @prop --calcite-block-section-heading-text-color: Specifies the component's heading text color.
- * @prop --calcite-block-section-switch-border-radius: Specifies the border radius of the switch.
+ * @prop --calcite-block-section-switch-corner-radius: Specifies the border radius of the switch.
  * @prop --calcite-block-section-switch-handle-background-color: Specifies the background color of the switch handle.
  * @prop --calcite-block-section-switch-handle-border-color-hover: Specifies the border color of the switch handle on hover.
  * @prop --calcite-block-section-switch-handle-border-color: Specifies the border color of the switch handle.
@@ -129,7 +129,7 @@ calcite-icon {
 }
 
 calcite-switch {
-  --calcite-switch-corner-radius: var(--calcite-block-section-switch-border-radius);
+  --calcite-switch-corner-radius: var(--calcite-block-section-switch-corner-radius);
   --calcite-switch-handle-background-color: var(--calcite-block-section-switch-handle-background-color);
   --calcite-switch-handle-border-color: var(--calcite-block-section-switch-handle-border-color);
   --calcite-switch-handle-shadow: var(--calcite-block-section-switch-handle-shadow);

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -5,8 +5,18 @@
  *
  * @prop --calcite-block-section-background-color: Specifies the background color of the component.
  * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
- * @prop --calcite-block-section-heading-text-color: Specifies the component's heading text color.
  * @prop --calcite-block-section-heading-text-color-hover: Specifies the component's heading text color on hover.
+ * @prop --calcite-block-section-heading-text-color: Specifies the component's heading text color.
+ * @prop --calcite-block-section-switch-border-radius: Specifies the border radius of the switch.
+ * @prop --calcite-block-section-switch-handle-background-color: Specifies the background color of the switch handle.
+ * @prop --calcite-block-section-switch-handle-border-color-hover: Specifies the border color of the switch handle on hover.
+ * @prop --calcite-block-section-switch-handle-border-color: Specifies the border color of the switch handle.
+ * @prop --calcite-block-section-switch-handle-shadow-hover: Specifies the shadow of the switch handle on hover.
+ * @prop --calcite-block-section-switch-handle-shadow: Specifies the shadow of the switch handle.
+ * @prop --calcite-block-section-switch-track-background-color-checked: Specifies the background color of the switch track when checked.
+ * @prop --calcite-block-section-switch-track-background-color: Specifies the background color of the switch track.
+ * @prop --calcite-block-section-switch-track-border-color-checked: Specifies the border color of the switch track when checked.
+ * @prop --calcite-block-section-switch-track-border-color: Specifies the border color of the switch track.
  */
 
 :host {
@@ -119,11 +129,27 @@ calcite-icon {
 }
 
 calcite-label {
-  // TODO: add sub-component tokens
+  --calcite-label-text-color: var(--calcite-block-section-heading-text-color);
 }
 
 calcite-switch {
-  // TODO: add sub-component tokens
+  --calcite-switch-corner-radius: var(--calcite-block-section-switch-border-radius);
+  --calcite-switch-handle-background-color: var(--calcite-block-section-switch-handle-background-color);
+  --calcite-switch-handle-border-color: var(--calcite-block-section-switch-handle-border-color);
+  --calcite-switch-handle-shadow: var(--calcite-block-section-switch-handle-shadow);
+  --calcite-switch-track-background-color: var(--calcite-block-section-switch-track-background-color);
+  --calcite-switch-track-border-color: var(--calcite-block-section-switch-track-border-color);
+
+  &:focus,
+  &:hover {
+    --calcite-switch-handle-border-color: var(--calcite-block-section-switch-handle-border-color-hover);
+    --calcite-switch-handle-shadow: var(--calcite-block-section-switch-handle-shadow-hover);
+  }
+
+  &[checked] {
+    --calcite-switch-track-background-color: var(--calcite-block-section-switch-track-background-color-checked);
+    --calcite-switch-track-border-color: var(--calcite-block-section-switch-track-border-color-checked);
+  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -128,10 +128,6 @@ calcite-icon {
   // TODO: add sub-component tokens
 }
 
-calcite-label {
-  --calcite-label-text-color: var(--calcite-block-section-heading-text-color);
-}
-
 calcite-switch {
   --calcite-switch-corner-radius: var(--calcite-block-section-switch-border-radius);
   --calcite-switch-handle-background-color: var(--calcite-block-section-switch-handle-background-color);


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds the following subcomponent tokens (CSS props):

* `--calcite-block-section-switch-corner-radius`
* `--calcite-block-section-switch-handle-background-color`
* `--calcite-block-section-switch-handle-border-color-hover`
* `--calcite-block-section-switch-handle-border-color`
* `--calcite-block-section-switch-handle-shadow-hover`
* `--calcite-block-section-switch-handle-shadow`
* `--calcite-block-section-switch-track-background-color-checked`
* `--calcite-block-section-switch-track-background-color`
* `--calcite-block-section-switch-track-border-color-checked`
* `--calcite-block-section-switch-track-border-color`

## Notes

* internal label does not require customization.
* icon-related CSS props will be added by https://github.com/Esri/calcite-design-system/pull/8868/.
