### PR TITLE
chore(linting): restore disabling of ESLint rules that warn on common, useful patterns

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -49,6 +49,7 @@ module.exports = {
     "@stencil-community/own-props-must-be-private": "off",
     "@stencil-community/prefer-vdom-listener": "warn",
     "@stencil-community/required-jsdoc": "off",
+    "@stencil-community/strict-boolean-conditions": "off",
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/explicit-module-boundary-types": [
       "error",
@@ -72,6 +73,7 @@ module.exports = {
     curly: "error",
     "import/no-dynamic-require": ["error", { esmodule: true }],
     "import/order": ["error", { "newlines-between": "never" }],
+    "jest/expect-expect": "off",
     "jest/no-export": "warn",
     "jsdoc/check-tag-names": "off",
     "jsdoc/require-jsdoc": "off",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

✨↩️📏🚫✨