### PR TITLE
refactor(tests): extract selected item assertion util

### DIFF
--- a/packages/calcite-components/src/components/card-group/card-group.e2e.ts
+++ b/packages/calcite-components/src/components/card-group/card-group.e2e.ts
@@ -1,8 +1,8 @@
-import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, disabled } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
 import { CSS } from "../card/resources";
+import { createSelectedItemsAsserter } from "../../tests/utils";
 
 describe("calcite-card-group", () => {
   describe("renders", () => {
@@ -74,7 +74,11 @@ describe("calcite-card-group", () => {
       const card2CheckAction = await page.find(`#card-2 >>> .${CSS.checkboxWrapper}`);
 
       const cardGroupSelectSpy = await element.spyOnEvent("calciteCardGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-card-group",
+        "calciteCardGroupSelect",
+      );
 
       const cardSelectSpy1 = await card1.spyOnEvent("calciteCardSelect");
       const cardSelectSpy2 = await card2.spyOnEvent("calciteCardSelect");
@@ -82,7 +86,7 @@ describe("calcite-card-group", () => {
       expect(cardSelectSpy1).toHaveReceivedEventTimes(0);
       expect(cardSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card2.id] });
+      await selectedItemAsserter([card2.id]);
 
       card1CheckAction.click();
       await page.waitForChanges();
@@ -92,7 +96,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(true);
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id] });
+      await selectedItemAsserter([card1.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -102,7 +106,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(false);
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card2.id] });
+      await selectedItemAsserter([card2.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -112,7 +116,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(false);
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
 
     it("selection mode single-persist allows one card to be selected", async () => {
@@ -132,11 +136,15 @@ describe("calcite-card-group", () => {
       const card2CheckAction = await page.find(`#card-2 >>> .${CSS.checkboxWrapper}`);
 
       const cardGroupSelectSpy = await element.spyOnEvent("calciteCardGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-card-group",
+        "calciteCardGroupSelect",
+      );
 
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id] });
+      await selectedItemAsserter([card1.id]);
 
       card1CheckAction.click();
       await page.waitForChanges();
@@ -144,7 +152,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(true);
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id] });
+      await selectedItemAsserter([card1.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -152,7 +160,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(false);
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card2.id] });
+      await selectedItemAsserter([card2.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -160,7 +168,7 @@ describe("calcite-card-group", () => {
       expect(await card1.getProperty("selected")).toBe(false);
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card2.id] });
+      await selectedItemAsserter([card2.id]);
     });
 
     it("selection mode multiple allows none, one, or multiple to be selected", async () => {
@@ -183,11 +191,15 @@ describe("calcite-card-group", () => {
       const card3CheckAction = await page.find(`#card-3 >>> .${CSS.checkboxWrapper}`);
 
       const cardGroupSelectSpy = await element.spyOnEvent("calciteCardGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-card-group",
+        "calciteCardGroupSelect",
+      );
 
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       card1CheckAction.click();
       await page.waitForChanges();
@@ -196,7 +208,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await card3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id] });
+      await selectedItemAsserter([card1.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -205,7 +217,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await card3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id, card2.id] });
+      await selectedItemAsserter([card1.id, card2.id]);
 
       card3CheckAction.click();
       await page.waitForChanges();
@@ -214,7 +226,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await card3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(3);
-      await assertSelectedItems(page, { expectedItemIds: [card1.id, card2.id, card3.id] });
+      await selectedItemAsserter([card1.id, card2.id, card3.id]);
 
       card1CheckAction.click();
       await page.waitForChanges();
@@ -223,7 +235,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(true);
       expect(await card3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [card2.id, card3.id] });
+      await selectedItemAsserter([card2.id, card3.id]);
 
       card2CheckAction.click();
       await page.waitForChanges();
@@ -232,7 +244,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await card3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card3.id] });
+      await selectedItemAsserter([card3.id]);
 
       card3CheckAction.click();
       await page.waitForChanges();
@@ -241,7 +253,7 @@ describe("calcite-card-group", () => {
       expect(await card2.getProperty("selected")).toBe(false);
       expect(await card3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
   });
 
@@ -260,7 +272,11 @@ describe("calcite-card-group", () => {
 
       const element = await page.find("calcite-card-group");
       const cardGroupSelectSpy = await element.spyOnEvent("calciteCardGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-card-group",
+        "calciteCardGroupSelect",
+      );
 
       const card1 = await page.find("#card-1");
       const card2 = await page.find("#card-2");
@@ -272,7 +288,7 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.id)).toEqual(card1.id);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await page.keyboard.press("ArrowRight");
       await page.waitForChanges();
@@ -290,7 +306,7 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(1);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card5.id] });
+      await selectedItemAsserter([card5.id]);
 
       await page.keyboard.press("ArrowLeft");
       await page.waitForChanges();
