### PR TITLE
fix(combobox): prevent spacebar from opening the menu when focused on chip's close button

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1959,7 +1959,7 @@ describe("calcite-combobox", () => {
 
     const wrapper = await page.find("calcite-combobox >>> .wrapper");
     const close = await wrapper.find("calcite-chip >>> .close");
-    await close.click();
+    await close.press(" ");
     await page.waitForChanges();
 
     const remainingChips = await page.findAll("calcite-combobox >>> calcite-chip");

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -681,18 +681,13 @@ export class Combobox
         }
         break;
       case " ":
-        if (!this.textInput.value) {
+        if (!this.textInput.value && !event.defaultPrevented) {
           if (!this.open) {
-            if (event.composedPath().find((el: HTMLElement) => el.tagName === "CALCITE-CHIP")) {
-              event.preventDefault();
-            } else {
-              this.open = true;
-              this.shiftActiveItemIndex(1);
-            }
+            this.open = true;
+            this.shiftActiveItemIndex(1);
           }
           event.preventDefault();
         }
-
         break;
       case "Home":
         if (!this.open) {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -683,15 +683,16 @@ export class Combobox
       case " ":
         if (!this.textInput.value) {
           if (!this.open) {
-            this.open = true;
-            this.shiftActiveItemIndex(1);
+            if (event.composedPath().find((el: HTMLElement) => el.tagName === "CALCITE-CHIP")) {
+              event.preventDefault();
+            } else {
+              this.open = true;
+              this.shiftActiveItemIndex(1);
+            }
           }
           event.preventDefault();
         }
 
-        if (event.composedPath().find((el: HTMLElement) => el.tagName === "CALCITE-CHIP")) {
-          event.preventDefault();
-        }
         break;
       case "Home":
         if (!this.open) {


### PR DESCRIPTION
**Related Issue:** #6777

## Summary

Prevent spacebar from opening the menu when focused on chip's `close` button.

Fixes a regression introduced in https://github.com/Esri/calcite-design-system/pull/8909.