### PR TITLE
refactor: update E2E tests to use a custom `waitForTimeout` util to prep for puppeteer removal

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -89,6 +89,14 @@ module.exports = {
       },
     ],
     "no-new-func": "error",
+    "no-restricted-properties": [
+      "error",
+      {
+        object: "page",
+        property: "waitForTimeout",
+        message: "`E2EPage.waitForTimeout` is deprecated. Find alternative or use `waitForTimeout` util from test utils instead.",
+      },
+    ],
     "no-unneeded-ternary": "error",
     "one-var": ["error", "never"],
     "react/forbid-component-props": [

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -11,7 +11,7 @@ import {
   slots,
   t9n,
 } from "../../tests/commonTests";
-import { getFocusedElementProp } from "../../tests/utils";
+import { getFocusedElementProp, waitForTimeout } from "../../tests/utils";
 import { CSS, SLOTS } from "./resources";
 import { overflowActionsDebounceInMs } from "./utils";
 
@@ -375,7 +375,7 @@ describe("calcite-action-bar", () => {
           </calcite-action-bar>
         </div>`,
       });
-      await page.waitForTimeout(overflowActionsDebounceInMs);
+      waitForTimeout(overflowActionsDebounceInMs);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(2);
       expect(await page.findAll(slottedActionsSelector)).toHaveLength(0);
@@ -392,7 +392,7 @@ describe("calcite-action-bar", () => {
           <calcite-action text="Table" icon="table"></calcite-action>`,
         );
       });
-      await page.waitForTimeout(overflowActionsDebounceInMs + 10);
+      waitForTimeout(overflowActionsDebounceInMs + 10);
       await page.waitForChanges();
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
@@ -423,7 +423,7 @@ describe("calcite-action-bar", () => {
         </div>`,
       );
       await page.waitForChanges();
-      await page.waitForTimeout(overflowActionsDebounceInMs + 10);
+      waitForTimeout(overflowActionsDebounceInMs + 10);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
       expect(await page.findAll(slottedActionsSelector)).toHaveLength(0);
@@ -431,7 +431,7 @@ describe("calcite-action-bar", () => {
       const actionBar = await page.find("calcite-action-bar");
       actionBar.setProperty("overflowActionsDisabled", false);
       await page.waitForChanges();
-      await page.waitForTimeout(overflowActionsDebounceInMs + 10);
+      waitForTimeout(overflowActionsDebounceInMs + 10);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
       expect(await page.findAll(slottedActionsSelector)).toHaveLength(7);
@@ -459,7 +459,7 @@ describe("calcite-action-bar", () => {
           </calcite-action-bar>
         </div>`,
       });
-      await page.waitForTimeout(overflowActionsDebounceInMs + 10);
+      waitForTimeout(overflowActionsDebounceInMs + 10);
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);
       expect(await page.findAll(slottedActionsSelector)).toHaveLength(7);
@@ -468,7 +468,7 @@ describe("calcite-action-bar", () => {
         element.style.height = "550px";
       });
 
-      await page.waitForTimeout(overflowActionsDebounceInMs + 10);
+      waitForTimeout(overflowActionsDebounceInMs + 10);
       await page.waitForChanges();
 
       expect(await page.findAll(dynamicGroupActionsSelector)).toHaveLength(8);

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -11,6 +11,7 @@ import {
   slots,
 } from "../../tests/commonTests";
 import { TOOLTIP_OPEN_DELAY_MS } from "../tooltip/resources";