@@ -300,13 +316,13 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(2);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [card4.id, card5.id] });
+      await selectedItemAsserter([card4.id, card5.id]);
 
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(3);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [card5.id] });
+      await selectedItemAsserter([card5.id]);
 
       await page.keyboard.press("Home");
       await page.waitForChanges();
@@ -334,7 +350,11 @@ describe("calcite-card-group", () => {
 
       const element = await page.find("calcite-card-group");
       const cardGroupSelectSpy = await element.spyOnEvent("calciteCardGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-card-group",
+        "calciteCardGroupSelect",
+      );
 
       const card1 = await page.find("#card-1");
       const card2 = await page.find("#card-2");
@@ -346,7 +366,7 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.id)).toEqual(card1.id);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await page.keyboard.press("ArrowRight");
       await page.waitForChanges();
@@ -364,7 +384,7 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await page.keyboard.press("ArrowLeft");
       await page.waitForChanges();
@@ -374,13 +394,13 @@ describe("calcite-card-group", () => {
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(cardGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await page.keyboard.press("Home");
       await page.waitForChanges();
@@ -410,53 +430,15 @@ describe("calcite-card-group", () => {
     const element = await page.find("calcite-card-group");
     const card4 = await page.find("#card-4");
     const card5 = await page.find("#card-5");
+    const selectedItemAsserter = await createSelectedItemsAsserter(
+      page,
+      "calcite-card-group",
+      "calciteCardGroupSelect",
+    );
+
     await page.waitForChanges();
 
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [card4.id, card5.id] });
+    await selectedItemAsserter([card4.id, card5.id]);
   });
 });
-
-// Borrowed from Dropdown until a generic utility is set up.
-interface SelectedItemsAssertionOptions {
-  /**
-   * IDs from items to assert selection
-   */
-  expectedItemIds: string[];
-}
-
-/**
- * Test helper for selected calcite-card-group items. Expects items to have IDs to test against.
- *
- * Note: assertSelectedItems.setUpEvents must be called before using this method
- *
- * @param page
- * @param root0
- * @param root0.expectedItemIds
- */
-async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
-  const selectedItemIds = await page.evaluate(() => {
-    const cardGroup = document.querySelector<HTMLCalciteCardGroupElement>("calcite-card-group");
-    return cardGroup.selectedItems.map((item) => item.id);
-  });
-
-  expect(selectedItemIds).toHaveLength(expectedItemIds.length);
-
-  expectedItemIds.forEach((itemId, index) => expect(selectedItemIds[index]).toEqual(itemId));
-}
-
-type SelectionEventTestWindow = GlobalTestProps<{ eventDetail: Selection }>;
-
-/**
- * Helper to wire up the page to assert on the event detail
- *
- * @param page
- */
-assertSelectedItems.setUpEvents = async (page: E2EPage) => {
-  await page.evaluate(() => {
-    document.addEventListener("calciteCardGroupSelect", ({ detail }: CustomEvent<Selection>) => {
-      (window as SelectionEventTestWindow).eventDetail = detail;
-    });
-  });
-};

--- a/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
+++ b/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
@@ -1,8 +1,8 @@
-import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, disabled } from "../../tests/commonTests";
-import { GlobalTestProps } from "../../tests/utils";
 import { CSS as CHIP_CSS } from "../chip/resources";
