### PR TITLE
chore: restore Stencil build step prior `screenshot-tests:preview`

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -34,7 +34,7 @@
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
     "posttest": "npm run test:prerender",
     "screenshot-tests": "storybook build",
-    "screenshot-tests:preview": "NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_SCREENSHOT_LOCAL_BUILD=true storybook dev",
+    "screenshot-tests:preview": "npm run util:prep-storybook-build && NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_SCREENSHOT_LOCAL_BUILD=true storybook dev",
     "screenshot-tests:publish": "npm run screenshot-tests && storybook-to-ghpages --existing-output-dir=docs",
     "start": "npm run util:clean-js-files && concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev -- --serve\"",
     "test": "stencil test --no-docs --no-build --spec --e2e",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restores build step unintentionally removed in https://github.com/Esri/calcite-design-system/pull/9030.