### PR TITLE
chore(linting): enable `import/order` rule to collapse newlines between imports

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -75,6 +75,7 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": "error",
     curly: "error",
     "import/no-dynamic-require": ["error", { esmodule: true }],
+    "import/order": ["error", { "newlines-between": "never" }],
     "jest/expect-expect": "off",
     "jest/no-export": "warn",
     "jsdoc/check-tag-names": "off",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Enables [`import/order`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) to help take care of any newlines left between imports after updating modules.