### PR TITLE
test(action-menu): skip unstable tests

### DIFF
--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -454,7 +454,7 @@ describe("calcite-action-menu", () => {
       expect(await actionMenu.getProperty("open")).toBe(false);
     });
 
-    it("should click the active action on Enter key and close the menu", async () => {
+    it.skip("should click the active action on Enter key and close the menu", async () => {
       const page = await newE2EPage({
         html: html`<calcite-action-menu>
           <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -490,7 +490,7 @@ describe("calcite-action-menu", () => {
       expect(clickSpy).toHaveReceivedEventTimes(1);
     });
 
-    it("should click the active action when clicked and close the menu", async () => {
+    it.skip("should click the active action when clicked and close the menu", async () => {
       const page = await newE2EPage({
         html: html`<calcite-action-menu>
           <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>


### PR DESCRIPTION
**Related Issue:** #9000

## Summary

```
 Summary of all failing tests
@esri/calcite-components:test: FAIL src/components/action-menu/action-menu.e2e.ts (19.748 s)
@esri/calcite-components:test:   ● calcite-action-menu › Keyboard navigation › should click the active action when clicked and close the menu
@esri/calcite-components:test: 
@esri/calcite-components:test:     expect(received).toBe(expected) // Object.is equality
@esri/calcite-components:test: 
@esri/calcite-components:test:     Expected: false
@esri/calcite-components:test:     Received: true
@esri/calcite-components:test: 
@esri/calcite-components:test:       523 |       await page.$eval("calcite-action", (el: HTMLCalciteActionElement) => el.click());
@esri/calcite-components:test:       524 |
@esri/calcite-components:test:     > 525 |       expect(await actionMenu.getProperty("open")).toBe(false);
@esri/calcite-components:test:           |                                                    ^
@esri/calcite-components:test:       526 |       expect(clickSpy).toHaveReceivedEventTimes(1);
@esri/calcite-components:test:       527 |     });
@esri/calcite-components:test:       528 |   });
@esri/calcite-components:test: 
@esri/calcite-components:test:       at Object.<anonymous> (src/components/action-menu/action-menu.e2e.ts:525:52)
```

```
@esri/calcite-components:test: FAIL src/components/action-menu/action-menu.e2e.ts (18.704 s)
@esri/calcite-components:test:   ● calcite-action-menu › Keyboard navigation › should click the active action on Enter key and close the menu
@esri/calcite-components:test: 
@esri/calcite-components:test:     expect(received).toBe(expected) // Object.is equality
@esri/calcite-components:test: 
@esri/calcite-components:test:     Expected: false
@esri/calcite-components:test:     Received: true
@esri/calcite-components:test: 
@esri/calcite-components:test:       487 |       await page.waitForChanges();
@esri/calcite-components:test:       488 |
@esri/calcite-components:test:     > 489 |       expect(await actionMenu.getProperty("open")).toBe(false);
@esri/calcite-components:test:           |                                                    ^
@esri/calcite-components:test:       490 |       expect(clickSpy).toHaveReceivedEventTimes(1);
@esri/calcite-components:test:       491 |     });
@esri/calcite-components:test:       492 |
@esri/calcite-components:test: 
@esri/calcite-components:test:       at Object.<anonymous> (src/components/action-menu/action-menu.e2e.ts:489:52)
```