### PR TITLE
feat(input-time-zone): allow clearing value

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -2616,6 +2616,10 @@ export namespace Components {
     }
     interface CalciteInputTimeZone {
         /**
+          * When `true`, an empty value (`null`) will be allowed as a `value`.  When `false`, an offset or name value is enforced, and clearing the input or blurring will restore the last valid `value`.
+         */
+        "clearable": boolean;
+        /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
@@ -10079,6 +10083,10 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface CalciteInputTimeZone {
+        /**
+          * When `true`, an empty value (`null`) will be allowed as a `value`.  When `false`, an offset or name value is enforced, and clearing the input or blurring will restore the last valid `value`.
+         */
+        "clearable"?: boolean;
         /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */

--- a/packages/calcite-components/src/components/input-time-zone/assets/input-time-zone/t9n/messages.json
+++ b/packages/calcite-components/src/components/input-time-zone/assets/input-time-zone/t9n/messages.json
@@ -1,5 +1,7 @@
 {
   "chooseTimeZone": "Choose time zone.",
+  "offsetPlaceholder": "Search by city, region or offset",
+  "namePlaceholder": "Search by time zone",
   "timeZoneLabel": "({offset}) {cities}",
   "Africa/Abidjan": "Abidjan",
   "Africa/Accra": "Accra",

--- a/packages/calcite-components/src/components/input-time-zone/assets/input-time-zone/t9n/messages_en.json
+++ b/packages/calcite-components/src/components/input-time-zone/assets/input-time-zone/t9n/messages_en.json
@@ -1,5 +1,7 @@
 {
   "chooseTimeZone": "Choose time zone.",
+  "offsetPlaceholder": "Search by city, region or offset",
+  "namePlaceholder": "Search by time zone",
   "timeZoneLabel": "({offset}) {cities}",
   "Africa/Abidjan": "Abidjan",
   "Africa/Accra": "Accra",

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import {
   accessible,
@@ -325,12 +325,42 @@ describe("calcite-input-time-zone", () => {
       expect(await input.getProperty("value")).toBe(`${testTimeZoneItems[1].offset}`);
       expect(await selectedTimeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].label);
 
-      input.setProperty("value", null);
+      input.setProperty("value", "");
       await page.waitForChanges();
 
       selectedTimeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
       expect(await input.getProperty("value")).toBe(`${testTimeZoneItems[1].offset}`);
       expect(await selectedTimeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].label);
+    });
+
+    describe("clearing by value", () => {
+      let page: E2EPage;
+      let input: E2EElement;
+
+      beforeEach(async () => {
+        page = await newE2EPage();
+        await page.emulateTimezone(testTimeZoneItems[0].name);
+        await page.setContent(
+          addTimeZoneNamePolyfill(
+            html` <calcite-input-time-zone value="${testTimeZoneItems[1].offset}" clearable></calcite-input-time-zone>`,
+          ),
+        );
+        input = await page.find("calcite-input-time-zone");
+      });
+
+      it("empty string", async () => {
+        await input.setProperty("value", "");
+        await page.waitForChanges();
+
+        expect(await input.getProperty("value")).toBe("");
+      });
+
+      it("null", async () => {
+        await input.setProperty("value", null);
+        await page.waitForChanges();
+
+        expect(await input.getProperty("value")).toBe("");
+      });
     });
 
     it("allows users to deselect a time zone value when clearable is enabled", async () => {
@@ -350,7 +380,7 @@ describe("calcite-input-time-zone", () => {
       await input.press("Escape");
       await page.waitForChanges();
 
-      expect(await input.getProperty("value")).toBe(null);
+      expect(await input.getProperty("value")).toBe("");
     });
 
     it("can be cleared on initialization when clearable is enabled", async () => {
@@ -361,7 +391,7 @@ describe("calcite-input-time-zone", () => {
       );
 
       const input = await page.find("calcite-input-time-zone");
-      expect(await input.getProperty("value")).toBe(null);
+      expect(await input.getProperty("value")).toBe("");
     });
 
     it("selects user time zone value when value is not set and clearable is enabled", async () => {
@@ -443,21 +473,21 @@ describe("calcite-input-time-zone", () => {
     const inputTimeZone = await page.find("calcite-input-time-zone");
 
     let prevComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
-    await inputTimeZone.setProperty("lang", "es");
+    inputTimeZone.setProperty("lang", "es");
     await page.waitForChanges();
 
     let currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
     expect(currComboboxItem).not.toBe(prevComboboxItem);
 
     prevComboboxItem = currComboboxItem;
-    await inputTimeZone.setProperty("referenceDate", "2021-01-01");
+    inputTimeZone.setProperty("referenceDate", "2021-01-01");
     await page.waitForChanges();
 
     currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");
     expect(currComboboxItem).not.toBe(prevComboboxItem);
 
     prevComboboxItem = currComboboxItem;
-    await inputTimeZone.setProperty("mode", "list");
+    inputTimeZone.setProperty("mode", "list");
     await page.waitForChanges();
 
     currComboboxItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item");

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -304,7 +304,7 @@ describe("calcite-input-time-zone", () => {
     });
   });
 
-  describe("selection behavior", () => {
+  describe("clearable", () => {
     it("does not allow users to deselect a time zone value by default", async () => {
       const page = await newE2EPage();
       await page.emulateTimezone(testTimeZoneItems[0].name);
@@ -362,6 +362,17 @@ describe("calcite-input-time-zone", () => {
 
       const input = await page.find("calcite-input-time-zone");
       expect(await input.getProperty("value")).toBe(null);
+    });
+
+    it("selects user time zone value when value is not set and clearable is enabled", async () => {
+      const page = await newE2EPage();
+      await page.emulateTimezone(testTimeZoneItems[0].name);
+      await page.setContent(
+        addTimeZoneNamePolyfill(html`<calcite-input-time-zone clearable></calcite-input-time-zone>`),
+      );
+
+      const input = await page.find("calcite-input-time-zone");
+      expect(await input.getProperty("value")).toBe(`${testTimeZoneItems[0].offset}`);
     });
   });
 

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
@@ -25,6 +25,16 @@ export const simple = (): string => html`
   ></calcite-input-time-zone>
 `;
 
+export const clearable = (): string => html`
+  <label>default</label>
+  <calcite-input-time-zone mode="offset" clearable></calcite-input-time-zone>
+  <calcite-input-time-zone mode="name" clearable></calcite-input-time-zone>
+  <br />
+  <label>initialized as empty</label>
+  <calcite-input-time-zone mode="offset" clearable value=""></calcite-input-time-zone>
+  <calcite-input-time-zone mode="name" clearable value=""></calcite-input-time-zone>
+`;
+
 export const timeZoneNameMode_TestOnly = (): string => html`
   <calcite-input-time-zone mode="name" open></calcite-input-time-zone>
 `;

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.stories.ts
@@ -35,6 +35,8 @@ export const clearable = (): string => html`
   <calcite-input-time-zone mode="name" clearable value=""></calcite-input-time-zone>
 `;
 
+clearable.parameters = { chromatic: { delay: 500 } };
+
 export const timeZoneNameMode_TestOnly = (): string => html`
   <calcite-input-time-zone mode="name" open></calcite-input-time-zone>
 `;

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -195,7 +195,10 @@ export class InputTimeZone
 
   @Watch("value")
   handleValueChange(value: string, oldValue: string): void {
+    value = this.normalizeValue(value);
+
     if (!value && this.clearable) {
+      this.value = value;
       this.selectedTimeZoneItem = null;
       return;
     }
@@ -359,7 +362,7 @@ export class InputTimeZone
   private async updateTimeZoneItemsAndSelection(): Promise<void> {
     this.timeZoneItems = await this.createTimeZoneItems();
 
-    if ((this.value === null || this.value === "") && this.clearable) {
+    if (this.value === "" && this.clearable) {
       this.selectedTimeZoneItem = null;
       return;
     }
@@ -406,9 +409,14 @@ export class InputTimeZone
     disconnectMessages(this);
   }
 
+  private normalizeValue(value: string | null): string {
+    return value === null ? "" : value;
+  }
+
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
     await setUpMessages(this);
+    this.value = this.normalizeValue(this.value);
 
     await this.updateTimeZoneItemsAndSelection();
 

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -442,6 +442,9 @@ export class InputTimeZone
             onCalciteComboboxOpen={this.onComboboxOpen}
             open={this.open}
             overlayPositioning={this.overlayPositioning}
+            placeholder={
+              this.mode === "name" ? this.messages.namePlaceholder : this.messages.offsetPlaceholder
+            }
             readOnly={this.readOnly}
             scale={this.scale}
             selectionMode={this.clearable ? "single" : "single-persist"}

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -359,7 +359,7 @@ export class InputTimeZone
   private async updateTimeZoneItemsAndSelection(): Promise<void> {
     this.timeZoneItems = await this.createTimeZoneItems();
 
-    if (!this.value && this.clearable) {
+    if ((this.value === null || this.value === "") && this.clearable) {
       this.selectedTimeZoneItem = null;
       return;
     }

--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -175,11 +175,13 @@ function getTimeZoneShortOffset(
 export function findTimeZoneItemByProp(
   timeZoneItems: TimeZoneItem[],
   prop: string,
-  valueToMatch: string | number,
-): TimeZoneItem {
-  return timeZoneItems.find(
-    (item) =>
-      // intentional == to match string to number
-      item[prop] == valueToMatch,
-  );
+  valueToMatch: string | number | null,
+): TimeZoneItem | null {
+  return valueToMatch == null
+    ? null
+    : timeZoneItems.find(
+        (item) =>
+          // intentional == to match string to number
+          item[prop] == valueToMatch,
+      );
 }

--- a/packages/calcite-components/src/demos/input-time-zone.html
+++ b/packages/calcite-components/src/demos/input-time-zone.html
@@ -63,6 +63,21 @@
       </div>
 
       <div class="parent">
+        <div class="child right-aligned-text">Basic (offset mode, clearable)</div>
+        <div class="child">
+          <calcite-input-time-zone scale="s" clearable></calcite-input-time-zone>
+        </div>
+
+        <div class="child">
+          <calcite-input-time-zone scale="m" clearable></calcite-input-time-zone>
+        </div>
+
+        <div class="child">
+          <calcite-input-time-zone scale="l" clearable></calcite-input-time-zone>
+        </div>
+      </div>
+
+      <div class="parent">
         <div class="child right-aligned-text">Basic (offset mode) + readonly</div>
         <div class="child">
           <calcite-input-time-zone scale="s" read-only="true"></calcite-input-time-zone>
@@ -134,6 +149,21 @@
 
         <div class="child">
           <calcite-input-time-zone scale="l" mode="name"></calcite-input-time-zone>
+        </div>
+      </div>
+
+      <div class="parent">
+        <div class="child right-aligned-text">name mode (clearable)</div>
+        <div class="child">
+          <calcite-input-time-zone scale="s" mode="name" clearable></calcite-input-time-zone>
+        </div>
+
+        <div class="child">
+          <calcite-input-time-zone scale="m" mode="name" clearable></calcite-input-time-zone>
+        </div>
+
+        <div class="child">
+          <calcite-input-time-zone scale="l" mode="name" clearable></calcite-input-time-zone>
         </div>
       </div>
     </demo-dom-swapper>


### PR DESCRIPTION
**Related Issue:** #9020

## Summary

Adds `clearable` property to allow `input-time-zone` to be cleared via the UI or programmatically via `””` or `null`.
