### PR TITLE
fix(slider): rename `highlightPlacement` to `fillPlacement`

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -4191,6 +4191,10 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
+         */
+        "fillPlacement": "start" | "none" | "end";
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
@@ -4202,10 +4206,6 @@ export namespace Components {
           * When `true`, indicates a histogram is present.
          */
         "hasHistogram": boolean;
-        /**
-          * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
-         */
-        "fillPlacement": "start" | "none" | "end";
         /**
           * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
           * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/main/src/components/graph/interfaces.ts#L5)
@@ -11771,6 +11771,10 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
+         */
+        "fillPlacement"?: "start" | "none" | "end";
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
@@ -11782,10 +11786,6 @@ declare namespace LocalJSX {
           * When `true`, indicates a histogram is present.
          */
         "hasHistogram"?: boolean;
-        /**
-          * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
-         */
-        "fillPlacement"?: "start" | "none" | "end";
         /**
           * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
           * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/main/src/components/graph/interfaces.ts#L5)

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -3383,6 +3383,11 @@ export namespace Components {
     }
     interface CalcitePagination {
         /**
+          * Set a specified page as active.
+          * @param page
+         */
+        "goTo": (page: number | "start" | "end") => Promise<void>;
+        /**
           * When `true`, number values are displayed with a group separator corresponding to the language and country format.
          */
         "groupSeparator": boolean;
@@ -4200,7 +4205,7 @@ export namespace Components {
         /**
           * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
          */
-        "highlightPlacement": "start" | "none" | "end";
+        "fillPlacement": "start" | "none" | "end";
         /**
           * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
           * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/main/src/components/graph/interfaces.ts#L5)
@@ -11780,7 +11785,7 @@ declare namespace LocalJSX {
         /**
           * Used to configure where the fill is placed along the slider track in relation to the value handle.  Range mode will always display the fill between the min and max handles.
          */
-        "highlightPlacement"?: "start" | "none" | "end";
+        "fillPlacement"?: "start" | "none" | "end";
         /**
           * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
           * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/main/src/components/graph/interfaces.ts#L5)

--- a/packages/calcite-components/src/components/slider/slider.e2e.ts
+++ b/packages/calcite-components/src/components/slider/slider.e2e.ts
@@ -30,6 +30,10 @@ describe("calcite-slider", () => {
         defaultValue: false,
       },
       {
+        propertyName: "fillPlacement",
+        defaultValue: "start",
+      },
+      {
         propertyName: "labelFormatter",
         defaultValue: undefined,
       },

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -97,7 +97,7 @@ export class Slider
    *
    * Range mode will always display the fill between the min and max handles.
    */
-  @Prop({ reflect: true }) highlightPlacement: "start" | "none" | "end" = "start";
+  @Prop({ reflect: true }) fillPlacement: "start" | "none" | "end" = "start";
 
   /**
    * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
@@ -296,14 +296,14 @@ export class Slider
         mirror,
       });
 
-    const { highlightPlacement } = this;
+    const { fillPlacement } = this;
     const trackRangePlacementStyles =
-      highlightPlacement === "none"
+      fillPlacement === "none"
         ? {
             left: `unset`,
             right: `unset`,
           }
-        : highlightPlacement === "end"
+        : fillPlacement === "end"
           ? {
               left: `${mirror ? minInterval : maxInterval}%`,
               right: `${mirror ? maxInterval : minInterval}%`,

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -78,6 +78,13 @@ export class Slider
   @Prop({ reflect: true }) disabled = false;
 
   /**
+   * Used to configure where the fill is placed along the slider track in relation to the value handle.
+   *
+   * Range mode will always display the fill between the min and max handles.
+   */
+  @Prop({ reflect: true }) fillPlacement: "start" | "none" | "end" = "start";
+
+  /**
    * The `id` of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.
@@ -91,13 +98,6 @@ export class Slider
 
   /** When `true`, indicates a histogram is present. */
   @Prop({ reflect: true, mutable: true }) hasHistogram = false;
-
-  /**
-   * Used to configure where the fill is placed along the slider track in relation to the value handle.
-   *
-   * Range mode will always display the fill between the min and max handles.
-   */
-  @Prop({ reflect: true }) fillPlacement: "start" | "none" | "end" = "start";
 
   /**
    * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.


### PR DESCRIPTION
**Related Issue:** #1631

## Summary

Renames the property according to thread in #9170. 
