### PR TITLE
fix(action): maintain equal height when text is not enabled in a small scale

### DIFF
--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -68,7 +68,7 @@
       items-center
       justify-center;
     min-inline-size: theme("spacing.4");
-    min-block-size: theme("spacing.4");
+    min-block-size: theme("spacing.6");
   }
 
   .text-container {

--- a/packages/calcite-components/src/components/action/action.stories.ts
+++ b/packages/calcite-components/src/components/action/action.stories.ts
@@ -210,6 +210,20 @@ export const indicatorNoTextEnabledNoIcon_TestOnly = (): string => html`
   <calcite-action indicator active text="click-me"></calcite-action>
 `;
 
+export const noTextHeight_TestOnly = (): string =>
+  html`<h2>All actions should be the same height</h2>
+    <div style="width: min-content">
+      <div style="border: solid 1px">
+        <calcite-action text="hello" text-enabled icon="home" scale="s"></calcite-action>
+      </div>
+      <div style="border: solid 1px">
+        <calcite-action text="hello" icon="home" scale="s"></calcite-action>
+      </div>
+      <div style="border: solid 1px">
+        <calcite-action icon="home" scale="s"></calcite-action>
+      </div>
+    </div>`;
+
 export const arabicLocale_TestOnly = (): string => html`
   <calcite-action
     dir="rtl"

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -299,7 +299,10 @@ export class Action
       buttonId,
       messages,
     } = this;
-    const ariaLabel = `${label || text}${indicator ? ` (${messages.indicator})` : ""}`;
+    const labelFallback = label || text;
+    const ariaLabel = labelFallback
+      ? `${labelFallback}${indicator ? ` (${messages.indicator})` : ""}`
+      : "";
 
     const buttonClasses = {
       [CSS.button]: true,

--- a/packages/calcite-components/src/components/navigation/navigation.e2e.ts
+++ b/packages/calcite-components/src/components/navigation/navigation.e2e.ts
@@ -37,7 +37,9 @@ describe("calcite-navigation", () => {
 
   describe("accessible", () => {
     accessible(
-      html`<calcite-navigation navigation-action><calcite-navigation-logo heading="Test" /></calcite-navigation>`,
+      html`<calcite-navigation label="test" navigation-action
+        ><calcite-navigation-logo heading="Test"
+      /></calcite-navigation>`,
     );
   });
 


### PR DESCRIPTION
**Related Issue:** #8900

## Summary

- Maintain equal height when text is not enabled in a small scale
- Add screenshot test