### PR TITLE
fix(list, list-item): support keyboard sorting in screen readers

### DIFF
--- a/packages/calcite-components/src/components/handle/handle.e2e.ts
+++ b/packages/calcite-components/src/components/handle/handle.e2e.ts
@@ -126,13 +126,21 @@ describe("calcite-handle", () => {
     t9n("calcite-handle");
   });
 
-  it("sets application role on handle", async () => {
+  it("sets radio role properly", async () => {
     const page = await newE2EPage();
     const label = "Hello World";
     await page.setContent(`<calcite-handle lang="en" label="${label}"></calcite-handle>`);
     await page.waitForChanges();
 
     const handle = await page.find("calcite-handle");
-    expect(handle.getAttribute("role")).toBe("application");
+
+    const internalHandle = await page.find(`calcite-handle >>> .${CSS.handle}`);
+    expect(internalHandle.getAttribute("role")).toBe("radio");
+    expect(internalHandle.getAttribute("aria-checked")).toBe("false");
+
+    handle.setProperty("selected", true);
+
+    await page.waitForChanges();
+    expect(internalHandle.getAttribute("aria-checked")).toBe("true");
   });
 });

--- a/packages/calcite-components/src/components/handle/handle.e2e.ts
+++ b/packages/calcite-components/src/components/handle/handle.e2e.ts
@@ -125,4 +125,14 @@ describe("calcite-handle", () => {
   describe("translation support", () => {
     t9n("calcite-handle");
   });
+
+  it("sets application role on handle", async () => {
+    const page = await newE2EPage();
+    const label = "Hello World";
+    await page.setContent(`<calcite-handle lang="en" label="${label}"></calcite-handle>`);
+    await page.waitForChanges();
+
+    const handle = await page.find("calcite-handle");
+    expect(handle.getAttribute("role")).toBe("application");
+  });
 });

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -298,14 +298,15 @@ export class Handle implements LoadableComponent, T9nComponent, InteractiveCompo
 
   render(): VNode {
     return (
+      // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
       <span
-        // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
         aria-checked={this.disabled ? null : toAriaBoolean(this.selected)}
         aria-disabled={this.disabled ? toAriaBoolean(this.disabled) : null}
         aria-label={this.disabled ? null : this.getAriaText("label")}
         class={{ [CSS.handle]: true, [CSS.handleSelected]: !this.disabled && this.selected }}
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}
+        // role of radio is being applied to allow space key to select in screen readers
         role="radio"
         tabIndex={this.disabled ? null : 0}
         title={this.getTooltip()}

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -4,7 +4,6 @@ import {
   Event,
   EventEmitter,
   h,
-  Host,
   Method,
   Prop,
   State,
@@ -299,26 +298,24 @@ export class Handle implements LoadableComponent, T9nComponent, InteractiveCompo
 
   render(): VNode {
     return (
-      <Host role="application">
-        <span
-          // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
-          aria-disabled={this.disabled ? toAriaBoolean(this.disabled) : null}
-          aria-label={this.disabled ? null : this.getAriaText("label")}
-          aria-pressed={this.disabled ? null : toAriaBoolean(this.selected)}
-          class={{ [CSS.handle]: true, [CSS.handleSelected]: !this.disabled && this.selected }}
-          onBlur={this.handleBlur}
-          onKeyDown={this.handleKeyDown}
-          role="button"
-          tabIndex={this.disabled ? null : 0}
-          title={this.getTooltip()}
-          // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
-          ref={(el): void => {
-            this.handleButton = el;
-          }}
-        >
-          <calcite-icon icon={ICONS.drag} scale="s" />
-        </span>
-      </Host>
+      <span
+        // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
+        aria-checked={this.disabled ? null : toAriaBoolean(this.selected)}
+        aria-disabled={this.disabled ? toAriaBoolean(this.disabled) : null}
+        aria-label={this.disabled ? null : this.getAriaText("label")}
+        class={{ [CSS.handle]: true, [CSS.handleSelected]: !this.disabled && this.selected }}
+        onBlur={this.handleBlur}
+        onKeyDown={this.handleKeyDown}
+        role="radio"
+        tabIndex={this.disabled ? null : 0}
+        title={this.getTooltip()}
+        // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
+        ref={(el): void => {
+          this.handleButton = el;
+        }}
+      >
+        <calcite-icon icon={ICONS.drag} scale="s" />
+      </span>
     );
   }
 }

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -4,6 +4,7 @@ import {
   Event,
   EventEmitter,
   h,
+  Host,
   Method,
   Prop,
   State,
@@ -298,24 +299,26 @@ export class Handle implements LoadableComponent, T9nComponent, InteractiveCompo
 
   render(): VNode {
     return (
-      // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
-      <span
-        aria-disabled={this.disabled ? toAriaBoolean(this.disabled) : null}
-        aria-label={this.disabled ? null : this.getAriaText("label")}
-        aria-pressed={this.disabled ? null : toAriaBoolean(this.selected)}
-        class={{ [CSS.handle]: true, [CSS.handleSelected]: !this.disabled && this.selected }}
-        onBlur={this.handleBlur}
-        onKeyDown={this.handleKeyDown}
-        role="button"
-        tabIndex={this.disabled ? null : 0}
-        title={this.getTooltip()}
-        // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
-        ref={(el): void => {
-          this.handleButton = el;
-        }}
-      >
-        <calcite-icon icon={ICONS.drag} scale="s" />
-      </span>
+      <Host role="application">
+        <span
+          // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486
+          aria-disabled={this.disabled ? toAriaBoolean(this.disabled) : null}
+          aria-label={this.disabled ? null : this.getAriaText("label")}
+          aria-pressed={this.disabled ? null : toAriaBoolean(this.selected)}
+          class={{ [CSS.handle]: true, [CSS.handleSelected]: !this.disabled && this.selected }}
+          onBlur={this.handleBlur}
+          onKeyDown={this.handleKeyDown}
+          role="button"
+          tabIndex={this.disabled ? null : 0}
+          title={this.getTooltip()}
+          // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
+          ref={(el): void => {
+            this.handleButton = el;
+          }}
+        >
+          <calcite-icon icon={ICONS.drag} scale="s" />
+        </span>
+      </Host>
     );
   }
 }


### PR DESCRIPTION
**Related Issue:** #7426

## Summary

- support keyboard sorting in screen readers by setting internal role to radio
- add e2e test.
- https://stackoverflow.com/questions/52261977/why-javascript-if-keycode-enter-key-or-spacebar-key-does-not-work-with-nvda