### PR TITLE
fix(list): border items when an item is programmatically opened.

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -6754,6 +6754,7 @@ declare global {
         "calciteInternalListItemActive": void;
         "calciteInternalFocusPreviousItem": void;
         "calciteInternalListItemChange": void;
+        "calciteInternalListItemToggle": void;
     }
     interface HTMLCalciteListItemElement extends Components.CalciteListItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteListItemElementEventMap>(type: K, listener: (this: HTMLCalciteListItemElement, ev: CalciteListItemCustomEvent<HTMLCalciteListItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -10806,6 +10807,7 @@ declare namespace LocalJSX {
         "onCalciteInternalListItemSelectMultiple"?: (event: CalciteListItemCustomEvent<{
     selectMultiple: boolean;
   }>) => void;
+        "onCalciteInternalListItemToggle"?: (event: CalciteListItemCustomEvent<void>) => void;
         /**
           * Fires when the close button is clicked.
          */

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -169,6 +169,11 @@ export class ListItem
    */
   @Prop({ mutable: true, reflect: true }) open = false;
 
+  @Watch("open")
+  handleOpenChange(): void {
+    this.emitCalciteInternalListItemToggle();
+  }
+
   /**
    * Used to specify the aria-setsize attribute to define the number of items in the current set of list for accessibility.
    *
@@ -292,6 +297,12 @@ export class ListItem
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalListItemChange: EventEmitter<void>;
+
+  /**
+   *
+   * @internal
+   */
+  @Event({ cancelable: false }) calciteInternalListItemToggle: EventEmitter<void>;
 
   @Listen("calciteInternalListItemGroupDefaultSlotChange")
   @Listen("calciteInternalListDefaultSlotChange")
@@ -733,6 +744,10 @@ export class ListItem
   private focusCellActionsEnd = (): void => {
     this.handleCellFocusIn(this.actionsEndEl);
   };
+
+  private emitCalciteInternalListItemToggle(): void {
+    this.calciteInternalListItemToggle.emit();
+  }
 
   private emitCalciteInternalListItemChange(): void {
     this.calciteInternalListItemChange.emit();

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -169,6 +169,57 @@ describe("calcite-list", () => {
     });
   });
 
+  it("should border nested list items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list>
+        <calcite-list-item
+          id="firstItem"
+          label="Hiking trails"
+          description="Designated routes for hikers to use."
+          value="hiking-trails"
+        >
+          <calcite-action slot="actions-end" icon="layer" text="Trails layer"></calcite-action>
+          <calcite-list>
+            <calcite-list-item
+              id="firstChildItem"
+              label="Hiking trails"
+              description="Designated routes for hikers to use."
+              value="hiking-trails"
+            >
+              <calcite-action slot="actions-end" icon="layer" text="Trails layer"></calcite-action>
+            </calcite-list-item>
+            <calcite-list-item label="Waterfalls" description="Vertical drops from a river." value="waterfalls">
+              <calcite-action slot="actions-end" icon="layer" text="Waterfalls layer"></calcite-action>
+            </calcite-list-item>
+            <calcite-list-item label="Rivers" description="Large naturally flowing watercourses." value="rivers">
+              <calcite-action slot="actions-end" icon="layer" text="Rivers layer"></calcite-action>
+            </calcite-list-item>
+          </calcite-list>
+        </calcite-list-item>
+        <calcite-list-item label="Waterfalls" description="Vertical drops from a river." value="waterfalls">
+          <calcite-action slot="actions-end" icon="layer" text="Waterfalls layer"></calcite-action>
+        </calcite-list-item>
+        <calcite-list-item label="Rivers" description="Large naturally flowing watercourses." value="rivers">
+          <calcite-action slot="actions-end" icon="layer" text="Rivers layer"></calcite-action>
+        </calcite-list-item>
+      </calcite-list>`,
+    );
+    await page.waitForChanges();
+
+    const firstItem = await page.find("#firstItem");
+    const firstChildItem = await page.find("#firstChildItem");
+
+    expect(await firstItem.getProperty("bordered")).toBe(true);
+    expect(await firstChildItem.getProperty("bordered")).toBe(false);
+
+    firstItem.setProperty("open", true);
+    await page.waitForChanges();
+
+    expect(await firstItem.getProperty("bordered")).toBe(true);
+    expect(await firstChildItem.getProperty("bordered")).toBe(true);
+  });
+
   it("navigating items after filtering", async () => {
     const page = await newE2EPage();
     await page.setContent(html`

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -254,7 +254,7 @@ export class List
    */
   @Event({ cancelable: false }) calciteInternalListDefaultSlotChange: EventEmitter<void>;
 
-  @Listen("calciteListItemToggle")
+  @Listen("calciteInternalListItemToggle")
   handleCalciteListItemToggle(): void {
     if (this.parentListEl) {
       return;

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -255,11 +255,12 @@ export class List
   @Event({ cancelable: false }) calciteInternalListDefaultSlotChange: EventEmitter<void>;
 
   @Listen("calciteInternalListItemToggle")
-  handleCalciteListItemToggle(): void {
+  handleCalciteListItemToggle(event: CustomEvent): void {
     if (this.parentListEl) {
       return;
     }
 
+    event.stopPropagation();
     this.borderItems();
   }
 


### PR DESCRIPTION
**Related Issue:** #9248

## Summary

- Use internal event on list-item to emit whenever `open` property changes
- Listen for internal event on the list to update bordering.