### PR TITLE
fix(radio-button): display validation message in parent group

### DIFF
--- a/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
+++ b/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
@@ -583,6 +583,7 @@ describe("calcite-radio-button", () => {
     });
 
     // skipped until the util supports a parent component wrapping the form associated element(s)
+    // https://github.com/Esri/calcite-design-system/issues/9221
     describe.skip("group", () => {
       formAssociated(
         html`

--- a/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
+++ b/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
@@ -575,6 +575,39 @@ describe("calcite-radio-button", () => {
   });
 
   describe("is form-associated", () => {
-    formAssociated("calcite-radio-button", { testValue: true, inputType: "radio" });
+    describe("no group", () => {
+      formAssociated("calcite-radio-button", {
+        testValue: true,
+        inputType: "radio",
+      });
+    });
+
+    // skipped until the util supports a parent component wrapping the form associated element(s)
+    describe.skip("group", () => {
+      formAssociated(
+        html`
+          <calcite-radio-button-group name="using" required>
+            <calcite-label layout="inline">
+              Yes
+              <calcite-radio-button value="yes" required></calcite-radio-button>
+            </calcite-label>
+            <calcite-label layout="inline">
+              No
+              <calcite-radio-button value="no" required></calcite-radio-button>
+            </calcite-label>
+            <calcite-label layout="inline">
+              Maybe
+              <calcite-radio-button value="maybe" required></calcite-radio-button>
+            </calcite-label>
+          </calcite-radio-button-group>
+        `,
+        {
+          testValue: true,
+          inputType: "radio",
+          validation: true,
+          changeValueKeys: ["Space"],
+        },
+      );
+    });
   });
 });

--- a/packages/calcite-components/src/demos/validation.html
+++ b/packages/calcite-components/src/demos/validation.html
@@ -1,5 +1,4 @@
 <!doctype html>
-<!--  updated version of https://codepen.io/jcfranco/pen/vYmoKYq -->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/calcite-components/src/demos/validation.html
+++ b/packages/calcite-components/src/demos/validation.html
@@ -1,0 +1,378 @@
+<!doctype html>
+<!--  updated version of https://codepen.io/jcfranco/pen/vYmoKYq -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Form</title>
+    <script src="./_assets/head.js"></script>
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      body {
+        font-family: var(--calcite-font-family-primary);
+        font-size: var(--calcite-font-size-xl);
+        color: var(--calcite-color-text-1);
+        max-width: 1024px;
+        min-width: 280px;
+        width: 70vw;
+        padding: 0 var(--calcite-spacing-xxl);
+        margin: 0 auto;
+        background-color: var(--calcite-color-background);
+      }
+
+      /* Mode Switcher */
+      #mode-container {
+        position: fixed;
+        top: var(--calcite-spacing-xxl);
+        right: var(--calcite-spacing-xxl);
+        z-index: 2;
+        border: var(--calcite-border-width-sm) solid;
+        background-color: var(--calcite-color-background);
+        border-color: var(--calcite-color-border-1);
+        border-radius: var(--calcite-corner-radius-round);
+      }
+
+      #mode-container > calcite-label {
+        --calcite-label-margin-bottom: 0;
+      }
+
+      #mode-container calcite-icon {
+        padding: var(--calcite-spacing-md);
+      }
+
+      /* Progress bar */
+      #progress {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: var(--calcite-z-index-overlay);
+      }
+
+      /* Form */
+      ol {
+        margin: var(--calcite-spacing-xl) 0;
+        padding: 0 var(--calcite-spacing-xxxl);
+      }
+
+      ol li {
+        padding: 0 0 var(--calcite-spacing-xxl) 0;
+      }
+
+      fieldset {
+        padding: var(--calcite-spacing-xl);
+        margin: var(--calcite-spacing-xxxl) 0;
+        border-collapse: collapse;
+        border: var(--calcite-border-width-sm) solid;
+        border-color: var(--calcite-color-border-1);
+        border-radius: var(--calcite-corner-radius-round);
+      }
+
+      #submit {
+        padding: 0 var(--calcite-spacing-sm);
+      }
+
+      /* custom styling of invalid elements */
+      [status="invalid"] {
+        --calcite-color-foreground-1: #f4c4d3;
+      }
+    </style>
+  </head>
+
+  <body>
+    <demo-dom-swapper>
+      <h1 style="margin: 0 auto; text-align: center">Form Validation</h1>
+
+      <!-- Switch, mode -->
+      <div id="mode-container">
+        <calcite-label layout="inline">
+          <calcite-icon icon="brightness" scale="s" class="mode-switch-icon"> </calcite-icon>
+          <calcite-switch id="mode"></calcite-switch>
+          <calcite-icon icon="moon" scale="s" class="mode-switch-icon"> </calcite-icon>
+        </calcite-label>
+      </div>
+
+      <!-- Notice -->
+      <calcite-notice icon="information" open closable>
+        <div slot="title">Please fill out our questionnaire</div>
+        <div slot="message">Help us develop better Calcite components.</div>
+      </calcite-notice>
+
+      <!-- Form -->
+      <form id="form">
+        <fieldset>
+          <legend>Questionnaire</legend>
+          <ol>
+            <!-- Text input, icon, tooltip -->
+            <li>
+              <calcite-label>
+                <span>
+                  Your name
+                  <calcite-icon tabindex="0" id="name-help" icon="question" scale="s"></calcite-icon>
+                </span>
+                <calcite-input-text
+                  pattern="^\w+\s\w+$"
+                  minlength="3"
+                  maxlength="69"
+                  placeholder="John Doe"
+                  name="fullName"
+                  id="fullName"
+                  validation-message="Please enter your name."
+                  required
+                ></calcite-input-text>
+              </calcite-label>
+              <calcite-tooltip reference-element="name-help">
+                It's a pleasure to meet you! Let us know your name incase we have any further questions.
+              </calcite-tooltip>
+            </li>
+
+            <!-- Select -->
+            <li>
+              <calcite-label>
+                Where did you hear about Calcite components?
+                <calcite-select name="where" required>
+                  <calcite-option label="Please select&hellip;"></calcite-option>
+                  <calcite-option value="Esri DevSummit" label="Esri DevSummit"></calcite-option>
+                  <calcite-option value="Search engine" label="Search engine"></calcite-option>
+                  <calcite-option value="Social media" label="Social media"></calcite-option>
+                  <calcite-option value="A little bird told me" label="A little bird told me"></calcite-option>
+                </calcite-select>
+              </calcite-label>
+            </li>
+
+            <!-- Date picker -->
+            <li>
+              <calcite-label>
+                When did you hear about Calcite components?
+                <calcite-input-date-picker id="when" name="when" required></calcite-input-date-picker>
+              </calcite-label>
+            </li>
+
+            <!-- Segmented control -->
+            <li>
+              <calcite-label>
+                How useful is the Calcite Design System?
+                <calcite-segmented-control layout="horizontal" name="usefulness" required>
+                  <calcite-segmented-control-item value="0">😴&nbsp;Very useless</calcite-segmented-control-item>
+                  <calcite-segmented-control-item value="1">🥱&nbsp;Somewhat useless</calcite-segmented-control-item>
+                  <calcite-segmented-control-item value="2" checked>🤔&nbsp;Undecided</calcite-segmented-control-item>
+                  <calcite-segmented-control-item value="3">😀&nbsp;Somewhat useful</calcite-segmented-control-item>
+                  <calcite-segmented-control-item value="5">🥳&nbsp;Very useful</calcite-segmented-control-item>
+                </calcite-segmented-control>
+              </calcite-label>
+            </li>
+
+            <!-- Radio group -->
+            <li>
+              <calcite-label>
+                Will you be using Calcite components in an upcoming project?
+                <calcite-radio-button-group name="using" required>
+                  <calcite-label layout="inline">
+                    Yes
+                    <calcite-radio-button value="yes"></calcite-radio-button>
+                  </calcite-label>
+                  <calcite-label layout="inline">
+                    No
+                    <calcite-radio-button value="no"></calcite-radio-button>
+                  </calcite-label>
+                  <calcite-label layout="inline">
+                    Maybe
+                    <calcite-radio-button value="maybe"></calcite-radio-button>
+                  </calcite-label>
+                </calcite-radio-button-group>
+              </calcite-label>
+            </li>
+
+            <!-- Combobox -->
+            <li>
+              <calcite-label>
+                What are your favorite component(s)?
+                <calcite-combobox
+                  id="favoriteComponents"
+                  name="favoriteComponents"
+                  placeholder="Select favorites&hellip;"
+                  max-items="6"
+                  required
+                ></calcite-combobox>
+              </calcite-label>
+            </li>
+
+            <!-- Text input -->
+            <li>
+              <calcite-label>
+                What is the URL of your favorite application that uses Calcite components?
+                <calcite-input-text
+                  name="favoriteApp"
+                  id="favoriteApp"
+                  pattern="^https:\/\/.+"
+                  minlength="3"
+                  required
+                ></calcite-input-text>
+              </calcite-label>
+            </li>
+
+            <!-- Slider -->
+            <li>
+              <calcite-label>
+                How many components will you be using in your project?
+                <calcite-slider
+                  id="usage"
+                  name="usage"
+                  snap
+                  label-handles
+                  label-ticks
+                  ticks="2"
+                  label="Number of components"
+                  value="0"
+                  min="0"
+                  max="10"
+                  step="1"
+                ></calcite-slider>
+              </calcite-label>
+            </li>
+
+            <!-- Checkbox -->
+            <li>
+              <calcite-label>
+                What are the most important aspect(s) of a component?
+                <div>
+                  <calcite-label layout="inline">
+                    <calcite-checkbox name="configurability"></calcite-checkbox>
+                    Configurability
+                  </calcite-label>
+                  <calcite-label layout="inline">
+                    <calcite-checkbox name="accessibility"></calcite-checkbox>
+                    Accessibility
+                  </calcite-label>
+                  <calcite-label layout="inline">
+                    <calcite-checkbox name="easy"></calcite-checkbox>
+                    Ease of use
+                  </calcite-label>
+                </div>
+              </calcite-label>
+            </li>
+
+            <!-- Number input -->
+            <li>
+              <calcite-label>
+                How many Calcite components have you seen in the wild?
+                <calcite-input-number
+                  id="numberSeen"
+                  name="numberSeen"
+                  min="0"
+                  max="100"
+                  required
+                ></calcite-input-number>
+              </calcite-label>
+            </li>
+
+            <!-- Rating -->
+            <li>
+              <calcite-label>
+                How many stars would you give Calcite components?
+                <calcite-rating name="rating" value="1"></calcite-rating>
+              </calcite-label>
+            </li>
+          </ol>
+
+          <!-- Button -->
+          <calcite-button id="submit" type="submit">Submit</calcite-button>
+          <calcite-button id="reset" type="reset">Reset</calcite-button>
+        </fieldset>
+      </form>
+
+      <!-- Alert -->
+      <calcite-alert id="alert" icon auto-close auto-close-duration="fast" kind="success" label="success">
+        <div slot="message">
+          <strong>Success!</strong>
+          Thank you for your feedback.
+        </div>
+      </calcite-alert>
+
+      <!-- Progress -->
+      <calcite-progress id="progress" type="indeterminate" hidden></calcite-progress>
+    </demo-dom-swapper>
+  </body>
+
+  <script>
+    window.onload = () => {
+      // Mode Switcher
+      document.getElementById("mode")?.addEventListener("calciteSwitchChange", () => {
+        document.body.classList.toggle("calcite-mode-dark");
+      });
+
+      // Combobox
+      const comboboxItems = [
+        "Accordion",
+        "Alert",
+        "Avatar",
+        "Button",
+        "Card",
+        "Chip",
+        "Combobox",
+        "Dropdown",
+        "Flow",
+        "Icon",
+        "Label",
+        "List",
+        "Loader",
+        "Menu",
+        "Meter",
+        "Modal",
+        "Navigation",
+        "Notice",
+        "Pagination",
+        "Panel",
+        "Popover",
+        "Progress",
+        "Rating",
+        "Shell",
+        "Slider",
+        "Switch",
+        "Table",
+        "Tabs",
+        "Tooltip",
+        "Tree",
+      ];
+
+      const combobox = document.getElementById("favoriteComponents");
+      comboboxItems.forEach((item, index) => {
+        const comboboxItem = document.createElement("calcite-combobox-item");
+        comboboxItem.textLabel = item;
+        comboboxItem.value = index;
+        combobox.appendChild(comboboxItem);
+      });
+
+      // Date picker
+      const datePicker = document.getElementById("when");
+      datePicker.maxAsDate = new Date();
+      datePicker.min = "2021-01-01";
+
+      // Form submission
+      const form = document.getElementById("form");
+      const submit = document.getElementById("submit");
+      const progress = document.getElementById("progress");
+      const alert = document.getElementById("alert");
+
+      form.onsubmit = (event) => {
+        event.preventDefault();
+        submit.loading = true;
+        progress.removeAttribute("hidden");
+
+        setTimeout(() => {
+          submit.loading = false;
+          progress.setAttribute("hidden", "");
+          alert.open = true;
+        }, 2500);
+      };
+    };
+  </script>
+</html>

--- a/packages/calcite-components/src/index.html
+++ b/packages/calcite-components/src/index.html
@@ -174,6 +174,13 @@
         </div>
 
         <div>
+          <a href="/demos/validation.html">
+            <calcite-action scale="s" text="Form Validation" alignment="start" text-enabled appearance="solid">
+            </calcite-action>
+          </a>
+        </div>
+
+        <div>
           <a href="/demos/graph.html">
             <calcite-action scale="s" text="Graph" alignment="start" text-enabled appearance="solid"> </calcite-action>
           </a>

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -2,7 +2,13 @@ import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing
 import { toHaveNoViolations } from "jest-axe";
 import { KeyInput } from "puppeteer";
 import { html } from "../../../support/formatting";
-import { getClearValidationEventName, hiddenFormInputSlotName, componentsWithInputEvent } from "../../utils/form";
+import {
+  getClearValidationEventName,
+  hiddenFormInputSlotName,
+  componentsWithInputEvent,
+  ValidationProps,
+} from "../../utils/form";
+import { closestElementCrossShadowBoundary } from "../../utils/dom";
 import { GlobalTestProps } from "./../utils";
 import { isHTML, getTag, getTagOrHTMLWithBeforeContent } from "./utils";
 import { TagOrHTMLWithBeforeContent, TagOrHTML } from "./interfaces";
@@ -139,7 +145,6 @@ export function formAssociated(
   }
 
   async function testRequiredPropertyValidation(): Promise<void> {
-    const requiredValidationMessage = "Please fill out this field.";
     const { beforeContent, tagOrHTML } = getTagOrHTMLWithBeforeContent(componentTagOrHtml);
     const tag = getTag(tagOrHTML);
     const componentHtml = ensureUnchecked(
@@ -162,6 +167,9 @@ export function formAssociated(
 
     const submitButton = await page.find("#submitButton");
     const spyEvent = await page.spyOnEvent(getClearValidationEventName(tag));
+
+    const requiredValidationMessage =
+      options?.inputType === "radio" ? "Please select one of these options." : "Please fill out this field.";
 
     await assertPreventsFormSubmission(page, component, submitButton, requiredValidationMessage);
     await assertClearsValidationOnValueChange(page, component, options, spyEvent, tag);
@@ -392,7 +400,7 @@ export function formAssociated(
     await submitButton.click();
     await page.waitForChanges();
 
-    await expectValidationInvalid(component, message);
+    await expectValidationProps(page, component, { message, icon: "", status: "invalid" });
   }
 
   async function assertClearsValidationOnValueChange(
@@ -420,7 +428,7 @@ export function formAssociated(
       expect(event).toHaveReceivedEventTimes(1);
     }
 
-    await expectValidationIdle(component);
+    await expectValidationProps(page, component);
   }
 
   async function assertUserMessageNotOverridden(page: E2EPage, component: E2EElement, submitButton: E2EElement) {
@@ -436,18 +444,35 @@ export function formAssociated(
     await submitButton.click();
     await page.waitForChanges();
 
-    await expectValidationInvalid(component, customValidationMessage, customValidationIcon);
+    await expectValidationProps(page, component, {
+      message: customValidationMessage,
+      icon: customValidationIcon,
+      status: "invalid",
+    });
   }
 
-  async function expectValidationIdle(element: E2EElement) {
-    expect(await element.getProperty("status")).toBe("idle");
-    expect(await element.getProperty("validationMessage")).toBe("");
-    expect(await element.getProperty("validationIcon")).toBe(false);
-  }
+  async function expectValidationProps(page: E2EPage, element: E2EElement, validationProps?: ValidationProps) {
+    let testProps = validationProps;
 
-  async function expectValidationInvalid(element: E2EElement, message: string, icon: string = "") {
-    expect(await element.getProperty("status")).toBe("invalid");
-    expect(await element.getProperty("validationMessage")).toBe(message);
-    expect(element.getAttribute("validation-icon")).toBe(icon);
+    if (element.nodeName === "CALCITE-RADIO-BUTTON") {
+      element.setProperty("id", "radio-button");
+      await page.waitForChanges();
+      testProps = await page.evaluate(() => {
+        const groupEl = closestElementCrossShadowBoundary<HTMLCalciteRadioButtonGroupElement>(
+          document.querySelector("#radio-button"),
+          "calcite-radio-button-group",
+        );
+
+        return {
+          message: groupEl.validationMessage,
+          icon: groupEl.validationIcon,
+          status: groupEl.status,
+        };
+      });
+    }
+
+    expect(await element.getProperty("status")).toBe(testProps?.status ?? "idle");
+    expect(await element.getProperty("validationMessage")).toBe(testProps?.message ?? "");
+    expect(element.getAttribute("validation-icon")).toBe(testProps?.icon ?? null);
   }
 }

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -454,6 +454,7 @@ export function formAssociated(
   async function expectValidationProps(page: E2EPage, element: E2EElement, validationProps?: ValidationProps) {
     let testProps = validationProps;
 
+    // radio-button is formAssociated, but the validation props are on the parent group
     if (element.nodeName === "CALCITE-RADIO-BUTTON") {
       element.setProperty("id", "radio-button");
       await page.waitForChanges();

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -1,4 +1,5 @@
 import { FunctionalComponent, h } from "@stencil/core";
+import { Status } from "../components";
 import { closestElementCrossShadowBoundary, queryElementRoots } from "./dom";
 
 /**
@@ -194,31 +195,52 @@ function hasRegisteredFormComponentParent(
   return hasRegisteredFormComponentParent;
 }
 
-function clearFormValidation(component: HTMLCalciteInputElement | FormComponent): void {
+function clearValidationMessage(component: HTMLCalciteInputElement | FormComponent): void {
   "status" in component && (component.status = "idle");
   "validationIcon" in component && (component.validationIcon = false);
   "validationMessage" in component && (component.validationMessage = "");
 }
 
-function setInvalidFormValidation(
-  component: HTMLCalciteInputElement | FormComponent,
-  message: string,
-): void {
-  "status" in component && (component.status = "invalid");
+// exported for test purposes only
+export interface ValidationProps {
+  status: Status;
+  message: string;
+  icon: string | boolean;
+}
 
-  "validationIcon" in component && !component.validationIcon && (component.validationIcon = true);
+function displayValidationMessage(
+  component: HTMLCalciteInputElement | FormComponent,
+  { status, message, icon }: ValidationProps,
+): void {
+  "status" in component && (component.status = status);
+
+  "validationIcon" in component &&
+    typeof component.validationIcon !== "string" &&
+    (component.validationIcon = icon);
 
   "validationMessage" in component &&
     !component.validationMessage &&
     (component.validationMessage = message);
 }
 
-function displayValidationMessage(event: Event) {
+function invalidHandler(event: Event) {
   // target is the hidden input, which is slotted in the actual form component
   const hiddenInput = event?.target as HTMLInputElement;
 
   // not necessarily a calcite-input, but we don't have an HTMLCalciteFormElement type
-  const formComponent = hiddenInput?.parentElement as HTMLCalciteInputElement;
+  let formComponent = hiddenInput?.parentElement;
+
+  // radio-button is formAssociated, but the validation props are on the parent group
+  if (hiddenInput?.parentElement.nodeName === "CALCITE-RADIO-BUTTON") {
+    formComponent = closestElementCrossShadowBoundary<HTMLCalciteRadioButtonGroupElement>(
+      hiddenInput?.parentElement,
+      "calcite-radio-button-group",
+    );
+
+    if (!formComponent) {
+      return;
+    }
+  }
 
   const componentTag = formComponent?.nodeName?.toLowerCase();
   const componentTagParts = componentTag?.split("-");
@@ -230,16 +252,24 @@ function displayValidationMessage(event: Event) {
   // prevent the browser from showing the native validation popover
   event?.preventDefault();
 
-  setInvalidFormValidation(formComponent, hiddenInput?.validationMessage);
+  displayValidationMessage(formComponent as HTMLCalciteInputElement, {
+    message: hiddenInput?.validationMessage,
+    icon: true,
+    status: "invalid",
+  });
 
-  if (formComponent?.validationMessage !== hiddenInput?.validationMessage) {
+  if (
+    (formComponent as HTMLCalciteInputElement).validationMessage !== hiddenInput?.validationMessage
+  ) {
     return;
   }
 
   const clearValidationEvent = getClearValidationEventName(componentTag);
-  formComponent.addEventListener(clearValidationEvent, () => clearFormValidation(formComponent), {
-    once: true,
-  });
+  formComponent.addEventListener(
+    clearValidationEvent,
+    () => clearValidationMessage(formComponent as HTMLCalciteInputElement),
+    { once: true },
+  );
 }
 
 /**
@@ -255,9 +285,9 @@ export function submitForm(component: FormOwner): boolean {
     return false;
   }
 
-  formEl.addEventListener("invalid", displayValidationMessage, true);
+  formEl.addEventListener("invalid", invalidHandler, true);
   formEl.requestSubmit();
-  formEl.removeEventListener("invalid", displayValidationMessage, true);
+  formEl.removeEventListener("invalid", invalidHandler, true);
 
   requestAnimationFrame(() => {
     const invalidEls = formEl.querySelectorAll("[status=invalid]");
@@ -323,7 +353,7 @@ export function findAssociatedForm(component: FormOwner): HTMLFormElement | null
 }
 
 function onFormReset<T>(this: FormComponent<T>): void {
-  clearFormValidation(this);
+  clearValidationMessage(this);
   if (isCheckable(this)) {
     this.checked = this.defaultChecked;
     return;


### PR DESCRIPTION
**Related Issue:** #9220

## Summary

Fix validation messages not displaying on `calcite-radio-button-group` during form submission.

Note: `calcite-radio-button`s need to be in a group, or else they will not display validation messages based on the `required` constraint.

The formAssociated common test needs to be updated to support a parent component wrapping the form associated element. Currently it assumes the first element it finds will be the form associated component to test. I will do this in a follow up PR, likely after the release.