### PR TITLE
refactor: use native keydown event for parent/child navigation instead of custom event

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -36,7 +36,6 @@ import { DatePickerMessages } from "./components/date-picker/assets/date-picker/
 import { DateLocaleData } from "./components/date-picker/utils";
 import { HoverRange } from "./utils/date";
 import { RequestedItem as RequestedItem2 } from "./components/dropdown-group/interfaces";
-import { ItemKeyboardEvent } from "./components/dropdown/interfaces";
 import { FilterMessages } from "./components/filter/assets/filter/t9n";
 import { FlowItemLikeElement } from "./components/flow/interfaces";
 import { FlowItemMessages } from "./components/flow-item/assets/flow-item/t9n";
@@ -60,7 +59,6 @@ import { SelectionAppearance } from "./components/list/resources";
 import { ListItemMessages } from "./components/list-item/assets/list-item/t9n";
 import { MenuMessages } from "./components/menu/assets/menu/t9n";
 import { MenuItemMessages } from "./components/menu-item/assets/menu-item/t9n";
-import { MenuItemCustomEvent } from "./components/menu-item/interfaces";
 import { MeterLabelType } from "./components/meter/interfaces";
 import { ModalMessages } from "./components/modal/assets/modal/t9n";
 import { NoticeMessages } from "./components/notice/assets/notice/t9n";
