### PR TITLE
fix(tile): apply center alignment only to x-axis

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -5255,6 +5255,10 @@ export namespace Components {
     }
     interface CalciteTileGroup {
         /**
+          * Specifies the alignment of each Tile's content.
+         */
+        "alignment": Exclude<Alignment, "end">;
+        /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
@@ -13150,6 +13154,10 @@ declare namespace LocalJSX {
   >;
     }
     interface CalciteTileGroup {
+        /**
+          * Specifies the alignment of each Tile's content.
+         */
+        "alignment"?: Exclude<Alignment, "end">;
         /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */

--- a/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
+++ b/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
@@ -547,6 +547,215 @@ export const allVariants = (): string => html`
     </div>
   </div>
 
+  <!-- center alignment -->
+  <div class="parent">
+    <div class="child right-aligned-text">center alignment</div>
+    <div class="child">
+      <calcite-tile-group alignment="center" scale="s">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" scale="s" selection-mode="single">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" scale="s" selection-mode="multiple">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+    </div>
+    <div class="child">
+      <calcite-tile-group alignment="center">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" selection-mode="single">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" selection-mode="multiple">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+    </div>
+    <div class="child">
+      <calcite-tile-group alignment="center" scale="l">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" scale="l" selection-mode="single">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+      <calcite-tile-group alignment="center" scale="l" selection-mode="multiple">
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+          icon="layers"
+        ></calcite-tile>
+        <calcite-tile
+          heading="Tile heading lorem ipsum"
+          description="Iterative approaches to corporate strategy foster collab."
+          icon="layers"
+        ></calcite-tile>
+      </calcite-tile-group>
+    </div>
+  </div>
+
   <!-- links -->
   <div class="parent">
     <div class="child right-aligned-text">links</div>

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -16,7 +16,7 @@ import {
   InteractiveContainer,
   updateHostInteraction,
 } from "../../utils/interactive";
-import { Layout, Scale, SelectionAppearance, SelectionMode } from "../interfaces";
+import { Alignment, Layout, Scale, SelectionAppearance, SelectionMode } from "../interfaces";
 import { createObserver } from "../../utils/observers";
 import { focusElementInGroup } from "../../utils/dom";
 import { SelectableGroupComponent } from "../../utils/selectableComponent";
@@ -36,6 +36,11 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
   //  Properties
   //
   //--------------------------------------------------------------------------
+
+  /**
+   * Specifies the alignment of each Tile's content.
+   */
+  @Prop({ reflect: true }) alignment: Exclude<Alignment, "end"> = "start";
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
@@ -157,6 +162,7 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
   private updateTiles = (): void => {
     this.items = this.getSlottedTiles();
     this.items?.forEach((el) => {
+      el.alignment = this.alignment;
       el.interactive = true;
       el.layout = this.layout;
       el.scale = this.scale;

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -38,7 +38,7 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
   //--------------------------------------------------------------------------
 
   /**
-   * Specifies the alignment of each Tile's content.
+   * Specifies the alignment of each `calcite-tile`'s content.
    */
   @Prop({ reflect: true }) alignment: Exclude<Alignment, "end"> = "start";
 

--- a/packages/calcite-components/src/components/tile/resources.ts
+++ b/packages/calcite-components/src/components/tile/resources.ts
@@ -6,6 +6,7 @@ export const CSS = {
   textContentContainer: "text-content-container",
   description: "description",
   heading: "heading",
+  icon: "icon",
   interactive: "interactive",
   largeVisualDeprecated: "large-visual-deprecated",
   row: "row",

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -100,9 +100,10 @@
 }
 
 :host([alignment="center"]) {
-  .row,
-  .content-container {
-    align-items: center;
+  .icon {
+    align-self: center;
+  }
+  .text-content {
     text-align: center;
   }
   slot[name="content-start"]::slotted(*),

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -328,7 +328,7 @@ export class Tile implements InteractiveComponent, SelectableComponent {
       interactive,
       selectionMode,
     } = this;
-    const isLargeVisual = heading && icon && !Boolean(description);
+    const isLargeVisual = heading && icon && !description;
     const disableInteraction = Boolean(this.href) || !interactive;
     const role =
       selectionMode === "multiple" && interactive
@@ -374,7 +374,7 @@ export class Tile implements InteractiveComponent, SelectableComponent {
             name={SLOTS.contentTop}
             onSlotchange={this.handleSlotChange}
           />
-          {icon && <calcite-icon flipRtl={iconFlipRtl} icon={icon} scale="l" />}
+          {icon && <calcite-icon class={CSS.icon} flipRtl={iconFlipRtl} icon={icon} scale="l" />}
           <div class={{ [CSS.textContentContainer]: true, [CSS.row]: true }}>
             <slot
               data-name="ContentStart"
@@ -406,7 +406,7 @@ export class Tile implements InteractiveComponent, SelectableComponent {
 
     return (
       <InteractiveContainer disabled={disabled}>
-        {!!this.href ? (
+        {this.href ? (
           <calcite-link disabled={disabled} href={this.href}>
             {this.renderTile()}
           </calcite-link>

--- a/packages/calcite-components/src/demos/tile-group.html
+++ b/packages/calcite-components/src/demos/tile-group.html
@@ -569,6 +569,215 @@
         </div>
       </div>
 
+      <!-- center alignment -->
+      <div class="parent">
+        <div class="child right-aligned-text">center alignment</div>
+        <div class="child">
+          <calcite-tile-group alignment="center" scale="s">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" scale="s" selection-mode="single">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" scale="s" selection-mode="multiple">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+        </div>
+        <div class="child">
+          <calcite-tile-group alignment="center">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" selection-mode="single">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" selection-mode="multiple">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+        </div>
+        <div class="child">
+          <calcite-tile-group alignment="center" scale="l">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" scale="l" selection-mode="single">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+          <calcite-tile-group alignment="center" scale="l" selection-mode="multiple">
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
+              icon="layers"
+            ></calcite-tile>
+            <calcite-tile
+              heading="Tile heading lorem ipsum"
+              description="Iterative approaches to corporate strategy foster collab."
+              icon="layers"
+            ></calcite-tile>
+          </calcite-tile-group>
+        </div>
+      </div>
+
       <!-- links -->
       <div class="parent">
         <div class="child right-aligned-text">links</div>


### PR DESCRIPTION
**Related Issue:** #9252

## Summary

This PR fixes Tile's `alignment="center"` option to only horizontally center the primary icon, heading and description.

<img width="1042" alt="image" src="https://github.com/Esri/calcite-design-system/assets/821864/2c4f19f3-6497-47ea-af45-02f8fb07bfee">
