### PR TITLE
fix(list): fix filter box when scrolling in Safari

### DIFF
--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -525,8 +525,8 @@ export class List
             role="treegrid"
           >
             {filterEnabled || hasFilterActionsStart || hasFilterActionsEnd ? (
-              <thead>
-                <tr class={{ [CSS.sticky]: true }}>
+              <thead class={CSS.sticky}>
+                <tr>
                   <th colSpan={MAX_COLUMNS}>
                     <calcite-stack class={CSS.stack}>
                       <slot


### PR DESCRIPTION
**Related Issue:** #8928

## Summary

- Moves sticky class to the table header from the table row