+import { createSelectedItemsAsserter } from "../../tests/utils";
 
 describe("calcite-chip-group", () => {
   describe("renders", () => {
@@ -74,7 +74,11 @@ describe("calcite-chip-group", () => {
       const chip2 = await page.find("#chip-2");
 
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip1.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip2.spyOnEvent("calciteChipSelect");
@@ -82,7 +86,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip2.id] });
+      await selectedItemAsserter([chip2.id]);
 
       await chip1.click();
       await page.waitForChanges();
@@ -93,7 +97,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(true);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id] });
+      await selectedItemAsserter([chip1.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -103,7 +107,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip2.id] });
+      await selectedItemAsserter([chip2.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -113,7 +117,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
 
     it("selection mode none (default) allows no chip to be selected", async () => {
@@ -130,10 +134,14 @@ describe("calcite-chip-group", () => {
       const chip1 = await page.find("#chip-1");
       const chip2 = await page.find("#chip-2");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await chip1.click();
       await page.waitForChanges();
@@ -141,7 +149,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -149,7 +157,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -157,7 +165,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
 
     it("selection mode single-persist allows one chip to be selected", async () => {
@@ -174,11 +182,15 @@ describe("calcite-chip-group", () => {
       const chip1 = await page.find("#chip-1");
       const chip2 = await page.find("#chip-2");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id] });
+      await selectedItemAsserter([chip1.id]);
 
       await chip1.click();
       await page.waitForChanges();
@@ -186,7 +198,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(true);
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id] });
+      await selectedItemAsserter([chip1.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -194,7 +206,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip2.id] });
+      await selectedItemAsserter([chip2.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -202,7 +214,7 @@ describe("calcite-chip-group", () => {
       expect(await chip1.getProperty("selected")).toBe(false);
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip2.id] });
+      await selectedItemAsserter([chip2.id]);
     });
 
     it("selection mode multiple allows none, one, or multiple to be selected", async () => {
@@ -222,11 +234,15 @@ describe("calcite-chip-group", () => {
       const chip3 = await page.find("#chip-3");
 
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       await chip1.click();
       await page.waitForChanges();
@@ -235,7 +251,7 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await chip3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id] });
+      await selectedItemAsserter([chip1.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -244,7 +260,7 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await chip3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id, chip2.id] });
+      await selectedItemAsserter([chip1.id, chip2.id]);
 
       await chip3.click();
       await page.waitForChanges();
@@ -253,7 +269,7 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await chip3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(3);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id, chip2.id, chip3.id] });
+      await selectedItemAsserter([chip1.id, chip2.id, chip3.id]);
 
       await chip1.click();
       await page.waitForChanges();
@@ -262,7 +278,7 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(true);
       expect(await chip3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip2.id, chip3.id] });
+      await selectedItemAsserter([chip2.id, chip3.id]);
 
       await chip2.click();
       await page.waitForChanges();
@@ -271,7 +287,7 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await chip3.getProperty("selected")).toBe(true);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip3.id] });
+      await selectedItemAsserter([chip3.id]);
 
       await chip3.click();
       await page.waitForChanges();
@@ -280,7 +296,8 @@ describe("calcite-chip-group", () => {
       expect(await chip2.getProperty("selected")).toBe(false);
       expect(await chip3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
+      3;
     });
   });
 
@@ -299,7 +316,11 @@ describe("calcite-chip-group", () => {
 
       const element = await page.find("calcite-chip-group");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chip1 = await page.find("#chip-1");
       const chip2 = await page.find("#chip-2");
@@ -311,7 +332,7 @@ describe("calcite-chip-group", () => {
       await page.waitForChanges();
       expect(await page.evaluate(() => document.activeElement.id)).toEqual(chip1.id);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id] });
+      await selectedItemAsserter([chip1.id]);
 
       await page.keyboard.press("ArrowRight");
       await page.waitForChanges();
@@ -329,7 +350,7 @@ describe("calcite-chip-group", () => {
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(2);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id, chip5.id] });
+      await selectedItemAsserter([chip1.id, chip5.id]);
 
       await page.keyboard.press("ArrowLeft");
       await page.waitForChanges();
@@ -339,13 +360,13 @@ describe("calcite-chip-group", () => {
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(3);
       expect(await element.getProperty("selectedItems")).toHaveLength(3);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id, chip4.id, chip5.id] });
+      await selectedItemAsserter([chip1.id, chip4.id, chip5.id]);
 
       await page.keyboard.press("Space");
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(4);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip1.id, chip5.id] });
+      await selectedItemAsserter([chip1.id, chip5.id]);
 
       await page.keyboard.press("Home");
       await page.waitForChanges();
@@ -454,11 +475,15 @@ describe("calcite-chip-group", () => {
       const element = await page.find("calcite-chip-group");
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
       await page.waitForChanges();
 
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id] });
+      await selectedItemAsserter([chip4.id, chip5.id]);
     });
   });
 
