### PR TITLE
test:  ensure 'test:watch' npm script rebuilds after code changes

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -39,7 +39,7 @@
     "start": "npm run util:clean-js-files && concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\"",
     "test": "stencil test --no-docs --no-build --spec --e2e",
     "test:prerender": "npm run build -- --prerender",
-    "test:watch": "npm run build && npm run test -- -- --watchAll",
+    "test:watch": "stencil test --no-docs --spec --e2e --watchAll",
     "util:clean-tested-build": "npm ci && npm test && npm run build",
     "util:copy-assets": "npm run util:copy-icons",
     "util:copy-icons": "cpy \"./node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/icon/\" --flat",


### PR DESCRIPTION
## Summary

Calcite Component's `test:watch` npm script was using the `test` one, which has the `--no-build` flag.
