### PR TITLE
fix(combobox): update the focused chevron icon color

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.scss
+++ b/packages/calcite-components/src/components/combobox/combobox.scss
@@ -60,8 +60,6 @@
   padding-block: calc(var(--calcite-combobox-item-spacing-unit-s) / 4);
   padding-inline: var(--calcite-combobox-item-spacing-unit-l);
 
-  &:focus-within,
-  &:active,
   &:hover {
     .icon {
       color: var(--calcite-color-text-1);


### PR DESCRIPTION
**Related Issue:** [#7711](https://github.com/Esri/calcite-design-system/issues/7711)

### Summary
This updates `combobox` chevron colors to be --calcite-color-text-3 when idle or focused, and `--calcite-color-text-1` when hovered.