@@ -76,7 +74,7 @@ import { DisplayMode } from "./components/sheet/interfaces";
 import { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 import { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
 import { DragDetail } from "./utils/sortableComponent";
-import { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
+import { StepperItemChangeEventDetail, StepperItemEventDetail, StepperLayout } from "./components/stepper/interfaces";
 import { StepperMessages } from "./components/stepper/assets/stepper/t9n";
 import { StepperItemMessages } from "./components/stepper-item/assets/stepper-item/t9n";
 import { TabID, TabLayout, TabPosition } from "./components/tabs/interfaces";
@@ -126,7 +124,6 @@ export { DatePickerMessages } from "./components/date-picker/assets/date-picker/
 export { DateLocaleData } from "./components/date-picker/utils";
 export { HoverRange } from "./utils/date";
 export { RequestedItem as RequestedItem2 } from "./components/dropdown-group/interfaces";
-export { ItemKeyboardEvent } from "./components/dropdown/interfaces";
 export { FilterMessages } from "./components/filter/assets/filter/t9n";
 export { FlowItemLikeElement } from "./components/flow/interfaces";
 export { FlowItemMessages } from "./components/flow-item/assets/flow-item/t9n";
@@ -150,7 +147,6 @@ export { SelectionAppearance } from "./components/list/resources";
 export { ListItemMessages } from "./components/list-item/assets/list-item/t9n";
 export { MenuMessages } from "./components/menu/assets/menu/t9n";
 export { MenuItemMessages } from "./components/menu-item/assets/menu-item/t9n";
-export { MenuItemCustomEvent } from "./components/menu-item/interfaces";
 export { MeterLabelType } from "./components/meter/interfaces";
 export { ModalMessages } from "./components/modal/assets/modal/t9n";
 export { NoticeMessages } from "./components/notice/assets/notice/t9n";
@@ -166,7 +162,7 @@ export { DisplayMode } from "./components/sheet/interfaces";
 export { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 export { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
 export { DragDetail } from "./utils/sortableComponent";
-export { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
+export { StepperItemChangeEventDetail, StepperItemEventDetail, StepperLayout } from "./components/stepper/interfaces";
 export { StepperMessages } from "./components/stepper/assets/stepper/t9n";
 export { StepperItemMessages } from "./components/stepper-item/assets/stepper-item/t9n";
 export { TabID, TabLayout, TabPosition } from "./components/tabs/interfaces";
@@ -6126,7 +6122,6 @@ declare global {
     };
     interface HTMLCalciteCardElementEventMap {
         "calciteCardSelect": void;
-        "calciteInternalCardKeyEvent": KeyboardEvent;
     }
     interface HTMLCalciteCardElement extends Components.CalciteCard, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteCardElementEventMap>(type: K, listener: (this: HTMLCalciteCardElement, ev: CalciteCardCustomEvent<HTMLCalciteCardElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6208,7 +6203,6 @@ declare global {
     interface HTMLCalciteChipElementEventMap {
         "calciteChipClose": void;
         "calciteChipSelect": void;
-        "calciteInternalChipKeyEvent": KeyboardEvent;
         "calciteInternalChipSelect": void;
         "calciteInternalSyncSelectedChips": void;
     }
@@ -6444,7 +6438,6 @@ declare global {
     interface HTMLCalciteDropdownItemElementEventMap {
         "calciteDropdownItemSelect": void;
         "calciteInternalDropdownItemSelect": RequestedItem2;
-        "calciteInternalDropdownItemKeyEvent": ItemKeyboardEvent;
         "calciteInternalDropdownCloseRequest": void;
     }
     interface HTMLCalciteDropdownItemElement extends Components.CalciteDropdownItem, HTMLStencilElement {
@@ -6799,7 +6792,6 @@ declare global {
         new (): HTMLCalciteMenuElement;
     };
     interface HTMLCalciteMenuItemElementEventMap {
-        "calciteInternalMenuItemKeyEvent": MenuItemCustomEvent;
         "calciteMenuItemSelect": void;
     }
     interface HTMLCalciteMenuItemElement extends Components.CalciteMenuItem, HTMLStencilElement {
@@ -7287,7 +7279,6 @@ declare global {
         new (): HTMLCalciteStepperElement;
     };
     interface HTMLCalciteStepperItemElementEventMap {
-        "calciteInternalStepperItemKeyEvent": StepperItemKeyEventDetail;
         "calciteInternalStepperItemSelect": StepperItemEventDetail;
         "calciteInternalUserRequestedStepperItemSelect": StepperItemChangeEventDetail;
         "calciteInternalStepperItemRegister": StepperItemEventDetail;
@@ -7458,7 +7449,6 @@ declare global {
         new (): HTMLCalciteTextAreaElement;
     };
     interface HTMLCalciteTileElementEventMap {
-        "calciteInternalTileKeyEvent": KeyboardEvent;
         "calciteTileSelect": void;
     }
     interface HTMLCalciteTileElement extends Components.CalciteTile, HTMLStencilElement {
@@ -8417,7 +8407,6 @@ declare namespace LocalJSX {
           * Fires when the deprecated `selectable` is true, or `selectionMode` set on parent `calcite-card-group` is not `none` and the component is selected.
          */
         "onCalciteCardSelect"?: (event: CalciteCardCustomEvent<void>) => void;
-        "onCalciteInternalCardKeyEvent"?: (event: CalciteCardCustomEvent<KeyboardEvent>) => void;
         /**
           * When `true`, the component is selectable.
           * @deprecated use `selectionMode` property on a parent `calcite-card-group` instead.
@@ -8657,7 +8646,6 @@ declare namespace LocalJSX {
           * Fires when the selected state of the component changes.
          */
         "onCalciteChipSelect"?: (event: CalciteChipCustomEvent<void>) => void;
-        "onCalciteInternalChipKeyEvent"?: (event: CalciteChipCustomEvent<KeyboardEvent>) => void;
         "onCalciteInternalChipSelect"?: (event: CalciteChipCustomEvent<void>) => void;
         "onCalciteInternalSyncSelectedChips"?: (event: CalciteChipCustomEvent<void>) => void;
         "parentChipGroup"?: HTMLCalciteChipGroupElement;
@@ -9411,7 +9399,6 @@ declare namespace LocalJSX {
          */
         "onCalciteDropdownItemSelect"?: (event: CalciteDropdownItemCustomEvent<void>) => void;
         "onCalciteInternalDropdownCloseRequest"?: (event: CalciteDropdownItemCustomEvent<void>) => void;
-        "onCalciteInternalDropdownItemKeyEvent"?: (event: CalciteDropdownItemCustomEvent<ItemKeyboardEvent>) => void;
         "onCalciteInternalDropdownItemSelect"?: (event: CalciteDropdownItemCustomEvent<RequestedItem2>) => void;
         /**
           * Specifies the relationship to the linked document defined in `href`.
@@ -10955,7 +10942,6 @@ declare namespace LocalJSX {
           * Made into a prop for testing purposes only.
          */
         "messages"?: MenuItemMessages;
-        "onCalciteInternalMenuItemKeyEvent"?: (event: CalciteMenuItemCustomEvent<MenuItemCustomEvent>) => void;
         /**
           * Emits when the component is selected.
          */
@@ -12490,7 +12476,6 @@ declare namespace LocalJSX {
          */
         "numbered"?: boolean;
         "numberingSystem"?: NumberingSystem;
-        "onCalciteInternalStepperItemKeyEvent"?: (event: CalciteStepperItemCustomEvent<StepperItemKeyEventDetail>) => void;
         "onCalciteInternalStepperItemRegister"?: (event: CalciteStepperItemCustomEvent<StepperItemEventDetail>) => void;
         "onCalciteInternalStepperItemSelect"?: (event: CalciteStepperItemCustomEvent<StepperItemEventDetail>) => void;
         "onCalciteInternalUserRequestedStepperItemSelect"?: (event: CalciteStepperItemCustomEvent<StepperItemChangeEventDetail>) => void;
@@ -13038,7 +13023,6 @@ declare namespace LocalJSX {
           * Defines the layout of the component.  Use `"horizontal"` for rows, and `"vertical"` for a single column.
          */
         "layout"?: Exclude<Layout, "grid">;
-        "onCalciteInternalTileKeyEvent"?: (event: CalciteTileCustomEvent<KeyboardEvent>) => void;
         /**
           * Fires when the selected state of the component changes.
          */

--- a/packages/calcite-components/src/components/card-group/card-group.tsx
+++ b/packages/calcite-components/src/components/card-group/card-group.tsx
@@ -125,24 +125,29 @@ export class CardGroup implements InteractiveComponent, LoadableComponent {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteInternalCardKeyEvent")
-  calciteInternalCardKeyEventListener(event: KeyboardEvent): void {
+  @Listen("keydown")
+  keyDownEventListener(event: KeyboardEvent): void {
     if (event.composedPath().includes(this.el)) {
       const interactiveItems = this.items.filter((el) => !el.disabled);
-      switch (event.detail["key"]) {
-        case "ArrowRight":
-          focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, "next");
-          break;
-        case "ArrowLeft":
-          focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, "previous");
-          break;
-        case "Home":
-          focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, "first");
-          break;
-        case "End":
-          focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, "last");
-          break;
+
+      const key = event.key;
+      const toDirection =
+        key === "ArrowRight"
+          ? "next"
+          : key === "ArrowLeft"
+            ? "previous"
+            : key === "Home"
+              ? "first"
+              : key === "End"
+                ? "last"
+                : null;
+
+      if (!toDirection) {
+        return;
       }
+
+      event.preventDefault();
+      focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, toDirection);
     }
   }
 

--- a/packages/calcite-components/src/components/card/card.tsx
+++ b/packages/calcite-components/src/components/card/card.tsx
@@ -124,11 +124,6 @@ export class Card
   /** Fires when the deprecated `selectable` is true, or `selectionMode` set on parent `calcite-card-group` is not `none` and the component is selected. */
   @Event({ cancelable: false }) calciteCardSelect: EventEmitter<void>;
 
-  /**
-   * @internal
-   */
-  @Event({ cancelable: false }) calciteInternalCardKeyEvent: EventEmitter<KeyboardEvent>;
-
   //--------------------------------------------------------------------------
   //
   //  Public Methods
@@ -211,16 +206,6 @@ export class Card
       if (isActivationKey(event.key) && this.selectionMode !== "none") {
         this.calciteCardSelect.emit();
         event.preventDefault();
-      } else {
-        switch (event.key) {
-          case "ArrowRight":
-          case "ArrowLeft":
-          case "Home":
-          case "End":
-            this.calciteInternalCardKeyEvent.emit(event);
-            event.preventDefault();
-            break;
-        }
       }
     }
   };

--- a/packages/calcite-components/src/components/chip-group/chip-group.tsx
+++ b/packages/calcite-components/src/components/chip-group/chip-group.tsx
@@ -125,26 +125,30 @@ export class ChipGroup implements InteractiveComponent {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteInternalChipKeyEvent")
-  calciteInternalChipKeyEventListener(event: CustomEvent): void {
+  @Listen("keydown")
+  keyDownEventListener(event: KeyboardEvent): void {
     if (event.composedPath().includes(this.el)) {
       const interactiveItems = this.items?.filter((el) => !el.disabled);
-      switch (event.detail.key) {
-        case "ArrowRight":
-          focusElementInGroup(interactiveItems, event.detail.target, "next");
-          break;
-        case "ArrowLeft":
-          focusElementInGroup(interactiveItems, event.detail.target, "previous");
-          break;
-        case "Home":
-          focusElementInGroup(interactiveItems, event.detail.target, "first");
-          break;
-        case "End":
-          focusElementInGroup(interactiveItems, event.detail.target, "last");
-          break;
+
+      const key = event.key;
+      const toDirection =
+        key === "ArrowRight"
+          ? "next"
+          : key === "ArrowLeft"
+            ? "previous"
+            : key === "Home"
+              ? "first"
+              : key === "End"
+                ? "last"
+                : null;
+
+      if (!toDirection) {
+        return;
       }
+
+      event.preventDefault();
+      focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, toDirection);
     }
-    event.stopPropagation();
   }
 
   @Listen("calciteChipClose")

--- a/packages/calcite-components/src/components/chip/chip.tsx
+++ b/packages/calcite-components/src/components/chip/chip.tsx
@@ -186,11 +186,6 @@ export class Chip
   /**
    * @internal
    */
-  @Event({ cancelable: false }) calciteInternalChipKeyEvent: EventEmitter<KeyboardEvent>;
-
-  /**
-   * @internal
-   */
   @Event({ cancelable: false }) calciteInternalChipSelect: EventEmitter<void>;
 
   /**
@@ -247,13 +242,6 @@ export class Chip
         case " ":
         case "Enter":
           this.handleEmittingEvent();
-          event.preventDefault();
-          break;
-        case "ArrowRight":
-        case "ArrowLeft":
-        case "Home":
-        case "End":
-          this.calciteInternalChipKeyEvent.emit(event);
           event.preventDefault();
           break;
       }

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.tsx
@@ -11,7 +11,6 @@ import {
   VNode,
 } from "@stencil/core";
 import { toAriaBoolean } from "../../utils/dom";
-import { ItemKeyboardEvent } from "../dropdown/interfaces";
 import { RequestedItem } from "../dropdown-group/interfaces";
 import { FlipContext, Scale, SelectionMode } from "../interfaces";
 import {
@@ -89,10 +88,6 @@ export class DropdownItem implements InteractiveComponent, LoadableComponent {
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalDropdownItemSelect: EventEmitter<RequestedItem>;
-
-  /** @internal */
-  @Event({ cancelable: false })
-  calciteInternalDropdownItemKeyEvent: EventEmitter<ItemKeyboardEvent>;
 
   /** @internal */
   @Event({ cancelable: false }) calciteInternalDropdownCloseRequest: EventEmitter<void>;
@@ -268,16 +263,6 @@ export class DropdownItem implements InteractiveComponent, LoadableComponent {
       case "Escape":
         this.calciteInternalDropdownCloseRequest.emit();
         event.preventDefault();
-        break;
-      case "Tab":
-        this.calciteInternalDropdownItemKeyEvent.emit({ keyboardEvent: event });
-        break;
-      case "ArrowUp":
-      case "ArrowDown":
-      case "Home":
-      case "End":
-        event.preventDefault();
-        this.calciteInternalDropdownItemKeyEvent.emit({ keyboardEvent: event });
         break;
     }
   }

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -43,7 +43,6 @@ import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { RequestedItem } from "../dropdown-group/interfaces";
 import { Scale } from "../interfaces";
-import { ItemKeyboardEvent } from "./interfaces";
 import { SLOTS } from "./resources";
 
 /**
@@ -231,13 +230,12 @@ export class Dropdown
   render(): VNode {
     const { open, guid } = this;
     return (
-      <Host>
+      <Host onKeyDown={this.keyDownHandler}>
         <InteractiveContainer disabled={this.disabled}>
           <div
             class="calcite-trigger-container"
             id={`${guid}-menubutton`}
             onClick={this.openCalciteDropdown}
-            onKeyDown={this.keyDownHandler}
             // eslint-disable-next-line react/jsx-sort-props -- ref should be last so node attrs/props are in sync (see https://github.com/Esri/calcite-design-system/pull/6530)
             ref={this.setReferenceEl}
           >
@@ -369,34 +367,6 @@ export class Dropdown
 
   private getTraversableItems(): HTMLCalciteDropdownItemElement[] {
     return this.items.filter((item) => !item.disabled && !item.hidden);
-  }
-
-  @Listen("calciteInternalDropdownItemKeyEvent")
-  calciteInternalDropdownItemKeyEvent(event: CustomEvent<ItemKeyboardEvent>): void {
-    const { keyboardEvent } = event.detail;
-    const target = keyboardEvent.target as HTMLCalciteDropdownItemElement;
-    const traversableItems = this.getTraversableItems();
-
-    switch (keyboardEvent.key) {
-      case "Tab":
-        this.open = false;
-        this.updateTabIndexOfItems(target);
-        break;
-      case "ArrowDown":
-        focusElementInGroup(traversableItems, target, "next");
-        break;
-      case "ArrowUp":
-        focusElementInGroup(traversableItems, target, "previous");
-        break;
-      case "Home":
-        focusElementInGroup(traversableItems, target, "first");
-        break;
-      case "End":
-        focusElementInGroup(traversableItems, target, "last");
-        break;
-    }
-
-    event.stopPropagation();
   }
 
   @Listen("calciteInternalDropdownItemSelect")
@@ -569,9 +539,9 @@ export class Dropdown
   };
 
   private keyDownHandler = (event: KeyboardEvent): void => {
-    if (!event.composedPath().includes(this.referenceEl)) {
-      return;
-    }
+    // if (!event.composedPath().includes(this.referenceEl)) {
+    //   return;
+    // }
 
     const { defaultPrevented, key } = event;
 
@@ -597,6 +567,34 @@ export class Dropdown
     } else if (key === "Escape") {
       this.closeCalciteDropdown();
       event.preventDefault();
+    }
+
+    const keyboardEvent = event;
+    const target = keyboardEvent.target as HTMLCalciteDropdownItemElement;
+    const traversableItems = this.getTraversableItems();
+
+    switch (keyboardEvent.key) {
+      case "Tab":
+        this.open = false;
+        this.updateTabIndexOfItems(target);
+        break;
+      case "ArrowDown":
+        console.log("loggg");
+        focusElementInGroup(traversableItems, target, "next");
+        event.preventDefault();
+        break;
+      case "ArrowUp":
+        focusElementInGroup(traversableItems, target, "previous");
+        event.preventDefault();
+        break;
+      case "Home":
+        focusElementInGroup(traversableItems, target, "first");
+        event.preventDefault();
+        break;
+      case "End":
+        focusElementInGroup(traversableItems, target, "last");
+        event.preventDefault();
+        break;
     }
   };
 

--- a/packages/calcite-components/src/components/menu-item/menu-item.tsx
+++ b/packages/calcite-components/src/components/menu-item/menu-item.tsx
@@ -31,7 +31,6 @@ import {
 } from "../../utils/t9n";
 import { LocalizedComponent, connectLocalized, disconnectLocalized } from "../../utils/locale";
 import { CSS } from "./resources";
-import { MenuItemCustomEvent } from "./interfaces";
 import { MenuItemMessages } from "./assets/menu-item/t9n";
 
 type Layout = "horizontal" | "vertical";
@@ -172,8 +171,6 @@ export class CalciteMenuItem implements LoadableComponent, T9nComponent, Localiz
   //  Events
   //
   //--------------------------------------------------------------------------
-  /** @internal */
-  @Event({ cancelable: true }) calciteInternalMenuItemKeyEvent: EventEmitter<MenuItemCustomEvent>;
 
   /** Emits when the component is selected.*/
   @Event() calciteMenuItemSelect: EventEmitter<void>;
@@ -266,7 +263,7 @@ export class CalciteMenuItem implements LoadableComponent, T9nComponent, Localiz
   };
 
   private keyDownHandler = async (event: KeyboardEvent): Promise<void> => {
-    const { hasSubmenu, href, layout, open, submenuItems } = this;
+    const { hasSubmenu, href, layout, open } = this;
     const key = event.key;
     const targetIsDropdown = event.target === this.dropdownActionEl;
 
@@ -287,39 +284,21 @@ export class CalciteMenuItem implements LoadableComponent, T9nComponent, Localiz
     } else if (key === "Escape") {
       if (open) {
         this.open = false;
+        event.preventDefault();
         return;
       }
-      this.calciteInternalMenuItemKeyEvent.emit({ event });
-      event.preventDefault();
     } else if (key === "ArrowDown" || key === "ArrowUp") {
-      event.preventDefault();
       if ((targetIsDropdown || !href) && hasSubmenu && !open && layout === "horizontal") {
         this.open = true;
+        event.preventDefault();
         return;
       }
-      this.calciteInternalMenuItemKeyEvent.emit({
-        event,
-        children: submenuItems,
-        isSubmenuOpen: open && hasSubmenu,
-      });
-    } else if (key === "ArrowLeft") {
-      event.preventDefault();
-      this.calciteInternalMenuItemKeyEvent.emit({
-        event,
-        children: submenuItems,
-        isSubmenuOpen: true,
-      });
     } else if (key === "ArrowRight") {
-      event.preventDefault();
       if ((targetIsDropdown || !href) && hasSubmenu && !open && layout === "vertical") {
         this.open = true;
+        event.preventDefault();
         return;
       }
-      this.calciteInternalMenuItemKeyEvent.emit({
-        event,
-        children: submenuItems,
-        isSubmenuOpen: open && hasSubmenu,
-      });
     }
   };
 

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -153,49 +153,55 @@ export class CalciteMenu implements LocalizedComponent, T9nComponent, LoadableCo
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteInternalMenuItemKeyEvent")
-  calciteInternalNavMenuItemKeyEvent(event: CustomEvent): void {
+  @Listen("keydown")
+  calciteInternalNavMenuItemKeyEvent(event: KeyboardEvent): void {
+    if (event.defaultPrevented) {
+      return;
+    }
+
     const target = event.target as HTMLCalciteMenuItemElement;
-    const submenuItems = event.detail.children;
-    const key = event.detail.event.key;
-    event.stopPropagation();
+    const submenuItems = Array.from(target.children) as HTMLCalciteMenuItemElement[];
+    const isSubmenuOpen = submenuItems.some((item) => item.open);
+    const key = event.key;
 
     if (key === "ArrowDown") {
       if (target.layout === "vertical") {
         focusElementInGroup(this.menuItems, target, "next", false);
       } else {
-        if (event.detail.isSubmenuOpen) {
+        if (isSubmenuOpen) {
           submenuItems[0].setFocus();
         }
       }
+      event.preventDefault();
     } else if (key === "ArrowUp") {
       if (this.layout === "vertical") {
         focusElementInGroup(this.menuItems, target, "previous", false);
       } else {
-        if (event.detail.isSubmenuOpen) {
+        if (isSubmenuOpen) {
           submenuItems[submenuItems.length - 1].setFocus();
         }
       }
+      event.preventDefault();
     } else if (key === "ArrowRight") {
       if (this.layout === "horizontal") {
         focusElementInGroup(this.menuItems, target, "next", false);
       } else {
-        if (event.detail.isSubmenuOpen) {
+        if (isSubmenuOpen) {
           submenuItems[0].setFocus();
         }
       }
+      event.preventDefault();
     } else if (key === "ArrowLeft") {
       if (this.layout === "horizontal") {
         focusElementInGroup(this.menuItems, target, "previous", false);
       } else {
-        if (event.detail.isSubmenuOpen) {
-          this.focusParentElement(event.target as HTMLCalciteMenuItemElement);
-        }
+        this.focusParentElement(target);
       }
+      event.preventDefault();
     } else if (key === "Escape") {
-      this.focusParentElement(event.target as HTMLCalciteMenuItemElement);
+      this.focusParentElement(target);
+      event.preventDefault();
     }
-    event.preventDefault();
   }
 
   //--------------------------------------------------------------------------

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -23,7 +23,6 @@ import {
 import {
   StepperItemChangeEventDetail,
   StepperItemEventDetail,
-  StepperItemKeyEventDetail,
   StepperLayout,
 } from "../stepper/interfaces";
 import {
@@ -187,12 +186,6 @@ export class StepperItem
    * @internal
    */
   @Event({ cancelable: false })
-  calciteInternalStepperItemKeyEvent: EventEmitter<StepperItemKeyEventDetail>;
-
-  /**
-   * @internal
-   */
-  @Event({ cancelable: false })
   calciteInternalStepperItemSelect: EventEmitter<StepperItemEventDetail>;
 
   /**
@@ -347,15 +340,6 @@ export class StepperItem
         case " ":
         case "Enter":
           this.emitUserRequestedItem();
-          event.preventDefault();
-          break;
-        case "ArrowUp":
-        case "ArrowDown":
-        case "ArrowLeft":
-        case "ArrowRight":
-        case "Home":
-        case "End":
-          this.calciteInternalStepperItemKeyEvent.emit({ item: event });
           event.preventDefault();
           break;
       }

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -32,11 +32,7 @@ import {
 } from "../../utils/t9n";
 import { CSS } from "./resources";
 import { StepBar } from "./functional/step-bar";
-import {
-  StepperItemChangeEventDetail,
-  StepperItemKeyEventDetail,
-  StepperLayout,
-} from "./interfaces";
+import { StepperItemChangeEventDetail, StepperLayout } from "./interfaces";
 import { StepperMessages } from "./assets/stepper/t9n";
 
 /**
@@ -209,28 +205,27 @@ export class Stepper implements LocalizedComponent, T9nComponent {
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteInternalStepperItemKeyEvent")
-  calciteInternalStepperItemKeyEvent(event: CustomEvent<StepperItemKeyEventDetail>): void {
-    const item = event.detail.item;
-    const itemToFocus = event.target as HTMLCalciteStepperItemElement;
+  @Listen("keydown")
+  keyDownEvent(event: KeyboardEvent): void {
+    const key = event.key;
+    const interactiveItems = this.enabledItems;
+    const toDirection =
+      key === "ArrowRight" || key === "ArrowDown"
+        ? "next"
+        : key === "ArrowLeft" || key === "ArrowUp"
+          ? "previous"
+          : key === "Home"
+            ? "first"
+            : key === "End"
+              ? "last"
+              : null;
 
-    switch (item.key) {
-      case "ArrowDown":
-      case "ArrowRight":
-        focusElementInGroup(this.enabledItems, itemToFocus, "next");
-        break;
-      case "ArrowUp":
-      case "ArrowLeft":
-        focusElementInGroup(this.enabledItems, itemToFocus, "previous");
-        break;
-      case "Home":
-        focusElementInGroup(this.enabledItems, itemToFocus, "first");
-        break;
-      case "End":
-        focusElementInGroup(this.enabledItems, itemToFocus, "last");
-        break;
+    if (!toDirection) {
+      return;
     }
-    event.stopPropagation();
+
+    event.preventDefault();
+    focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, toDirection);
   }
 
   @Listen("calciteInternalStepperItemRegister")

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -202,28 +202,31 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
   //
   //--------------------------------------------------------------------------
 
-  @Listen("calciteInternalTileKeyEvent")
-  calciteInternalTileKeyEventListener(event: CustomEvent): void {
+  @Listen("keydown")
+  keyDownEventListener(event: KeyboardEvent): void {
     if (event.composedPath().includes(this.el)) {
       event.preventDefault();
       event.stopPropagation();
       const interactiveItems = this.items?.filter((el) => !el.disabled);
-      switch (event.detail.key) {
-        case "ArrowDown":
-        case "ArrowRight":
-          focusElementInGroup(interactiveItems, event.detail.target, "next");
-          break;
-        case "ArrowUp":
-        case "ArrowLeft":
-          focusElementInGroup(interactiveItems, event.detail.target, "previous");
-          break;
-        case "Home":
-          focusElementInGroup(interactiveItems, event.detail.target, "first");
-          break;
-        case "End":
-          focusElementInGroup(interactiveItems, event.detail.target, "last");
-          break;
+
+      const key = event.key;
+      const toDirection =
+        key === "ArrowRight" || key === "ArrowDown"
+          ? "next"
+          : key === "ArrowLeft" || key === "ArrowUp"
+            ? "previous"
+            : key === "Home"
+              ? "first"
+              : key === "End"
+                ? "last"
+                : null;
+
+      if (!toDirection) {
+        return;
       }
+
+      event.preventDefault();
+      focusElementInGroup(interactiveItems, event.target as HTMLCalciteCardElement, toDirection);
     }
   }
 

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -188,11 +188,6 @@ export class Tile implements InteractiveComponent, SelectableComponent {
   //--------------------------------------------------------------------------
 
   /**
-   * @internal
-   */
-  @Event({ cancelable: false }) calciteInternalTileKeyEvent: EventEmitter<KeyboardEvent>;
-
-  /**
    * Fires when the selected state of the component changes.
    */
   @Event() calciteTileSelect: EventEmitter<void>;
@@ -257,15 +252,6 @@ export class Tile implements InteractiveComponent, SelectableComponent {
         case " ":
         case "Enter":
           this.handleSelectEvent();
-          event.preventDefault();
-          break;
-        case "ArrowDown":
-        case "ArrowLeft":
-        case "ArrowRight":
-        case "ArrowUp":
-        case "Home":
-        case "End":
-          this.calciteInternalTileKeyEvent.emit(event);
           event.preventDefault();
           break;
       }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes custom key events in favor of native `KeyboardEvent`.
