### PR TITLE
refactor(color-picker, color-picker-hex-input): update component tokens

### DIFF
--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.scss
@@ -3,22 +3,14 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-filter-input-prefix-background-color: defines the background color of the prefix in the input sub-component.
- * @prop --calcite-filter-input-prefix-text-color: defines the text color of the prefix in the input sub-component.
- * @prop --calcite-filter-input-suffix-background-color: defines the background color of the suffix in the input sub-component.
- * @prop --calcite-filter-input-suffix-text-color: defines the text color of the suffix in the input sub-component.
- * @prop --calcite-hex-input-background-color: defines the background color of the input sub-component.
- * @prop --calcite-hex-input-border-color: defines the border color of the input sub-component.
- * @prop --calcite-hex-input-button-background-color: defines the background color of the button in the input sub-component.
- * @prop --calcite-hex-input-button-background-color-hover: defines the background color of the button when hovered in the input sub-component.
- * @prop --calcite-hex-input-button-border-color: defines the border color of the button in the input sub-component.
- * @prop --calcite-hex-input-button-icon-color: defines the icon color of the button in the input sub-component.
- * @prop --calcite-hex-input-button-icon-color-active: defines the icon color of the button when active in the input sub-component.
- * @prop --calcite-hex-input-button-icon-color-hover: defines the icon color of the button when hovered in the input sub-component.
- * @prop --calcite-hex-input-corner-radius: defines the corner radius of the input sub-component.
- * @prop --calcite-hex-input-icon-color: defines the icon color of the input sub-component.
- * @prop --calcite-hex-input-text-color: defines the text color of the input sub-component.
- *
+ * @prop --calcite-color-picker-hex-input-background-color: defines the background color of the input sub-component.
+ * @prop --calcite-color-picker-hex-input-border-color: defines the border color of the input sub-component.
+ * @prop --calcite-color-picker-hex-input-corner-radius: defines the corner radius of the input sub-component.
+ * @prop --calcite-color-picker-hex-input-prefix-background-color: defines the background color of the prefix sub-component.
+ * @prop --calcite-color-picker-hex-input-prefix-text-color: defines the text color of the prefix sub-component.
+ * @prop --calcite-color-picker-hex-input-suffix-background-color: defines the background color of the suffix sub-component.
+ * @prop --calcite-color-picker-hex-input-suffix-text-color: defines the text color of the suffix sub-component.
+ * @prop --calcite-color-picker-hex-input-text-color: defines the text color of the input sub-component.
 */
 
 :host {
@@ -55,21 +47,16 @@
   }
 }
 