@@ -478,14 +503,18 @@ describe("calcite-chip-group", () => {
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip5.spyOnEvent("calciteChipSelect");
       await page.waitForChanges();
 
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
 
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -497,7 +526,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip5.id] });
+      await selectedItemAsserter([chip5.id]);
     });
 
     it("programmatically setting selected on a chip in single-persist should update the component but not emit public events", async () => {
@@ -515,14 +544,18 @@ describe("calcite-chip-group", () => {
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip5.spyOnEvent("calciteChipSelect");
       await page.waitForChanges();
 
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
 
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -534,7 +567,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
 
       chip5.setAttribute("selected", true);
       await page.waitForChanges();
@@ -542,7 +575,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip5.id] });
+      await selectedItemAsserter([chip5.id]);
 
       chip4.setAttribute("selected", true);
       await page.waitForChanges();
@@ -550,7 +583,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
     });
     it("programmatically setting selected on a chip in multiple should update the component but not emit public events", async () => {
       const page = await newE2EPage();
@@ -567,14 +600,18 @@ describe("calcite-chip-group", () => {
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip5.spyOnEvent("calciteChipSelect");
       await page.waitForChanges();
 
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
 
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -586,7 +623,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id] });
+      await selectedItemAsserter([chip4.id, chip5.id]);
     });
   });
 
