### PR TITLE
fix(input, input-number, input-text): restore `autofocus`, `enter-key-mode` and `input-mode` attributes

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -2035,6 +2035,10 @@ export namespace Components {
          */
         "autocomplete": string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus": boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value. The clear button shows by default for `"search"`, `"time"`, and `"date"` types, and will not display for the `"textarea"` type.
          */
         "clearable": boolean;
@@ -2045,8 +2049,8 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint": string;
         /**
@@ -2071,8 +2075,8 @@ export namespace Components {
          */
         "iconFlipRtl": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode": string;
         /**
@@ -2375,6 +2379,10 @@ export namespace Components {
          */
         "autocomplete": string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus": boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value.
          */
         "clearable": boolean;
@@ -2385,8 +2393,8 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint": string;
         /**
@@ -2407,8 +2415,8 @@ export namespace Components {
          */
         "iconFlipRtl": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode": string;
         /**
@@ -2543,6 +2551,10 @@ export namespace Components {
          */
         "autocomplete": string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus": boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value.
          */
         "clearable": boolean;
@@ -2553,8 +2565,8 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint": string;
         /**
@@ -2571,8 +2583,8 @@ export namespace Components {
          */
         "iconFlipRtl": boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode": string;
         /**
@@ -9779,6 +9791,10 @@ declare namespace LocalJSX {
          */
         "autocomplete"?: string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus"?: boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value. The clear button shows by default for `"search"`, `"time"`, and `"date"` types, and will not display for the `"textarea"` type.
          */
         "clearable"?: boolean;
@@ -9789,8 +9805,8 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint"?: string;
         /**
@@ -9815,8 +9831,8 @@ declare namespace LocalJSX {
          */
         "iconFlipRtl"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode"?: string;
         /**
@@ -10132,6 +10148,10 @@ declare namespace LocalJSX {
          */
         "autocomplete"?: string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus"?: boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value.
          */
         "clearable"?: boolean;
@@ -10142,8 +10162,8 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint"?: string;
         /**
@@ -10164,8 +10184,8 @@ declare namespace LocalJSX {
          */
         "iconFlipRtl"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode"?: string;
         /**
@@ -10302,6 +10322,10 @@ declare namespace LocalJSX {
          */
         "autocomplete"?: string;
         /**
+          * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+         */
+        "autofocus"?: boolean;
+        /**
           * When `true`, a clear button is displayed when the component has a value.
          */
         "clearable"?: boolean;
@@ -10312,8 +10336,8 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "enterKeyHint"?: string;
         /**
@@ -10330,8 +10354,8 @@ declare namespace LocalJSX {
          */
         "iconFlipRtl"?: boolean;
         /**
-          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
-          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+          * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-cased attribute will not be supported in a future release
          */
         "inputMode"?: string;
         /**

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -2045,6 +2045,11 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint": string;
+        /**
           * When `type` is `"file"`, specifies the component's selected files.
           * @mdn https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/files
          */
@@ -2065,6 +2070,11 @@ export namespace Components {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl": boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode": string;
         /**
           * Accessible name for the component.
          */
@@ -2375,6 +2385,11 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint": string;
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
@@ -2391,6 +2406,11 @@ export namespace Components {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl": boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode": string;
         /**
           * When `true`, restricts the component to integer numbers only and disables exponential notation.
          */
@@ -2533,6 +2553,11 @@ export namespace Components {
         "disabled": boolean;
         "editingEnabled": boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint": string;
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form": string;
@@ -2545,6 +2570,11 @@ export namespace Components {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl": boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode": string;
         /**
           * Accessible name for the component's button or hyperlink.
          */
@@ -9759,6 +9789,11 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint"?: string;
+        /**
           * When `type` is `"file"`, specifies the component's selected files.
           * @mdn https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/files
          */
@@ -9779,6 +9814,11 @@ declare namespace LocalJSX {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl"?: boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode"?: string;
         /**
           * Accessible name for the component.
          */
@@ -10102,6 +10142,11 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint"?: string;
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
@@ -10118,6 +10163,11 @@ declare namespace LocalJSX {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl"?: boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode"?: string;
         /**
           * When `true`, restricts the component to integer numbers only and disables exponential notation.
          */
@@ -10262,6 +10312,11 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "editingEnabled"?: boolean;
         /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "enterKeyHint"?: string;
+        /**
           * The `id` of the form that will be associated with the component.  When not set, the component will be associated with its ancestor form element, if any.
          */
         "form"?: string;
@@ -10274,6 +10329,11 @@ declare namespace LocalJSX {
           * When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`).
          */
         "iconFlipRtl"?: boolean;
+        /**
+          * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+          * @futureBreaking kebab-case of this attribute will not be supported in a future release
+         */
+        "inputMode"?: string;
         /**
           * Accessible name for the component's button or hyperlink.
          */

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -15,7 +15,11 @@ import {
 import { getElementRect, getElementXY, selectText } from "../../tests/utils";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
-import { testHiddenInputSyncing, testPostValidationFocusing } from "../input/common/tests";
+import {
+  testWorkaroundForGlobalPropRemoval,
+  testHiddenInputSyncing,
+  testPostValidationFocusing,
+} from "../input/common/tests";
 
 describe("calcite-input-number", () => {
   const delayFor2UpdatesInMs = 200;
@@ -1756,6 +1760,8 @@ describe("calcite-input-number", () => {
 
     testHiddenInputSyncing("calcite-input-number");
   });
+
+  testWorkaroundForGlobalPropRemoval("calcite-input-number");
 
   describe("translation support", () => {
     t9n("calcite-input-number");

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -120,6 +120,14 @@ export class InputNumber
   @Prop({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
 
   /**
+   * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+   *
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() autofocus: boolean;
+
+  /**
    * When `true`, a clear button is displayed when the component has a value.
    */
   @Prop({ reflect: true }) clearable = false;
@@ -137,9 +145,9 @@ export class InputNumber
   }
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -168,9 +176,9 @@ export class InputNumber
   @Prop({ reflect: true }) iconFlipRtl = false;
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -1077,8 +1085,8 @@ export class InputNumber
         autofocus={this.el.autofocus ? true : null}
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
-        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
-        inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
+        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enterkeyhint")}
+        inputMode={this.el.inputMode || this.el.getAttribute("inputmode")}
         key="localized-input"
         maxLength={this.maxLength}
         minLength={this.minLength}

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -137,6 +137,15 @@ export class InputNumber
   }
 
   /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() enterKeyHint: string;
+
+  /**
    * The `id` of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.
@@ -157,6 +166,15 @@ export class InputNumber
 
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
+
+  /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() inputMode: string;
 
   /** When `true`, restricts the component to integer numbers only and disables exponential notation. */
   @Prop() integer = false;
@@ -1059,8 +1077,8 @@ export class InputNumber
         autofocus={this.el.autofocus ? true : null}
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
-        enterKeyHint={this.el.enterKeyHint}
-        inputMode={this.el.inputMode}
+        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
+        inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
         key="localized-input"
         maxLength={this.maxLength}
         minLength={this.minLength}

--- a/packages/calcite-components/src/components/input-text/input-text.e2e.ts
+++ b/packages/calcite-components/src/components/input-text/input-text.e2e.ts
@@ -12,7 +12,11 @@ import {
   t9n,
 } from "../../tests/commonTests";
 import { selectText } from "../../tests/utils";
-import { testHiddenInputSyncing, testPostValidationFocusing } from "../input/common/tests";
+import {
+  testHiddenInputSyncing,
+  testPostValidationFocusing,
+  testWorkaroundForGlobalPropRemoval,
+} from "../input/common/tests";
 
 describe("calcite-input-text", () => {
   describe("labelable", () => {
@@ -468,6 +472,8 @@ describe("calcite-input-text", () => {
 
     testHiddenInputSyncing("calcite-input-text");
   });
+
+  testWorkaroundForGlobalPropRemoval("calcite-input-text");
 
   describe("translation support", () => {
     t9n("calcite-input-text");

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -113,6 +113,15 @@ export class InputText
   }
 
   /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() enterKeyHint: string;
+
+  /**
    * The `id` of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.
@@ -129,6 +138,15 @@ export class InputText
 
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
+
+  /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() inputMode: string;
 
   /** Accessible name for the component's button or hyperlink. */
   @Prop() label: string;
@@ -646,8 +664,8 @@ export class InputText
         }}
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
-        enterKeyHint={this.el.enterKeyHint}
-        inputMode={this.el.inputMode}
+        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
+        inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
         maxLength={this.maxLength}
         minLength={this.minLength}
         name={this.name}

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -96,6 +96,14 @@ export class InputText
   @Prop({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
 
   /**
+   * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+   *
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() autofocus: boolean;
+
+  /**
    * When `true`, a clear button is displayed when the component has a value.
    */
   @Prop({ reflect: true }) clearable = false;
@@ -113,9 +121,9 @@ export class InputText
   }
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -140,9 +148,9 @@ export class InputText
   @Prop({ reflect: true }) iconFlipRtl = false;
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -650,7 +658,6 @@ export class InputText
       />
     );
     const prefixText = <div class={CSS.prefix}>{this.prefixText}</div>;
-
     const suffixText = <div class={CSS.suffix}>{this.suffixText}</div>;
 
     const childEl = (
@@ -664,8 +671,8 @@ export class InputText
         }}
         defaultValue={this.defaultValue}
         disabled={this.disabled ? true : null}
-        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
-        inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
+        enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enterkeyhint")}
+        inputMode={this.el.inputMode || this.el.getAttribute("inputmode")}
         maxLength={this.maxLength}
         minLength={this.minLength}
         name={this.name}

--- a/packages/calcite-components/src/components/input/common/tests.ts
+++ b/packages/calcite-components/src/components/input/common/tests.ts
@@ -117,32 +117,33 @@ export function testHiddenInputSyncing(
 export function testWorkaroundForGlobalPropRemoval(
   inputTag: Extract<keyof JSX.IntrinsicElements, "calcite-input" | "calcite-input-text" | "calcite-input-number">,
 ): void {
-  it("supports kebab-casing", async () => {
+  const testInputMode = "tel";
+  const testEnterKeyHint = "done";
+
+  it("supports global attribute kebab-casing (deprecated)", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
-        <${inputTag} autofocus input-mode="tel" enter-key-hint="let's go!"></${inputTag}>
+        <${inputTag} autofocus input-mode="${testInputMode}" enter-key-hint="${testEnterKeyHint}"></${inputTag}>
     `);
-    await page.waitForChanges();
 
     const input = await page.find(`${inputTag} >>> input`);
 
     expect(input.getAttribute("autofocus")).toBe("");
-    expect(input.getAttribute("inputmode")).toBe("tel");
-    expect(input.getAttribute("enterkeyhint")).toBe("let's go!");
+    expect(input.getAttribute("inputmode")).toBe(testInputMode);
+    expect(input.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
   });
 
   it("supports global attribute casing", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
-        <${inputTag} autofocus inputmode="tel" enterkeyhint="let's go!"></${inputTag}>
+        <${inputTag} autofocus inputmode="${testInputMode}" enterkeyhint="${testEnterKeyHint}"></${inputTag}>
     `);
-    await page.waitForChanges();
 
     const input = await page.find(`${inputTag} >>> input`);
 
     expect(input.getAttribute("autofocus")).toBe("");
-    expect(input.getAttribute("inputmode")).toBe("tel");
-    expect(input.getAttribute("enterkeyhint")).toBe("let's go!");
+    expect(input.getAttribute("inputmode")).toBe(testInputMode);
+    expect(input.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
   });
 
   it("supports global props", async () => {
@@ -153,12 +154,12 @@ export function testWorkaroundForGlobalPropRemoval(
     const internalInput = await page.find(`${inputTag} >>> input`);
 
     input.setProperty("autofocus", true);
-    input.setProperty("inputMode", "tel");
-    input.setProperty("enterKeyHint", "let's go!");
+    input.setProperty("inputMode", testInputMode);
+    input.setProperty("enterKeyHint", testEnterKeyHint);
     await page.waitForChanges();
 
     expect(internalInput.getAttribute("autofocus")).toBe("");
-    expect(internalInput.getAttribute("inputmode")).toBe("tel");
-    expect(internalInput.getAttribute("enterkeyhint")).toBe("let's go!");
+    expect(internalInput.getAttribute("inputmode")).toBe(testInputMode);
+    expect(internalInput.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
   });
 }

--- a/packages/calcite-components/src/components/input/common/tests.ts
+++ b/packages/calcite-components/src/components/input/common/tests.ts
@@ -58,7 +58,9 @@ export function testHiddenInputSyncing(
   it("syncs hidden input with the input component", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
-      <${inputTag} name="form-name"></${inputTag}>
+      <form>
+        <${inputTag} name="form-name"></${inputTag}>
+      </form>
     `);
     const input = await page.find(inputTag);
     const hiddenInput = await page.find(`input[slot=${hiddenFormInputSlotName}]`);

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -15,7 +15,7 @@ import { html } from "../../../support/formatting";
 import { letterKeys, numberKeys } from "../../utils/key";
 import { locales, numberStringFormatter } from "../../utils/locale";
 import { getElementRect, getElementXY, selectText } from "../../tests/utils";
-import { testHiddenInputSyncing, testPostValidationFocusing } from "./common/tests";
+import { testHiddenInputSyncing, testPostValidationFocusing, testWorkaroundForGlobalPropRemoval } from "./common/tests";
 
 describe("calcite-input", () => {
   const delayFor2UpdatesInMs = 200;
@@ -2061,6 +2061,8 @@ describe("calcite-input", () => {
 
     testHiddenInputSyncing("calcite-input");
   });
+
+  testWorkaroundForGlobalPropRemoval("calcite-input");
 
   describe("translation support", () => {
     t9n("calcite-input");

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -133,6 +133,15 @@ export class Input
   }
 
   /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() enterKeyHint: string;
+
+  /**
    * The `id` of the form that will be associated with the component.
    *
    * When not set, the component will be associated with its ancestor form element, if any.
@@ -151,6 +160,15 @@ export class Input
 
   /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
   @Prop({ reflect: true }) iconFlipRtl = false;
+
+  /**
+   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   *
+   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() inputMode: string;
 
   /** Accessible name for the component. */
   @Prop() label: string;
@@ -1147,8 +1165,8 @@ export class Input
           autofocus={this.el.autofocus ? true : null}
           defaultValue={this.defaultValue}
           disabled={this.disabled ? true : null}
-          enterKeyHint={this.el.enterKeyHint}
-          inputMode={this.el.inputMode}
+          enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
+          inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
           key="localized-input"
           maxLength={this.maxLength}
           minLength={this.minLength}
@@ -1183,8 +1201,8 @@ export class Input
               }}
               defaultValue={this.defaultValue}
               disabled={this.disabled ? true : null}
-              enterKeyHint={this.el.enterKeyHint}
-              inputMode={this.el.inputMode}
+              enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
+              inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
               max={this.maxString}
               maxLength={this.maxLength}
               min={this.minString}

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -116,6 +116,14 @@ export class Input
   @Prop({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
 
   /**
+   * Adds global prop, missing from Stencil's `HTMLElement` type, see https://github.com/ionic-team/stencil/issues/5726
+   *
+   * @internal
+   */
+  // eslint-disable-next-line @stencil-community/reserved-member-names
+  @Prop() autofocus: boolean;
+
+  /**
    * When `true`, a clear button is displayed when the component has a value. The clear button shows by default for `"search"`, `"time"`, and `"date"` types, and will not display for the `"textarea"` type.
    */
   @Prop({ reflect: true }) clearable = false;
@@ -133,9 +141,9 @@ export class Input
   }
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -162,9 +170,9 @@ export class Input
   @Prop({ reflect: true }) iconFlipRtl = false;
 
   /**
-   * Custom global prop added to support kebab-cased attribute from custom global prop removed in https://github.com/Esri/calcite-design-system/pull/9123
+   * Adds support for kebab-cased attribute, removed in https://github.com/Esri/calcite-design-system/pull/9123
    *
-   * @futureBreaking kebab-case of this attribute will not be supported in a future release
+   * @futureBreaking kebab-cased attribute will not be supported in a future release
    * @internal
    */
   // eslint-disable-next-line @stencil-community/reserved-member-names
@@ -1162,11 +1170,11 @@ export class Input
           accept={this.accept}
           aria-label={getLabelText(this)}
           autocomplete={this.autocomplete}
-          autofocus={this.el.autofocus ? true : null}
+          autofocus={this.el.autofocus || this.el.hasAttribute("autofocus") ? true : null}
           defaultValue={this.defaultValue}
           disabled={this.disabled ? true : null}
-          enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
-          inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
+          enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enterkeyhint")}
+          inputMode={this.el.inputMode || this.el.getAttribute("inputmode")}
           key="localized-input"
           maxLength={this.maxLength}
           minLength={this.minLength}
@@ -1194,15 +1202,23 @@ export class Input
               accept={this.accept}
               aria-label={getLabelText(this)}
               autocomplete={this.autocomplete}
-              autofocus={this.el.autofocus ? true : null}
+              autofocus={this.el.autofocus || this.el.hasAttribute("autofocus") ? true : null}
               class={{
                 [CSS.editingEnabled]: this.editingEnabled,
                 [CSS.inlineChild]: !!this.inlineEditableEl,
               }}
               defaultValue={this.defaultValue}
               disabled={this.disabled ? true : null}
-              enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enter-key-hint")}
-              inputMode={this.el.inputMode || this.el.getAttribute("input-mode")}
+              enterKeyHint={
+                this.el.enterKeyHint ||
+                this.el.getAttribute("enterkeyhint") ||
+                this.el.getAttribute("enter-key-hint")
+              }
+              inputMode={
+                this.el.inputMode ||
+                this.el.getAttribute("inputmode") ||
+                this.el.getAttribute("input-mode")
+              }
               max={this.maxString}
               maxLength={this.maxLength}
               min={this.minString}

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -1161,8 +1161,11 @@ export class Input
     );
 
     const prefixText = <div class={CSS.prefix}>{this.prefixText}</div>;
-
     const suffixText = <div class={CSS.suffix}>{this.suffixText}</div>;
+
+    const autofocus = this.el.autofocus || this.el.hasAttribute("autofocus") ? true : null;
+    const enterKeyHint = this.el.enterKeyHint || this.el.getAttribute("enterkeyhint");
+    const inputMode = this.el.inputMode || this.el.getAttribute("inputmode");
 
     const localeNumberInput =
       this.type === "number" ? (
@@ -1170,11 +1173,11 @@ export class Input
           accept={this.accept}
           aria-label={getLabelText(this)}
           autocomplete={this.autocomplete}
-          autofocus={this.el.autofocus || this.el.hasAttribute("autofocus") ? true : null}
+          autofocus={autofocus}
           defaultValue={this.defaultValue}
           disabled={this.disabled ? true : null}
-          enterKeyHint={this.el.enterKeyHint || this.el.getAttribute("enterkeyhint")}
-          inputMode={this.el.inputMode || this.el.getAttribute("inputmode")}
+          enterKeyHint={enterKeyHint}
+          inputMode={inputMode}
           key="localized-input"
           maxLength={this.maxLength}
           minLength={this.minLength}
@@ -1202,23 +1205,15 @@ export class Input
               accept={this.accept}
               aria-label={getLabelText(this)}
               autocomplete={this.autocomplete}
-              autofocus={this.el.autofocus || this.el.hasAttribute("autofocus") ? true : null}
+              autofocus={autofocus}
               class={{
                 [CSS.editingEnabled]: this.editingEnabled,
                 [CSS.inlineChild]: !!this.inlineEditableEl,
               }}
               defaultValue={this.defaultValue}
               disabled={this.disabled ? true : null}
-              enterKeyHint={
-                this.el.enterKeyHint ||
-                this.el.getAttribute("enterkeyhint") ||
-                this.el.getAttribute("enter-key-hint")
-              }
-              inputMode={
-                this.el.inputMode ||
-                this.el.getAttribute("inputmode") ||
-                this.el.getAttribute("input-mode")
-              }
+              enterKeyHint={enterKeyHint}
+              inputMode={inputMode}
               max={this.maxString}
               maxLength={this.maxLength}
               min={this.minString}


### PR DESCRIPTION
**Related Issue:** #9235

## Summary

This fixes the following issues introduced by #9123 when component props that shadowed global attributes were removed:

* the kebab-cased attribute names of those props would no longer work (namely, `enter-key-mode`, `input-mode`)
* `autofocus` was missing from component types as Stencil does not include it in the base `HTMLAttribute` type (see https://github.com/ionic-team/stencil/issues/5726).
