### PR TITLE
refactor(action, action-pad, action-bar, action-group, action-menu, popover): component tokens

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -98,6 +98,30 @@ calcite-action-group {
   }
 
   ::slotted(calcite-action-group) {
+    --calcite-action-group-border-color: var(--calcite-action-bar-border-color);
+    --calcite-action-group-popover-background-color: var(--calcite-action-bar-popover-background-color);
+    --calcite-action-group-popover-border-color: var(--calcite-action-bar-popover-border-color);
+    --calcite-action-group-popover-corner-radius: var(--calcite-action-bar-popover-corner-radius);
+    --calcite-action-group-popover-shadow: var(--calcite-action-bar-popover-shadow);
+    --calcite-action-group-trigger-background-color-active: var(--calcite-action-bar-trigger-background-color-active);
+    --calcite-action-group-trigger-background-color-focus: var(--calcite-action-bar-trigger-background-color-focus);
+    --calcite-action-group-trigger-background-color-hover: var(--calcite-action-bar-trigger-background-color-hover);
+    --calcite-action-group-trigger-background-color: var(--calcite-action-bar-trigger-background-color);
+    --calcite-action-group-trigger-icon-color-active: var(--calcite-action-bar-trigger-icon-color-active);
+    --calcite-action-group-trigger-icon-color-focus: var(--calcite-action-bar-trigger-icon-color-focus);
+    --calcite-action-group-trigger-icon-color-hover: var(--calcite-action-bar-trigger-icon-color-hover);
+    --calcite-action-group-trigger-icon-color: var(--calcite-action-bar-trigger-icon-color);
+    --calcite-action-group-trigger-indicator-color: var(--calcite-action-bar-trigger-indicator-color);
+    --calcite-action-group-trigger-loader-color: var(--calcite-action-bar-trigger-loader-color);
+    --calcite-action-group-trigger-shadow-active: var(--calcite-action-bar-trigger-shadow-active);
+    --calcite-action-group-trigger-shadow-focus: var(--calcite-action-bar-trigger-shadow-focus);
+    --calcite-action-group-trigger-shadow-hover: var(--calcite-action-bar-trigger-shadow-hover);
+    --calcite-action-group-trigger-shadow: var(--calcite-action-bar-trigger-shadow);
+    --calcite-action-group-trigger-text-color-active: var(--calcite-action-bar-trigger-text-color-active);
+    --calcite-action-group-trigger-text-color-focus: var(--calcite-action-bar-trigger-text-color-focus);
+    --calcite-action-group-trigger-text-color-hover: var(--calcite-action-bar-trigger-text-color-hover);
+    --calcite-action-group-trigger-text-color: var(--calcite-action-bar-trigger-text-color);
+
     border-block-end: 0;
     border-inline-end-style: solid;
   }

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -3,17 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-bar-action-background-color: defines the background color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-indicator-color: defines the indicator color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-text-color: defines the text color of an action sub-component inside the component.
- * @prop --calcite-action-bar-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-bar-action-background-color-active: defines the background color of an action sub-component when active inside the component.
- * @prop --calcite-action-bar-action-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
- * @prop --calcite-action-bar-action-text-color-active: defines the text color of an action sub-component when active inside the component.
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
- *
  */
 
 :host {
@@ -21,11 +11,22 @@
   @apply pointer-events-auto
     inline-flex
     self-stretch;
-  --calcite-action-bar-expanded-max-width: auto;
+}
+
+.action-group--end {
+  @apply justify-end;
 }
 
 :host([layout="vertical"]) {
   @apply flex-col;
+
+  &:host([overflow-actions-disabled]) {
+    overflow-y: auto;
+  }
+  &:host([expanded]) {
+    max-inline-size: var(--calcite-action-bar-expanded-max-width, auto);
+  }
+
   .action-group--end {
     margin-block-start: auto;
   }
@@ -33,61 +34,23 @@
 
 :host([layout="horizontal"]) {
   @apply flex-row;
+
+  &:host([overflow-actions-disabled]) {
+    overflow-x: auto;
+  }
+  &:host([expand-disabled]) {
+    ::slotted(calcite-action-group:last-of-type) {
+      border-inline-end: 0;
+    }
+  }
+
   .action-group--end {
     @apply ms-auto;
   }
-}
 
-:host([layout="vertical"][overflow-actions-disabled]) {
-  overflow-y: auto;
-}
-
-:host([layout="horizontal"][overflow-actions-disabled]) {
-  overflow-x: auto;
-}
-
-:host([layout="vertical"][expanded]) {
-  max-inline-size: var(--calcite-action-bar-expanded-max-width);
-}
-
-::slotted(calcite-action-group) {
-  border-block-end: 1px solid var(--calcite-color-border-3);
-}
-
-:host([layout="horizontal"]) ::slotted(calcite-action-group) {
-  border-block-end: 0;
-  border-inline-end: 1px solid var(--calcite-color-border-3);
-}
-
-:host([layout="horizontal"][expand-disabled]) ::slotted(calcite-action-group:last-of-type) {
-  border-inline-end: 0;
-}
-
-::slotted(calcite-action-group:last-child) {
-  border-block-end: 0;
-  border-inline-end: 0;
-}
-
-.action-group--end {
-  @apply justify-end;
-}
-
-calcite-action {
-  --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color);
-  --calcite-action-background-color: var(--calcite-action-bar-action-background-color);
-  --calcite-action-text-color: var(--calcite-action-bar-action-text-color);
-
-  &:hover,
-  &:focus {
-    --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color-hover);
-    --calcite-action-background-color: var(--calcite-action-bar-action-background-color-hover);
-    --calcite-action-text-color: var(--calcite-action-bar-action-text-color-hover);
-  }
-
-  &:active {
-    --calcite-action-indicator-color: var(--calcite-action-bar-action-indicator-color-active);
-    --calcite-action-background-color: var(--calcite-action-bar-action-background-color-active);
-    --calcite-action-text-color: var(--calcite-action-bar-action-text-color-active);
+  ::slotted(calcite-action-group) {
+    border-block-end: 0;
+    border-inline-end-style: solid;
   }
 }
 

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -4,6 +4,29 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
+ * @prop --calcite-action-bar-border-color: Specifies the border color of the component.
+ * @prop --calcite-action-bar-popover-background-color: Specifies the background color of the popover in the component.
+ * @prop --calcite-action-bar-popover-border-color: Specifies the border color of the popover in the component.
+ * @prop --calcite-action-bar-popover-corner-radius: Specifies the corner radius of the popover in the component.
+ * @prop --calcite-action-bar-popover-shadow: Specifies the shadow of the popover in the component.
+ * @prop --calcite-action-bar-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
+ * @prop --calcite-action-bar-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
+ * @prop --calcite-action-bar-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-bar-trigger-background-color: Specifies the background color of the nested trigger in the component.
+ * @prop --calcite-action-bar-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
+ * @prop --calcite-action-bar-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
+ * @prop --calcite-action-bar-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-bar-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
+ * @prop --calcite-action-bar-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
+ * @prop --calcite-action-bar-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
+ * @prop --calcite-action-bar-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
+ * @prop --calcite-action-bar-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
+ * @prop --calcite-action-bar-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
+ * @prop --calcite-action-bar-trigger-shadow: Specifies the shadow of the nested trigger in the component.
+ * @prop --calcite-action-bar-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
+ * @prop --calcite-action-bar-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
+ * @prop --calcite-action-bar-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-bar-trigger-text-color: Specifies the text color of the nested trigger in the component.
  */
 
 :host {
@@ -11,6 +34,32 @@
   @apply pointer-events-auto
     inline-flex
     self-stretch;
+}
+
+calcite-action-group {
+  --calcite-action-group-border-color: var(--calcite-action-bar-border-color);
+  --calcite-action-group-popover-background-color: var(--calcite-action-bar-popover-background-color);
+  --calcite-action-group-popover-border-color: var(--calcite-action-bar-popover-border-color);
+  --calcite-action-group-popover-corner-radius: var(--calcite-action-bar-popover-corner-radius);
+  --calcite-action-group-popover-shadow: var(--calcite-action-bar-popover-shadow);
+  --calcite-action-group-trigger-background-color-active: var(--calcite-action-bar-trigger-background-color-active);
+  --calcite-action-group-trigger-background-color-focus: var(--calcite-action-bar-trigger-background-color-focus);
+  --calcite-action-group-trigger-background-color-hover: var(--calcite-action-bar-trigger-background-color-hover);
+  --calcite-action-group-trigger-background-color: var(--calcite-action-bar-trigger-background-color);
+  --calcite-action-group-trigger-icon-color-active: var(--calcite-action-bar-trigger-icon-color-active);
+  --calcite-action-group-trigger-icon-color-focus: var(--calcite-action-bar-trigger-icon-color-focus);
+  --calcite-action-group-trigger-icon-color-hover: var(--calcite-action-bar-trigger-icon-color-hover);
+  --calcite-action-group-trigger-icon-color: var(--calcite-action-bar-trigger-icon-color);
+  --calcite-action-group-trigger-indicator-color: var(--calcite-action-bar-trigger-indicator-color);
+  --calcite-action-group-trigger-loader-color: var(--calcite-action-bar-trigger-loader-color);
+  --calcite-action-group-trigger-shadow-active: var(--calcite-action-bar-trigger-shadow-active);
+  --calcite-action-group-trigger-shadow-focus: var(--calcite-action-bar-trigger-shadow-focus);
+  --calcite-action-group-trigger-shadow-hover: var(--calcite-action-bar-trigger-shadow-hover);
+  --calcite-action-group-trigger-shadow: var(--calcite-action-bar-trigger-shadow);
+  --calcite-action-group-trigger-text-color-active: var(--calcite-action-bar-trigger-text-color-active);
+  --calcite-action-group-trigger-text-color-focus: var(--calcite-action-bar-trigger-text-color-focus);
+  --calcite-action-group-trigger-text-color-hover: var(--calcite-action-bar-trigger-text-color-hover);
+  --calcite-action-group-trigger-text-color: var(--calcite-action-bar-trigger-text-color);
 }
 
 .action-group--end {

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -3,62 +3,44 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-group-action-background-color: defines the background color of an action sub-component inside the component.
- * @prop --calcite-action-group-action-indicator-color: defines the indicator color of an action sub-component inside the component.
- * @prop --calcite-action-group-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-group-action-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-group-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-group-action-background-color-active: defines the background color of an action sub-component when active inside the component.
- * @prop --calcite-action-group-action-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
- * @prop --calcite-action-group-action-text-color-active: defines the text color of an action sub-component when active inside the component.
- * @prop --calcite-action-group-action-menu-border-color: The border color of the sub-component.
- * @prop --calcite-action-group-action-menu-text-color: The text color of the sub-component.
- * @prop --calcite-action-group-action-text-color: defines the text color of an action sub-component inside the component.
- * @prop --calcite-action-group-background-color: defines the background color of the component.
- * @prop --calcite-action-group-columns: [Deprecated]  Sets number of grid-template-columns when the `layout` property is `"grid"`.
- * @prop --calcite-action-group-gap: [Deprecated]  Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
- * @prop --calcite-action-group-padding: [Deprecated]  Sets the padding when the `layout` property is `"grid"`.
- * @prop --calcite-internal-action-group-columns: Sets number of grid-template-columns when the `layout` property is `"grid"`.
- * @prop --calcite-internal-action-group-gap, var(te-internal-action-group-gap: Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`).
- *
+ * @prop --calcite-action-group-columns: [Deprecated] Sets number of grid-template-columns when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-gap: [Deprecated] Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-padding: [Deprecated] Sets the padding when the `layout` property is `"grid"`.
  */
 
 :host {
   @extend %component-host;
-
   @apply flex
   flex-col
   p-0;
 
   --calcite-internal-action-group-columns: 3;
-  --calcite-internal-action-group-gap: theme("gap.px");
+
+  border-style: none;
+  border-block-end-style: solid;
+  border-width: var(--calcite-border-width-sm);
+  border-color: var(--calcite-action-group-border-color, var(--calcite-color-border-3));
 }
 
 .container {
-  @apply flex flex-col flex-grow;
+  @apply flex-col flex-grow;
+  display: var(--calcite-internal-action-group-display, flex);
+  background-color: var(--calcite-action-group-background, var(--calcite-internal-action-group-background-color));
 }
 
-:host([columns="1"]) {
-  --calcite-internal-action-group-columns: 1;
-}
-:host([columns="2"]) {
-  --calcite-internal-action-group-columns: 2;
-}
-:host([columns="3"]) {
-  --calcite-internal-action-group-columns: 3;
-}
-:host([columns="4"]) {
-  --calcite-internal-action-group-columns: 4;
-}
-:host([columns="5"]) {
-  --calcite-internal-action-group-columns: 5;
-}
-:host([columns="6"]) {
-  --calcite-internal-action-group-columns: 6;
+// :host([columns="1 - 6"])
+@for $i from 1 through 6 {
+  :host([columns="#{$i}"]) {
+    --calcite-internal-action-group-columns: $i;
+  }
 }
 
 :host(:first-child) {
-  @apply pt-0;
+  padding-block-start: 0;
+}
+:host(:last-child) {
+  border-block-end: 0;
+  border-inline-end: 0;
 }
 
 :host([layout="horizontal"]),
@@ -71,39 +53,17 @@
 }
 
 :host([layout="grid"]) .container {
-  @apply grid
-  place-content-stretch;
-  gap: var(--calcite-action-group-gap, var(--calcite-internal-action-group-gap));
-  padding: var(--calcite-action-group-gap, var(--calcite-internal-action-group-gap));
+  --calcite-internal-action-group-space: var(--calcite-spacing-px);
+  --calcite-internal-action-group-display: grid;
+  --calcite-internal-action-group-background-color: var(--calcite-color-background);
+  @apply place-content-stretch;
+
+  gap: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
+  padding: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
   grid-template-columns: repeat(
     var(--calcite-action-group-columns, var(--calcite-internal-action-group-columns)),
     auto
   );
-  background-color: var(--calcite-action-group-background-color, var(--calcite-color-background));
-}
-
-calcite-action-menu {
-  --calcite-action-menu-border-color: var(--calcite-action-group-action-menu-border-color);
-  --calcite-action-menu-text-color: var(--calcite-action-group-action-menu-text-color);
-}
-
-calcite-action {
-  --calcite-action-indicator-color: var(--calcite-action-group-action-indicator-color);
-  --calcite-action-background-color: var(--calcite-action-group-action-background-color);
-  --calcite-action-text-color: var(--calcite-action-group-action-text-color);
-
-  &:hover,
-  &:focus {
-    --calcite-action-indicator-color: var(--calcite-action-group-action-indicator-color-hover);
-    --calcite-action-background-color: var(--calcite-action-group-action-background-color-hover);
-    --calcite-action-text-color: var(--calcite-action-group-action-text-color-hover);
-  }
-
-  &:active {
-    --calcite-action-indicator-color: var(--calcite-action-group-action-indicator-color-active);
-    --calcite-action-background-color: var(--calcite-action-group-action-background-color-active);
-    --calcite-action-text-color: var(--calcite-action-group-action-text-color-active);
-  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -127,18 +127,21 @@ calcite-action-menu {
   @apply grid;
 }
 
-:host([layout="grid"]) .container {
+:host([layout="grid"]) {
   --calcite-internal-action-group-space: var(--calcite-spacing-px);
   --calcite-internal-action-group-display: grid;
   --calcite-internal-action-group-background-color: var(--calcite-color-background);
-  @apply place-content-stretch;
 
-  gap: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
-  padding: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
-  grid-template-columns: repeat(
-    var(--calcite-action-group-columns, var(--calcite-internal-action-group-columns)),
-    auto
-  );
+  .container {
+    @apply place-content-stretch;
+
+    gap: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
+    padding: var(--calcite-action-group-gap, var(--calcite-internal-action-group-space));
+    grid-template-columns: repeat(
+      var(--calcite-action-group-columns, var(--calcite-internal-action-group-columns)),
+      auto
+    );
+  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -3,9 +3,33 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-action-group-border-color: Specifies the border color of the component.
  * @prop --calcite-action-group-columns: [Deprecated] Sets number of grid-template-columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-gap: [Deprecated] Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
  * @prop --calcite-action-group-padding: [Deprecated] Sets the padding when the `layout` property is `"grid"`.
+ * @prop --calcite-action-group-popover-background-color: Specifies the background color of the popover in the component.
+ * @prop --calcite-action-group-popover-border-color: Specifies the border color of the popover in the component.
+ * @prop --calcite-action-group-popover-corner-radius: Specifies the corner radius of the popover in the component.
+ * @prop --calcite-action-group-popover-shadow: Specifies the shadow of the popover in the component.
+ * @prop --calcite-action-group-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
+ * @prop --calcite-action-group-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
+ * @prop --calcite-action-group-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-group-trigger-background-color: Specifies the background color of the nested trigger in the component.
+ * @prop --calcite-action-group-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
+ * @prop --calcite-action-group-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
+ * @prop --calcite-action-group-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-group-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
+ * @prop --calcite-action-group-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
+ * @prop --calcite-action-group-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
+ * @prop --calcite-action-group-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
+ * @prop --calcite-action-group-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
+ * @prop --calcite-action-group-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
+ * @prop --calcite-action-group-trigger-shadow: Specifies the shadow of the nested trigger in the component.
+ * @prop --calcite-action-group-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
+ * @prop --calcite-action-group-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
+ * @prop --calcite-action-group-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-group-trigger-text-color: Specifies the text color of the nested trigger in the component.
+ *
  */
 
 :host {
@@ -20,6 +44,58 @@
   border-block-end-style: solid;
   border-width: var(--calcite-border-width-sm);
   border-color: var(--calcite-action-group-border-color, var(--calcite-color-border-3));
+}
+
+calcite-action {
+  --calcite-action-background-color: var(--calcite-action-group-trigger-background-color);
+  --calcite-action-text-color: var(--calcite-action-group-trigger-text-color);
+  --calcite-action-shadow: var(--calcite-action-group-trigger-shadow);
+  --calcite-action-icon-color: var(--calcite-action-group-trigger-icon-color);
+  --calcite-action-indicator-color: var(--calcite-action-group-trigger-indicator-color);
+  --calcite-action-loader-color: var(--calcite-action-group-trigger-loader-color);
+
+  &:hover {
+    --calcite-action-background-color: var(--calcite-action-group-trigger-background-color-hover);
+    --calcite-action-text-color: var(--calcite-action-group-trigger-text-color-hover);
+    --calcite-action-shadow: var(--calcite-action-group-trigger-shadow-hover);
+    --calcite-action-icon-color: var(--calcite-action-group-trigger-icon-color-hover);
+  }
+  &:focus {
+    --calcite-action-background-color: var(--calcite-action-group-trigger-background-color-focus);
+    --calcite-action-text-color: var(--calcite-action-group-trigger-text-color-focus);
+    --calcite-action-shadow: var(--calcite-action-group-trigger-shadow-focus);
+    --calcite-action-icon-color: var(--calcite-action-group-trigger-icon-color-focus);
+  }
+  &:active {
+    --calcite-action-background-color: var(--calcite-action-group-trigger-background-color-active);
+    --calcite-action-text-color: var(--calcite-action-group-trigger-text-color-active);
+    --calcite-action-shadow: var(--calcite-action-group-trigger-shadow-active);
+    --calcite-action-icon-color: var(--calcite-action-group-trigger-icon-color-active);
+  }
+}
+calcite-action-menu {
+  --calcite-action-menu-popover-background-color: var(--calcite-action-group-popover-background-color);
+  --calcite-action-menu-popover-border-color: var(
+    --calcite-action-group-popover-border-color,
+    var(--calcite-action-group-border-color)
+  );
+  --calcite-action-menu-popover-corner-radius: var(--calcite-action-group-popover-corner-radius);
+  --calcite-action-menu-popover-shadow: var(--calcite-action-group-popover-shadow);
+  --calcite-action-menu-trigger-background-color-active: var(--calcite-action-group-trigger-background-color-active);
+  --calcite-action-menu-trigger-background-color-focus: var(--calcite-action-group-trigger-background-color-focus);
+  --calcite-action-menu-trigger-background-color-hover: var(--calcite-action-group-trigger-background-color-hover);
+  --calcite-action-menu-trigger-background-color: var(--calcite-action-group-trigger-background-color);
+  --calcite-action-menu-trigger-icon-color-active: var(--calcite-action-group-trigger-icon-color-active);
+  --calcite-action-menu-trigger-icon-color-focus: var(--calcite-action-group-trigger-icon-color-focus);
+  --calcite-action-menu-trigger-icon-color-hover: var(--calcite-action-group-trigger-icon-color-hover);
+  --calcite-action-menu-trigger-icon-color: var(--calcite-action-group-trigger-icon-color);
+  --calcite-action-menu-trigger-indicator-color: var(--calcite-action-group-trigger-indicator-color);
+  --calcite-action-menu-trigger-loader-color: var(--calcite-action-group-trigger-loader-color);
+  --calcite-action-menu-trigger-shadow: var(--calcite-action-group-trigger-shadow);
+  --calcite-action-menu-trigger-text-color-active: var(--calcite-action-group-trigger-text-color-active);
+  --calcite-action-menu-trigger-text-color-focus: var(--calcite-action-group-trigger-text-color-focus);
+  --calcite-action-menu-trigger-text-color-hover: var(--calcite-action-group-trigger-text-color-hover);
+  --calcite-action-menu-trigger-text-color: var(--calcite-action-group-trigger-text-color);
 }
 
 .container {

--- a/packages/calcite-components/src/components/action-group/action-group.scss
+++ b/packages/calcite-components/src/components/action-group/action-group.scss
@@ -104,7 +104,6 @@ calcite-action-menu {
   background-color: var(--calcite-action-group-background, var(--calcite-internal-action-group-background-color));
 }
 
-// :host([columns="1 - 6"])
 @for $i from 1 through 6 {
   :host([columns="#{$i}"]) {
     --calcite-internal-action-group-columns: $i;

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -3,21 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-menu-action-background-color: defines the background color of an action sub-component inside the component.
- * @prop --calcite-action-menu-action-indicator-color: defines the indicator color of an action sub-component inside the component.
- * @prop --calcite-action-menu-action-text-color: defines the text color of an action sub-component inside the component.
- * @prop --calcite-action-menu-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-menu-action-indicator-color-hover: defines the indicator color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-menu-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
- * @prop --calcite-action-menu-action-background-color-active: defines the background color of an action sub-component when active inside the component.
- * @prop --calcite-action-menu-action-indicator-color-active: defines the indicator color of an action sub-component when active inside the component.
- * @prop --calcite-action-menu-action-text-color-active: defines the text color of an action sub-component when active inside the component.
- * @prop --calcite-action-menu-group-separator-border-color: The border color of the sub-component.
- * @prop --calcite-action-menu-popover-background-color: defines the background color of the sub-component.
- * @prop --calcite-action-menu-popover-border-color: defines the border color of the sub-component.
- * @prop --calcite-action-menu-popover-corner-radius: defines the corner radius of the sub-component.
- * @prop --calcite-action-menu-popover-shadow: defines the shadow of the component.
- * @prop --calcite-action-menu-popover-text-color: defines the text color of the sub-component.
+ * @prop --calcite-action-menu-text-color: Specifies the text color of the component.
+ *
  */
 
 :host {
@@ -25,26 +12,10 @@
   box-border
   flex
   flex-col;
-}
-
-::slotted(calcite-action-group) {
-  border-block-end-style: solid;
-  border-block-end-width: var(--calcite-border-width-sm);
-  border-block-end-color: var(--calcite-action-menu-group-separator-border-color, var(--calcite-color-border-3));
-}
-
-::slotted(calcite-action-group:last-child) {
-  border-block-end: var(--calcite-border-width-none);
+  color: var(--calcite-action-menu-text-color, var(--calcite-color-text-2));
 }
 
 .default-trigger {
-  @apply relative
-  flex-initial
-  self-stretch;
-  block-size: var(--calcite-container-size-content-fluid);
-}
-
-@include slotted("trigger", "calcite-action") {
   @apply relative
   flex-initial
   self-stretch;
@@ -60,31 +31,12 @@
   max-h-menu;
 }
 
-calcite-action {
-  --calcite-action-indicator-color: var(--calcite-action-menu-action-indicator-color);
-  --calcite-action-background-color: var(--calcite-action-menu-action-background-color);
-  --calcite-action-text-color: var(--calcite-action-menu-action-text-color);
+@include slotted("trigger", "calcite-action") {
+  @apply relative
+  flex-initial
+  self-stretch;
 
-  &:hover,
-  &:focus {
-    --calcite-action-indicator-color: var(--calcite-action-menu-action-indicator-color-hover);
-    --calcite-action-background-color: var(--calcite-action-menu-action-background-color-hover);
-    --calcite-action-text-color: var(--calcite-action-menu-action-text-color-hover);
-  }
-
-  &:active {
-    --calcite-action-indicator-color: var(--calcite-action-menu-action-indicator-color-active);
-    --calcite-action-background-color: var(--calcite-action-menu-action-background-color-active);
-    --calcite-action-text-color: var(--calcite-action-menu-action-text-color-active);
-  }
-}
-
-calcite-popover {
-  --calcite-popover-background-color: var(--calcite-action-menu-popover-background-color);
-  --calcite-popover-border-color: var(--calcite-action-menu-popover-border-color);
-  --calcite-popover-corner-radius: var(--calcite-action-menu-popover-corner-radius);
-  --calcite-popover-shadow: var(--calcite-action-menu-popover-shadow);
-  --calcite-popover-text-color: var(--calcite-action-menu-popover-text-color);
+  block-size: var(--calcite-container-size-content-fluid);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-menu/action-menu.scss
+++ b/packages/calcite-components/src/components/action-menu/action-menu.scss
@@ -3,7 +3,35 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-menu-text-color: Specifies the text color of the component.
+ * @prop --calcite-action-menu-close-background-color-active: Specifies the background color of an action sub-component when active inside the component.
+ * @prop --calcite-action-menu-close-background-color-hover: Specifies the background color of an action sub-component when hovered or focused inside the component.
+ * @prop --calcite-action-menu-close-background-color: Specifies the background color of an action sub-component inside the component.
+ * @prop --calcite-action-menu-close-icon-color-active: Specifies the component's close icon color when active.
+ * @prop --calcite-action-menu-close-icon-color-hover: Specifies the component's close icon color on hover.
+ * @prop --calcite-action-menu-close-icon-color: Specifies the component's close icon color.
+ * @prop --calcite-action-menu-close-text-color-active: Specifies the text color of an action sub-component when active inside the component.
+ * @prop --calcite-action-menu-close-text-color-hover: Specifies the text color of an action sub-component when hovered or focused inside the component.
+ * @prop --calcite-action-menu-close-text-color: Specifies the text color of an action sub-component inside the component.
+ * @prop --calcite-action-menu-popover-background-color: Specifies the background color of the component.
+ * @prop --calcite-action-menu-popover-border-color: Specifies the border color of the component.
+ * @prop --calcite-action-menu-popover-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-action-menu-popover-shadow: Specifies the shadow of the component.
+ * @prop --calcite-action-menu-popover-text-color: Specifies the text color of the component.
+ * @prop --calcite-action-menu-trigger-background-color-active: Specifies the background color of the component's default trigger when active.
+ * @prop --calcite-action-menu-trigger-background-color-focus: Specifies the background color of the component's default trigger when focused.
+ * @prop --calcite-action-menu-trigger-background-color-hover: Specifies the background color of the component's default trigger when hovered.
+ * @prop --calcite-action-menu-trigger-background-color: Specifies the background color of the component.
+ * @prop --calcite-action-menu-trigger-icon-color-active: Specifies the background color of the component's default trigger when active.
+ * @prop --calcite-action-menu-trigger-icon-color-focus: Specifies the background color of the component's default trigger when focused.
+ * @prop --calcite-action-menu-trigger-icon-color-hover: Specifies the background color of the component's default trigger when hovered.
+ * @prop --calcite-action-menu-trigger-icon-color: Specifies the color of the component's icon.
+ * @prop --calcite-action-menu-trigger-indicator-color: Specifies the color of the component's indicator.
+ * @prop --calcite-action-menu-trigger-loader-color: Specifies the color of the component's loader.
+ * @prop --calcite-action-menu-trigger-shadow: Specifies the shadow of the component.
+ * @prop --calcite-action-menu-trigger-text-color-active: Specifies the background color of the component's default trigger when active.
+ * @prop --calcite-action-menu-trigger-text-color-focus: Specifies the background color of the component's default trigger when focused.
+ * @prop --calcite-action-menu-trigger-text-color-hover: Specifies the background color of the component's default trigger when hovered.
+ * @prop --calcite-action-menu-trigger-text-color: Specifies the text color of the component.
  *
  */
 
@@ -12,7 +40,69 @@
   box-border
   flex
   flex-col;
-  color: var(--calcite-action-menu-text-color, var(--calcite-color-text-2));
+}
+
+calcite-action {
+  --calcite-action-background-color: var(--calcite-action-menu-trigger-background-color);
+  --calcite-action-text-color: var(--calcite-action-menu-trigger-text-color);
+  --calcite-action-icon-color: var(--calcite-action-menu-trigger-icon-color);
+  --calcite-action-shadow: var(--calcite-action-menu-trigger-shadow);
+  --calcite-action-indicator-color: var(--calcite-action-menu-trigger-indicator-color);
+  --calcite-action-loader-color: var(--calcite-action-menu-trigger-loader-color);
+
+  &:hover {
+    --calcite-action-background-color: var(--calcite-action-menu-trigger-background-color-hover);
+    --calcite-action-text-color: var(--calcite-action-menu-trigger-text-color-hover);
+    --calcite-action-icon-color: var(--calcite-action-menu-trigger-icon-color-hover);
+  }
+  &:focus {
+    --calcite-action-background-color: var(--calcite-action-menu-trigger-background-color-focus);
+    --calcite-action-text-color: var(--calcite-action-menu-trigger-text-color-focus);
+    --calcite-action-icon-color: var(--calcite-action-menu-trigger-icon-color-focus);
+  }
+  &:active {
+    --calcite-action-background-color: var(--calcite-action-menu-trigger-background-color-active);
+    --calcite-action-text-color: var(--calcite-action-menu-trigger-text-color-active);
+    --calcite-action-icon-color: var(--calcite-action-menu-trigger-icon-color-active);
+  }
+}
+
+calcite-popover {
+  --calcite-popover-background-color: var(--calcite-action-menu-popover-background-color);
+  --calcite-popover-border-color: var(--calcite-action-menu-popover-border-color);
+  --calcite-popover-close-background-color-active: var(
+    --calcite-action-menu-close-background-color-active,
+    var(--calcite-action-menu-trigger-background-color-active)
+  );
+  --calcite-popover-close-background-color-hover: var(
+    --calcite-action-menu-close-background-color-hover,
+    var(--calcite-action-menu-trigger-background-color-hover)
+  );
+  --calcite-popover-close-background-color: var(
+    --calcite-action-menu-close-background-color,
+    var(--calcite-action-menu-trigger-background-color)
+  );
+  --calcite-popover-close-icon-color-active: var(--calcite-action-menu-close-icon-color-active);
+  --calcite-popover-close-icon-color-hover: var(--calcite-action-menu-close-icon-color-hover);
+  --calcite-popover-close-icon-color: var(--calcite-action-menu-close-icon-color);
+  --calcite-popover-close-text-color-active: var(
+    --calcite-action-menu-close-text-color-active,
+    var(--calcite-action-menu-trigger-text-color-active)
+  );
+  --calcite-popover-close-text-color-hover: var(
+    --calcite-action-menu-close-text-color-hover,
+    var(--calcite-action-menu-trigger-text-color-hover)
+  );
+  --calcite-popover-close-text-color: var(
+    --calcite-action-menu-close-text-color,
+    var(--calcite-action-menu-trigger-text-color)
+  );
+  --calcite-popover-corner-radius: var(--calcite-action-menu-popover-corner-radius);
+  --calcite-popover-shadow: var(--calcite-action-menu-popover-shadow);
+  --calcite-popover-text-color: var(
+    --calcite-action-menu-popover-text-color,
+    var(--calcite-action-menu-trigger-text-color)
+  );
 }
 
 .default-trigger {

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -4,56 +4,58 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
+ * @prop --calcite-action-pad-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-action-pad-background-color: Specifies the background color of the component.
+ * @prop --calcite-action-pad-shadow: Specifies the shadow of the component.
+ *
  */
 
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;
-  --calcite-action-pad-expanded-max-width: auto;
   background: transparent;
 }
 
 :host([expanded][layout="vertical"]) .container {
-  max-inline-size: var(--calcite-action-pad-expanded-max-width);
+  max-inline-size: var(--calcite-action-pad-expanded-max-width, auto);
 }
 
 ::slotted(calcite-action-group) {
-  @apply border-color-3
-  border-0
-  border-b
-  border-solid
-  pb-0 pt-0;
+  padding-block: 0px;
 }
 
 .container {
-  @apply bg-background
-  shadow-2
-  inline-flex
+  @apply inline-flex
   flex-col
-  overflow-y-auto
-  rounded;
+  overflow-y-auto;
+  border-radius: var(--calcite-action-pad-corner-radius, var(--calcite-corner-radius-round));
+  background-color: var(--calcite-action-pad-background-color, var(--calcite-color-background));
+  box-shadow: var(
+    --calcite-action-pad-shadow,
+    var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000),
+    0 6px 20px -4px rgba(0, 0, 0, 0.1),
+    0 4px 12px -2px rgba(0, 0, 0, 0.08)
+  );
 }
 
 .action-group--bottom {
-  @apply flex-grow justify-end pb-0;
+  @apply flex-grow justify-end;
+  padding-block-end: 0px;
 }
 
 :host([layout="horizontal"]) {
   .container {
     @apply flex-row;
+
     .action-group--bottom {
       @apply p-0;
     }
-    ::slotted(calcite-action-group) {
-      @apply border-0
-      p-0;
-      border-inline-end-width: theme("borderWidth.DEFAULT");
-    }
   }
-}
-
-::slotted(calcite-action-group:last-child) {
-  @apply border-b-0;
+  ::slotted(calcite-action-group) {
+    border-block-end-style: none;
+    border-inline-end-style: solid;
+  }
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -3,17 +3,68 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
- * @prop --calcite-action-pad-corner-radius: Specifies the corner radius of the component.
  * @prop --calcite-action-pad-background-color: Specifies the background color of the component.
+ * @prop --calcite-action-pad-border-color: Specifies the border color of the component.
+ * @prop --calcite-action-pad-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
+ * @prop --calcite-action-pad-popover-background-color: Specifies the background color of the popover in the component.
+ * @prop --calcite-action-pad-popover-border-color: Specifies the border color of the popover in the component.
+ * @prop --calcite-action-pad-popover-corner-radius: Specifies the corner radius of the popover in the component.
+ * @prop --calcite-action-pad-popover-shadow: Specifies the shadow of the popover in the component.
  * @prop --calcite-action-pad-shadow: Specifies the shadow of the component.
- *
+ * @prop --calcite-action-pad-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
+ * @prop --calcite-action-pad-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
+ * @prop --calcite-action-pad-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-pad-trigger-background-color: Specifies the background color of the nested trigger in the component.
+ * @prop --calcite-action-pad-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
+ * @prop --calcite-action-pad-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
+ * @prop --calcite-action-pad-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-pad-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
+ * @prop --calcite-action-pad-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
+ * @prop --calcite-action-pad-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
+ * @prop --calcite-action-pad-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
+ * @prop --calcite-action-pad-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
+ * @prop --calcite-action-pad-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
+ * @prop --calcite-action-pad-trigger-shadow: Specifies the shadow of the nested trigger in the component.
+ * @prop --calcite-action-pad-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
+ * @prop --calcite-action-pad-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
+ * @prop --calcite-action-pad-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
+ * @prop --calcite-action-pad-trigger-text-color: Specifies the text color of the nested trigger in the component.
  */
 
 :host {
   @extend %component-host;
   @apply animate-in block rounded-sm;
   background: transparent;
+}
+
+calcite-action-group {
+  --calcite-action-group-border-color: var(--calcite-action-pad-border-color);
+  --calcite-action-group-popover-background-color: var(--calcite-action-pad-popover-background-color);
+  --calcite-action-group-popover-border-color: var(--calcite-action-pad-popover-border-color);
+  --calcite-action-group-popover-corner-radius: var(--calcite-action-pad-corner-radius);
+  --calcite-action-group-popover-shadow: var(--calcite-action-pad-popover-shadow, var(--calcite-action-pad-shadow));
+  --calcite-action-group-trigger-background-color-active: var(--calcite-action-pad-trigger-background-color-active);
+  --calcite-action-group-trigger-background-color-focus: var(--calcite-action-pad-trigger-background-color-focus);
+  --calcite-action-group-trigger-background-color-hover: var(--calcite-action-pad-trigger-background-color-hover);
+  --calcite-action-group-trigger-background-color: var(
+    --calcite-action-pad-trigger-background-color,
+    var(--calcite-action-pad-background-color)
+  );
+  --calcite-action-group-trigger-icon-color-active: var(--calcite-action-pad-trigger-icon-color-active);
+  --calcite-action-group-trigger-icon-color-focus: var(--calcite-action-pad-trigger-icon-color-focus);
+  --calcite-action-group-trigger-icon-color-hover: var(--calcite-action-pad-trigger-icon-color-hover);
+  --calcite-action-group-trigger-icon-color: var(--calcite-action-pad-trigger-icon-color);
+  --calcite-action-group-trigger-indicator-color: var(--calcite-action-pad-trigger-indicator-color);
+  --calcite-action-group-trigger-loader-color: var(--calcite-action-pad-trigger-loader-color);
+  --calcite-action-group-trigger-shadow-active: var(--calcite-action-pad-trigger-shadow-active);
+  --calcite-action-group-trigger-shadow-focus: var(--calcite-action-pad-trigger-shadow-focus);
+  --calcite-action-group-trigger-shadow-hover: var(--calcite-action-pad-trigger-shadow-hover);
+  --calcite-action-group-trigger-shadow: var(--calcite-action-pad-trigger-shadow);
+  --calcite-action-group-trigger-text-color-active: var(--calcite-action-pad-trigger-text-color-active);
+  --calcite-action-group-trigger-text-color-focus: var(--calcite-action-pad-trigger-text-color-focus);
+  --calcite-action-group-trigger-text-color-hover: var(--calcite-action-pad-trigger-text-color-hover);
+  --calcite-action-group-trigger-text-color: var(--calcite-action-pad-trigger-text-color);
 }
 
 :host([expanded][layout="vertical"]) .container {
@@ -53,6 +104,33 @@
     }
   }
   ::slotted(calcite-action-group) {
+    --calcite-action-group-border-color: var(--calcite-action-pad-border-color);
+    --calcite-action-group-popover-background-color: var(--calcite-action-pad-popover-background-color);
+    --calcite-action-group-popover-border-color: var(--calcite-action-pad-popover-border-color);
+    --calcite-action-group-popover-corner-radius: var(--calcite-action-pad-corner-radius);
+    --calcite-action-group-popover-shadow: var(--calcite-action-pad-popover-shadow, var(--calcite-action-pad-shadow));
+    --calcite-action-group-trigger-background-color-active: var(--calcite-action-pad-trigger-background-color-active);
+    --calcite-action-group-trigger-background-color-focus: var(--calcite-action-pad-trigger-background-color-focus);
+    --calcite-action-group-trigger-background-color-hover: var(--calcite-action-pad-trigger-background-color-hover);
+    --calcite-action-group-trigger-background-color: var(
+      --calcite-action-pad-trigger-background-color,
+      var(--calcite-action-pad-background-color)
+    );
+    --calcite-action-group-trigger-icon-color-active: var(--calcite-action-pad-trigger-icon-color-active);
+    --calcite-action-group-trigger-icon-color-focus: var(--calcite-action-pad-trigger-icon-color-focus);
+    --calcite-action-group-trigger-icon-color-hover: var(--calcite-action-pad-trigger-icon-color-hover);
+    --calcite-action-group-trigger-icon-color: var(--calcite-action-pad-trigger-icon-color);
+    --calcite-action-group-trigger-indicator-color: var(--calcite-action-pad-trigger-indicator-color);
+    --calcite-action-group-trigger-loader-color: var(--calcite-action-pad-trigger-loader-color);
+    --calcite-action-group-trigger-shadow-active: var(--calcite-action-pad-trigger-shadow-active);
+    --calcite-action-group-trigger-shadow-focus: var(--calcite-action-pad-trigger-shadow-focus);
+    --calcite-action-group-trigger-shadow-hover: var(--calcite-action-pad-trigger-shadow-hover);
+    --calcite-action-group-trigger-shadow: var(--calcite-action-pad-trigger-shadow);
+    --calcite-action-group-trigger-text-color-active: var(--calcite-action-pad-trigger-text-color-active);
+    --calcite-action-group-trigger-text-color-focus: var(--calcite-action-pad-trigger-text-color-focus);
+    --calcite-action-group-trigger-text-color-hover: var(--calcite-action-pad-trigger-text-color-hover);
+    --calcite-action-group-trigger-text-color: var(--calcite-action-pad-trigger-text-color);
+
     border-block-end-style: none;
     border-inline-end-style: solid;
   }

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -4,246 +4,261 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-background-color: Specifies the background color of the component.
- * @prop --calcite-action-indicator-color: Specifies the color of the component's indicator.
- * @prop --calcite-action-loader-color-one-third: Specifies the starting color of the loader
- * @prop --calcite-action-loader-color-start: Specifies the starting color of the loader
- * @prop --calcite-action-loader-color-two-thirds: Specifies the starting color of the loader
  * @prop --calcite-action-text-color: Specifies the text color of the component.
- *
+ * @prop --calcite-action-shadow: Specifies the shadow of the component.
+ * @prop --calcite-action-icon-color: Specifies the color of the component's icon.
+ * @prop --calcite-action-indicator-color: Specifies the color of the component's indicator.
+ * @prop --calcite-action-loader-color: Specifies the color of the component's loader.
  */
-@include base-component();
-@include disabled();
 
 :host {
-  @extend %component-host;
-  @apply flex;
-  background-color: var(--calcite-action-background-color, transparent);
-}
+  box-sizing: border-box;
+  display: flex;
+  background-color: var(--calcite-color-transparent);
 
-@mixin action-indicator() {
-  position: relative;
-  &::after {
-    content: "";
-    @apply absolute
-      h-2
-      w-2
-      rounded-full;
-    inset-block-end: calc(-0.275rem);
-    inset-inline-end: calc(-0.275rem);
-    background-color: var(--calcite-action-indicator-color, var(--calcite-color-brand));
+  * {
+    box-sizing: border-box;
   }
 }
 
-button {
+.button {
   @apply focus-base
-    text-n2h
     relative
     m-0
     flex
     w-auto
     cursor-pointer
     items-center
-    justify-start
-    border-none
-    font-sans
-    font-medium;
-  background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-1));
-  color: var(--calcite-action-text-color, var(--calcite-color-text-3));
-  text-align: unset;
+    border-none;
+  background-color: var(
+    --calcite-action-background-color,
+    var(--calcite-internal-action-background-color, var(--calcite-color-foreground-1))
+  );
+  color: var(--calcite-action-text-color, var(--calcite-internal-action-text-color, var(--calcite-color-text-3)));
   flex: 1 0 auto;
-
-  &:hover,
-  &:focus {
-    @apply focus-inset;
-    background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-2));
-    color: var(--calcite-action-text-color, var(--calcite-color-text-1));
-  }
-
-  &:active {
-    background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-3));
-  }
+  font-size: var(--calcite-internal-action-font-size, var(--calcite-font-size--2));
+  justify-content: var(--calcite-internal-action-justify-content, start);
+  line-height: var(--calcite-internal-action-line-height, 1rem /* 16px */);
+  text-align: unset;
+  padding-inline: var(--calcite-internal-action-space-x);
+  padding-block: var(--calcite-internal-action-space-y);
+  box-shadow: var(--calcite-action-shadow);
 
   &.button--text-visible {
-    inline-size: 100%;
-  }
+    inline-size: var(--calcite-container-size-content-fluid);
 
-  .icon-container {
-    @apply pointer-events-none
-      m-0
-      flex
-      items-center
-      justify-center;
-    min-inline-size: theme("spacing.4");
-    min-block-size: theme("spacing.4");
-  }
-
-  .text-container {
-    @apply m-0
-      w-0
-      truncate
-      leading-6
-      opacity-0
-      transition-opacity
-      duration-150
-      ease-in-out;
-    transition-property: margin;
-    transition-property: inline-size;
-  }
-
-  .text-container--visible {
-    @apply w-auto flex-auto opacity-100;
+    .icon-container {
+      margin-inline-end: var(--calcite-internal-action-icon-container-space-x-end, theme("spacing.3"));
+    }
   }
 }
 
-.indicator-with-icon {
-  @include action-indicator();
+.icon-container {
+  @apply pointer-events-none
+    m-0
+    flex
+    items-center
+    justify-center;
+  min-inline-size: theme("spacing.4");
+  min-block-size: theme("spacing.4");
+}
+
+.text-container {
+  @apply m-0
+    w-0
+    truncate
+    leading-6
+    opacity-0
+    transition-opacity
+    duration-150
+    ease-in-out;
+  transition-property: margin;
+  transition-property: inline-size;
+}
+
+.text-container--visible {
+  @apply w-auto flex-auto;
+  opacity: var(--calcite-opacity-full);
+}
+
+.action-indicator {
+  position: relative;
+  &::after {
+    position: absolute;
+    block-size: 0.5rem /* 8px */;
+    inline-size: 0.5rem /* 8px */;
+    content: "";
+    @apply rounded-full;
+    inset-block-end: -0.275rem;
+    inset-inline-end: -0.275rem;
+    background-color: var(
+      --calcite-action-indicator-color,
+      var(--calcite-internal-action-indicator-color, var(--calcite-color-brand))
+    );
+  }
+}
+
+.icon {
+  --calcite-icon-color: var(
+    --calcite-action-icon-color,
+    var(--calcite-internal-action-icon-color, var(--calcite-color-text-3))
+  );
 }
 
 .indicator-without-icon {
   @apply w-4 mx-1;
-  @include action-indicator();
-}
-
-:host([data-active]) button {
-  @apply focus-inset;
-}
-
-// Scale
-:host([scale="s"]) {
-  button {
-    @apply text-n2h px-2 py-1 font-normal;
-
-    &.button--text-visible .icon-container {
-      margin-inline-end: theme("spacing.2");
-    }
-  }
-}
-:host([scale="m"]) {
-  button {
-    @apply text-n1h px-4 py-3 font-normal;
-
-    &.button--text-visible .icon-container {
-      margin-inline-end: theme("spacing.3");
-    }
-  }
-}
-:host([scale="l"]) {
-  button {
-    @apply text-0h p-5 font-normal;
-
-    &.button--text-visible .icon-container {
-      margin-inline-end: theme("spacing.4");
-    }
-  }
-}
-// Compact
-:host([scale="s"][compact]),
-:host([scale="m"][compact]),
-:host([scale="l"][compact]) {
-  button {
-    @apply px-0;
-  }
-}
-
-// Alignment
-:host([alignment="center"]),
-:host([alignment="end"]) {
-  button .text-container--visible {
-    @apply flex-initial;
-  }
-}
-:host([alignment="center"]) button {
-  @apply justify-center;
-}
-:host([alignment="end"]) button {
-  @apply justify-end;
-}
-
-:host(:is([active], [active][loading])) {
-  button {
-    &,
-    &:hover,
-    &:focus {
-      color: var(--calcite-action-text-color, var(--calcite-color-text-1));
-
-      background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-3));
-    }
-  }
-}
-
-:host([active]) button:active {
-  background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-1));
-}
-
-:host([appearance="transparent"]) button,
-:host([appearance="transparent"][disabled]) button {
-  background-color: transparent;
-}
-
-:host([appearance="transparent"][active]) button,
-:host([appearance="transparent"]) button:hover,
-:host([appearance="transparent"]) button:focus {
-  background-color: var(--calcite-action-background-color, var(--calcite-color-transparent-hover));
-}
-
-:host([appearance="transparent"]) button:active {
-  background-color: var(--calcite-action-background-color, var(--calcite-color-transparent-press));
-}
-
-:host([loading][appearance="solid"]) button,
-:host([loading][appearance="solid"]) button:hover,
-:host([loading][appearance="solid"]) button:focus {
-  background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-1));
-  .text-container {
-    @apply opacity-disabled;
-  }
-}
-
-:host([loading]) calcite-loader[inline] {
-  color: var(--calcite-color-text-3);
-  margin-inline-end: theme("spacing.0");
-}
-
-:host([disabled]),
-:host([disabled]),
-:host([disabled]) {
-  button {
-    &,
-    &:hover,
-    &:focus {
-      @apply opacity-disabled cursor-default;
-      background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-1));
-    }
-  }
-}
-
-:host([disabled][active]) button,
-:host([disabled][active]) button:hover,
-:host([disabled][active]) button:focus {
-  button {
-    &,
-    &:hover,
-    &:focus {
-      @apply opacity-disabled;
-      background-color: var(--calcite-action-background-color, var(--calcite-color-foreground-3));
-    }
-  }
-}
-
-:host([appearance="transparent"]) button {
-  @apply transition-shadow
-    duration-150
-    ease-in-out;
 }
 
 .indicator-text {
   @apply sr-only;
 }
 
+.slot-container {
+  @apply flex;
+
+  &.slot-container--hidden {
+    @apply hidden;
+  }
+}
+
 calcite-loader {
-  --calcite-loader-color-middle: var(--calcite-action-loader-color-one-third);
-  --calcite-loader-color-start: var(--calcite-action-loader-color-start);
-  --calcite-loader-color-end: var(--calcite-action-loader-color-two-thirds);
+  --calcite-loader-color-start: var(--calcite-action-loader-color, var(--calcite-color-text-3));
+  margin-inline-end: theme("spacing.0");
+}
+
+// States
+:host(:hover),
+:host(:focus) {
+  .button {
+    --calcite-internal-action-text-color: var(--calcite-color-text-1);
+    --calcite-internal-action-icon-color: var(--calcite-color-text-1);
+    --calcite-internal-action-indicator-color: var(--calcite-color-brand-hover);
+  }
+}
+:host(:focus) {
+  @apply focus-inset;
+}
+:host(:active),
+:host([active]),
+:host([data-active]) {
+  .button {
+    --calcite-internal-action-icon-color: ar(--calcite-color-text-1);
+    --calcite-internal-action-text-color: ar(--calcite-color-text-1);
+    --calcite-internal-action-indicator-color: var(--calcite-color-brand-press);
+    @apply focus-inset;
+  }
+}
+
+// Appearance
+:host([appearance="solid"]) {
+  &:host(:hover),
+  &:host(:focus) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-color-foreground-2);
+    }
+  }
+  &:host(:active),
+  &:host([active]),
+  &:host([data-active]) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
+    }
+  }
+
+  &:host([loading]) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-color-foreground-1);
+    }
+    .text-container {
+      @apply opacity-disabled;
+    }
+  }
+}
+:host([appearance="transparent"]) {
+  .button {
+    --calcite-internal-action-background-color: var(--calcite-color-transparent);
+    @apply transition-shadow
+      duration-150
+      ease-in-out;
+  }
+
+  &:host(:hover),
+  &:host(:focus) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-action-color-transparent-hover);
+    }
+  }
+  &:host(:active),
+  &:host([active]),
+  &:host([data-active]) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-action-color-transparent-press);
+    }
+  }
+}
+
+// Scale
+:host([scale="s"]) {
+  .button {
+    --calcite-internal-action-font-size: var(--calcite-font-size--2);
+    --calcite-internal-action-line-height: 1rem /* 16px */;
+    --calcite-internal-action-icon-container-space-x-end: theme("spacing.2");
+    --calcite-internal-action-space-x: 0.5rem /* 8px */;
+    --calcite-internal-action-space-y: 0.25rem /* 4px */;
+  }
+}
+:host([scale="m"]) {
+  .button {
+    --calcite-internal-action-font-size: var(--calcite-font-size--1);
+    --calcite-internal-action-line-height: 1rem /* 16px */;
+    --calcite-internal-action-icon-container-space-x-end: theme("spacing.3");
+    --calcite-internal-action-space-x: 1rem /* 8px */;
+    --calcite-internal-action-space-y: 0.75rem /* 12px */;
+  }
+}
+:host([scale="l"]) {
+  .button {
+    --calcite-internal-action-font-size: var(--calcite-font-size-0);
+    --calcite-internal-action-line-height: 1.25rem /* 20px */;
+    --calcite-internal-action-icon-container-space-x-end: theme("spacing.4");
+    --calcite-internal-action-space-x: 1.25rem /* 20px */;
+    --calcite-internal-action-space-y: 1.25rem /* 20px */;
+  }
+}
+// Compact
+:host([scale="s"][compact]),
+:host([scale="m"][compact]),
+:host([scale="l"][compact]) {
+  .button {
+    --calcite-internal-action-space-x: 0;
+  }
+}
+
+// Alignment
+:host([alignment="center"]) .button {
+  --calcite-internal-action-justify-content: center;
+}
+:host([alignment="end"]) .button {
+  --calcite-internal-action-justify-content: end;
+}
+:host([alignment="center"]),
+:host([alignment="end"]) {
+  .text-container--visible {
+    @apply flex-initial;
+  }
 }
 
 @include base-component();
+@include disabled() {
+  &:host([active]) {
+    .button {
+      --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
+    }
+  }
+  &:host([appearance="solid"]) .button {
+    --calcite-internal-action-background-color: var(--calcite-color-foreground-1);
+  }
+  &:host([appearance="transparent"]) .button {
+    --calcite-internal-action-background-color: var(--calcite-color-transparent);
+  }
+}

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -132,14 +132,14 @@ calcite-loader {
     --calcite-internal-action-icon-color: var(--calcite-color-text-1);
   }
 }
-:host(:focus) {
+:host(:focus),
+:host([data-active]) {
   .button {
     @apply focus-inset;
   }
 }
 :host(:active),
-:host([active]),
-:host([data-active]) {
+:host([active]) {
   .button {
     --calcite-internal-action-icon-color: var(--calcite-color-text-1);
     --calcite-internal-action-text-color: var(--calcite-color-text-1);
@@ -155,8 +155,7 @@ calcite-loader {
     }
   }
   &:host(:active),
-  &:host([active]),
-  &:host([data-active]) {
+  &:host([active]) {
     .button {
       --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
     }
@@ -186,8 +185,7 @@ calcite-loader {
     }
   }
   &:host(:active),
-  &:host([active]),
-  &:host([data-active]) {
+  &:host([active]) {
     .button {
       --calcite-internal-action-background-color: var(--calcite-action-color-transparent-press);
     }

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -125,10 +125,8 @@ calcite-loader {
 // States
 :host(:hover),
 :host(:focus) {
-  .button {
-    --calcite-internal-action-text-color: var(--calcite-color-text-1);
-    --calcite-internal-action-icon-color: var(--calcite-color-text-1);
-  }
+  --calcite-internal-action-text-color: var(--calcite-color-text-1);
+  --calcite-internal-action-icon-color: var(--calcite-color-text-1);
 }
 :host(:focus),
 :host([data-active]) {
@@ -138,39 +136,32 @@ calcite-loader {
 }
 :host(:active),
 :host([active]) {
-  .button {
-    --calcite-internal-action-icon-color: var(--calcite-color-text-1);
-    --calcite-internal-action-text-color: var(--calcite-color-text-1);
-  }
+  --calcite-internal-action-icon-color: var(--calcite-color-text-1);
+  --calcite-internal-action-text-color: var(--calcite-color-text-1);
 }
 
 // Appearance
 :host([appearance="solid"]) {
   &:host(:hover),
   &:host(:focus) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-color-foreground-2);
-    }
+    --calcite-internal-action-background-color: var(--calcite-color-foreground-2);
   }
   &:host(:active),
   &:host([active]) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
-    }
+    --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
   }
 
   &:host([loading]) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-color-foreground-1);
-    }
+    --calcite-internal-action-background-color: var(--calcite-color-foreground-1);
     .text-container {
       @apply opacity-disabled;
     }
   }
 }
 :host([appearance="transparent"]) {
+  --calcite-internal-action-background-color: var(--calcite-color-transparent);
+
   .button {
-    --calcite-internal-action-background-color: var(--calcite-color-transparent);
     @apply transition-shadow
       duration-150
       ease-in-out;
@@ -178,60 +169,48 @@ calcite-loader {
 
   &:host(:hover),
   &:host(:focus) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-action-color-transparent-hover);
-    }
+    --calcite-internal-action-background-color: var(--calcite-action-color-transparent-hover);
   }
   &:host(:active),
   &:host([active]) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-action-color-transparent-press);
-    }
+    --calcite-internal-action-background-color: var(--calcite-action-color-transparent-press);
   }
 }
 
 // Scale
 :host([scale="s"]) {
-  .button {
-    --calcite-internal-action-font-size: var(--calcite-font-size--2);
-    --calcite-internal-action-line-height: 1rem /* 16px */;
-    --calcite-internal-action-icon-container-space-x-end: theme("spacing.2");
-    --calcite-internal-action-space-x: 0.5rem /* 8px */;
-    --calcite-internal-action-space-y: 0.25rem /* 4px */;
-  }
+  --calcite-internal-action-font-size: var(--calcite-font-size--2);
+  --calcite-internal-action-line-height: 1rem /* 16px */;
+  --calcite-internal-action-icon-container-space-x-end: theme("spacing.2");
+  --calcite-internal-action-space-x: 0.5rem /* 8px */;
+  --calcite-internal-action-space-y: 0.25rem /* 4px */;
 }
 :host([scale="m"]) {
-  .button {
-    --calcite-internal-action-font-size: var(--calcite-font-size--1);
-    --calcite-internal-action-line-height: 1rem /* 16px */;
-    --calcite-internal-action-icon-container-space-x-end: theme("spacing.3");
-    --calcite-internal-action-space-x: 1rem /* 8px */;
-    --calcite-internal-action-space-y: 0.75rem /* 12px */;
-  }
+  --calcite-internal-action-font-size: var(--calcite-font-size--1);
+  --calcite-internal-action-line-height: 1rem /* 16px */;
+  --calcite-internal-action-icon-container-space-x-end: theme("spacing.3");
+  --calcite-internal-action-space-x: 1rem /* 8px */;
+  --calcite-internal-action-space-y: 0.75rem /* 12px */;
 }
 :host([scale="l"]) {
-  .button {
-    --calcite-internal-action-font-size: var(--calcite-font-size-0);
-    --calcite-internal-action-line-height: 1.25rem /* 20px */;
-    --calcite-internal-action-icon-container-space-x-end: theme("spacing.4");
-    --calcite-internal-action-space-x: 1.25rem /* 20px */;
-    --calcite-internal-action-space-y: 1.25rem /* 20px */;
-  }
+  --calcite-internal-action-font-size: var(--calcite-font-size-0);
+  --calcite-internal-action-line-height: 1.25rem /* 20px */;
+  --calcite-internal-action-icon-container-space-x-end: theme("spacing.4");
+  --calcite-internal-action-space-x: 1.25rem /* 20px */;
+  --calcite-internal-action-space-y: 1.25rem /* 20px */;
 }
 // Compact
 :host([scale="s"][compact]),
 :host([scale="m"][compact]),
 :host([scale="l"][compact]) {
-  .button {
-    --calcite-internal-action-space-x: 0;
-  }
+  --calcite-internal-action-space-x: 0;
 }
 
 // Alignment
-:host([alignment="center"]) .button {
+:host([alignment="center"]) {
   --calcite-internal-action-justify-content: center;
 }
-:host([alignment="end"]) .button {
+:host([alignment="end"]) {
   --calcite-internal-action-justify-content: end;
 }
 :host([alignment="center"]),
@@ -244,14 +223,12 @@ calcite-loader {
 @include base-component();
 @include disabled() {
   &:host([active]) {
-    .button {
-      --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
-    }
+    --calcite-internal-action-background-color: var(--calcite-color-foreground-3);
   }
-  &:host([appearance="solid"]) .button {
+  &:host([appearance="solid"]) {
     --calcite-internal-action-background-color: var(--calcite-color-foreground-1);
   }
-  &:host([appearance="transparent"]) .button {
+  &:host([appearance="transparent"]) {
     --calcite-internal-action-background-color: var(--calcite-color-transparent);
   }
 }

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -36,6 +36,7 @@
   );
   color: var(--calcite-action-text-color, var(--calcite-internal-action-text-color, var(--calcite-color-text-3)));
   flex: 1 0 auto;
+  font-family: var(--calcite-font-family);
   font-size: var(--calcite-internal-action-font-size, var(--calcite-font-size--2));
   justify-content: var(--calcite-internal-action-justify-content, start);
   line-height: var(--calcite-internal-action-line-height, 1rem /* 16px */);
@@ -136,16 +137,17 @@ calcite-loader {
   }
 }
 :host(:focus) {
-  @apply focus-inset;
+  .button {
+    @apply focus-inset;
+  }
 }
 :host(:active),
 :host([active]),
 :host([data-active]) {
   .button {
-    --calcite-internal-action-icon-color: ar(--calcite-color-text-1);
-    --calcite-internal-action-text-color: ar(--calcite-color-text-1);
+    --calcite-internal-action-icon-color: var(--calcite-color-text-1);
+    --calcite-internal-action-text-color: var(--calcite-color-text-1);
     --calcite-internal-action-indicator-color: var(--calcite-color-brand-press);
-    @apply focus-inset;
   }
 }
 

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -12,13 +12,11 @@
  */
 
 :host {
+  @include base-host();
+
   box-sizing: border-box;
   display: flex;
   background-color: var(--calcite-color-transparent);
-
-  * {
-    box-sizing: border-box;
-  }
 }
 
 .button {

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -92,10 +92,7 @@
     @apply rounded-full;
     inset-block-end: -0.275rem;
     inset-inline-end: -0.275rem;
-    background-color: var(
-      --calcite-action-indicator-color,
-      var(--calcite-internal-action-indicator-color, var(--calcite-color-brand))
-    );
+    background-color: var(--calcite-action-indicator-color, var(--calcite-color-brand));
   }
 }
 
@@ -133,7 +130,6 @@ calcite-loader {
   .button {
     --calcite-internal-action-text-color: var(--calcite-color-text-1);
     --calcite-internal-action-icon-color: var(--calcite-color-text-1);
-    --calcite-internal-action-indicator-color: var(--calcite-color-brand-hover);
   }
 }
 :host(:focus) {
@@ -147,7 +143,6 @@ calcite-loader {
   .button {
     --calcite-internal-action-icon-color: var(--calcite-color-text-1);
     --calcite-internal-action-text-color: var(--calcite-color-text-1);
-    --calcite-internal-action-indicator-color: var(--calcite-color-brand-press);
   }
 }
 

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -256,7 +256,7 @@ export class Action
     ) : null;
     const calciteIconNode = icon ? (
       <calcite-icon
-        class={{ [CSS.indicatorWithIcon]: indicator }}
+        class={{ [CSS.actionIndicator]: indicator, [CSS.icon]: true }}
         flipRtl={iconFlipRtl}
         icon={icon}
         scale={getIconScale(this.scale)}
@@ -324,7 +324,12 @@ export class Action
           >
             {this.renderIconContainer()}
             {this.renderTextContainer()}
-            {!icon && indicator && <div class={CSS.indicatorWithoutIcon} key="indicator-no-icon" />}
+            {!icon && indicator && (
+              <div
+                class={{ [CSS.indicatorWithoutIcon]: true, [CSS.actionIndicator]: true }}
+                key="indicator-no-icon"
+              />
+            )}
           </button>
           <slot name={SLOTS.tooltip} onSlotchange={this.handleTooltipSlotChange} />
           {this.renderIndicatorText()}

--- a/packages/calcite-components/src/components/action/resources.ts
+++ b/packages/calcite-components/src/components/action/resources.ts
@@ -5,7 +5,7 @@ export const CSS = {
   buttonTextVisible: "button--text-visible",
   iconContainer: "icon-container",
   indicatorText: "indicator-text",
-  indicatorWithIcon: "indicator-with-icon",
+  icon: "icon",
   indicatorWithoutIcon: "indicator-without-icon",
   slotContainer: "slot-container",
   slotContainerHidden: "slot-container--hidden",

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -3,20 +3,20 @@
 *
 * These properties can be overridden using the component's tag as selector.
 *
-* @prop --calcite-popover-action-background-color: defines the background color of an action sub-component inside the component.
-* @prop --calcite-popover-action-text-color: defines the text color of an action sub-component inside the component.
-* @prop --calcite-popover-action-background-color-hover: defines the background color of an action sub-component when hovered or focused inside the component.
-* @prop --calcite-popover-action-text-color-hover: defines the text color of an action sub-component when hovered or focused inside the component.
-* @prop --calcite-popover-action-background-color-active: defines the background color of an action sub-component when active inside the component.
-* @prop --calcite-popover-action-text-color-active: defines the text color of an action sub-component when active inside the component.
-* @prop --calcite-popover-background-color: defines the background color of the component.
-* @prop --calcite-popover-border-color: defines the border color of the component.
-* @prop --calcite-popover-corner-radius: defines the corner radius of the component.
-* @prop --calcite-popover-shadow: defines the shadow of the component.
-* @prop --calcite-popover-text-color: defines the text color of the component.
-* @prop --calcite-popover-close-icon-color: defines the component's close icon color.
-* @prop --calcite-popover-close-icon-color-hover: defines the component's close icon color on hover.
-* @prop --calcite-popover-close-icon-color-active: defines the component's close icon color when active.
+* @prop --calcite-popover-background-color: Specifies the background color of the component.
+* @prop --calcite-popover-border-color: Specifies the border color of the component.
+* @prop --calcite-popover-close-background-color-active: Specifies the background color of an action sub-component when active inside the component.
+* @prop --calcite-popover-close-background-color-hover: Specifies the background color of an action sub-component when hovered or focused inside the component.
+* @prop --calcite-popover-close-background-color: Specifies the background color of an action sub-component inside the component.
+* @prop --calcite-popover-close-icon-color-active: Specifies the component's close icon color when active.
+* @prop --calcite-popover-close-icon-color-hover: Specifies the component's close icon color on hover.
+* @prop --calcite-popover-close-icon-color: Specifies the component's close icon color.
+* @prop --calcite-popover-close-text-color-active: Specifies the text color of an action sub-component when active inside the component.
+* @prop --calcite-popover-close-text-color-hover: Specifies the text color of an action sub-component when hovered or focused inside the component.
+* @prop --calcite-popover-close-text-color: Specifies the text color of an action sub-component inside the component.
+* @prop --calcite-popover-corner-radius: Specifies the corner radius of the component.
+* @prop --calcite-popover-shadow: Specifies the shadow of the component.
+* @prop --calcite-popover-text-color: Specifies the text color of the component.
 *
 */
 
@@ -136,18 +136,18 @@
 }
 
 calcite-action {
-  --calcite-action-background-color: var(--calcite-popover-action-background-color);
-  --calcite-action-text-color: var(--calcite-popover-action-text-color);
+  --calcite-action-background-color: var(--calcite-popover-close-background-color);
+  --calcite-action-text-color: var(--calcite-popover-close-text-color);
 
   &:hover,
   &:focus {
-    --calcite-action-background-color: var(--calcite-popover-action-background-color-hover);
-    --calcite-action-text-color: var(--calcite-popover-action-text-color-hover);
+    --calcite-action-background-color: var(--calcite-popover-close-background-color-hover);
+    --calcite-action-text-color: var(--calcite-popover-close-text-color-hover);
   }
 
   &:active {
-    --calcite-action-background-color: var(--calcite-popover-action-background-color-active);
-    --calcite-action-text-color: var(--calcite-popover-action-text-color-active);
+    --calcite-action-background-color: var(--calcite-popover-close-background-color-active);
+    --calcite-action-text-color: var(--calcite-popover-close-text-color-active);
   }
 }
 


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

### Action

--calcite-action-shadow: Specifies the shadow of the component.
--calcite-action-icon-color: Specifies the color of the component's icon.
--calcite-action-indicator-color: Specifies the color of the component's indicator.
--calcite-action-loader-color: Specifies the color of the component's loader.

### Action Pad

--calcite-action-pad-background-color: Specifies the background color of the component.
--calcite-action-pad-border-color: Specifies the border color of the component.
--calcite-action-pad-corner-radius: Specifies the corner radius of the component.
--calcite-action-pad-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
--calcite-action-pad-popover-background-color: Specifies the background color of the popover in the component.
--calcite-action-pad-popover-border-color: Specifies the border color of the popover in the component.
--calcite-action-pad-popover-corner-radius: Specifies the corner radius of the popover in the component.
--calcite-action-pad-popover-shadow: Specifies the shadow of the popover in the component.
--calcite-action-pad-shadow: Specifies the shadow of the component.
--calcite-action-pad-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
--calcite-action-pad-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
--calcite-action-pad-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
--calcite-action-pad-trigger-background-color: Specifies the background color of the nested trigger in the component.
--calcite-action-pad-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
--calcite-action-pad-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
--calcite-action-pad-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
--calcite-action-pad-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
--calcite-action-pad-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
--calcite-action-pad-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
--calcite-action-pad-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
--calcite-action-pad-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
--calcite-action-pad-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
--calcite-action-pad-trigger-shadow: Specifies the shadow of the nested trigger in the component.
--calcite-action-pad-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
--calcite-action-pad-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
--calcite-action-pad-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
--calcite-action-pad-trigger-text-color: Specifies the text color of the nested trigger in the component.

### Action Bar

--calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the expanded max width of the component.
--calcite-action-bar-border-color: Specifies the border color of the component.
--calcite-action-bar-popover-background-color: Specifies the background color of the popover in the component.
--calcite-action-bar-popover-border-color: Specifies the border color of the popover in the component.
--calcite-action-bar-popover-corner-radius: Specifies the corner radius of the popover in the component.
--calcite-action-bar-popover-shadow: Specifies the shadow of the popover in the component.
--calcite-action-bar-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
--calcite-action-bar-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
--calcite-action-bar-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
--calcite-action-bar-trigger-background-color: Specifies the background color of the nested trigger in the component.
--calcite-action-bar-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
--calcite-action-bar-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
--calcite-action-bar-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
--calcite-action-bar-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
--calcite-action-bar-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
--calcite-action-bar-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
--calcite-action-bar-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
--calcite-action-bar-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
--calcite-action-bar-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
--calcite-action-bar-trigger-shadow: Specifies the shadow of the nested trigger in the component.
--calcite-action-bar-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
--calcite-action-bar-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
--calcite-action-bar-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
--calcite-action-bar-trigger-text-color: Specifies the text color of the nested trigger in the component.

### Action Group

 --calcite-action-group-border-color: Specifies the border color of the component.
 --calcite-action-group-columns: [Deprecated] Sets number of grid-template-columns when the `layout` property is `"grid"`.
 --calcite-action-group-gap: [Deprecated] Sets the gap (gutters) between rows and columns when the `layout` property is `"grid"`.
 --calcite-action-group-padding: [Deprecated] Sets the padding when the `layout` property is `"grid"`.
 --calcite-action-group-popover-background-color: Specifies the background color of the popover in the component.
 --calcite-action-group-popover-border-color: Specifies the border color of the popover in the component.
 --calcite-action-group-popover-corner-radius: Specifies the corner radius of the popover in the component.
 --calcite-action-group-popover-shadow: Specifies the shadow of the popover in the component.
 --calcite-action-group-trigger-background-color-active: Specifies the background color of the nested trigger when active in the component.
 --calcite-action-group-trigger-background-color-focus: Specifies the background color of the nested trigger when focused in the component.
 --calcite-action-group-trigger-background-color-hover: Specifies the background color of the nested trigger when hovered in the component.
 --calcite-action-group-trigger-background-color: Specifies the background color of the nested trigger in the component.
 --calcite-action-group-trigger-icon-color-active: Specifies the icon color color of the nested trigger when active in the component
 --calcite-action-group-trigger-icon-color-focus: Specifies the icon color of the nested trigger when focused in the component.
 --calcite-action-group-trigger-icon-color-hover: Specifies the icon color of the nested trigger when hovered in the component.
 --calcite-action-group-trigger-icon-color: Specifies the icon color of the nested trigger in the component.
 --calcite-action-group-trigger-indicator-color: Specifies the indicator color of the nested trigger in the component.
 --calcite-action-group-trigger-loader-color: Specifies the loader color of the nested trigger in the component component.
 --calcite-action-group-trigger-shadow-active: Specifies the shadow of the nested trigger when active in the component.
 --calcite-action-group-trigger-shadow-focus: Specifies the shadow of the nested trigger when focused in the component.
 --calcite-action-group-trigger-shadow-hover: Specifies the shadow of the nested trigger when hovered in the component.
 --calcite-action-group-trigger-shadow: Specifies the shadow of the nested trigger in the component.
 --calcite-action-group-trigger-text-color-active: Specifies the text color of the nested trigger when active in the component.
 --calcite-action-group-trigger-text-color-focus: Specifies the text color of the nested trigger when focused in the component.
 --calcite-action-group-trigger-text-color-hover: Specifies the text color of the nested trigger when hovered in the component.
 --calcite-action-group-trigger-text-color: Specifies the text color of the nested trigger in the component.

### Action Menu

--calcite-action-menu-close-background-color-active: Specifies the background color of an action sub-component when active inside the component.
--calcite-action-menu-close-background-color-hover: Specifies the background color of an action sub-component when hovered or focused inside the component.
--calcite-action-menu-close-background-color: Specifies the background color of an action sub-component inside the component.
--calcite-action-menu-close-icon-color-active: Specifies the component's close icon color when active.
--calcite-action-menu-close-icon-color-hover: Specifies the component's close icon color on hover.
--calcite-action-menu-close-icon-color: Specifies the component's close icon color.
--calcite-action-menu-close-text-color-active: Specifies the text color of an action sub-component when active inside the component.
--calcite-action-menu-close-text-color-hover: Specifies the text color of an action sub-component when hovered or focused inside the component.
--calcite-action-menu-close-text-color: Specifies the text color of an action sub-component inside the component.
--calcite-action-menu-popover-background-color: Specifies the background color of the component.
--calcite-action-menu-popover-border-color: Specifies the border color of the component.
--calcite-action-menu-popover-corner-radius: Specifies the corner radius of the component.
--calcite-action-menu-popover-shadow: Specifies the shadow of the component.
--calcite-action-menu-popover-text-color: Specifies the text color of the component.
--calcite-action-menu-trigger-background-color-active: Specifies the background color of the component's default trigger when active.
--calcite-action-menu-trigger-background-color-focus: Specifies the background color of the component's default trigger when focused.
--calcite-action-menu-trigger-background-color-hover: Specifies the background color of the component's default trigger when hovered.
--calcite-action-menu-trigger-background-color: Specifies the background color of the component.
--calcite-action-menu-trigger-icon-color-active: Specifies the background color of the component's default trigger when active.
--calcite-action-menu-trigger-icon-color-focus: Specifies the background color of the component's default trigger when focused.
--calcite-action-menu-trigger-icon-color-hover: Specifies the background color of the component's default trigger when hovered.
--calcite-action-menu-trigger-icon-color: Specifies the color of the component's icon.
--calcite-action-menu-trigger-indicator-color: Specifies the color of the component's indicator.
--calcite-action-menu-trigger-loader-color: Specifies the color of the component's loader.
--calcite-action-menu-trigger-shadow: Specifies the shadow of the component.
--calcite-action-menu-trigger-text-color-active: Specifies the background color of the component's default trigger when active.
--calcite-action-menu-trigger-text-color-focus: Specifies the background color of the component's default trigger when focused.
--calcite-action-menu-trigger-text-color-hover: Specifies the background color of the component's default trigger when hovered.
--calcite-action-menu-trigger-text-color: Specifies the text color of the component.

### Popover

--calcite-popover-background-color: Specifies the background color of the component.
--calcite-popover-border-color: Specifies the border color of the component.
--calcite-popover-close-background-color-active: Specifies the background color of an action sub-component when active inside the component.
--calcite-popover-close-background-color-hover: Specifies the background color of an action sub-component when hovered or focused inside the component.
--calcite-popover-close-background-color: Specifies the background color of an action sub-component inside the component.
--calcite-popover-close-icon-color-active: Specifies the component's close icon color when active.
--calcite-popover-close-icon-color-hover: Specifies the component's close icon color on hover.
--calcite-popover-close-icon-color: Specifies the component's close icon color.
--calcite-popover-close-text-color-active: Specifies the text color of an action sub-component when active inside the component.
--calcite-popover-close-text-color-hover: Specifies the text color of an action sub-component when hovered or focused inside the component.
--calcite-popover-close-text-color: Specifies the text color of an action sub-component inside the component.
--calcite-popover-corner-radius: Specifies the corner radius of the component.
--calcite-popover-shadow: Specifies the shadow of the component.
--calcite-popover-text-color: Specifies the text color of the component.