### PR TITLE
fix(input-time-picker): update toggle icon color

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -36,5 +36,13 @@
   padding-inline: var(--calcite-toggle-spacing);
 }
 
+calcite-icon {
+  --calcite-ui-icon-color: var(--calcite-color-text-3);
+}
+
+calcite-icon:hover {
+  --calcite-ui-icon-color: var(--calcite-color-text-1);
+}
+
 @include form-validation-message();
 @include base-component();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -34,13 +34,14 @@
   inset-inline-end: 0;
   inset-block: 0;
   padding-inline: var(--calcite-toggle-spacing);
-}
-
-calcite-icon {
   --calcite-ui-icon-color: var(--calcite-color-text-3);
 }
 
-calcite-icon:hover {
+.input-wrapper:hover .toggle-icon {
+  --calcite-ui-icon-color: var(--calcite-color-text-1);
+}
+
+calcite-input-text:focus + .toggle-icon {
   --calcite-ui-icon-color: var(--calcite-color-text-1);
 }
 

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -37,10 +37,7 @@
   --calcite-ui-icon-color: var(--calcite-color-text-3);
 }
 
-.input-wrapper:hover .toggle-icon {
-  --calcite-ui-icon-color: var(--calcite-color-text-1);
-}
-
+.input-wrapper:hover .toggle-icon,
 calcite-input-text:focus + .toggle-icon {
   --calcite-ui-icon-color: var(--calcite-color-text-1);
 }


### PR DESCRIPTION
**Related Issue:** #7713 

## Summary

Updates toggle icon color in `calcite-input-time-picker`.