### PR TITLE
revert: ci(renovate): remove rate limiting on esri and stencil deps (#8693)

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:base",
     "npm:unpublishSafe",
-    "schedule:daily",
     "workarounds:typesNodeVersioning",
     ":pinAllExceptPeerDependencies",
     ":widenPeerDependencies"
@@ -11,6 +10,7 @@
   "platformCommit": true,
   "enabledManagers": ["npm"],
   "timezone": "America/Los_Angeles",
+  "schedule": ["before 5am on every weekday"],
   "labels": ["dependencies"],
   "ignoreDeps": [
     "@types/jest",
@@ -35,11 +35,6 @@
       "semanticCommitType": "build",
       "semanticCommitScope": "deps",
       "addLabels": ["chore"]
-    },
-    {
-      "matchPackagePatterns": ["^@(esri|stencil)/*"],
-      "schedule": ["8am", "12pm", "4pm"],
-      "extends": [":disableRateLimiting"]
     }
   ]
 }


### PR DESCRIPTION
This reverts commit d01461d3896bd9791783341999207fb2fa0244e4.

**Related Issue:** #8693

## Summary

The reverted commit appears to have broken dependency updates for stencil and esri packages. I'll do some additional testing in a separate repo to find a working solution for prioritizing specific packages.
