### PR TITLE
build(components.d.ts): update types for release

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -5007,10 +5007,6 @@ export namespace Components {
          */
         "wrap": "soft" | "hard";
     }
-    /**
-     * @deprecated use `content-top` slot instead
-     * @deprecated use `content-bottom` slot instead
-     */
     interface CalciteTile {
         /**
           * When `true`, the component is active.
@@ -7243,10 +7239,6 @@ declare global {
         prototype: HTMLCalciteTextAreaElement;
         new (): HTMLCalciteTextAreaElement;
     };
-    /**
-     * @deprecated use `content-top` slot instead
-     * @deprecated use `content-bottom` slot instead
-     */
     interface HTMLCalciteTileElement extends Components.CalciteTile, HTMLStencilElement {
     }
     var HTMLCalciteTileElement: {
@@ -12628,10 +12620,6 @@ declare namespace LocalJSX {
          */
         "wrap"?: "soft" | "hard";
     }
-    /**
-     * @deprecated use `content-top` slot instead
-     * @deprecated use `content-bottom` slot instead
-     */
     interface CalciteTile {
         /**
           * When `true`, the component is active.
@@ -13321,10 +13309,6 @@ declare module "@stencil/core" {
             "calcite-table-row": LocalJSX.CalciteTableRow & JSXBase.HTMLAttributes<HTMLCalciteTableRowElement>;
             "calcite-tabs": LocalJSX.CalciteTabs & JSXBase.HTMLAttributes<HTMLCalciteTabsElement>;
             "calcite-text-area": LocalJSX.CalciteTextArea & JSXBase.HTMLAttributes<HTMLCalciteTextAreaElement>;
-            /**
-             * @deprecated use `content-top` slot instead
-             * @deprecated use `content-bottom` slot instead
-             */
             "calcite-tile": LocalJSX.CalciteTile & JSXBase.HTMLAttributes<HTMLCalciteTileElement>;
             "calcite-tile-group": LocalJSX.CalciteTileGroup & JSXBase.HTMLAttributes<HTMLCalciteTileGroupElement>;
             "calcite-tile-select": LocalJSX.CalciteTileSelect & JSXBase.HTMLAttributes<HTMLCalciteTileSelectElement>;


### PR DESCRIPTION
## Summary

The [release failed](https://github.com/Esri/calcite-design-system/actions/runs/8445236842/job/23132122216) due to the `components.d.ts` file being outdated, with the following error:

```sh
lerna notice cli v7.4.2
lerna info versioning independent
lerna info ci enabled
lerna ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna ERR! EUNCOMMIT  M packages/calcite-components/src/components.d.ts
Error: Process completed with exit code 1.
```

I will add an actual fix to the CI in a subsequent PR.
