### PR TITLE
ci(renovate): enable github action version management

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,7 +8,7 @@
     ":widenPeerDependencies"
   ],
   "platformCommit": true,
-  "enabledManagers": ["npm"],
+  "enabledManagers": ["npm", "github-actions"],
   "timezone": "America/Los_Angeles",
   "schedule": ["before 5am on every weekday"],
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary

Enable Renovate's GitHub Action version manager.

ref: https://docs.renovatebot.com/modules/manager/github-actions/