### PR TITLE
fix(tab): remove tabpanel from keyboard tab sequence

### DIFF
--- a/packages/calcite-components/src/components/tab/tab.tsx
+++ b/packages/calcite-components/src/components/tab/tab.tsx
@@ -64,11 +64,7 @@ export class Tab {
 
     return (
       <Host aria-labelledby={this.labeledBy} id={id}>
-        <div
-          class={{ [CSS.container]: true, [`scale-${this.scale}`]: true }}
-          role="tabpanel"
-          tabIndex={this.selected ? 0 : -1}
-        >
+        <div class={{ [CSS.container]: true, [`scale-${this.scale}`]: true }} role="tabpanel">
           <section class={CSS.content}>
             <slot />
           </section>


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/7576

## Summary
Removes `tabpanel` from keyboard tab sequence per [W3Cspecs](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-manual/#:~:text=Note%20that%20since,is%20not%20focusable.).