-calcite-input {
-  --calcite-input-suffix-background-color: var(--calcite-hex-input-suffix-background-color);
-  --calcite-input-suffix-text-color: var(--calcite-hex-input-suffix-text-color);
-  --calcite-input-prefix-background-color: var(--calcite-hex-input-prefix-background-color);
-  --calcite-input-prefix-text-color: var(--calcite-hex-input-prefix-text-color);
-  --calcite-input-text-color: var(--calcite-hex-input-text-color);
-  --calcite-input-background-color: var(--calcite-hex-input-background-color);
-  --calcite-input-border-color: var(--calcite-hex-input-border-color);
-  --calcite-input-corner-radius: var(--calcite-hex-input-corner-radius);
-  --calcite-input-button-border-color: var(--calcite-hex-input-button-border-color);
-  --calcite-input-button-background-color: var(--calcite-hex-input-button-background-color);
-  --calcite-input-button-background-color-hover: var(--calcite-hex-input-button-background-color-hover);
-  --calcite-input-button-icon-color: var(--calcite-hex-input-button-icon-color);
-  --calcite-input-button-icon-color-hover: var(--calcite-hex-input-button-icon-color-hover);
-  --calcite-input-button-icon-color-active: var(--calcite-hex-input-button-icon-color-active);
+calcite-input-text,
+calcite-input-number {
+  --calcite-input-suffix-background-color: var(--calcite-color-picker-hex-input-suffix-background-color);
+  --calcite-input-suffix-text-color: var(--calcite-color-picker-hex-input-suffix-text-color);
+  --calcite-input-prefix-background-color: var(--calcite-color-picker-hex-input-prefix-background-color);
+  --calcite-input-prefix-text-color: var(--calcite-color-picker-hex-input-prefix-text-color);
+  --calcite-input-text-color: var(--calcite-color-picker-hex-input-text-color);
+  --calcite-input-background-color: var(--calcite-color-picker-hex-input-background-color);
+  --calcite-input-border-color: var(--calcite-color-picker-hex-input-border-color);
+  --calcite-input-corner-radius: var(--calcite-color-picker-hex-input-corner-radius);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -20,6 +20,9 @@
  * @prop --calcite-color-picker-input-border-color: defines the border color of the input in the component.
  * @prop --calcite-color-picker-input-corner-radius: defines the corner radius of the input in the component.
  * @prop --calcite-color-picker-input-prefix-background-color: defines the background color of the prefix sub-component.
+ * @prop --calcite-color-picker-input-prefix-text-color: defines the text color of the prefix sub-component.
+ * @prop --calcite-color-picker-input-suffix-background-color: defines the background color of the suffix sub-component.
+ * @prop --calcite-color-picker-input-suffix-text-color: defines the text color of the suffix sub-component.
  * @prop --calcite-color-picker-input-text-color: defines the text color of the input in the component.
  * @prop --calcite-color-picker-tab-nav-indicator-color: Specifies the color of the active tab indicator.
  * @prop --calcite-color-picker-tab-title-background-color: Specifies the background color of the sub-component.
@@ -251,11 +254,23 @@ calcite-button {
   }
 }
 
+calcite-color-picker-hex-input {
+  --calcite-color-picker-hex-input-prefix-background-color: var(--calcite-color-picker-input-prefix-background-color);
+  --calcite-color-picker-hex-input-prefix-text-color: var(--calcite-color-picker-input-prefix-text-color);
+  --calcite-color-picker-hex-input-suffix-background-color: var(--calcite-color-picker-input-suffix-background-color);
+  --calcite-color-picker-hex-input-suffix-text-color: var(--calcite-color-picker-input-suffix-text-color);
+  --calcite-color-picker-hex-input-background-color: var(--calcite-color-picker-input-background-color);
+  --calcite-color-picker-hex-input-border-color: var(--calcite-color-picker-input-border-color);
+  --calcite-color-picker-hex-input-corner-radius: var(--calcite-color-picker-input-corner-radius);
+  --calcite-color-picker-hex-input-text-color: var(--calcite-color-picker-input-text-color);
+}
+
 calcite-input-number {
   --calcite-input-background-color: var(--calcite-color-picker-input-background-color);
   --calcite-input-border-color: var(--calcite-color-picker-input-border-color);
   --calcite-input-text-color: var(--calcite-color-picker-input-text-color);
-  --calcite-input-prefix-background-color: var(--calcite-color-picker-input-prefix-background-color);
+  --calcite-input-suffix-background-color: var(--calcite-color-picker-input-suffix-background-color);
+  --calcite-input-suffix-text-color: var(--calcite-color-picker-input-suffix-background-color);
   --calcite-input-corner-radius: var(--calcite-color-picker-input-corner-radius);
 }
 


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following component tokens (CSS props):

* `--calcite-color-picker-input-prefix-text-color`
* `--calcite-color-picker-input-suffix-background-color`
* `--calcite-color-picker-input-suffix-text-color`
* `--calcite-color-picker-hex-input-background-color`
* `--calcite-color-picker-hex-input-border-color`
* `--calcite-color-picker-hex-input-corner-radius`
* `--calcite-color-picker-hex-input-prefix-background-color`
* `--calcite-color-picker-hex-input-prefix-text-color`
* `--calcite-color-picker-hex-input-suffix-background-color`
* `--calcite-color-picker-hex-input-suffix-text-color`
* `--calcite-color-picker-hex-input-text-color`

Removes the following (either unused or name does not match component):

* `--calcite-filter-input-prefix-background-color`
* `--calcite-filter-input-prefix-text-color`
* `--calcite-filter-input-suffix-background-color`
* `--calcite-filter-input-suffix-text-color`
* `--calcite-hex-input-background-color`
* `--calcite-hex-input-border-color`
* `--calcite-hex-input-button-background-color`
* `--calcite-hex-input-button-background-color-hover`
* `--calcite-hex-input-button-border-color`
* `--calcite-hex-input-button-icon-color`
* `--calcite-hex-input-button-icon-color-active`
* `--calcite-hex-input-button-icon-color-hover`
* `--calcite-hex-input-corner-radius`
* `--calcite-hex-input-icon-color`
* `--calcite-hex-input-text-color`