### PR TITLE
fix(list, list-item): calcite-select becomes unresponsive in a list-item if drag-disabled is true

### DIFF
--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -129,7 +129,7 @@ export function connectSortableComponent(component: SortableComponent): void {
       },
     }),
     handle,
-    filter: "[drag-disabled]",
+    filter: `${handle}[disabled]`,
     onStart: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       dragState.active = true;
       onGlobalDragStart();


### PR DESCRIPTION
**Related Issue:** #8954

## Summary

- Sortablejs by default calls `event.preventDefault()` because the option `preventOnFilter` is true by default.
- This affects any elements slotted within the `drag-disabled` list item.
- In order to fix this, we move the `filter` selector to just the `calcite-handle` instead of the whole `list-item`.

```js
filter: ".ignore-elements",  // Selectors that do not lead to dragging (String or Function)
preventOnFilter: true, // Call `event.preventDefault()` when triggered `filter`
```