### PR TITLE
refactor(tile): use internal variables for token value assignment

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -205,55 +205,55 @@ calcite-icon {
   }
 }
 
-:host([selection-appearance="border"]) {
-  &:host([layout="horizontal"]),
-  &:host([layout="vertical"]) {
-    .container.selected:focus::before {
-      --calcite-internal-tile-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
+:host([selection-appearance="border"][layout="horizontal"]),
+:host([selection-appearance="border"][layout="vertical"]) {
+  .container.selected:focus::before {
+    --calcite-internal-tile-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
 
-      block-size: 100%;
-      content: "";
-      display: block;
-      inline-size: 100%;
-      inset-block-start: 0;
-      inset-inline-start: 0;
-      position: absolute;
-    }
+    block-size: 100%;
+    box-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
+    content: "";
+    display: block;
+    inline-size: 100%;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    position: absolute;
   }
-  &:host([layout="horizontal"]) .container.selected {
+}
+
+:host([selection-appearance="border"][layout="horizontal"]) {
+  .container.selected {
     --calcite-internal-tile-shadow: inset 0px -4px 0px 0px var(--calcite-color-brand);
   }
+}
 
-  &:host([layout="vertical"]) .container.selected {
+:host([selection-appearance="border"][layout="vertical"]) {
+  .container.selected {
     --calcite-internal-tile-shadow: inset 4px 0px 0px 0px var(--calcite-color-brand);
   }
 }
 
-:host(:not([disabled])) {
-  &:host(:hover),
-  &:host([active]) {
-    --calcite-internal-tile-description-text-color: var(--calcite-color-text-2);
-    --calcite-internal-tile-heading-text-color: var(--calcite-color-text-1);
+:host([href]:focus:not([disabled])),
+:host([href]:hover:not([disabled])) {
+  --calcite-internal-tile-border-color: var(--calcite-color-text-link);
+  --calcite-internal-tile-heading-text-color: var(--calcite-color-text-link);
+  --calcite-internal-tile-icon-color: var(--calcite-color-text-link);
+  .container {
+    position: relative;
+    z-index: var(--calcite-z-index);
   }
+}
 
-  &:host([href]) {
-    &:focus,
-    &:hover {
-      --calcite-internal-tile-border-color: var(--calcite-color-text-link);
-      --calcite-internal-tile-heading-text-color: var(--calcite-color-text-link);
-      --calcite-internal-tile-icon-color: var(--calcite-color-text-link);
-      .container {
-        position: relative;
-        z-index: var(--calcite-z-index);
-      }
-    }
-
-    &:active {
-      .container {
-        --calcite-internal-tile-shadow: 0 0 0 3px var(--calcite-internal-tile-border-color);
-      }
-    }
+:host([href]:active:not([disabled])) {
+  .container {
+    --calcite-internal-tile-shadow: 0 0 0 3px var(--calcite-tile-border-color);
   }
+}
+
+:host(:hover:not([disabled])),
+:host([active]:not([disabled])) {
+  --calcite-internal-tile-description-text-color: var(--calcite-color-text-2);
+  --calcite-internal-tile-heading-text-color: var(--calcite-color-text-1);
 }
 
 :host([embed]) {
@@ -266,6 +266,7 @@ calcite-icon {
 :host([selection-mode="none"]) {
   .container {
     --calcite-internal-tile-outline-color: var(--calcite-internal-tile-border-color);
+
     &:focus {
       --calcite-internal-tile-outline-color: var(--calcite-color-brand);
       position: relative;
@@ -274,5 +275,4 @@ calcite-icon {
 }
 
 @include disabled();
-
 @include base-component();

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -7,42 +7,56 @@
  * @prop --calcite-tile-border-color: Specifies the border color of the component.
  * @prop --calcite-tile-description-text-color: Specifies the description text color of the component.
  * @prop --calcite-tile-heading-text-color: Specifies the heading text color of the component.
+ * @prop --calcite-tile-icon-color: Specifies the color of the selected icon in the component.
+ * @prop --calcite-tile-selection-icon-color-hover: Specifies the color of the selection icon in the component on hover.
  */
 
+/** Internal variables
+  * --calcite-internal-tile-border-color
+  * --calcite-internal-tile-description-text-color
+  * --calcite-internal-tile-heading-text-color
+  * --calcite-internal-tile-icon-color
+  * --calcite-internal-tile-outline-color
+  * --calcite-internal-tile-selection-icon-color
+  */
+
 :host {
-  --calcite-tile-background-color: var(--calcite-color-foreground-1);
-  --calcite-tile-border-color: var(--calcite-color-border-2);
-  --calcite-tile-description-text-color: var(--calcite-color-text-3);
-  --calcite-tile-heading-text-color: var(--calcite-color-text-2);
-  --calcite-ui-icon-color: var(--calcite-color-text-3);
+  --calcite-internal-tile-border-color: var(--calcite-color-border-2);
+  --calcite-internal-tile-description-text-color: var(--calcite-color-text-3);
+  --calcite-internal-tile-heading-text-color: var(--calcite-color-text-2);
 
   box-sizing: border-box;
   display: inline-block;
 }
 
 .container {
-  background-color: var(--calcite-tile-background-color);
+  --calcite-internal-tile-outline-color: var(--calcite-tile-border-color, var(--calcite-internal-tile-border-color));
+  --calcite-internal-tile-select-icon-color: var(--calcite-tile-selection-icon-color, var(--calcite-color-text-3));
+
+  background-color: var(--calcite-tile-background-color, var(--calcite-color-foreground-1));
   block-size: var(--calcite-container-size-content-fluid);
   box-sizing: border-box;
   inline-size: var(--calcite-container-size-content-fluid);
-  outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-tile-border-color);
+  outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-internal-tile-outline-color);
   user-select: none;
-  &.interactive {
+  box-shadow: var(--calcite-tile-shadow, var(--calcite-internal-tile-shadow, none)) &.interactive {
     cursor: pointer;
+
     &:hover,
     &:focus,
     &.selected {
-      outline-color: var(--calcite-color-brand);
+      --calcite-internal-tile-outline-color: var(--calcite-tile-border-color, var(--calcite-color-brand));
+      --calcite-internal-tile-select-icon-color: var(
+        --calcite-tile-selection-icon-color-hover,
+        var(--calcite-color-brand)
+      );
       position: relative;
-      .selection-icon {
-        --calcite-ui-icon-color: var(--calcite-color-brand);
-      }
     }
     &.selected {
       z-index: var(--calcite-z-index);
     }
     &:focus {
-      box-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
+      --calcite-internal-tile-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
       z-index: var(--calcite-z-index-sticky);
     }
   }
@@ -70,7 +84,7 @@
 }
 
 .heading {
-  color: var(--calcite-tile-heading-text-color);
+  color: var(--calcite-tile-heading-text-color, var(--calcite-internal-tile-heading-text-color));
   font-weight: var(--calcite-font-weight-medium);
   line-height: 1.20313rem;
   overflow-wrap: break-word;
@@ -94,9 +108,20 @@
 }
 
 .description {
-  color: var(--calcite-tile-description-text-color);
+  color: var(--calcite-tile-description-text-color, var(--calcite-internal-tile-description-text-color));
   font-weight: var(--calcite-font-weight-regular);
   overflow-wrap: break-word;
+}
+
+calcite-icon {
+  --calcite-icon-color: var(
+    --calcite-tile-icon-color,
+    var(--calcite-internal-tile-icon-color, var(--calcite-color-text-3))
+  );
+
+  &.selection-icon {
+    --calcite-icon-color: var(--calcite-internal-tile-select-icon-color);
+  }
 }
 
 :host([alignment="center"]) {
@@ -180,72 +205,74 @@
   }
 }
 
-:host([selection-appearance="border"][layout="horizontal"]),
-:host([selection-appearance="border"][layout="vertical"]) {
-  .container.selected:focus::before {
-    block-size: 100%;
-    box-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
-    content: "";
-    display: block;
-    inline-size: 100%;
-    inset-block-start: 0;
-    inset-inline-start: 0;
-    position: absolute;
+:host([selection-appearance="border"]) {
+  &:host([layout="horizontal"]),
+  &:host([layout="vertical"]) {
+    .container.selected:focus::before {
+      --calcite-internal-tile-shadow: inset 0px 0px 0px 1px var(--calcite-color-brand);
+
+      block-size: 100%;
+      content: "";
+      display: block;
+      inline-size: 100%;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      position: absolute;
+    }
+  }
+  &:host([layout="horizontal"]) .container.selected {
+    --calcite-internal-tile-shadow: inset 0px -4px 0px 0px var(--calcite-color-brand);
+  }
+
+  &:host([layout="vertical"]) .container.selected {
+    --calcite-internal-tile-shadow: inset 4px 0px 0px 0px var(--calcite-color-brand);
   }
 }
 
-:host([selection-appearance="border"][layout="horizontal"]) {
-  .container.selected {
-    box-shadow: inset 0px -4px 0px 0px var(--calcite-color-brand);
+:host(:not([disabled])) {
+  &:host(:hover),
+  &:host([active]) {
+    --calcite-internal-tile-description-text-color: var(--calcite-color-text-2);
+    --calcite-internal-tile-heading-text-color: var(--calcite-color-text-1);
   }
-}
 
-:host([selection-appearance="border"][layout="vertical"]) {
-  .container.selected {
-    box-shadow: inset 4px 0px 0px 0px var(--calcite-color-brand);
-  }
-}
+  &:host([href]) {
+    &:focus,
+    &:hover {
+      --calcite-internal-tile-border-color: var(--calcite-color-text-link);
+      --calcite-internal-tile-heading-text-color: var(--calcite-color-text-link);
+      --calcite-internal-tile-icon-color: var(--calcite-color-text-link);
+      .container {
+        position: relative;
+        z-index: var(--calcite-z-index);
+      }
+    }
 
-:host([href]:focus:not([disabled])),
-:host([href]:hover:not([disabled])) {
-  --calcite-tile-border-color: var(--calcite-color-text-link);
-  --calcite-tile-heading-text-color: var(--calcite-color-text-link);
-  --calcite-ui-icon-color: var(--calcite-color-text-link);
-  .container {
-    position: relative;
-    z-index: var(--calcite-z-index);
-  }
-}
-
-:host([href]:active:not([disabled])) {
-  .container {
-    box-shadow: 0 0 0 3px var(--calcite-tile-border-color);
+    &:active {
+      .container {
+        --calcite-internal-tile-shadow: 0 0 0 3px var(--calcite-internal-tile-border-color);
+      }
+    }
   }
 }
 
 :host([embed]) {
   .container {
-    box-shadow: none;
+    --calcite-internal-tile-shadow: none;
     padding: 0;
   }
 }
 
 :host([selection-mode="none"]) {
   .container {
-    outline-color: var(--calcite-tile-border-color);
+    --calcite-internal-tile-outline-color: var(--calcite-internal-tile-border-color);
     &:focus {
-      outline-color: var(--calcite-color-brand);
+      --calcite-internal-tile-outline-color: var(--calcite-color-brand);
       position: relative;
     }
   }
 }
 
 @include disabled();
-
-:host(:hover:not([disabled])),
-:host([active]:not([disabled])) {
-  --calcite-tile-description-text-color: var(--calcite-color-text-2);
-  --calcite-tile-heading-text-color: var(--calcite-color-text-1);
-}
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #9278

## Summary

Resolves an issue where component tokens were being set internally and therefor were not reassignable by end-users.
The bug is only noticeable if someone in Online tries to adjust the component tokens for tile which is not yet documented. Since component tokens aren't technically released yet it could be argued this is a refactor
it does seem low risk. The only changes I made were some edits to the CSS organization and then adding internal component tokens to allow for internal value reassignment. I only noticed because I tried to get the epic #7180 in alignment with main.