### PR TITLE
chore(renovate): update ignore list

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -17,8 +17,6 @@
     "@types/node",
     "@types/react",
     "@types/react-dom",
-    "@whitespace/storybook-addon-html",
-    "cheerio",
     "jest",
     "jest-cli",
     "node",


### PR DESCRIPTION
**Related Issue:** #4678

## Summary

Removing `cheerio` and `storybook-addon-html` from Renovate's ignore list as we are using recent versions of these dependencies.
