### PR TITLE
fix(stepper): fix layout when switching modes dynamically to `horizontal-single`

### DIFF
--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -858,5 +858,34 @@ describe("calcite-stepper", () => {
       await page.waitForChanges();
       expect(eventSpy).toHaveReceivedEventTimes(2);
     });
+
+    it(`switching to layout="horizontal-single" dynamically from another option should display a single item (#8931)`, async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`
+          <calcite-stepper layout="horizontal">
+            <calcite-stepper-item heading="Step 1" selected>
+              <div>Step 1 content</div>
+            </calcite-stepper-item>
+            <calcite-stepper-item heading="Step 2">
+              <div>Step 2 content</div>
+            </calcite-stepper-item>
+            <calcite-stepper-item heading="Step 3">
+              <div>Step 3 content</div>
+            </calcite-stepper-item>
+            <calcite-stepper-item heading="Review">
+              <div>Step 4 content</div>
+            </calcite-stepper-item>
+          </calcite-stepper>
+          </calcite-stepper>`,
+      );
+
+      const stepper = await page.find("calcite-stepper");
+      await stepper.setProperty("layout", "horizontal-single");
+      await page.waitForChanges();
+
+      const displayedItems = await page.findAll("calcite-stepper-item:not([hidden])");
+      expect(displayedItems.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
**Related Issue:** #8931 

## Summary

Fixes an issue that caused step labels to overlap when dynamically switching to `horizontal-single` layout mode.
