### PR TITLE
feat(pagination): Update component tokens

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -23,6 +23,8 @@ import { BlockSectionMessages } from "./components/block-section/assets/block-se
 import { ButtonAlignment, DropdownIconType } from "./components/button/interfaces";
 import { ButtonMessages } from "./components/button/assets/button/t9n";
 import { CardMessages } from "./components/card/assets/card/t9n";
+import { CarouselMessages } from "./components/carousel/assets/carousel/t9n";
+import { CarouselItemMessages } from "./components/carousel-item/assets/carousel-item/t9n";
 import { ChipMessages } from "./components/chip/assets/chip/t9n";
 import { ColorValue, InternalColor } from "./components/color-picker/interfaces";
 import { Format } from "./components/color-picker/utils";
@@ -110,6 +112,8 @@ export { BlockSectionMessages } from "./components/block-section/assets/block-se
 export { ButtonAlignment, DropdownIconType } from "./components/button/interfaces";
 export { ButtonMessages } from "./components/button/assets/button/t9n";
 export { CardMessages } from "./components/card/assets/card/t9n";
+export { CarouselMessages } from "./components/carousel/assets/carousel/t9n";
+export { CarouselItemMessages } from "./components/carousel-item/assets/carousel-item/t9n";
 export { ChipMessages } from "./components/chip/assets/chip/t9n";
 export { ColorValue, InternalColor } from "./components/color-picker/interfaces";
 export { Format } from "./components/color-picker/utils";
@@ -823,6 +827,67 @@ export namespace Components {
   >;
         /**
           * Sets focus on the component's first focusable element.
+         */
+        "setFocus": () => Promise<void>;
+    }
+    interface CalciteCarousel {
+        /**
+          * The component's selected option `calcite-carousel-item`.
+          * @readonly
+         */
+        "activeItem": HTMLCalciteCarouselItemElement;
+        /**
+          * control if the dot / bar and arrows are overlaid on the slotted content container or displayed adjacent to the slotted content
+         */
+        "controlOverlay"?: boolean;
+        /**
+          * control if the displayed control are dot, or bar
+         */
+        "controlType"?: "circle" | "square";
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled": boolean;
+        /**
+          * control if the displayed control are dot, or bar
+         */
+        "displayArrows"?: boolean;
+        /**
+          * Use this property to override individual strings used by the component.
+         */
+        "messageOverrides": Partial<CarouselMessages>;
+        /**
+          * Made into a prop for testing purposes only
+         */
+        "messages": CarouselMessages;
+        /**
+          * Specifies the size of the component.
+         */
+        "scale": Scale;
+    }
+    interface CalciteCarouselItem {
+        /**
+          * When `true`, the component is active if it has a parent `calcite-carousel`.
+         */
+        "active": boolean;
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled": boolean;
+        /**
+          * The component label text.
+         */
+        "label": string;
+        /**
+          * Use this property to override individual strings used by the component.
+         */
+        "messageOverrides": Partial<CarouselItemMessages>;
+        /**
+          * Made into a prop for testing purposes only
+         */
+        "messages": CarouselItemMessages;
+        /**
+          * Sets focus on the component.
          */
         "setFocus": () => Promise<void>;
     }
@@ -5481,6 +5546,10 @@ export interface CalciteCardGroupCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCardGroupElement;
 }
+export interface CalciteCarouselCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLCalciteCarouselElement;
+}
 export interface CalciteCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCheckboxElement;
