### PR TITLE
fix(notice): Fix close button focus outline color

### DIFF
--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -172,7 +172,7 @@
 
   &:focus {
     background-color: var(--calcite-notice-close-background-color-focus, var(--calcite-color-foreground-2));
-    outline-color: var(--calcite-notice-close-focus-color, inherit);
+    outline-color: var(--calcite-notice-close-focus-color, var(--calcite-color-brand));
     color: var(--calcite-notice-close-icon-color, var(--calcite-color-text-1));
   }
 }


### PR DESCRIPTION
## Summary
Fix for incorrect fallback.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-03-14 at 9 38 00 AM](https://github.com/Esri/calcite-design-system/assets/4733155/e923fd70-7005-4fcc-9ba4-09dd4ae5edb0)  |   ![Screenshot 2024-03-14 at 9 37 21 AM](https://github.com/Esri/calcite-design-system/assets/4733155/7fc2962d-0923-4f24-89d4-a21d86906881) |