@@ -606,7 +643,11 @@ describe("calcite-chip-group", () => {
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip5.spyOnEvent("calciteChipSelect");
@@ -616,7 +657,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id] });
+      await selectedItemAsserter([chip4.id, chip5.id]);
 
       await page.evaluate(() => {
         const group = document.querySelector("calcite-chip-group");
@@ -631,7 +672,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(3);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id, "chip-6"] });
+      await selectedItemAsserter([chip4.id, chip5.id, "chip-6"]);
     });
 
     it("should update selected items without emitting event if chips are added after page load in single", async () => {
@@ -648,7 +689,11 @@ describe("calcite-chip-group", () => {
       const element = await page.find("calcite-chip-group");
       const chip4 = await page.find("#chip-4");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       await page.waitForChanges();
@@ -656,7 +701,7 @@ describe("calcite-chip-group", () => {
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
 
       await page.evaluate(() => {
         const group = document.querySelector("calcite-chip-group");
@@ -670,7 +715,7 @@ describe("calcite-chip-group", () => {
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: ["chip-6"] });
+      await selectedItemAsserter(["chip-6"]);
     });
 
     it("should update selected items without emitting event if chips are removed after page load", async () => {
@@ -688,7 +733,11 @@ describe("calcite-chip-group", () => {
       const chip4 = await page.find("#chip-4");
       const chip5 = await page.find("#chip-5");
       const chipGroupSelectSpy = await element.spyOnEvent("calciteChipGroupSelect");
-      await assertSelectedItems.setUpEvents(page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-chip-group",
+        "calciteChipGroupSelect",
+      );
 
       const chipSelectSpy1 = await chip4.spyOnEvent("calciteChipSelect");
       const chipSelectSpy2 = await chip5.spyOnEvent("calciteChipSelect");
@@ -698,7 +747,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(2);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id, chip5.id] });
+      await selectedItemAsserter([chip4.id, chip5.id]);
 
       await page.evaluate(() => {
         document.querySelector("calcite-chip:last-child").remove();
@@ -709,7 +758,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
-      await assertSelectedItems(page, { expectedItemIds: [chip4.id] });
+      await selectedItemAsserter([chip4.id]);
 
       await page.evaluate(() => {
         document.querySelector("calcite-chip:last-child").remove();
@@ -720,51 +769,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
-      await assertSelectedItems(page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
   });
 });
-
-// Borrowed from Dropdown until a generic utility is set up.
-interface SelectedItemsAssertionOptions {
-  /**
-   * IDs from items to assert selection
-   */
-  expectedItemIds: string[];
-}
-
-/**
- * Test helper for selected calcite-chip-group items. Expects items to have IDs to test against.
- *
- * Note: assertSelectedItems.setUpEvents must be called before using this method
- *
- * @param page
- * @param root0
- * @param root0.expectedItemIds
- */
-async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
-  const selectedItemIds = await page.evaluate(() => {
-    const chipGroup = document.querySelector<HTMLCalciteChipGroupElement>("calcite-chip-group");
-    return chipGroup.selectedItems.map((item) => item.id);
-  });
-
-  expect(selectedItemIds).toHaveLength(expectedItemIds.length);
-
-  expectedItemIds.forEach((itemId, index) => expect(selectedItemIds[index]).toEqual(itemId));
-}
-
-type SelectionEventTestWindow = GlobalTestProps<{ eventDetail: Selection }>;
-
-/**
- * Helper to wire up the page to assert on the event detail
- *
- * @param page
- */
-assertSelectedItems.setUpEvents = async (page: E2EPage) => {
-  await page.evaluate(() => {
-    document.addEventListener("calciteChipGroupSelect", ({ detail }: CustomEvent<Selection>) => {
-      (window as SelectionEventTestWindow).eventDetail = detail;
-    });
-  });
-};

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -292,17 +292,17 @@ describe("calcite-dropdown", () => {
     const itemChangeSpy = await element.spyOnEvent("calciteDropdownSelect");
     const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-dropdown", "calciteDropdownSelect");
     expect(group1).toEqualAttribute("selection-mode", "single");
-    selectedItemAsserter(["item-2"]);
+    await selectedItemAsserter(["item-2"]);
     await trigger.click();
     await page.waitForChanges();
     await item1.click();
     await page.waitForChanges();
-    selectedItemAsserter(["item-1"]);
+    await selectedItemAsserter(["item-1"]);
     await trigger.click();
     await page.waitForChanges();
     await item3.click();
     await page.waitForChanges();
-    selectedItemAsserter(["item-3"]);
+    await selectedItemAsserter(["item-3"]);
 
     expect(item1).not.toHaveAttribute("selected");
     expect(item2).not.toHaveAttribute("selected");

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -1,7 +1,7 @@
-import { E2EPage, newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
 import { accessible, renders, hidden, defaults, reflects } from "../../tests/commonTests";
-import { GlobalTestProps, getFocusedElementProp } from "../../tests/utils";
+import { createSelectedItemsAsserter, getFocusedElementProp } from "../../tests/utils";
 import { CSS } from "../table-header/resources";
 import { CSS as CELL_CSS } from "../table-cell/resources";
 import { SLOTS } from "../table/resources";
@@ -371,7 +371,7 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
 
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
@@ -390,7 +390,7 @@ describe("selection modes", () => {
     expect(rowSelectSpy3).toHaveReceivedEventTimes(0);
 
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row3.id] });
+    await selectedItemAsserter([row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-1");
@@ -408,7 +408,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-2");
@@ -425,7 +425,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id] });
+    await selectedItemAsserter([row2.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-3");
@@ -442,7 +442,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row3.id] });
+    await selectedItemAsserter([row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-3");
@@ -460,7 +460,7 @@ describe("selection modes", () => {
     expect(await row3.getProperty("selected")).toBe(false);
 
     expect(await element.getProperty("selectedItems")).toEqual([]);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
 
   it("selection mode multiple allows one, multiple, or no rows to be selected", async () => {
@@ -486,7 +486,7 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
 
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
@@ -506,7 +506,7 @@ describe("selection modes", () => {
     expect(rowSelectSpy3).toHaveReceivedEventTimes(0);
 
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id, row3.id] });
+    await selectedItemAsserter([row2.id, row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-1");
@@ -523,7 +523,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-2");
@@ -540,7 +540,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row3.id] });
+    await selectedItemAsserter([row1.id, row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-3");
@@ -557,7 +557,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-1");
@@ -575,7 +575,7 @@ describe("selection modes", () => {
     expect(await row3.getProperty("selected")).toBe(false);
 
     expect(await element.getProperty("selectedItems")).toEqual([]);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
 
   it("selection mode single allows one or no rows to be selected with keyboard", async () => {
@@ -601,7 +601,7 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
 
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
@@ -624,7 +624,7 @@ describe("selection modes", () => {
     expect(rowSelectSpy3).toHaveReceivedEventTimes(0);
 
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row3.id] });
+    await selectedItemAsserter([row3.id]);
     await selectionCell1.callMethod("setFocus");
     await page.waitForChanges();
 
@@ -639,7 +639,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
 
     await selectionCell2.callMethod("setFocus");
     await page.waitForChanges();
@@ -654,7 +654,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id] });
+    await selectedItemAsserter([row2.id]);
 
     await selectionCell3.callMethod("setFocus");
     await page.waitForChanges();
@@ -669,7 +669,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row3.id] });
+    await selectedItemAsserter([row3.id]);
 
     await selectionCell3.callMethod("setFocus");
 
@@ -685,7 +685,7 @@ describe("selection modes", () => {
     expect(await row3.getProperty("selected")).toBe(false);
 
     expect(await element.getProperty("selectedItems")).toEqual([]);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
 
   it("selection mode multiple allows one, multiple, or no rows to be selected with keyboard", async () => {
@@ -711,7 +711,7 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
 
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
@@ -734,7 +734,7 @@ describe("selection modes", () => {
     expect(rowSelectSpy3).toHaveReceivedEventTimes(0);
 
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id, row3.id] });
+    await selectedItemAsserter([row2.id, row3.id]);
 
     await selectionCell1.callMethod("setFocus");
 
@@ -749,7 +749,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
 
     await selectionCell2.callMethod("setFocus");
 
@@ -764,7 +764,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row3.id] });
+    await selectedItemAsserter([row1.id, row3.id]);
 
     await selectionCell3.callMethod("setFocus");
 
@@ -779,7 +779,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
 
     await selectionCell1.callMethod("setFocus");
 
@@ -795,7 +795,7 @@ describe("selection modes", () => {
     expect(await row3.getProperty("selected")).toBe(false);
 
     expect(await element.getProperty("selectedItems")).toEqual([]);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
   it("correctly has no selected items after user clears selection via clear button", async () => {
     const page = await newE2EPage();
@@ -820,7 +820,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -831,7 +832,7 @@ describe("selection modes", () => {
 
     expect(tableSelectSpy).toHaveReceivedEventTimes(0);
     expect(await element.getProperty("selectedItems")).toHaveLength(2);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id, row3.id] });
+    await selectedItemAsserter([row2.id, row3.id]);
 
     await page.$eval("calcite-table", () => {
       const table = document.querySelector("calcite-table");
@@ -845,7 +846,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(0);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
 
   it("correctly has all items selected after user uses select all cell while none selected", async () => {
@@ -871,7 +872,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -882,7 +884,7 @@ describe("selection modes", () => {
 
     expect(tableSelectSpy).toHaveReceivedEventTimes(0);
     expect(await element.getProperty("selectedItems")).toHaveLength(0);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-head");
@@ -896,7 +898,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
   });
 
   it("correctly has all items selected after user uses select all cell while none selected and multiple pages", async () => {
@@ -922,7 +924,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -933,7 +936,7 @@ describe("selection modes", () => {
 
     expect(tableSelectSpy).toHaveReceivedEventTimes(0);
     expect(await element.getProperty("selectedItems")).toHaveLength(0);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-head");
@@ -947,7 +950,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
   });
 
   it("correctly has all items selected after user uses select all cell while some selected", async () => {
@@ -973,7 +976,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -987,7 +991,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row2.id] });
+    await selectedItemAsserter([row2.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-head");
@@ -1001,7 +1005,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
   });
 
   it("correctly has no items selected after user uses select none cell while all selected", async () => {
@@ -1027,7 +1031,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -1041,7 +1046,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(true);
     expect(await row3.getProperty("selected")).toBe(true);
     expect(await element.getProperty("selectedItems")).toHaveLength(3);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id, row2.id, row3.id] });
+    await selectedItemAsserter([row1.id, row2.id, row3.id]);
 
     await page.$eval("calcite-table", () => {
       const row = document.getElementById("row-head");
@@ -1055,7 +1060,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(0);
-    await assertSelectedItems(page, { expectedItemIds: [] });
+    await selectedItemAsserter([]);
   });
 
   it("correctly maintains selected items if they are paginated out of view", async () => {
@@ -1081,7 +1086,8 @@ describe("selection modes", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
+    const selectedItemAsserter = await createSelectedItemsAsserter(page, "calcite-table", "calciteTableSelect");
+
     const element = await page.find("calcite-table");
     const row1 = await page.find("#row-1");
     const row2 = await page.find("#row-2");
@@ -1098,7 +1104,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
 
     await page.$eval("calcite-table", () => {
       const table = document.querySelector("calcite-table");
@@ -1115,7 +1121,7 @@ describe("selection modes", () => {
     expect(await row2.getProperty("selected")).toBe(false);
     expect(await row3.getProperty("selected")).toBe(false);
     expect(await element.getProperty("selectedItems")).toHaveLength(1);
-    await assertSelectedItems(page, { expectedItemIds: [row1.id] });
+    await selectedItemAsserter([row1.id]);
   });
 });
 
@@ -1143,7 +1149,6 @@ describe("pagination event", () => {
       </calcite-table>`,
     );
 
-    await assertSelectedItems.setUpEvents(page);
     const element = await page.find("calcite-table");
     const tablePaginateSpy = await element.spyOnEvent("calciteTablePageChange");
     await page.waitForChanges();
@@ -2593,47 +2598,3 @@ describe("keyboard navigation", () => {
     ).toEqual({ "0": CSS.selectionCell });
   });
 });
-
-// Borrowed from Dropdown until a generic utility is set up.
-interface SelectedItemsAssertionOptions {
-  /**
-   * IDs from items to assert selection
-   */
-  expectedItemIds: string[];
-}
-
-/**
- * Test helper for selected calcite-table-row items. Expects items to have IDs to test against.
- *
- * Note: assertSelectedItems.setUpEvents must be called before using this method
- *
- * @param page
- * @param root0
- * @param root0.expectedItemIds
- */
-async function assertSelectedItems(page: E2EPage, { expectedItemIds }: SelectedItemsAssertionOptions): Promise<void> {
-  await page.waitForTimeout(100);
-  const selectedItemIds = await page.evaluate(() => {
-    const table = document.querySelector<HTMLCalciteTableElement>("calcite-table");
-    return table.selectedItems.map((item) => item.id);
-  });
-
-  expect(selectedItemIds).toHaveLength(expectedItemIds.length);
-
-  expectedItemIds.forEach((itemId, index) => expect(selectedItemIds[index]).toEqual(itemId));
-}
-
-type SelectionEventTestWindow = GlobalTestProps<{ eventDetail: Selection }>;
-
-/**
- * Helper to wire up the page to assert on the event detail
- *
- * @param page
- */
-assertSelectedItems.setUpEvents = async (page: E2EPage) => {
-  await page.evaluate(() => {
-    document.addEventListener("calciteTableSelect", ({ detail }: CustomEvent<Selection>) => {
-      (window as SelectionEventTestWindow).eventDetail = detail;
-    });
-  });
-};

--- a/packages/calcite-components/src/components/tile-group/tile-group.e2e.ts
+++ b/packages/calcite-components/src/components/tile-group/tile-group.e2e.ts
@@ -1,7 +1,7 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, disabled, reflects, renders, hidden } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { assertSelectedItems, isElementFocused } from "../../tests/utils";
+import { createSelectedItemsAsserter, isElementFocused } from "../../tests/utils";
 
 describe("calcite-tile-group", () => {
   describe("accessible", () => {
@@ -68,8 +68,13 @@ describe("calcite-tile-group", () => {
       `);
       const item4 = await page.find("#item-4");
       const item5 = await page.find("#item-5");
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item4.id, item5.id] });
+      await selectedItemAsserter([item4.id, item5.id]);
     });
   });
 
@@ -113,7 +118,11 @@ describe("calcite-tile-group", () => {
           <calcite-tile id="item-5" label="test-label"></calcite-tile>
         </calcite-tile-group>
       `);
-      await assertSelectedItems.setUpEvents("calciteTileGroupSelect", page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
       const element = await page.find("calcite-tile-group");
       const groupSelectSpy = await element.spyOnEvent("calciteTileGroupSelect");
@@ -126,7 +135,8 @@ describe("calcite-tile-group", () => {
 
       expect(await isElementFocused(page, "#item-1")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id] });
+      await selectedItemAsserter([item1.id]);
+
       await page.keyboard.press("ArrowRight");
       await page.waitForChanges();
 
@@ -147,7 +157,8 @@ describe("calcite-tile-group", () => {
 
       expect(groupSelectSpy).toHaveReceivedEventTimes(2);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id, item5.id] });
+      await selectedItemAsserter([item1.id, item5.id]);
+
       await page.keyboard.press("ArrowLeft");
       await page.waitForChanges();
 
@@ -158,13 +169,15 @@ describe("calcite-tile-group", () => {
 
       expect(groupSelectSpy).toHaveReceivedEventTimes(3);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id, item4.id, item5.id] });
+      await selectedItemAsserter([item1.id, item4.id, item5.id]);
+
       await page.keyboard.press("Space");
       await page.waitForChanges();
 
       expect(groupSelectSpy).toHaveReceivedEventTimes(4);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id, item5.id] });
+      await selectedItemAsserter([item1.id, item5.id]);
+
       await page.keyboard.press("Home");
       await page.waitForChanges();
 
@@ -220,7 +233,11 @@ describe("calcite-tile-group", () => {
         </calcite-tile-group>
       `);
       await page.waitForChanges();
-      await assertSelectedItems.setUpEvents("calciteTileGroupSelect", page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
       const element = await page.find("calcite-tile-group");
       const item1 = await page.find("#item-1");
@@ -230,7 +247,7 @@ describe("calcite-tile-group", () => {
       expect(itemGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(await element.getProperty("selectedItems")).toEqual([]);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
       await item1.click();
       await page.waitForChanges();
 
@@ -239,7 +256,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -248,7 +266,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -257,7 +276,7 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
 
     it("single selection-mode allows only 1 item to be selected and allows deselecting", async () => {
@@ -270,7 +289,11 @@ describe("calcite-tile-group", () => {
         </calcite-tile-group>
       `);
       await page.waitForChanges();
-      await assertSelectedItems.setUpEvents("calciteTileSelect", page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
       const element = await page.find("calcite-tile-group");
       const item1 = await page.find("#item-1");
@@ -283,7 +306,8 @@ describe("calcite-tile-group", () => {
       expect(tileSelectSpy1).toHaveReceivedEventTimes(0);
       expect(tileSelectSpy2).toHaveReceivedEventTimes(0);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id] });
+      await selectedItemAsserter([item2.id]);
+
       await item1.click();
       await page.waitForChanges();
 
@@ -293,7 +317,8 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(true);
       expect(await item2.getProperty("selected")).toBe(false);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id] });
+      await selectedItemAsserter([item1.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -303,7 +328,8 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id] });
+      await selectedItemAsserter([item2.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -313,7 +339,7 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(false);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
 
     it("single-persist selection-mode allows only 1 item to be selected and disallows deselecting", async () => {
@@ -326,7 +352,11 @@ describe("calcite-tile-group", () => {
         </calcite-tile-group>
       `);
       await page.waitForChanges();
-      await assertSelectedItems.setUpEvents("calciteTileSelect", page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
       const element = await page.find("calcite-tile-group");
       const item1 = await page.find("#item-1");
@@ -339,7 +369,8 @@ describe("calcite-tile-group", () => {
       expect(tileSelectSpy1).toHaveReceivedEventTimes(0);
       expect(tileSelectSpy2).toHaveReceivedEventTimes(0);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id] });
+      await selectedItemAsserter([item2.id]);
+
       await item1.click();
       await page.waitForChanges();
 
@@ -349,7 +380,8 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(true);
       expect(await item2.getProperty("selected")).toBe(false);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id] });
+      await selectedItemAsserter([item1.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -359,7 +391,8 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id] });
+      await selectedItemAsserter([item2.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -369,7 +402,7 @@ describe("calcite-tile-group", () => {
       expect(await item1.getProperty("selected")).toBe(false);
       expect(await item2.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id] });
+      await selectedItemAsserter([item2.id]);
     });
 
     it("multiple selection-mode allows multiple items to be selected and allows deselecting", async () => {
@@ -382,7 +415,11 @@ describe("calcite-tile-group", () => {
         </calcite-tile-group>
       `);
       await page.waitForChanges();
-      await assertSelectedItems.setUpEvents("calciteTileSelect", page);
+      const selectedItemAsserter = await createSelectedItemsAsserter(
+        page,
+        "calcite-tile-group",
+        "calciteTileGroupSelect",
+      );
 
       const element = await page.find("calcite-tile-group");
       const item1 = await page.find("#item-1");
@@ -392,7 +429,8 @@ describe("calcite-tile-group", () => {
 
       expect(groupSelectSpy).toHaveReceivedEventTimes(0);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
+
       await item1.click();
       await page.waitForChanges();
 
@@ -401,7 +439,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(false);
       expect(await item3.getProperty("selected")).toBe(false);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id] });
+      await selectedItemAsserter([item1.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -410,7 +449,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(true);
       expect(await item3.getProperty("selected")).toBe(false);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id, item2.id] });
+      await selectedItemAsserter([item1.id, item2.id]);
+
       await item3.click();
       await page.waitForChanges();
 
@@ -419,7 +459,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(true);
       expect(await item3.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item1.id, item2.id, item3.id] });
+      await selectedItemAsserter([item1.id, item2.id, item3.id]);
+
       await item1.click();
       await page.waitForChanges();
 
@@ -428,7 +469,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(true);
       expect(await item3.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item2.id, item3.id] });
+      await selectedItemAsserter([item2.id, item3.id]);
+
       await item2.click();
       await page.waitForChanges();
 
@@ -437,7 +479,8 @@ describe("calcite-tile-group", () => {
       expect(await item2.getProperty("selected")).toBe(false);
       expect(await item3.getProperty("selected")).toBe(true);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [item3.id] });
+      await selectedItemAsserter([item3.id]);
+
       await item3.click();
       await page.waitForChanges();
 
@@ -447,7 +490,7 @@ describe("calcite-tile-group", () => {
       expect(await item3.getProperty("selected")).toBe(false);
       expect(await element.getProperty("selectedItems")).toEqual([]);
 
-      await assertSelectedItems("calcite-tile-group", page, { expectedItemIds: [] });
+      await selectedItemAsserter([]);
     });
   });
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Adds new `createSelectedItemAsserter` util to help with selection assertions on selectable components.

