### PR TITLE
ci: prevent outdated types from blocking release

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -36,6 +36,13 @@ jobs:
         run: |
           npm install
           npm run build
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          # the "|| true" prevents failure if there are no changes
+          git add packages/calcite-components/src/components.d.ts || true
+          git commit -m "build: update types" || true
+
           npm run publish:latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -37,6 +37,8 @@ jobs:
           npm install
           npm run build
 
+          # These git commands can be removed once we stop tracking components.d.ts
+          # For more info, see: https://github.com/Esri/calcite-design-system/pull/9011
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           # the "|| true" prevents failure if there are no changes


### PR DESCRIPTION
**Related Issue:** #9008

## Summary

Commit changes to `components.d.ts` after building for release to
prevent lerna/npm publishing errors due to an unclean working tree. The
commit will be discarded once the workflow run's container is destroyed.

### Background

The `components.d.ts` file is tracked as a temporary workaround for
https://github.com/ionic-team/stencil/issues/3239

To keep the types updated, `components.d.ts` is added to the index in a
pre-commit hook.

https://github.com/Esri/calcite-design-system/blob/2bb1ee24bb317c95e2bef8165c75583fe98ad714/.husky/pre-commit#L7-L13

However, the file can still be outdated if people make changes and don't
rebuild before creating another commit. This is mostly an issue with
small doc updates, like the PR linked above. If that happens, the
release will fail due to an unclean working tree.
