### PR TITLE
test(tile): use explicit dimensions to stabilize all-variants screenshot test

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -796,6 +796,11 @@ export const allVariants = (): string => html`
   </div>
 `;
 
+allVariants.decorators = [
+  (storyFn: () => string) =>
+    html` <div style="width: 1200px; height: 6000px;">This is a decorator for modals and such ${storyFn()}</div>`,
+];
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-tile
     ${boolean("active", false)}

--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -797,19 +797,12 @@ export const allVariants = (): string => html`
 `;
 
 allVariants.decorators = [
-  (storyFn: () => string) => html` <div style="width: 1400px; height: 6000px;">${storyFn()}</div>`,
+  (storyFn: () => string) => html` <div style="width: 1800px; display: flex;">${storyFn()}</div>`,
 ];
 allVariants.parameters = {
   chromatic: {
     delay: 1000,
-  },
-  modes: {
-    default: {
-      viewport: {
-        height: 6000,
-        width: 1400,
-      },
-    },
+    viewports: [1800],
   },
 };
 

--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -803,6 +803,14 @@ allVariants.parameters = {
   chromatic: {
     delay: 1000,
   },
+  modes: {
+    default: {
+      viewport: {
+        height: 6000,
+        width: 1400,
+      },
+    },
+  },
 };
 
 export const darkModeRTL_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -800,7 +800,11 @@ allVariants.decorators = [
   (storyFn: () => string) =>
     html` <div style="width: 1200px; height: 6000px;">This is a decorator for modals and such ${storyFn()}</div>`,
 ];
-
+allVariants.parameters = {
+  chromatic: {
+    delay: 500
+  },
+};
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-tile
     ${boolean("active", false)}

--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -804,6 +804,7 @@ allVariants.parameters = {
     delay: 1000,
   },
 };
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-tile
     ${boolean("active", false)}

--- a/packages/calcite-components/src/components/tile/tile.stories.ts
+++ b/packages/calcite-components/src/components/tile/tile.stories.ts
@@ -797,12 +797,11 @@ export const allVariants = (): string => html`
 `;
 
 allVariants.decorators = [
-  (storyFn: () => string) =>
-    html` <div style="width: 1200px; height: 6000px;">This is a decorator for modals and such ${storyFn()}</div>`,
+  (storyFn: () => string) => html` <div style="width: 1400px; height: 6000px;">${storyFn()}</div>`,
 ];
 allVariants.parameters = {
   chromatic: {
-    delay: 500
+    delay: 1000,
   },
 };
 export const darkModeRTL_TestOnly = (): string => html`


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Updates story to use explicit dimensions via decorator as recommended in [Chromatic doc](https://www.chromatic.com/docs/snapshots/#why-isn%E2%80%99t-my-modal-or-dialog-captured).
