### PR TITLE
docs: fix the description of headingLevel property

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -93,7 +93,7 @@ export class Block
   @Prop() heading!: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -93,7 +93,7 @@ export class Block
   @Prop() heading!: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -82,7 +82,7 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
   @Prop({ mutable: true }) value: string | string[];
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -82,7 +82,7 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
   @Prop({ mutable: true }) value: string | string[];
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -107,7 +107,7 @@ export class FlowItem
   @Prop() heading: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -107,7 +107,7 @@ export class FlowItem
   @Prop() heading: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -203,7 +203,7 @@ export class InputDatePicker
   }
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -203,7 +203,7 @@ export class InputDatePicker
   }
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -100,7 +100,7 @@ export class Panel
   @Prop({ reflect: true }) collapsible = false;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -100,7 +100,7 @@ export class Panel
   @Prop({ reflect: true }) collapsible = false;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.tsx
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.tsx
@@ -31,7 +31,7 @@ export class PickListGroup implements ConditionalSlotComponent {
   @Prop({ reflect: true }) groupTitle: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/pick-list-group/pick-list-group.tsx
+++ b/packages/calcite-components/src/components/pick-list-group/pick-list-group.tsx
@@ -31,7 +31,7 @@ export class PickListGroup implements ConditionalSlotComponent {
   @Prop({ reflect: true }) groupTitle: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/pick-list/pick-list.tsx
+++ b/packages/calcite-components/src/components/pick-list/pick-list.tsx
@@ -107,7 +107,7 @@ export class PickList<
   @Prop({ reflect: true, mutable: true }) filterText: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/pick-list/pick-list.tsx
+++ b/packages/calcite-components/src/components/pick-list/pick-list.tsx
@@ -107,7 +107,7 @@ export class PickList<
   @Prop({ reflect: true, mutable: true }) filterText: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -138,7 +138,7 @@ export class Popover
   @Prop() heading: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -138,7 +138,7 @@ export class Popover
   @Prop() heading: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
@@ -49,7 +49,7 @@ export class TipManager {
   }
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
@@ -49,7 +49,7 @@ export class TipManager {
   }
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -60,7 +60,7 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
   @Prop() heading: string;
 
   /**
-   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
+   * Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -60,7 +60,7 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
   @Prop() heading: string;
 
   /**
-   * Specifies the number at which section headings should start.
+   * Specifies the semantic heading level of the internally-rendered text container for proper document structure, without affecting visual styling.
    */
   @Prop({ reflect: true }) headingLevel: HeadingLevel;
 


### PR DESCRIPTION
**Related Issue:** #9044 

## Summary
Updating the description of `headingLevel` prop to eliminate confusion on what it's purpose is.