### PR TITLE
docs(tip, tip-group, tip-manager): deprecate components

### DIFF
--- a/packages/calcite-components/src/components/tip-group/tip-group.tsx
+++ b/packages/calcite-components/src/components/tip-group/tip-group.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, VNode } from "@stencil/core";
 
 /**
- * @deprecated Use the `carousel` component instead.
+ * @deprecated Use the `calcite-carousel` and `calcite-carousel-item` components instead.
  * @slot - A slot for adding `calcite-tip`s.
  */
 @Component({

--- a/packages/calcite-components/src/components/tip-group/tip-group.tsx
+++ b/packages/calcite-components/src/components/tip-group/tip-group.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, VNode } from "@stencil/core";
 
 /**
+ * @deprecated Use the `carousel` component instead.
  * @slot - A slot for adding `calcite-tip`s.
  */
 @Component({

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
@@ -24,6 +24,7 @@ import { TipManagerMessages } from "./assets/tip-manager/t9n";
 import { CSS, ICONS } from "./resources";
 
 /**
+ * @deprecated Use the `carousel` component instead.
  * @slot - A slot for adding `calcite-tip`s.
  */
 @Component({

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
@@ -24,7 +24,7 @@ import { TipManagerMessages } from "./assets/tip-manager/t9n";
 import { CSS, ICONS } from "./resources";
 
 /**
- * @deprecated Use the `carousel` component instead.
+ * @deprecated Use the `calcite-carousel` and `calcite-carousel-item` components instead.
  * @slot - A slot for adding `calcite-tip`s.
  */
 @Component({

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -29,7 +29,7 @@ import { TipMessages } from "./assets/tip/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
 
 /**
- * @deprecated Use the `carousel` component instead.
+ * @deprecated Use the `calcite-card`, `calcite-notice`, or `calcite-tile` component instead.
  * @slot - A slot for adding text and a hyperlink.
  * @slot thumbnail - A slot for adding an HTML image element.
  */

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -29,6 +29,7 @@ import { TipMessages } from "./assets/tip/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
 
 /**
+ * @deprecated Use the `carousel` component instead.
  * @slot - A slot for adding text and a hyperlink.
  * @slot thumbnail - A slot for adding an HTML image element.
  */

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -29,7 +29,7 @@ import { TipMessages } from "./assets/tip/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
 
 /**
- * @deprecated Use the `calcite-card`, `calcite-notice`, or `calcite-tile` component instead.
+ * @deprecated Use the `calcite-card`, `calcite-notice`, `calcite-panel`, or `calcite-tile` component instead.
  * @slot - A slot for adding text and a hyperlink.
  * @slot thumbnail - A slot for adding an HTML image element.
  */


### PR DESCRIPTION
**Related Issue:** #9228

## Summary
Deprecates the `tip`, `tip-group` and `tip-manager` components with the following:
- Tip and Tip Manager: `carousel` and `carousel-item`
- Tip: `card`, `notice`, `panel`, or `tile` 