### PR TITLE
fix(tabs): use border prop for bordered styling

### DIFF
--- a/packages/calcite-components/src/components/tab-title/tab-title.scss
+++ b/packages/calcite-components/src/components/tab-title/tab-title.scss
@@ -228,8 +228,7 @@
 }
 
 :host([selected][bordered]) .container {
-  border-inline-start-color: var(--calcite-color-border-1);
-  border-inline-end-color: var(--calcite-color-border-1);
+  border-inline-color: var(--calcite-internal-tabs-border-color);
 }
 
 :host([layout="inline"][bordered]),

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -18,16 +18,18 @@
   box-shadow: inset 0 1px 0 var(--calcite-internal-tabs-border-color);
   background-color: var(--calcite-internal-tabs-background-color);
 
+  section {
+    border-color: var(--calcite-internal-tabs-border-color);
+    border-style: solid;
+  }
+
   ::slotted(calcite-tab-nav) {
     margin-block-end: -1px;
   }
 }
 
 section {
-  @apply border-color-1 border border-solid flex
-  border-t
-  flex-grow
-  overflow-hidden;
+  @apply border flex flex-grow overflow-hidden;
 
   border-block-start-style: solid;
   border-block-start-color: var(--calcite-internal-tabs-border-color);
@@ -35,8 +37,8 @@ section {
 
 :host([bordered][position="bottom"]) {
   box-shadow:
-    inset 0 1px 0 var(--calcite-color-border-1),
-    inset 0 -1px 0 var(--calcite-color-border-1);
+    inset 0 1px 0 var(--calcite-internal-tabs-border-color),
+    inset 0 -1px 0 var(--calcite-internal-tabs-border-color);
 
   ::slotted(calcite-tab-nav) {
     margin-block-start: -1px;

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -15,7 +15,7 @@
 }
 
 :host([bordered]) {
-  box-shadow: inset 0 1px 0 var(--calcite-color-border-1);
+  box-shadow: inset 0 1px 0 var(--calcite-internal-tabs-border-color);
   background-color: var(--calcite-internal-tabs-background-color);
 
   ::slotted(calcite-tab-nav) {


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

🔳✨🔨

**Note**: this also fixes a regression from https://github.com/Esri/calcite-design-system/pull/8783 where non-bordered tabs displayed a border.