@@ -5958,6 +6027,29 @@ declare global {
     var HTMLCalciteCardGroupElement: {
         prototype: HTMLCalciteCardGroupElement;
         new (): HTMLCalciteCardGroupElement;
+    };
+    interface HTMLCalciteCarouselElementEventMap {
+        "calciteCarouselChange": void;
+    }
+    interface HTMLCalciteCarouselElement extends Components.CalciteCarousel, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLCalciteCarouselElementEventMap>(type: K, listener: (this: HTMLCalciteCarouselElement, ev: CalciteCarouselCustomEvent<HTMLCalciteCarouselElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLCalciteCarouselElementEventMap>(type: K, listener: (this: HTMLCalciteCarouselElement, ev: CalciteCarouselCustomEvent<HTMLCalciteCarouselElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLCalciteCarouselElement: {
+        prototype: HTMLCalciteCarouselElement;
+        new (): HTMLCalciteCarouselElement;
+    };
+    interface HTMLCalciteCarouselItemElement extends Components.CalciteCarouselItem, HTMLStencilElement {
+    }
+    var HTMLCalciteCarouselItemElement: {
+        prototype: HTMLCalciteCarouselItemElement;
+        new (): HTMLCalciteCarouselItemElement;
     };
     interface HTMLCalciteCheckboxElementEventMap {
         "calciteInternalCheckboxBlur": boolean;
@@ -7440,6 +7532,8 @@ declare global {
         "calcite-button": HTMLCalciteButtonElement;
         "calcite-card": HTMLCalciteCardElement;
         "calcite-card-group": HTMLCalciteCardGroupElement;
+        "calcite-carousel": HTMLCalciteCarouselElement;
+        "calcite-carousel-item": HTMLCalciteCarouselItemElement;
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
@@ -8207,6 +8301,67 @@ declare namespace LocalJSX {
     "multiple" | "single" | "single-persist" | "none",
     SelectionMode
   >;
+    }
+    interface CalciteCarousel {
+        /**
+          * The component's selected option `calcite-carousel-item`.
+          * @readonly
+         */
+        "activeItem"?: HTMLCalciteCarouselItemElement;
+        /**
+          * control if the dot / bar and arrows are overlaid on the slotted content container or displayed adjacent to the slotted content
+         */
+        "controlOverlay"?: boolean;
+        /**
+          * control if the displayed control are dot, or bar
+         */
+        "controlType"?: "circle" | "square";
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled"?: boolean;
+        /**
+          * control if the displayed control are dot, or bar
+         */
+        "displayArrows"?: boolean;
+        /**
+          * Use this property to override individual strings used by the component.
+         */
+        "messageOverrides"?: Partial<CarouselMessages>;
+        /**
+          * Made into a prop for testing purposes only
+         */
+        "messages"?: CarouselMessages;
+        /**
+          * Fires when the selected carousel item changes.
+         */
+        "onCalciteCarouselChange"?: (event: CalciteCarouselCustomEvent<void>) => void;
+        /**
+          * Specifies the size of the component.
+         */
+        "scale"?: Scale;
+    }
+    interface CalciteCarouselItem {
+        /**
+          * When `true`, the component is active if it has a parent `calcite-carousel`.
+         */
+        "active"?: boolean;
+        /**
+          * When `true`, interaction is prevented and the component is displayed with lower opacity.
+         */
+        "disabled"?: boolean;
+        /**
+          * The component label text.
+         */
+        "label": string;
+        /**
+          * Use this property to override individual strings used by the component.
+         */
+        "messageOverrides"?: Partial<CarouselItemMessages>;
+        /**
+          * Made into a prop for testing purposes only
+         */
+        "messages"?: CarouselItemMessages;
     }
     interface CalciteCheckbox {
         /**
@@ -13080,6 +13235,8 @@ declare namespace LocalJSX {
         "calcite-button": CalciteButton;
         "calcite-card": CalciteCard;
         "calcite-card-group": CalciteCardGroup;
+        "calcite-carousel": CalciteCarousel;
+        "calcite-carousel-item": CalciteCarouselItem;
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
@@ -13194,6 +13351,8 @@ declare module "@stencil/core" {
             "calcite-button": LocalJSX.CalciteButton & JSXBase.HTMLAttributes<HTMLCalciteButtonElement>;
             "calcite-card": LocalJSX.CalciteCard & JSXBase.HTMLAttributes<HTMLCalciteCardElement>;
             "calcite-card-group": LocalJSX.CalciteCardGroup & JSXBase.HTMLAttributes<HTMLCalciteCardGroupElement>;
+            "calcite-carousel": LocalJSX.CalciteCarousel & JSXBase.HTMLAttributes<HTMLCalciteCarouselElement>;
+            "calcite-carousel-item": LocalJSX.CalciteCarouselItem & JSXBase.HTMLAttributes<HTMLCalciteCarouselItemElement>;
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -23,8 +23,6 @@ import { BlockSectionMessages } from "./components/block-section/assets/block-se
 import { ButtonAlignment, DropdownIconType } from "./components/button/interfaces";
 import { ButtonMessages } from "./components/button/assets/button/t9n";
 import { CardMessages } from "./components/card/assets/card/t9n";
-import { CarouselMessages } from "./components/carousel/assets/carousel/t9n";
-import { CarouselItemMessages } from "./components/carousel-item/assets/carousel-item/t9n";
 import { ChipMessages } from "./components/chip/assets/chip/t9n";
 import { ColorValue, InternalColor } from "./components/color-picker/interfaces";
 import { Format } from "./components/color-picker/utils";
@@ -112,8 +110,6 @@ export { BlockSectionMessages } from "./components/block-section/assets/block-se
 export { ButtonAlignment, DropdownIconType } from "./components/button/interfaces";
 export { ButtonMessages } from "./components/button/assets/button/t9n";
 export { CardMessages } from "./components/card/assets/card/t9n";
-export { CarouselMessages } from "./components/carousel/assets/carousel/t9n";
-export { CarouselItemMessages } from "./components/carousel-item/assets/carousel-item/t9n";
 export { ChipMessages } from "./components/chip/assets/chip/t9n";
 export { ColorValue, InternalColor } from "./components/color-picker/interfaces";
 export { Format } from "./components/color-picker/utils";
@@ -827,67 +823,6 @@ export namespace Components {
   >;
         /**
           * Sets focus on the component's first focusable element.
-         */
-        "setFocus": () => Promise<void>;
-    }
-    interface CalciteCarousel {
-        /**
-          * The component's selected option `calcite-carousel-item`.
-          * @readonly
-         */
-        "activeItem": HTMLCalciteCarouselItemElement;
-        /**
-          * control if the dot / bar and arrows are overlaid on the slotted content container or displayed adjacent to the slotted content
-         */
-        "controlOverlay"?: boolean;
-        /**
-          * control if the displayed control are dot, or bar
-         */
-        "controlType"?: "circle" | "square";
-        /**
-          * When `true`, interaction is prevented and the component is displayed with lower opacity.
-         */
-        "disabled": boolean;
-        /**
-          * control if the displayed control are dot, or bar
-         */
-        "displayArrows"?: boolean;
-        /**
-          * Use this property to override individual strings used by the component.
-         */
-        "messageOverrides": Partial<CarouselMessages>;
-        /**
-          * Made into a prop for testing purposes only
-         */
-        "messages": CarouselMessages;
-        /**
-          * Specifies the size of the component.
-         */
-        "scale": Scale;
-    }
-    interface CalciteCarouselItem {
-        /**
-          * When `true`, the component is active if it has a parent `calcite-carousel`.
-         */
-        "active": boolean;
-        /**
-          * When `true`, interaction is prevented and the component is displayed with lower opacity.
-         */
-        "disabled": boolean;
-        /**
-          * The component label text.
-         */
-        "label": string;
-        /**
-          * Use this property to override individual strings used by the component.
-         */
-        "messageOverrides": Partial<CarouselItemMessages>;
-        /**
-          * Made into a prop for testing purposes only
-         */
-        "messages": CarouselItemMessages;
-        /**
-          * Sets focus on the component.
          */
         "setFocus": () => Promise<void>;
     }
@@ -5546,10 +5481,6 @@ export interface CalciteCardGroupCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCardGroupElement;
 }
-export interface CalciteCarouselCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLCalciteCarouselElement;
-}
 export interface CalciteCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLCalciteCheckboxElement;
@@ -6027,29 +5958,6 @@ declare global {
     var HTMLCalciteCardGroupElement: {
         prototype: HTMLCalciteCardGroupElement;
         new (): HTMLCalciteCardGroupElement;
-    };
-    interface HTMLCalciteCarouselElementEventMap {
-        "calciteCarouselChange": void;
-    }
-    interface HTMLCalciteCarouselElement extends Components.CalciteCarousel, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLCalciteCarouselElementEventMap>(type: K, listener: (this: HTMLCalciteCarouselElement, ev: CalciteCarouselCustomEvent<HTMLCalciteCarouselElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLCalciteCarouselElementEventMap>(type: K, listener: (this: HTMLCalciteCarouselElement, ev: CalciteCarouselCustomEvent<HTMLCalciteCarouselElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    }
-    var HTMLCalciteCarouselElement: {
-        prototype: HTMLCalciteCarouselElement;
-        new (): HTMLCalciteCarouselElement;
-    };
-    interface HTMLCalciteCarouselItemElement extends Components.CalciteCarouselItem, HTMLStencilElement {
-    }
-    var HTMLCalciteCarouselItemElement: {
-        prototype: HTMLCalciteCarouselItemElement;
-        new (): HTMLCalciteCarouselItemElement;
     };
     interface HTMLCalciteCheckboxElementEventMap {
         "calciteInternalCheckboxBlur": boolean;
@@ -7532,8 +7440,6 @@ declare global {
         "calcite-button": HTMLCalciteButtonElement;
         "calcite-card": HTMLCalciteCardElement;
         "calcite-card-group": HTMLCalciteCardGroupElement;
-        "calcite-carousel": HTMLCalciteCarouselElement;
-        "calcite-carousel-item": HTMLCalciteCarouselItemElement;
         "calcite-checkbox": HTMLCalciteCheckboxElement;
         "calcite-chip": HTMLCalciteChipElement;
         "calcite-chip-group": HTMLCalciteChipGroupElement;
@@ -8301,67 +8207,6 @@ declare namespace LocalJSX {
     "multiple" | "single" | "single-persist" | "none",
     SelectionMode
   >;
-    }
-    interface CalciteCarousel {
-        /**
-          * The component's selected option `calcite-carousel-item`.
-          * @readonly
-         */
-        "activeItem"?: HTMLCalciteCarouselItemElement;
-        /**
-          * control if the dot / bar and arrows are overlaid on the slotted content container or displayed adjacent to the slotted content
-         */
-        "controlOverlay"?: boolean;
-        /**
-          * control if the displayed control are dot, or bar
-         */
-        "controlType"?: "circle" | "square";
-        /**
-          * When `true`, interaction is prevented and the component is displayed with lower opacity.
-         */
-        "disabled"?: boolean;
-        /**
-          * control if the displayed control are dot, or bar
-         */
-        "displayArrows"?: boolean;
-        /**
-          * Use this property to override individual strings used by the component.
-         */
-        "messageOverrides"?: Partial<CarouselMessages>;
-        /**
-          * Made into a prop for testing purposes only
-         */
-        "messages"?: CarouselMessages;
-        /**
-          * Fires when the selected carousel item changes.
-         */
-        "onCalciteCarouselChange"?: (event: CalciteCarouselCustomEvent<void>) => void;
-        /**
-          * Specifies the size of the component.
-         */
-        "scale"?: Scale;
-    }
-    interface CalciteCarouselItem {
-        /**
-          * When `true`, the component is active if it has a parent `calcite-carousel`.
-         */
-        "active"?: boolean;
-        /**
-          * When `true`, interaction is prevented and the component is displayed with lower opacity.
-         */
-        "disabled"?: boolean;
-        /**
-          * The component label text.
-         */
-        "label": string;
-        /**
-          * Use this property to override individual strings used by the component.
-         */
-        "messageOverrides"?: Partial<CarouselItemMessages>;
-        /**
-          * Made into a prop for testing purposes only
-         */
-        "messages"?: CarouselItemMessages;
     }
     interface CalciteCheckbox {
         /**
@@ -13235,8 +13080,6 @@ declare namespace LocalJSX {
         "calcite-button": CalciteButton;
         "calcite-card": CalciteCard;
         "calcite-card-group": CalciteCardGroup;
-        "calcite-carousel": CalciteCarousel;
-        "calcite-carousel-item": CalciteCarouselItem;
         "calcite-checkbox": CalciteCheckbox;
         "calcite-chip": CalciteChip;
         "calcite-chip-group": CalciteChipGroup;
@@ -13351,8 +13194,6 @@ declare module "@stencil/core" {
             "calcite-button": LocalJSX.CalciteButton & JSXBase.HTMLAttributes<HTMLCalciteButtonElement>;
             "calcite-card": LocalJSX.CalciteCard & JSXBase.HTMLAttributes<HTMLCalciteCardElement>;
             "calcite-card-group": LocalJSX.CalciteCardGroup & JSXBase.HTMLAttributes<HTMLCalciteCardGroupElement>;
-            "calcite-carousel": LocalJSX.CalciteCarousel & JSXBase.HTMLAttributes<HTMLCalciteCarouselElement>;
-            "calcite-carousel-item": LocalJSX.CalciteCarouselItem & JSXBase.HTMLAttributes<HTMLCalciteCarouselItemElement>;
             "calcite-checkbox": LocalJSX.CalciteCheckbox & JSXBase.HTMLAttributes<HTMLCalciteCheckboxElement>;
             "calcite-chip": LocalJSX.CalciteChip & JSXBase.HTMLAttributes<HTMLCalciteChipElement>;
             "calcite-chip-group": LocalJSX.CalciteChipGroup & JSXBase.HTMLAttributes<HTMLCalciteChipGroupElement>;

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -4,14 +4,14 @@
  * These properties can be overridden using the component's tag as selector.
  *
 
- * @prop --calcite-pagination-background-color-active: Specifies the background color of the pagination items while active.
- * @prop --calcite-pagination-background-color-hover: Specifies the background color of the pagination items while hovered.
- * @prop --calcite-pagination-background-color: Specifies the background color of the pagination items.
- * @prop --calcite-pagination-border-color-hover: Specifies the border color the pagination items while hovered.
- * @prop --calcite-pagination-border-color-selected: Specifies the border color of the pagination items when selected.
- * @prop --calcite-pagination-text-color-hover: Specifies the text color of the pagination items items while hovered.
- * @prop --calcite-pagination-text-color-selected: Specifies the text color of the pagination items when selected.
- * @prop --calcite-pagination-text-color: Specifies the text color of the pagination items.
+ * @prop --calcite-pagination-item-background-color-active: Specifies the background color of the pagination items while active.
+ * @prop --calcite-pagination-item-background-color-hover: Specifies the background color of the pagination items while hovered.
+ * @prop --calcite-pagination-item-background-color: Specifies the background color of the pagination items.
+ * @prop --calcite-pagination-item-border-color-hover: Specifies the border color the pagination items while hovered.
+ * @prop --calcite-pagination-item-border-color-selected: Specifies the border color of the pagination items when selected.
+ * @prop --calcite-pagination-item-text-color-hover: Specifies the text color of the pagination items items while hovered.
+ * @prop --calcite-pagination-item-text-color-selected: Specifies the text color of the pagination items when selected.
+ * @prop --calcite-pagination-item-text-color: Specifies the text color of the pagination items.
  * @prop --calcite-pagination-arrow-background-color-active: Specifies the background color of the arrow items while active.
  * @prop --calcite-pagination-arrow-background-color-hover: Specifies the background color of the arrow items while hovered.
  * @prop --calcite-pagination-arrow-background-color: Specifies the background color of the arrow items.
@@ -21,6 +21,7 @@
  *
  */
 /**
+
   * Local props
   * These properties are intended for internal component use only. It is not recommended that these properties be overwritten.
   *
@@ -94,8 +95,8 @@
   min-inline-size: var(--calcite-internal-pagination-item-size);
   block-size: var(--calcite-internal-pagination-item-size);
   padding-inline: var(--calcite-internal-pagination-item-space);
-  color: var(--calcite-pagination-text-color, var(--calcite-color-text-3));
-  background-color: var(--calcite-pagination-background-color, transparent);
+  color: var(--calcite-pagination-item-text-color, var(--calcite-color-text-3));
+  background-color: var(--calcite-pagination-item-background-color, transparent);
 }
 
 .chevron,
@@ -105,32 +106,32 @@
 
   &:hover {
     @apply transition-default;
-    color: var(--calcite-pagination-text-color-hover, var(--calcite-color-text-1));
-    background-color: var(--calcite-pagination-background-color-hover, transparent);
+    color: var(--calcite-pagination-item-text-color-hover, var(--calcite-color-text-1));
+    background-color: var(--calcite-pagination-item-background-color-hover, transparent);
   }
   &:active {
-    background-color: var(--calcite-pagination-background-color-active, transparent);
+    background-color: var(--calcite-pagination-item-background-color-active, transparent);
   }
 }
 
 .page {
   &:hover {
-    border-block-end-color: var(--calcite-pagination-border-color-hover, var(--calcite-color-border-2));
+    border-block-end-color: var(--calcite-pagination-item-border-color-hover, var(--calcite-color-border-2));
   }
 
   &.selected {
     font-weight: var(--calcite-font-weight-medium);
-    color: var(--calcite-pagination-text-color-selected, var(--calcite-color-text-1));
-    border-block-end-color: var(--calcite-pagination-border-color-selected, var(--calcite-color-brand));
+    color: var(--calcite-pagination-item-text-color-selected, var(--calcite-color-text-1));
+    border-block-end-color: var(--calcite-pagination-item-border-color-selected, var(--calcite-color-brand));
   }
 }
 
 .chevron {
   background-color: var(
     --calcite-pagination-arrow-background-color,
-    var(--calcite-pagination-background-color, transparent)
+    var(--calcite-pagination-item-background-color, transparent)
   );
-  color: var(--calcite-pagination-text-color, var(--calcite-color-text-3));
+  color: var(--calcite-pagination-item-text-color, var(--calcite-color-text-3));
   &:hover {
     background-color: var(--calcite-pagination-arrow-background-color-hover);
     color: var(--calcite-pagination-arrow-icon-color-hover, var(--calcite-color-brand));

--- a/packages/calcite-components/src/components/pagination/pagination.stories.ts
+++ b/packages/calcite-components/src/components/pagination/pagination.stories.ts
@@ -129,14 +129,14 @@ export const theming_TestOnly = (): string => html`
       page-size="100"
       start-item="1"
       style="
-      --calcite-pagination-text-color: green;
-      --calcite-pagination-text-color-hover: darkgreen;
-      --calcite-pagination-text-color-selected: teal;
-      --calcite-pagination-background-color: lightyellow;
-      --calcite-pagination-background-color-hover: yellow;
-      --calcite-pagination-background-color-active: gold;
-      --calcite-pagination-border-color-selected: green;
-      --calcite-pagination-border-color-hover: orange;
+      --calcite-pagination-item-text-color: green;
+      --calcite-pagination-item-text-color-hover: darkgreen;
+      --calcite-pagination-item-text-color-selected: teal;
+      --calcite-pagination-item-background-color: lightyellow;
+      --calcite-pagination-item-background-color-hover: yellow;
+      --calcite-pagination-item-background-color-active: gold;
+      --calcite-pagination-item-border-color-selected: green;
+      --calcite-pagination-item-border-color-hover: orange;
       --calcite-pagination-arrow-icon-color: blue;
       --calcite-pagination-arrow-icon-color-hover: pink;
       --calcite-pagination-arrow-icon-color-active: red;

--- a/packages/calcite-components/src/demos/pagination.html
+++ b/packages/calcite-components/src/demos/pagination.html
@@ -29,14 +29,14 @@
       }
 
       .themed-example {
-        --calcite-pagination-text-color: green;
-        --calcite-pagination-text-color-hover: darkgreen;
-        --calcite-pagination-text-color-selected: teal;
-        --calcite-pagination-background-color: lightyellow;
-        --calcite-pagination-background-color-hover: yellow;
-        --calcite-pagination-background-color-active: gold;
-        --calcite-pagination-border-color-selected: green;
-        --calcite-pagination-border-color-hover: orange;
+        --calcite-pagination-item-text-color: green;
+        --calcite-pagination-item-text-color-hover: darkgreen;
+        --calcite-pagination-item-text-color-selected: teal;
+        --calcite-pagination-item-background-color: lightyellow;
+        --calcite-pagination-item-background-color-hover: yellow;
+        --calcite-pagination-item-background-color-active: gold;
+        --calcite-pagination-item-border-color-selected: green;
+        --calcite-pagination-item-border-color-hover: orange;
         --calcite-pagination-arrow-icon-color: blue;
         --calcite-pagination-arrow-icon-color-hover: pink;
         --calcite-pagination-arrow-icon-color-active: red;
@@ -77,14 +77,14 @@
               page-size="100"
               start-item="1"
               style="
-                --calcite-pagination-text-color: green;
-                --calcite-pagination-text-color-hover: darkgreen;
-                --calcite-pagination-text-color-selected: teal;
-                --calcite-pagination-background-color: lightyellow;
-                --calcite-pagination-background-color-hover: yellow;
-                --calcite-pagination-background-color-active: gold;
-                --calcite-pagination-border-color-selected: green;
-                --calcite-pagination-border-color-hover: orange;
+                --calcite-pagination-item-text-color: green;
+                --calcite-pagination-item-text-color-hover: darkgreen;
+                --calcite-pagination-item-text-color-selected: teal;
+                --calcite-pagination-item-background-color: lightyellow;
+                --calcite-pagination-item-background-color-hover: yellow;
+                --calcite-pagination-item-background-color-active: gold;
+                --calcite-pagination-item-border-color-selected: green;
+                --calcite-pagination-item-border-color-hover: orange;
                 --calcite-pagination-arrow-icon-color: blue;
                 --calcite-pagination-arrow-icon-color-hover: pink;
                 --calcite-pagination-arrow-icon-color-active: red;


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary
Updates nomenclature of Pagination design tokens to be more specific / accurate. Previously, the naming made it seem like the tokens applied to the parent container - in practice, they apply to the internally rendered items. It also follows the structure of `pagination-arrow-x`.