+import { waitForTimeout } from "../../tests/utils";
 import { CSS, SLOTS, activeAttr } from "./resources";
 
 describe("calcite-action-menu", () => {
@@ -228,7 +229,7 @@ describe("calcite-action-menu", () => {
     expect(await tooltip.isVisible()).toBe(false);
 
     await trigger.hover();
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     expect(await tooltip.isVisible()).toBe(true);
 
@@ -260,7 +261,7 @@ describe("calcite-action-menu", () => {
       await page.waitForChanges();
 
       await page.keyboard.press("ArrowDown");
-      await page.waitForTimeout(0);
+      waitForTimeout(0);
       await page.waitForChanges();
 
       expect(await trigger.getProperty("active")).toBe(true);
@@ -270,7 +271,7 @@ describe("calcite-action-menu", () => {
       expect(actions[2].getAttribute(activeAttr)).toBe(null);
 
       await page.keyboard.press("ArrowDown");
-      await page.waitForTimeout(0);
+      waitForTimeout(0);
       await page.waitForChanges();
 
       expect(actions[0].getAttribute(activeAttr)).toBe(null);
@@ -340,7 +341,7 @@ describe("calcite-action-menu", () => {
       await page.waitForChanges();
 
       await page.keyboard.press("ArrowUp");
-      await page.waitForTimeout(0);
+      waitForTimeout(0);
       await page.waitForChanges();
 
       expect(await trigger.getProperty("active")).toBe(true);
@@ -350,7 +351,7 @@ describe("calcite-action-menu", () => {
       expect(actions[2].getAttribute(activeAttr)).toBe("");
 
       await page.keyboard.press("ArrowUp");
-      await page.waitForTimeout(0);
+      waitForTimeout(0);
       await page.waitForChanges();
 
       expect(actions[0].getAttribute(activeAttr)).toBe(null);

--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, disabled, hidden, renders, slots, t9n, defaults } from "../../tests/commonTests";
+import { waitForTimeout } from "../../tests/utils";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-action", () => {
@@ -98,7 +99,7 @@ describe("calcite-action", () => {
 
     const action = await page.find("calcite-action");
 
-    await page.waitForTimeout(1);
+    waitForTimeout(1);
 
     action.innerHTML = `<calcite-icon icon="hamburger" scale="s"></calcite-icon>`;
 

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, defaults, hidden, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
-import { getElementXY } from "../../tests/utils";
+import { getElementXY, waitForTimeout } from "../../tests/utils";
 import { openClose } from "../../tests/commonTests";
 import { CSS, DURATIONS } from "./resources";
 
@@ -111,7 +111,7 @@ describe("calcite-alert", () => {
     await button2.click();
     expect(await alert2.isVisible()).toBe(true);
 
-    await page.waitForTimeout(alertSpeedFastMs);
+    waitForTimeout(alertSpeedFastMs);
     expect(await alert2.isVisible()).not.toBe(true);
   });
 
@@ -134,11 +134,11 @@ describe("calcite-alert", () => {
     expect(await alert1.isVisible()).not.toBe(true);
 
     await button1.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     expect(await alert1.isVisible()).toBe(true);
 
     await alertClose1.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     expect(await alert1.isVisible()).not.toBe(true);
   });
 
@@ -170,15 +170,15 @@ describe("calcite-alert", () => {
     const alertClose2 = await page.find(`#alert-2 >>> .${CSS.close}`);
 
     await button1.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     await alertClose1.click();
 
     await button2.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     await alertClose2.click();
 
     await button3.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
 
     expect(await alert1.isVisible()).not.toBe(true);
     expect(await alert2.isVisible()).not.toBe(true);
@@ -248,7 +248,7 @@ describe("calcite-alert", () => {
     describe("when mode attribute is not provided", () => {
       it("should render alert dismiss progress bar with default value tied to light mode", async () => {
         page = await newE2EPage({ html: alertSnippet });
-        await page.waitForTimeout(animationDurationInMs);
+        waitForTimeout(animationDurationInMs);
         alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
         progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
         expect(await progressBarStyles.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.8)");
@@ -260,7 +260,7 @@ describe("calcite-alert", () => {
         page = await newE2EPage({
           html: `<div class="calcite-mode-dark">${alertSnippet}</div>`,
         });
-        await page.waitForTimeout(animationDurationInMs);
+        waitForTimeout(animationDurationInMs);
         alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
         progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
         expect(await progressBarStyles.getPropertyValue("background-color")).toEqual("rgba(43, 43, 43, 0.8)");
@@ -278,7 +278,7 @@ describe("calcite-alert", () => {
         </style>
         <div>${alertSnippet}</div>`,
       });
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
       alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
       progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
       expect(await progressBarStyles.getPropertyValue("background-color")).toEqual(overrideStyle);
@@ -325,7 +325,7 @@ describe("calcite-alert", () => {
     const alertThree = await page.find("#third-open");
 
     await buttonOne.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     expect(await alertOne.isVisible()).toBe(true);
 
     await buttonTwo.click();
@@ -385,7 +385,7 @@ describe("calcite-alert", () => {
       const alertTwo = await page.find("#alert-to-be-queued");
 
       await buttonOne.click();
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
       expect(await alertOne.isVisible()).toBe(true);
 
       await buttonTwo.click();
@@ -396,7 +396,7 @@ describe("calcite-alert", () => {
       expect(await chip.getProperty("value")).toEqual(chipQueueCount);
       expect(chip.textContent).toEqual(chipQueueCount);
 
-      await page.waitForTimeout(DURATIONS.medium * 2 + animationDurationInMs * 5);
+      waitForTimeout(DURATIONS.medium * 2 + animationDurationInMs * 5);
       await page.waitForSelector("#first-open", { visible: false });
       await page.waitForSelector("#alert-to-be-queued", { visible: false });
     });
@@ -433,7 +433,7 @@ describe("calcite-alert", () => {
 
     it("should render close button", async () => {
       await button.click();
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
 
       expect(await alert.isVisible()).toBe(true);
       expect(buttonClose).toBeTruthy();
@@ -449,12 +449,12 @@ describe("calcite-alert", () => {
       const [alertLocationX, alertLocationY] = await getElementXY(page, "calcite-alert", `.${CSS.close}`);
       await page.mouse.move(alertLocationX, alertLocationY);
 
-      await page.waitForTimeout(DURATIONS.medium);
+      waitForTimeout(DURATIONS.medium);
       expect(await alert.isVisible()).toBe(true);
 
       await page.mouse.move(0, 0);
 
-      await page.waitForTimeout(DURATIONS.medium + animationDurationInMs);
+      waitForTimeout(DURATIONS.medium + animationDurationInMs);
       await page.waitForSelector("#alert", { visible: false });
     });
   });

--- a/packages/calcite-components/src/components/button/button.e2e.ts
+++ b/packages/calcite-components/src/components/button/button.e2e.ts
@@ -1,6 +1,6 @@
 import { E2EElement, newE2EPage } from "@stencil/core/testing";
 import { accessible, disabled, HYDRATED_ATTR, labelable, defaults, hidden, t9n } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
+import { GlobalTestProps, waitForTimeout } from "../../tests/utils";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -640,7 +640,7 @@ describe("calcite-button", () => {
       const element = await page.find("calcite-button");
       await element.setProperty("loading", false);
       await page.waitForChanges();
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
       const loader = await page.find(`calcite-button >>> .${CSS.buttonLoader} calcite-loader`);
       expect(loader).toBeNull();
     });

--- a/packages/calcite-components/src/components/card-group/card-group.e2e.ts
+++ b/packages/calcite-components/src/components/card-group/card-group.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, disabled } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
+import { GlobalTestProps, waitForTimeout } from "../../tests/utils";
 import { CSS } from "../card/resources";
 
 describe("calcite-card-group", () => {
@@ -435,7 +435,7 @@ interface SelectedItemsAssertionOptions {
  * @param root0.expectedItemIds
  */
 async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
+  await waitForTimeout(100);
   const selectedItemIds = await page.evaluate(() => {
     const cardGroup = document.querySelector<HTMLCalciteCardGroupElement>("calcite-card-group");
     return cardGroup.selectedItems.map((item) => item.id);

--- a/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
+++ b/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, disabled } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
+import { GlobalTestProps, waitForTimeout } from "../../tests/utils";
 import { CSS as CHIP_CSS } from "../chip/resources";
 
 describe("calcite-chip-group", () => {
@@ -480,7 +480,7 @@ interface SelectedItemsAssertionOptions {
  * @param root0.expectedItemIds
  */
 async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
+  waitForTimeout(100);
   const selectedItemIds = await page.evaluate(() => {
     const chipGroup = document.querySelector<HTMLCalciteChipGroupElement>("calcite-chip-group");
     return chipGroup.selectedItems.map((item) => item.id);

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -15,7 +15,7 @@ import {
 import { html } from "../../../support/formatting";
 import { CSS as ComboboxItemCSS } from "../combobox-item/resources";
 import { CSS as XButtonCSS } from "../functional/XButton";
-import { getElementXY, skipAnimations } from "../../tests/utils";
+import { getElementXY, skipAnimations, waitForTimeout } from "../../tests/utils";
 import { CSS } from "./resources";
 
 const selectionModes = ["single", "single-persist", "ancestors", "multiple"];
@@ -1030,12 +1030,12 @@ describe("calcite-combobox", () => {
       expect(await page.evaluate(() => window.scrollY)).toEqual(0);
 
       await page.keyboard.press("PageDown");
-      await page.waitForTimeout(scrollTestDelayInMilliseconds);
+      waitForTimeout(scrollTestDelayInMilliseconds);
       const scrollPosition = await page.evaluate(() => window.scrollY);
       expect(scrollPosition).toBeTruthy();
 
       await page.keyboard.press("PageUp");
-      await page.waitForTimeout(scrollTestDelayInMilliseconds);
+      waitForTimeout(scrollTestDelayInMilliseconds);
       expect(
         await page.evaluate((scrollPosition) => {
           return window.scrollY < scrollPosition;

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests";
-import { skipAnimations } from "../../tests/utils";
+import { skipAnimations, waitForTimeout } from "../../tests/utils";
 import { formatTimePart } from "../../utils/time";
 
 describe("calcite-date-picker", () => {
@@ -36,7 +36,7 @@ describe("calcite-date-picker", () => {
     const date = await page.find("calcite-date-picker");
     const changedEvent = await page.spyOnEvent("calciteDatePickerChange");
 
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     // can't find this input as it's deeply nested in shadow dom, so just tab to it
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
@@ -55,7 +55,7 @@ describe("calcite-date-picker", () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-date-picker value="2015-02-28" active></calcite-date-picker>`);
     const datePicker = await page.find("calcite-date-picker");
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
 
     async function getActiveMonthDate(): Promise<string> {
       return page.$eval("calcite-date-picker", (datePicker: HTMLCalciteDatePickerElement) =>
@@ -99,7 +99,7 @@ describe("calcite-date-picker", () => {
     await page.setContent("<calcite-date-picker value='2000-11-27' active></calcite-date-picker>");
     const changedEvent = await page.spyOnEvent("calciteDatePickerChange");
 
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
 
     await selectFirstAvailableDay(page, "mouse");
     expect(changedEvent).toHaveReceivedEventTimes(1);
@@ -114,7 +114,7 @@ describe("calcite-date-picker", () => {
     const datePicker = await page.find("calcite-date-picker");
     const eventSpy = await page.spyOnEvent("calciteDatePickerRangeChange");
 
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
 
     const now = new Date();
     const currentYear = now.getUTCFullYear();
@@ -460,7 +460,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
       await page.keyboard.press("Enter");
       await page.waitForChanges();
-      await page.waitForTimeout(4000);
+      await waitForTimeout(4000);
       expect(await datePicker.getProperty("value")).toEqual(["2023-11-25", "2023-12-25"]);
 
       await page.keyboard.press("PageDown");
@@ -469,7 +469,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
       await page.keyboard.press("Enter");
       await page.waitForChanges();
-      await page.waitForTimeout(4000);
+      await waitForTimeout(4000);
       expect(await datePicker.getProperty("value")).toEqual(["2023-11-25", "2024-01-25"]);
 
       await page.keyboard.press("ArrowDown");

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -12,7 +12,13 @@ import {
   reflects,
   renders,
 } from "../../tests/commonTests";
-import { GlobalTestProps, getFocusedElementProp, isElementFocused, skipAnimations } from "../../tests/utils";
+import {
+  GlobalTestProps,
+  getFocusedElementProp,
+  isElementFocused,
+  skipAnimations,
+  waitForTimeout,
+} from "../../tests/utils";
 
 describe("calcite-dropdown", () => {
   const simpleDropdownHTML = html`
@@ -96,7 +102,7 @@ describe("calcite-dropdown", () => {
    * @param root0.expectedItemIds
    */
   async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-    await page.waitForTimeout(100);
+    waitForTimeout(100);
     const selectedItemIds = await page.evaluate(() => {
       const dropdown = document.querySelector<HTMLCalciteDropdownElement>("calcite-dropdown");
       return dropdown.selectedItems.map((item) => item.id);

--- a/packages/calcite-components/src/components/filter/filter.e2e.ts
+++ b/packages/calcite-components/src/components/filter/filter.e2e.ts
@@ -1,6 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";
 import { CSS as INPUT_CSS } from "../input/resources";
+import { waitForTimeout } from "../../tests/utils";
 import { DEBOUNCE_TIMEOUT } from "./resources";
 
 describe("calcite-filter", () => {
@@ -190,7 +191,7 @@ describe("calcite-filter", () => {
     it("updates filtered items after filtering", async () => {
       const filter = await page.find("calcite-filter");
       const filterChangeSpy = await page.spyOnEvent("calciteFilterChange");
-      await page.waitForTimeout(DEBOUNCE_TIMEOUT);
+      waitForTimeout(DEBOUNCE_TIMEOUT);
       await page.waitForChanges();
 
       expect(filterChangeSpy).toHaveReceivedEventTimes(0);
@@ -215,7 +216,7 @@ describe("calcite-filter", () => {
       await page.$eval("calcite-filter", (filter: HTMLCalciteFilterElement): void => {
         filter.items = filter.items.slice(3);
       });
-      await page.waitForTimeout(DEBOUNCE_TIMEOUT);
+      waitForTimeout(DEBOUNCE_TIMEOUT);
       await page.waitForChanges();
 
       assertMatchingItems(await filter.getProperty("filteredItems"), ["jon"]);
@@ -274,7 +275,7 @@ describe("calcite-filter", () => {
 
     it("should return matching value", async () => {
       const filter = await page.find("calcite-filter");
-      await page.waitForTimeout(DEBOUNCE_TIMEOUT);
+      waitForTimeout(DEBOUNCE_TIMEOUT);
       assertMatchingItems(await filter.getProperty("filteredItems"), ["harry"]);
     });
   });

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -13,7 +13,7 @@ import {
 } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS as MONTH_HEADER_CSS } from "../date-picker-month-header/resources";
-import { getFocusedElementProp, skipAnimations } from "../../tests/utils";
+import { getFocusedElementProp, skipAnimations, waitForTimeout } from "../../tests/utils";
 import { CSS } from "./resources";
 const animationDurationInMs = 200;
 
@@ -144,7 +144,7 @@ describe("calcite-input-date-picker", () => {
 
       await input.click();
       await page.waitForChanges();
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
       const wrapper = await page.waitForFunction(
         (calendarWrapperClass: string) =>
           document.querySelector("calcite-input-date-picker").shadowRoot.querySelector(`.${calendarWrapperClass}`),
@@ -215,7 +215,7 @@ describe("calcite-input-date-picker", () => {
 
       await input.click();
       await page.waitForChanges();
-      await page.waitForTimeout(animationDurationInMs);
+      waitForTimeout(animationDurationInMs);
 
       const wrapper = await page.waitForFunction(
         (calendarWrapperClass: string) =>

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -12,7 +12,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests";
-import { getElementRect, getElementXY, selectText } from "../../tests/utils";
+import { getElementRect, getElementXY, selectText, waitForTimeout } from "../../tests/utils";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 import { testHiddenInputSyncing, testPostValidationFocusing } from "../input/common/tests";
@@ -371,7 +371,7 @@ describe("calcite-input-number", () => {
       const inputEventSpy = await input.spyOnEvent("calciteInputNumberInput");
       await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
       const totalNudgesUp = inputEventSpy.length;
@@ -385,7 +385,7 @@ describe("calcite-input-number", () => {
 
       await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
       const totalNudgesDown = inputEventSpy.length - totalNudgesUp;
@@ -538,7 +538,7 @@ describe("calcite-input-number", () => {
       await page.waitForChanges();
 
       await page.keyboard.down("ArrowUp");
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.waitForEvent("calciteInputNumberInput");
       await page.keyboard.up("ArrowUp");
       await page.waitForChanges();
@@ -547,7 +547,7 @@ describe("calcite-input-number", () => {
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
 
       await page.keyboard.down("ArrowDown");
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.keyboard.up("ArrowDown");
       await page.waitForChanges();
 
@@ -578,7 +578,7 @@ describe("calcite-input-number", () => {
           expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
           await page.mouse.move(buttonUpLocation.x, buttonUpLocation.y);
           await page.mouse.down();
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.up();
           await page.waitForChanges();
           const totalNudgesUp = calciteInputNumberInput.length;
@@ -589,12 +589,12 @@ describe("calcite-input-number", () => {
           expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
           await page.mouse.move(buttonUpLocation.x, buttonUpLocation.y);
           await page.mouse.down();
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.move(buttonUpLocation.x - 1, buttonUpLocation.y - 1);
 
           const totalNudgesUp = calciteInputNumberInput.length;
           // assert changes no longer emitted after moving away from stepper
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.up(); // mouseleave assertion done, we release
           expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
         });
@@ -616,7 +616,7 @@ describe("calcite-input-number", () => {
           expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
           await page.mouse.move(buttonDownLocation.x, buttonDownLocation.y);
           await page.mouse.down();
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.up();
           await page.waitForChanges();
           const totalNudgesUp = calciteInputNumberInput.length;
@@ -627,12 +627,12 @@ describe("calcite-input-number", () => {
           expect(calciteInputNumberInput).toHaveReceivedEventTimes(0);
           await page.mouse.move(buttonDownLocation.x, buttonDownLocation.y);
           await page.mouse.down();
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.move(buttonDownLocation.x - 1, buttonDownLocation.y - 1);
 
           const totalNudgesUp = calciteInputNumberInput.length;
           // assert changes no longer emitted after moving away from stepper
-          await page.waitForTimeout(delayFor2UpdatesInMs);
+          waitForTimeout(delayFor2UpdatesInMs);
           await page.mouse.up(); // mouseleave assertion done, we release
           expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
         });
@@ -646,7 +646,7 @@ describe("calcite-input-number", () => {
       await page.waitForChanges();
 
       await Promise.all((["ArrowUp", "ArrowDown"] as const).map((key) => page.keyboard.press(key)));
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       expect(await element.getProperty("value")).toBe("0");
     });
 
@@ -1651,7 +1651,7 @@ describe("calcite-input-number", () => {
         },
         cursorHomeCount,
       );
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
 
       await page.keyboard.up("ArrowUp");
       await page.waitForChanges();
@@ -1775,7 +1775,7 @@ describe("calcite-input-number", () => {
     await page.mouse.down();
     await page.waitForChanges();
     // timeout is used to simulate long press.
-    await page.waitForTimeout(3000);
+    waitForTimeout(3000);
     expect(await inputNumber.getProperty("value")).not.toBe("");
 
     const value = await inputNumber.getProperty("value");
@@ -1799,7 +1799,7 @@ describe("calcite-input-number", () => {
     await page.waitForChanges();
     await page.keyboard.down("ArrowUp");
     // timeout is used to simulate long press.
-    await page.waitForTimeout(3000);
+    waitForTimeout(3000);
     await page.keyboard.press("Tab");
     await page.waitForChanges();
 
@@ -1807,7 +1807,7 @@ describe("calcite-input-number", () => {
     expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
     expect(calciteInputNumberInput).toHaveReceivedEventTimes(totalNudgesUp);
 
-    await page.waitForTimeout(3000);
+    waitForTimeout(3000);
     expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
     expect(calciteInputNumberInput).toHaveReceivedEventTimes(totalNudgesUp);
   });

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -12,7 +12,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests";
-import { getFocusedElementProp, skipAnimations, waitForAnimationFrame } from "../../tests/utils";
+import { getFocusedElementProp, skipAnimations, waitForAnimationFrame, waitForTimeout } from "../../tests/utils";
 import { html } from "../../../support/formatting";
 import { openClose } from "../../tests/commonTests";
 
@@ -874,7 +874,7 @@ describe("calcite-input-time-picker", () => {
 
       await page.keyboard.press("ArrowDown");
       await page.waitForChanges();
-      await page.waitForTimeout(stopgapDelayUntilOpenCloseEventsAreImplemented);
+      waitForTimeout(stopgapDelayUntilOpenCloseEventsAreImplemented);
 
       expect(await popover.isVisible()).toBe(true);
       expect(await getFocusedElementProp(page, "tagName", { shadow: true })).toBe("CALCITE-TIME-PICKER");
@@ -889,7 +889,7 @@ describe("calcite-input-time-picker", () => {
 
       await page.keyboard.press("Escape");
       await page.waitForChanges();
-      await page.waitForTimeout(stopgapDelayUntilOpenCloseEventsAreImplemented);
+      waitForTimeout(stopgapDelayUntilOpenCloseEventsAreImplemented);
 
       expect(await popover.isVisible()).toBe(false);
       expect(await getFocusedElementProp(page, "tagName")).toBe("CALCITE-INPUT-TIME-PICKER");

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -14,7 +14,7 @@ import {
 import { html } from "../../../support/formatting";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
-import { getElementRect, getElementXY, selectText } from "../../tests/utils";
+import { getElementRect, getElementXY, selectText, waitForTimeout } from "../../tests/utils";
 import { testHiddenInputSyncing, testPostValidationFocusing } from "./common/tests";
 
 describe("calcite-input", () => {
@@ -380,7 +380,7 @@ describe("calcite-input", () => {
       const inputEventSpy = await input.spyOnEvent("calciteInputInput");
       await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
       const totalNudgesUp = inputEventSpy.length;
@@ -394,7 +394,7 @@ describe("calcite-input", () => {
 
       await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
       const totalNudgesDown = inputEventSpy.length - totalNudgesUp;
@@ -527,7 +527,7 @@ describe("calcite-input", () => {
       await page.waitForChanges();
 
       await page.keyboard.down("ArrowUp");
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.waitForEvent("calciteInputInput");
       await page.keyboard.up("ArrowUp");
       await page.waitForChanges();
@@ -536,7 +536,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
 
       await page.keyboard.down("ArrowDown");
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.keyboard.up("ArrowDown");
       await page.waitForChanges();
 
@@ -557,21 +557,21 @@ describe("calcite-input", () => {
       expect(calciteInputInput).toHaveReceivedEventTimes(0);
       await page.mouse.move(buttonUpLocationX, buttonUpLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
       let totalNudgesUp = calciteInputInput.length;
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
 
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.move(buttonUpLocationX - 1, buttonUpLocationY - 1);
 
       totalNudgesUp = calciteInputInput.length;
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
 
       // assert changes no longer emitted after moving away from stepper
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
       await page.mouse.up(); // mouseleave assertion done, we release
 
@@ -583,7 +583,7 @@ describe("calcite-input", () => {
 
       await page.mouse.move(buttonDownLocationX, buttonDownLocationY);
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.up();
       await page.waitForChanges();
 
@@ -592,7 +592,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
 
       await page.mouse.down();
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       await page.mouse.move(buttonDownLocationX - 1, buttonDownLocationY - 1);
 
       totalNudgesDown = calciteInputInput.length - totalNudgesUp;
@@ -600,7 +600,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
 
       // assert changes no longer emitted after moving away from stepper
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       expect(await input.getProperty("value")).toBe(`${finalNudgedValue}`);
     });
 
@@ -611,7 +611,7 @@ describe("calcite-input", () => {
       await page.waitForChanges();
 
       await Promise.all((["ArrowUp", "ArrowDown"] as const).map((key) => page.keyboard.press(key)));
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
       expect(await element.getProperty("value")).toBe("0");
     });
 
@@ -694,7 +694,7 @@ describe("calcite-input", () => {
       await page.mouse.down();
       await page.waitForChanges();
       // timeout is used to simulate long press.
-      await page.waitForTimeout(3000);
+      waitForTimeout(3000);
       expect(await input.getProperty("value")).not.toBe("");
 
       const value = await input.getProperty("value");
@@ -718,7 +718,7 @@ describe("calcite-input", () => {
       await page.waitForChanges();
       await page.keyboard.down("ArrowUp");
       // timeout is used to simulate long press.
-      await page.waitForTimeout(3000);
+      waitForTimeout(3000);
       await page.keyboard.press("Tab");
       await page.waitForChanges();
 
@@ -726,7 +726,7 @@ describe("calcite-input", () => {
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
       expect(calciteInputInput).toHaveReceivedEventTimes(totalNudgesUp);
 
-      await page.waitForTimeout(3000);
+      waitForTimeout(3000);
       expect(await input.getProperty("value")).toBe(`${totalNudgesUp}`);
       expect(calciteInputInput).toHaveReceivedEventTimes(totalNudgesUp);
     });
@@ -1930,7 +1930,7 @@ describe("calcite-input", () => {
         },
         cursorHomeCount,
       );
-      await page.waitForTimeout(delayFor2UpdatesInMs);
+      waitForTimeout(delayFor2UpdatesInMs);
 
       await page.keyboard.up("ArrowUp");
       await page.waitForChanges();

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -4,7 +4,13 @@ import { placeholderImage } from "../../../.storybook/placeholderImage";
 import { html } from "../../../support/formatting";
 import { CSS as ListItemCSS, activeCellTestAttribute } from "../list-item/resources";
 import { DEBOUNCE_TIMEOUT as FILTER_DEBOUNCE_TIMEOUT } from "../filter/resources";
-import { GlobalTestProps, dragAndDrop, isElementFocused, getFocusedElementProp } from "../../tests/utils";
+import {
+  GlobalTestProps,
+  dragAndDrop,
+  isElementFocused,
+  getFocusedElementProp,
+  waitForTimeout,
+} from "../../tests/utils";
 import { debounceTimeout } from "./resources";
 import { ListDragDetail } from "./interfaces";
 
@@ -180,7 +186,7 @@ describe("calcite-list", () => {
     await page.waitForChanges();
     const list = await page.find("calcite-list");
     const filter = await page.find(`calcite-list >>> calcite-filter`);
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(await list.getProperty("filteredItems")).toHaveLength(2);
     expect(await list.getProperty("filteredData")).toHaveLength(2);
     expect(await list.getProperty("filterText")).toBeUndefined();
@@ -191,7 +197,7 @@ describe("calcite-list", () => {
     const calciteListFilterEvent = list.waitForEvent("calciteListFilter");
     await page.keyboard.type("one");
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     await calciteListFilterEvent;
     expect(await list.getProperty("filteredItems")).toHaveLength(1);
     expect(await list.getProperty("filteredData")).toHaveLength(1);
@@ -205,7 +211,7 @@ describe("calcite-list", () => {
     const calciteListFilterEvent2 = list.waitForEvent("calciteListFilter");
     await page.keyboard.type("two");
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     await calciteListFilterEvent2;
     expect(await list.getProperty("filteredItems")).toHaveLength(1);
     expect(await list.getProperty("filteredData")).toHaveLength(1);
@@ -214,7 +220,7 @@ describe("calcite-list", () => {
     const calciteListFilterEvent3 = list.waitForEvent("calciteListFilter");
     await page.keyboard.type(" blah");
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     await calciteListFilterEvent3;
     expect(await list.getProperty("filteredItems")).toHaveLength(0);
     expect(await list.getProperty("filteredData")).toHaveLength(0);
@@ -240,14 +246,14 @@ describe("calcite-list", () => {
 
     const list = await page.find("calcite-list");
     const listItems = await page.findAll("calcite-list-item");
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(await list.getProperty("filteredItems")).toHaveLength(3);
     expect(await list.getProperty("filteredData")).toHaveLength(3);
     expect(await list.getProperty("filterText")).toBeUndefined();
 
     listItems[0].setProperty("selected", true);
     list.setProperty("filterText", "two");
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     await page.waitForChanges();
     let selectedItemValues = await getSelectedItemValues();
     expect(selectedItemValues).toHaveLength(1);
@@ -262,7 +268,7 @@ describe("calcite-list", () => {
 
     list.setProperty("filterText", "three");
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     listItems[2].setProperty("selected", true);
     await page.waitForChanges();
     selectedItemValues = await getSelectedItemValues();
@@ -312,7 +318,7 @@ describe("calcite-list", () => {
 
     await page.waitForChanges();
     const list = await page.find("calcite-list");
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
 
     expect(await list.getProperty("filteredItems")).toHaveLength(3);
     expect(await list.getProperty("filteredData")).toHaveLength(3);
@@ -337,7 +343,7 @@ describe("calcite-list", () => {
       </calcite-list>`,
     );
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
 
     const list = await page.find("calcite-list");
     const items = await page.findAll("calcite-list-item");
@@ -352,7 +358,7 @@ describe("calcite-list", () => {
     await items[0].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(1);
     expect(await list.getProperty("selectedItems")).toHaveLength(1);
 
@@ -363,7 +369,7 @@ describe("calcite-list", () => {
 
     await page.$eval("#item-4", clickItemContent, `.${ListItemCSS.contentContainer}`);
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(2);
     expect(await list.getProperty("selectedItems")).toHaveLength(4);
 
@@ -375,7 +381,7 @@ describe("calcite-list", () => {
     await items[3].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(3);
     expect(await list.getProperty("selectedItems")).toHaveLength(3);
 
@@ -386,7 +392,7 @@ describe("calcite-list", () => {
 
     await page.$eval("#item-1", clickItemContent, `.${ListItemCSS.contentContainer}`);
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(4);
     expect(await list.getProperty("selectedItems")).toHaveLength(0);
 
@@ -406,7 +412,7 @@ describe("calcite-list", () => {
       </calcite-list>`,
     );
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
 
     const list = await page.find("calcite-list");
     const items = await page.findAll("calcite-list-item");
@@ -420,7 +426,7 @@ describe("calcite-list", () => {
     await items[1].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(1);
 
     expect(await items[0].getProperty("active")).toBe(false);
@@ -439,7 +445,7 @@ describe("calcite-list", () => {
     );
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
 
     const items = await page.findAll("calcite-list-item");
 
@@ -452,7 +458,7 @@ describe("calcite-list", () => {
     await items[2].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(1);
 
     expect(await items[0].getProperty("selected")).toBe(false);
@@ -471,7 +477,7 @@ describe("calcite-list", () => {
     );
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
 
     const items = await page.findAll("calcite-list-item");
 
@@ -484,7 +490,7 @@ describe("calcite-list", () => {
     await items[2].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(1);
 
     expect(await items[0].getProperty("selected")).toBe(false);
@@ -494,7 +500,7 @@ describe("calcite-list", () => {
     await items[0].click();
 
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(eventSpy).toHaveReceivedEventTimes(2);
 
     expect(await items[0].getProperty("selected")).toBe(true);
@@ -532,13 +538,13 @@ describe("calcite-list", () => {
 
     listItemOne.setProperty("selected", true);
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(await listItemOne.getProperty("selected")).toBe(true);
     expect(await list.getProperty("selectedItems")).toHaveLength(1);
 
     listItemOne.setProperty("selected", false);
     await page.waitForChanges();
-    await page.waitForTimeout(listDebounceTimeout);
+    waitForTimeout(listDebounceTimeout);
     expect(await listItemOne.getProperty("selected")).toBe(false);
     expect(await list.getProperty("selectedItems")).toHaveLength(0);
   });
@@ -623,7 +629,7 @@ describe("calcite-list", () => {
       const listItemThree = await page.find("#three");
       listItemThree.setProperty("disabled", false);
       await page.waitForChanges();
-      await page.waitForTimeout(listDebounceTimeout);
+      waitForTimeout(listDebounceTimeout);
       expect(calciteListChange).toHaveReceivedEventTimes(0);
 
       await list.press("ArrowDown");
@@ -633,7 +639,7 @@ describe("calcite-list", () => {
       const listItemFour = await page.find("#four");
       listItemFour.setProperty("closed", false);
       await page.waitForChanges();
-      await page.waitForTimeout(listDebounceTimeout);
+      waitForTimeout(listDebounceTimeout);
       expect(calciteListChange).toHaveReceivedEventTimes(0);
 
       await list.press("ArrowDown");
@@ -663,7 +669,7 @@ describe("calcite-list", () => {
       `);
       await page.waitForChanges();
       const list = await page.find("calcite-list");
-      await page.waitForTimeout(listDebounceTimeout);
+      waitForTimeout(listDebounceTimeout);
       await list.callMethod("setFocus");
       await page.waitForChanges();
 
@@ -905,7 +911,7 @@ describe("calcite-list", () => {
       await secondDragHandle.click();
 
       await page.waitForChanges();
-      await page.waitForTimeout(listDebounceTimeout);
+      waitForTimeout(listDebounceTimeout);
 
       expect(await items[0].getProperty("active")).toBe(false);
       expect(await items[1].getProperty("active")).toBe(true);
@@ -925,7 +931,7 @@ describe("calcite-list", () => {
         </calcite-list>`,
       );
       await page.waitForChanges();
-      await page.waitForTimeout(listDebounceTimeout);
+      waitForTimeout(listDebounceTimeout);
       return page;
     }
 
@@ -1242,7 +1248,7 @@ describe("calcite-list", () => {
       await page.keyboard.press("ArrowDown");
       await page.waitForChanges();
       expect(await handle.getProperty("selected")).toBe(true);
-      await page.waitForTimeout(debounceTimeout);
+      waitForTimeout(debounceTimeout);
 
       startIndex += 1;
       const changeHandleLabel = await getAriaLabel();

--- a/packages/calcite-components/src/components/notice/notice.e2e.ts
+++ b/packages/calcite-components/src/components/notice/notice.e2e.ts
@@ -2,6 +2,7 @@ import { newE2EPage } from "@stencil/core/testing";
 import { accessible, focusable, renders, slots, hidden, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { openClose } from "../../tests/commonTests";
+import { waitForTimeout } from "../../tests/utils";
 import { CSS, SLOTS } from "./resources";
 
 describe("calcite-notice", () => {
@@ -99,7 +100,7 @@ describe("calcite-notice", () => {
     expect(await notice1.isVisible()).toBe(true);
 
     await noticeClose1.click();
-    await page.waitForTimeout(animationDurationInMs);
+    waitForTimeout(animationDurationInMs);
     expect(await notice1.isVisible()).not.toBe(true);
   });
 

--- a/packages/calcite-components/src/components/pick-list/pick-list.e2e.ts
+++ b/packages/calcite-components/src/components/pick-list/pick-list.e2e.ts
@@ -2,6 +2,7 @@ import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests";
 import { CSS as PICK_LIST_GROUP_CSS } from "../pick-list-group/resources";
+import { waitForTimeout } from "../../tests/utils";
 import { ICON_TYPES } from "./resources";
 import {
   disabling,
@@ -179,7 +180,7 @@ describe("calcite-pick-list", () => {
           filterInput.value = "numbers";
           filterInput.dispatchEvent(new CustomEvent("calciteInputInput"));
         });
-        await page.waitForTimeout(500);
+        waitForTimeout(500);
 
         const item1Visible = await item1.isVisible();
         const item2Visible = await item2.isVisible();

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -9,7 +9,7 @@ import {
   renders,
   t9n,
 } from "../../tests/commonTests";
-import { isElementFocused } from "../../tests/utils";
+import { isElementFocused, waitForTimeout } from "../../tests/utils";
 
 describe("calcite-rating", () => {
   describe("common tests", () => {
@@ -602,7 +602,7 @@ describe("calcite-rating", () => {
       await page.waitForChanges();
       await page.keyboard.press("Tab");
       await page.waitForChanges();
-      await page.waitForTimeout(200);
+      waitForTimeout(200);
 
       const hoveredElements = await page.findAll("calcite-rating >>> .star.hovered");
       const selectedElements = await page.findAll("calcite-rating >>> .star.selected");

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, defaults, reflects } from "../../tests/commonTests";
-import { GlobalTestProps, getFocusedElementProp } from "../../tests/utils";
+import { GlobalTestProps, getFocusedElementProp, waitForTimeout } from "../../tests/utils";
 import { CSS } from "../table-header/resources";
 import { CSS as CELL_CSS } from "../table-cell/resources";
 import { SLOTS } from "../table/resources";
@@ -2612,7 +2612,7 @@ interface SelectedItemsAssertionOptions {
  * @param root0.expectedItemIds
  */
 async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
+  waitForTimeout(100);
   const selectedItemIds = await page.evaluate(() => {
     const table = document.querySelector<HTMLCalciteTableElement>("calcite-table");
     return table.selectedItems.map((item) => item.id);

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -2,7 +2,7 @@ import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { TOOLTIP_OPEN_DELAY_MS, TOOLTIP_CLOSE_DELAY_MS } from "../tooltip/resources";
 import { accessible, defaults, floatingUIOwner, hidden, openClose, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { getElementXY, GlobalTestProps } from "../../tests/utils";
+import { getElementXY, GlobalTestProps, waitForTimeout } from "../../tests/utils";
 
 interface PointerMoveOptions {
   delay: number;
@@ -260,7 +260,7 @@ describe("calcite-tooltip", () => {
 
     await ref.hover();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     expect(await tooltip.isVisible()).toBe(true);
   });
@@ -282,7 +282,7 @@ describe("calcite-tooltip", () => {
 
     await ref.hover();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     expect(await tooltip.isVisible()).toBe(true);
   });
@@ -324,7 +324,7 @@ describe("calcite-tooltip", () => {
 
     await page.waitForChanges();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     expect(await tooltip.getProperty("open")).toBe(true);
 
@@ -334,7 +334,7 @@ describe("calcite-tooltip", () => {
 
     await page.waitForChanges();
 
-    await page.waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
+    waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
 
     expect(await tooltip.getProperty("open")).toBe(false);
   });
@@ -445,7 +445,7 @@ describe("calcite-tooltip", () => {
 
     await referenceElement.hover();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -480,7 +480,7 @@ describe("calcite-tooltip", () => {
 
     await referenceElement.hover();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -519,7 +519,7 @@ describe("calcite-tooltip", () => {
       el.dispatchEvent(new Event("pointermove"));
     });
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -575,7 +575,7 @@ describe("calcite-tooltip", () => {
       el.dispatchEvent(new Event("pointermove"));
     });
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -602,7 +602,7 @@ describe("calcite-tooltip", () => {
 
     await referenceElement.hover();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -643,7 +643,7 @@ describe("calcite-tooltip", () => {
 
     await referenceElement.click();
 
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
 
     await page.waitForChanges();
 
@@ -731,7 +731,7 @@ describe("calcite-tooltip", () => {
           await page.mouse.move(refElementX + xMoveOffset, refElementY, moveOptions);
           await page.waitForChanges();
 
-          await page.waitForTimeout(totalDelayFromMoveSteps);
+          waitForTimeout(totalDelayFromMoveSteps);
         },
         closeTooltip: async (page: E2EPage) => {
           const [refElementX, refElementY] = await getElementXY(page, "#ref");
@@ -741,7 +741,7 @@ describe("calcite-tooltip", () => {
           await page.mouse.move(0, 0, moveOptions);
           await page.waitForChanges();
 
-          await page.waitForTimeout(totalDelayFromMoveSteps);
+          waitForTimeout(totalDelayFromMoveSteps);
         },
       });
     });
@@ -839,7 +839,7 @@ describe("calcite-tooltip", () => {
       const ref = await page.find("#ref");
       await ref.hover();
 
-      await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+      waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
       await page.waitForChanges();
 
       expect(await tooltip.isVisible()).toBe(true);
@@ -852,7 +852,7 @@ describe("calcite-tooltip", () => {
       const hoverOutsideContainer = await page.find(".hoverOutsideContainer");
       await hoverOutsideContainer.hover();
 
-      await page.waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
+      waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
       await page.waitForChanges();
 
       expect(await tooltip.isVisible()).not.toBe(true);
@@ -909,7 +909,7 @@ describe("calcite-tooltip", () => {
 
     for (let i = 0; i < pointerMoves.length; i++) {
       const { delay, selector } = pointerMoves[i];
-      await page.waitForTimeout(delay);
+      waitForTimeout(delay);
       await page.$eval(selector, (el: HTMLElement) => {
         el.dispatchEvent(new Event("pointermove"));
       });
@@ -968,7 +968,7 @@ describe("calcite-tooltip", () => {
 
     for (let i = 0; i < pointerMoves.length; i++) {
       const { delay, selector } = pointerMoves[i];
-      await page.waitForTimeout(delay);
+      waitForTimeout(delay);
       await page.$eval(selector, (el: HTMLElement) => {
         el.dispatchEvent(new Event("pointermove"));
       });
@@ -1063,7 +1063,7 @@ describe("calcite-tooltip", () => {
     await page.$eval("#ref1", (el: HTMLElement) => {
       el.dispatchEvent(new Event("pointermove"));
     });
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+    waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
     await page.waitForChanges();
 
     expect(await tooltip1.getProperty("open")).toBe(true);
@@ -1072,7 +1072,7 @@ describe("calcite-tooltip", () => {
     await page.$eval("#ref2", (el: HTMLElement) => {
       el.dispatchEvent(new Event("pointermove"));
     });
-    await page.waitForTimeout(0);
+    waitForTimeout(0);
     await page.waitForChanges();
 
     expect(await tooltip1.getProperty("open")).toBe(false);

--- a/packages/calcite-components/src/tests/commonTests.ts
+++ b/packages/calcite-components/src/tests/commonTests.ts
@@ -15,6 +15,7 @@ import {
   isElementFocused,
   newProgrammaticE2EPage,
   skipAnimations,
+  waitForTimeout,
 } from "./utils";
 
 expect.extend(toHaveNoViolations);
@@ -1629,7 +1630,7 @@ export async function t9n(componentTestSetup: ComponentTestSetup): Promise<void>
 
     component.setAttribute("lang", "es");
     await page.waitForChanges();
-    await page.waitForTimeout(3000);
+    waitForTimeout(3000);
     const esMessages = await getCurrentMessages();
 
     expect(esMessages).toHaveProperty(fakeBundleIdentifier);

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -294,6 +294,16 @@ export async function waitForAnimationFrame(): Promise<void> {
 }
 
 /**
+ * Waits for the given number of milliseconds.
+ *
+ * @param ms
+ * @deprecated Waiting for arbitrary time is discouraged, please refer to https://github.com/puppeteer/puppeteer/pull/11780#issue-2106207539 for alternatives.
+ */
+export async function waitForTimeout(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
  * Creates an E2E page for tests that need to create and set up elements programmatically.
  *
  * @returns {Promise<E2EPage>} an e2e page


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

[`puppeteer@22.2.0` removed `page.waitForTimeout`](https://github.com/puppeteer/puppeteer/blob/7966dd726288bda48650a3604f8e12c6e4be41db/packages/puppeteer-core/CHANGELOG.md#2200-2024-02-05), so this PR:

* introduces a replacement util
* updates E2E tests
* bans usage of the method (error message shows alternative)

