### PR TITLE
feat(date-picker, date-picker-month-header): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -1,3 +1,18 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-date-picker-month-header-background-color: Specifies the background color of component.
+ * @prop --calcite-date-picker-month-header-navigation-button-background-color-active: Specifies the background color of navigation button of component when active.
+ * @prop --calcite-date-picker-month-header-navigation-button-background-color-hover: Specifies the background color of navigation button of component when hovered.
+ * @prop --calcite-date-picker-month-header-navigation-button-background-color: Specifies the background color of navigation button of component.
+ * @prop --calcite-date-picker-month-header-navigation-button-text-color-hover: Specifies the text of navigation button of component when hovered.
+ * @prop --calcite-date-picker-month-header-navigation-button-text-color: Specifies the text of navigation button of component.
+ * @prop --calcite-date-picker-month-header-text-color: Specifies the text color of component.
+ *
+*/
+
 :host {
   @apply block;
 }
@@ -9,7 +24,9 @@
 
 :host([scale="s"]) {
   .text {
-    @apply text-n1h my-2;
+    @apply my-2;
+    font-size: var(--calcite-font-size);
+    line-height: var(--calcite-font-line-height-fixed-base);
   }
   .chevron {
     @apply h-9;
@@ -18,7 +35,9 @@
 
 :host([scale="m"]) {
   .text {
-    @apply text-0h my-3;
+    @apply my-3;
+    font-size: var(--calcite-font-size-md);
+    line-height: var(--calcite-font-line-height-fixed-lg);
   }
   .chevron {
     @apply h-12;
@@ -27,7 +46,9 @@
 
 :host([scale="l"]) {
   .text {
-    @apply text-1h my-4;
+    @apply my-4;
+    font-size: var(--calcite-font-size-lg);
+    line-height: var(--calcite-font-line-height-fixed-xl);
   }
   .chevron {
     block-size: 3.5rem;
@@ -35,9 +56,7 @@
 }
 
 .chevron {
-  @apply text-color-3
-    bg-foreground-1
-    focus-base
+  @apply focus-base
     -mx-1
     box-content
     flex
@@ -49,6 +68,11 @@
     px-1
     outline-none
     transition-default;
+  background-color: var(
+    --calcite-date-picker-month-header-navigation-button-background-color,
+    var(--calcite-color-foreground-1)
+  );
+  color: var(--calcite-date-picker-month-header-navigation-button-text-color, var(--calcite-color-text-3));
   inline-size: calc(100% / 7);
 
   &:focus {
@@ -57,11 +81,19 @@
 
   &:hover,
   &:focus {
-    @apply text-color-1 bg-foreground-2 fill-color-1;
+    background-color: var(
+      --calcite-date-picker-month-header-navigation-button-background-color-hover,
+      var(--calcite-color-foreground-2)
+    );
+    color: var(--calcite-date-picker-month-header-navigation-button-text-color-hover, var(--calcite-color-text-1));
+    fill: var(--calcite-color-text-1);
   }
 
   &:active {
-    @apply bg-foreground-3;
+    background-color: var(
+      --calcite-date-picker-month-header-navigation-button-background-color-active,
+      var(--calcite-color-foreground-3)
+    );
   }
 
   &[aria-disabled="true"] {
@@ -78,6 +110,7 @@
     justify-center
     text-center
     leading-none;
+  background-color: var(--calcite-date-picker-month-header-background-color, var(--calcite-color-foreground-1));
 }
 
 .text--reverse {
@@ -87,14 +120,13 @@
 .month,
 .year,
 .suffix {
-  @apply text-color-1
-    bg-foreground-1
-    mx-1
+  @apply mx-1
     my-auto
     inline-block
-    font-medium
     leading-tight;
   font-size: inherit;
+  color: var(--calcite-date-picker-month-header-text-color, var(--calcite-color-text-1));
+  font-weight: var(--calcite-font-weight-medium);
 }
 
 .year {

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -17,6 +17,14 @@
  * @prop --calcite-date-picker-day-text-selected: Specifies the text color of day when selected.
  * @prop --calcite-date-picker-week-headers-border-color: Specifies the border color of week headers.
  * @prop --calcite-date-picker-week-headers-text-color: Specifies the text color of week headers.
+ * @prop --calcite-date-picker-header-background-color: Specifies the background color of month header.
+ * @prop --calcite-date-picker-header-navigation-button-background-color-active: Specifies the background color of navigation button of month header when active.
+ * @prop --calcite-date-picker-header-navigation-button-background-color-hover: Specifies the background color of navigation button of month header when hovered.
+ * @prop --calcite-date-picker-header-navigation-button-background-color: Specifies the background color of navigation button of month header.
+ * @prop --calcite-date-picker-header-navigation-button-text-color-hover: Specifies the text color of navigation button of month header when hovered.
+ * @porp --calcite-date-picker-header-navigation-button-text-color: Specifies the text color of navigation button of month header.
+ * @prop --calcite-date-picker-header-text-color: Specifies the text color of month header.
+ *
  */
 
 :host {
@@ -66,6 +74,26 @@ calcite-date-picker-month {
   --calcite-date-picker-month-day-range-background-color-hovered: var(
     --calcite-date-picker-day-range-background-color-hover
   );
+}
+
+calcite-date-picker-header {
+  --calcite-date-picker-month-header-background-color: var(--calcite-date-picker-header-background-color);
+  --calcite-date-picker-month-header-navigation-button-background-color-active: var(
+    --calcite-date-picker-header-navigation-button-background-color-active
+  );
+  --calcite-date-picker-month-header-navigation-button-background-color-hover: var(
+    --calcite-date-picker-header-navigation-button-background-color-hover
+  );
+  --calcite-date-picker-month-header-navigation-button-background-color: var(
+    --calcite-date-picker-header-navigation-button-background-color
+  );
+  --calcite-date-picker-month-header-navigation-button-text-color-hover: var(
+    --calcite-date-picker-header-navigation-button-text-color-hover
+  );
+  --calcite-date-picker-month-header-navigation-button-text-color: var(
+    --calcite-date-picker-header-navigation-button-text-color
+  );
+  --calcite-date-picker-month-header-text-color: var(--calcite-date-picker-header-text-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -22,7 +22,7 @@
  * @prop --calcite-date-picker-header-navigation-button-background-color-hover: Specifies the background color of navigation button of month header when hovered.
  * @prop --calcite-date-picker-header-navigation-button-background-color: Specifies the background color of navigation button of month header.
  * @prop --calcite-date-picker-header-navigation-button-text-color-hover: Specifies the text color of navigation button of month header when hovered.
- * @porp --calcite-date-picker-header-navigation-button-text-color: Specifies the text color of navigation button of month header.
+ * @prop --calcite-date-picker-header-navigation-button-text-color: Specifies the text color of navigation button of month header.
  * @prop --calcite-date-picker-header-text-color: Specifies the text color of month header.
  *
  */
@@ -76,7 +76,7 @@ calcite-date-picker-month {
   );
 }
 
-calcite-date-picker-header {
+calcite-date-picker-month-header {
   --calcite-date-picker-month-header-background-color: var(--calcite-date-picker-header-background-color);
   --calcite-date-picker-month-header-navigation-button-background-color-active: var(
     --calcite-date-picker-header-navigation-button-background-color-active

--- a/packages/calcite-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.stories.ts
@@ -278,6 +278,7 @@ export const theming_TestOnly = (): string =>
         --calcite-date-picker-border-color: #294b29;
         --calcite-date-picker-border-radius: 2px;
         --calcite-date-picker-day-background-color: #50623a;
+        --calcite-date-picker-day-background-color-selected: #ffb000;
         --calcite-date-picker-day-corner-radius: 0px;
         --calcite-date-picker-day-text-color: #a4ce95;
         --calcite-date-picker-week-headers-text-color: #5f5d9c;

--- a/packages/calcite-components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.stories.ts
@@ -271,3 +271,20 @@ export const greaterThanMaxWidthAllScales_TestOnly = (): string => html`
   <calcite-date-picker scale="m" value="2000-11-27"></calcite-date-picker>
   <calcite-date-picker scale="l" value="2000-11-27"></calcite-date-picker>
 `;
+
+export const theming_TestOnly = (): string =>
+  html`<style>
+      calcite-date-picker {
+        --calcite-date-picker-border-color: #294b29;
+        --calcite-date-picker-border-radius: 2px;
+        --calcite-date-picker-day-background-color: #50623a;
+        --calcite-date-picker-day-corner-radius: 0px;
+        --calcite-date-picker-day-text-color: #a4ce95;
+        --calcite-date-picker-week-headers-text-color: #5f5d9c;
+        --calcite-date-picker-header-background-color: green;
+        --calcite-date-picker-header-navigation-button-background-color: #6d2932;
+        --calcite-date-picker-header-navigation-button-text-color: #c7b7a3;
+        --calcite-date-picker-header-text-color: #e8d8c4;
+      }
+    </style>
+    <calcite-date-picker scale="s" value="2000-11-27" lang="th"></calcite-date-picker>`;


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds following corresponding tokens in `calcite-date-picker` component :

```
--calcite-date-picker-header-background-color: Specifies the background color of month header.
--calcite-date-picker-header-navigation-button-background-color-active: Specifies the background color of navigation button of month header when active.
--calcite-date-picker-header-navigation-button-background-color-hover: Specifies the background color of navigation button of month header when hovered.
--calcite-date-picker-header-navigation-button-background-color: Specifies the background color of navigation button of month header.
--calcite-date-picker-header-navigation-button-text-color-hover: Specifies the text color of navigation button of month header when hovered.
--calcite-date-picker-header-navigation-button-text-color: Specifies the text color of navigation button of month header.
--calcite-date-picker-header-text-color: Specifies the text color of month header.