### PR TITLE
ci(e2e): use chrome included with puppeteer again

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -30,12 +30,4 @@ jobs:
         with:
           node-version-file: package.json
       - if: steps.markdown-check.outputs.SKIP == 'false'
-        uses: browser-actions/setup-chrome@v1
-        id: setup-chrome
-        with:
-          chrome-version: stable
-      - if: steps.markdown-check.outputs.SKIP == 'false'
         run: npm install && npm run build && npm run test
-        env:
-          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-          PUPPETEER_SKIP_DOWNLOAD: true


### PR DESCRIPTION
**Related Issue:** #8819

## Summary

Switch back to using the Chrome executable downloaded with Puppeteer.
Chrome was manually installed via a GitHub Action due to a broken URL,
which has since been fixed.
