### PR TITLE
refactor: use `slotchange` event instead of `MutationObserver` when possible

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -5255,7 +5255,7 @@ export namespace Components {
     }
     interface CalciteTileGroup {
         /**
-          * Specifies the alignment of each Tile's content.
+          * Specifies the alignment of each `calcite-tile`'s content.
          */
         "alignment": Exclude<Alignment, "end">;
         /**
@@ -13155,7 +13155,7 @@ declare namespace LocalJSX {
     }
     interface CalciteTileGroup {
         /**
-          * Specifies the alignment of each Tile's content.
+          * Specifies the alignment of each `calcite-tile`'s content.
          */
         "alignment"?: Exclude<Alignment, "end">;
         /**

--- a/packages/calcite-components/src/components/accordion/accordion.tsx
+++ b/packages/calcite-components/src/components/accordion/accordion.tsx
@@ -10,7 +10,6 @@ import {
   Watch,
 } from "@stencil/core";
 import { Appearance, Position, Scale, SelectionMode } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { RequestedItem } from "./interfaces";
 /**
  * @slot - A slot for adding `calcite-accordion-item`s. `calcite-accordion` cannot be nested, however `calcite-accordion-item`s can.
@@ -58,7 +57,7 @@ export class Accordion {
   @Watch("scale")
   @Watch("selectionMode")
   handlePropsChange(): void {
-    this.updateAccordionItems();
+    this.updateItems();
   }
 
   //--------------------------------------------------------------------------
@@ -78,15 +77,6 @@ export class Accordion {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.mutationObserver?.observe(this.el, { childList: true });
-    this.updateAccordionItems();
-  }
-
-  disconnectedCallback(): void {
-    this.mutationObserver?.disconnect();
-  }
-
   render(): VNode {
     const transparent = this.appearance === "transparent";
     return (
@@ -96,7 +86,7 @@ export class Accordion {
           accordion: !transparent,
         }}
       >
-        <slot />
+        <slot onSlotchange={this.handleSlotChange} />
       </div>
     );
   }
@@ -123,15 +113,13 @@ export class Accordion {
 
   @Element() el: HTMLCalciteAccordionElement;
 
-  mutationObserver = createObserver("mutation", () => this.updateAccordionItems());
-
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
 
-  private updateAccordionItems(): void {
+  private updateItems(): void {
     this.el.querySelectorAll("calcite-accordion-item").forEach((item) => {
       item.iconPosition = this.iconPosition;
       item.iconType = this.iconType;
@@ -141,4 +129,6 @@ export class Accordion {
     // sync props on items across shadow DOM
     document.dispatchEvent(new CustomEvent("calciteInternalAccordionItemsSync"));
   }
+
+  private handleSlotChange = (): void => this.updateItems();
 }

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -27,7 +27,6 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { createObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
 import {
   connectMessages,
@@ -147,8 +146,6 @@ export class Action
 
   buttonEl: HTMLButtonElement;
 
-  mutationObserver = createObserver("mutation", () => forceUpdate(this));
-
   @State() effectiveLocale = "";
 
   @Watch("effectiveLocale")
@@ -174,7 +171,6 @@ export class Action
     connectInteractive(this);
     connectLocalized(this);
     connectMessages(this);
-    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
   }
 
   async componentWillLoad(): Promise<void> {
@@ -192,7 +188,6 @@ export class Action
     disconnectInteractive(this);
     disconnectLocalized(this);
     disconnectMessages(this);
-    this.mutationObserver?.disconnect();
   }
 
   componentDidRender(): void {
@@ -272,16 +267,16 @@ export class Action
           [CSS.slotContainerHidden]: loading,
         }}
       >
-        <slot />
+        <slot onSlotchange={this.handleSlotChange} />
       </div>
     );
 
-    return hasIconToDisplay ? (
-      <div aria-hidden="true" class={CSS.iconContainer} key="icon-container">
+    return (
+      <div class={CSS.iconContainer} hidden={!hasIconToDisplay} key="icon-container">
         {iconNode}
         {slotContainerNode}
       </div>
-    ) : null;
+    );
   }
 
   render(): VNode {
@@ -354,4 +349,6 @@ export class Action
       tooltip.referenceElement = this.buttonEl;
     }
   };
+
+  private handleSlotChange = (): void => forceUpdate(this);
 }

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
@@ -11,7 +11,6 @@ import {
   Watch,
 } from "@stencil/core";
 import { Scale, SelectionMode } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { CSS } from "../dropdown-item/resources";
 import { RequestedItem } from "./interfaces";
 
@@ -76,17 +75,8 @@ export class DropdownGroup {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.updateItems();
-    this.mutationObserver?.observe(this.el, { childList: true });
-  }
-
   componentWillLoad(): void {
     this.groupPosition = this.getGroupPosition();
-  }
-
-  disconnectedCallback(): void {
-    this.mutationObserver?.disconnect();
   }
 
   render(): VNode {
@@ -109,7 +99,7 @@ export class DropdownGroup {
         >
           {dropdownSeparator}
           {groupTitle}
-          <slot />
+          <slot onSlotchange={this.handleSlotChange} />
         </div>
       </Host>
     );
@@ -148,19 +138,17 @@ export class DropdownGroup {
   /** the requested item */
   private requestedDropdownItem: HTMLCalciteDropdownItemElement;
 
-  private updateItems = (): void => {
-    Array.from(this.el.querySelectorAll("calcite-dropdown-item")).forEach(
-      (item) => (item.selectionMode = this.selectionMode),
-    );
-  };
-
-  mutationObserver = createObserver("mutation", () => this.updateItems());
-
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private updateItems = (): void => {
+    Array.from(this.el.querySelectorAll("calcite-dropdown-item")).forEach(
+      (item) => (item.selectionMode = this.selectionMode),
+    );
+  };
 
   private getGroupPosition(): number {
     return Array.prototype.indexOf.call(
@@ -168,4 +156,6 @@ export class DropdownGroup {
       this.el,
     );
   }
+
+  private handleSlotChange = (): void => this.updateItems();
 }

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, h, Listen, Method, Prop, State, VNode } from "@stencil/core";
-import { createObserver } from "../../utils/observers";
 import {
   componentFocusable,
   LoadableComponent,
@@ -93,18 +92,11 @@ export class Flow implements LoadableComponent {
 
   @State() items: FlowItemLikeElement[] = [];
 
-  itemMutationObserver = createObserver("mutation", () => this.updateFlowProps());
-
   // --------------------------------------------------------------------------
   //
   //  Lifecycle
   //
   // --------------------------------------------------------------------------
-
-  connectedCallback(): void {
-    this.itemMutationObserver?.observe(this.el, { childList: true, subtree: true });
-    this.updateFlowProps();
-  }
 
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
@@ -112,10 +104,6 @@ export class Flow implements LoadableComponent {
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-  }
-
-  disconnectedCallback(): void {
-    this.itemMutationObserver?.disconnect();
   }
 
   // --------------------------------------------------------------------------
@@ -179,6 +167,8 @@ export class Flow implements LoadableComponent {
     }
   };
 
+  private handleSlotChange = (): void => this.updateFlowProps();
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -196,7 +186,7 @@ export class Flow implements LoadableComponent {
 
     return (
       <div class={frameDirectionClasses}>
-        <slot />
+        <slot onSlotchange={this.handleSlotChange} />
       </div>
     );
   }

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -27,7 +27,6 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { createObserver } from "../../utils/observers";
 import {
   connectMessages,
   disconnectMessages,
@@ -133,7 +132,6 @@ export class InlineEditable
     connectLabel(this);
     connectLocalized(this);
     connectMessages(this);
-    this.mutationObserver?.observe(this.el, { childList: true });
     this.mutationObserverCallback();
   }
 
@@ -151,7 +149,6 @@ export class InlineEditable
     disconnectLabel(this);
     disconnectLocalized(this);
     disconnectMessages(this);
-    this.mutationObserver?.disconnect();
   }
 
   componentDidRender(): void {
@@ -167,7 +164,7 @@ export class InlineEditable
           onKeyDown={this.escapeKeyHandler}
         >
           <div class={CSS.inputWrapper}>
-            <slot />
+            <slot onSlotchange={this.handleSlotChange} />
           </div>
           <div class={CSS.controlsWrapper}>
             <calcite-button
@@ -278,8 +275,6 @@ export class InlineEditable
 
   labelEl: HTMLCalciteLabelElement;
 
-  mutationObserver = createObserver("mutation", () => this.mutationObserverCallback());
-
   @State() defaultMessages: InlineEditableMessages;
 
   @State() effectiveLocale: string;
@@ -309,11 +304,6 @@ export class InlineEditable
   //
   //--------------------------------------------------------------------------
 
-  mutationObserverCallback(): void {
-    this.updateSlottedInput();
-    this.scale = this.scale || this.inputElement?.scale;
-  }
-
   onLabelClick(): void {
     this.setFocus();
   }
@@ -324,6 +314,7 @@ export class InlineEditable
     });
 
     this.inputElement = inputElement;
+    this.scale = this.scale || inputElement?.scale;
 
     if (!inputElement) {
       return;
@@ -417,4 +408,6 @@ export class InlineEditable
       this.loading = false;
     }
   };
+
+  private handleSlotChange = (): void => this.updateSlottedInput();
 }

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -132,7 +132,6 @@ export class InlineEditable
     connectLabel(this);
     connectLocalized(this);
     connectMessages(this);
-    this.mutationObserverCallback();
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -57,7 +57,6 @@ import {
   parseNumberString,
   sanitizeNumberString,
 } from "../../utils/number";
-import { createObserver } from "../../utils/observers";
 import { CSS_UTILITY } from "../../utils/resources";
 import {
   connectMessages,
@@ -426,8 +425,6 @@ export class InputNumber
 
   private nudgeNumberValueIntervalId: number;
 
-  mutationObserver = createObserver("mutation", () => this.setDisabledAction());
-
   private userChangedValue = false;
 
   //--------------------------------------------------------------------------
@@ -470,8 +467,6 @@ export class InputNumber
     }
     connectLabel(this);
     connectForm(this);
-
-    this.mutationObserver?.observe(this.el, { childList: true });
     this.setDisabledAction();
     this.el.addEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
@@ -487,7 +482,6 @@ export class InputNumber
     disconnectLocalized(this);
     disconnectMessages(this);
 
-    this.mutationObserver?.disconnect();
     this.el.removeEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
 
@@ -992,6 +986,8 @@ export class InputNumber
     }
   }
 
+  private handleSlotChange = (): void => this.setDisabledAction();
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -1119,7 +1115,7 @@ export class InputNumber
               {this.loading ? loader : null}
             </div>
             <div class={CSS.actionWrapper}>
-              <slot name={SLOTS.action} />
+              <slot name={SLOTS.action} onSlotchange={this.handleSlotChange} />
             </div>
             {this.numberButtonType === "vertical" && !this.readOnly ? numberButtonsVertical : null}
             {this.suffixText ? suffixText : null}

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -37,7 +37,6 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { createObserver } from "../../utils/observers";
 import { CSS_UTILITY } from "../../utils/resources";
 import {
   connectMessages,
@@ -333,8 +332,6 @@ export class InputText
   /** the computed icon to render */
   private requestedIcon?: string;
 
-  mutationObserver = createObserver("mutation", () => this.setDisabledAction());
-
   private userChangedValue = false;
 
   @State() effectiveLocale: string;
@@ -366,7 +363,6 @@ export class InputText
 
     connectLabel(this);
     connectForm(this);
-    this.mutationObserver?.observe(this.el, { childList: true });
     this.setDisabledAction();
     this.el.addEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
@@ -377,8 +373,6 @@ export class InputText
     disconnectForm(this);
     disconnectLocalized(this);
     disconnectMessages(this);
-
-    this.mutationObserver?.disconnect();
     this.el.removeEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
 
@@ -623,6 +617,8 @@ export class InputText
     }
   };
 
+  private handleSlotChange = (): void => this.setDisabledAction();
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -703,7 +699,7 @@ export class InputText
               {this.loading ? loader : null}
             </div>
             <div class={CSS.actionWrapper}>
-              <slot name={SLOTS.action} />
+              <slot name={SLOTS.action} onSlotchange={this.handleSlotChange} />
             </div>
             {this.suffixText ? suffixText : null}
             <HiddenFormInputSlot component={this} />

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -57,7 +57,6 @@ import {
   parseNumberString,
   sanitizeNumberString,
 } from "../../utils/number";
-import { createObserver } from "../../utils/observers";
 import { CSS_UTILITY } from "../../utils/resources";
 import {
   connectMessages,
@@ -483,8 +482,6 @@ export class Input
 
   private nudgeNumberValueIntervalId: number;
 
-  mutationObserver = createObserver("mutation", () => this.setDisabledAction());
-
   private userChangedValue = false;
 
   //--------------------------------------------------------------------------
@@ -524,8 +521,6 @@ export class Input
     connectLabel(this);
     connectForm(this);
 
-    this.mutationObserver?.observe(this.el, { childList: true });
-
     this.setDisabledAction();
     this.el.addEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
@@ -537,7 +532,6 @@ export class Input
     disconnectLocalized(this);
     disconnectMessages(this);
 
-    this.mutationObserver?.disconnect();
     this.el.removeEventListener(internalHiddenInputInputEvent, this.onHiddenFormInputInput);
   }
 
@@ -1078,6 +1072,8 @@ export class Input
     }
   }
 
+  private handleSlotChange = (): void => this.setDisabledAction();
+
   // --------------------------------------------------------------------------
   //
   //  Render Methods
@@ -1261,7 +1257,7 @@ export class Input
               {this.loading ? loader : null}
             </div>
             <div class={CSS.actionWrapper}>
-              <slot name={SLOTS.action} />
+              <slot name={SLOTS.action} onSlotchange={this.handleSlotChange} />
             </div>
             {this.type === "number" && this.numberButtonType === "vertical" && !this.readOnly
               ? numberButtonsVertical

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
@@ -12,7 +12,6 @@ import {
   VNode,
   Watch,
 } from "@stencil/core";
-import { createObserver } from "../../utils/observers";
 import { Layout, Scale, Status } from "../interfaces";
 import {
   componentFocusable,
@@ -103,8 +102,6 @@ export class RadioButtonGroup implements LoadableComponent {
 
   @Element() el!: HTMLCalciteRadioButtonGroupElement;
 
-  mutationObserver = createObserver("mutation", () => this.passPropsToRadioButtons());
-
   @State() radioButtons: HTMLCalciteRadioButtonElement[] = [];
 
   //--------------------------------------------------------------------------
@@ -113,21 +110,12 @@ export class RadioButtonGroup implements LoadableComponent {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.passPropsToRadioButtons();
-    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
-  }
-
   componentWillLoad(): void {
     setUpLoadableComponent(this);
   }
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-  }
-
-  disconnectedCallback(): void {
-    this.mutationObserver?.disconnect();
   }
 
   //--------------------------------------------------------------------------
@@ -154,6 +142,8 @@ export class RadioButtonGroup implements LoadableComponent {
   private getFocusableRadioButton(): HTMLCalciteRadioButtonElement | null {
     return this.radioButtons.find((radiobutton) => !radiobutton.disabled) ?? null;
   }
+
+  private handleSlotChange = (): void => this.passPropsToRadioButtons();
 
   //--------------------------------------------------------------------------
   //
@@ -206,7 +196,7 @@ export class RadioButtonGroup implements LoadableComponent {
     return (
       <Host role="radiogroup">
         <div class={CSS.itemWrapper}>
-          <slot />
+          <slot onSlotchange={this.handleSlotChange} />
         </div>
         {this.validationMessage && this.status === "invalid" ? (
           <Validation

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -36,7 +36,6 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { Appearance, Layout, Scale, Status, Width } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { Validation } from "../functional/Validation";
 import { CSS } from "./resources";
 
@@ -182,7 +181,6 @@ export class SegmentedControl
     connectInteractive(this);
     connectLabel(this);
     connectForm(this);
-    this.mutationObserver?.observe(this.el, { childList: true });
 
     this.handleItemPropChange();
   }
@@ -203,7 +201,7 @@ export class SegmentedControl
       <Host onClick={this.handleClick} role="radiogroup">
         <div class={CSS.itemWrapper}>
           <InteractiveContainer disabled={this.disabled}>
-            <slot />
+            <slot onSlotchange={this.handleSlotChange} />
             <HiddenFormInputSlot component={this} />
           </InteractiveContainer>
         </div>
@@ -333,8 +331,6 @@ export class SegmentedControl
 
   defaultValue: SegmentedControl["value"];
 
-  private mutationObserver = createObserver("mutation", () => this.setUpItems());
-
   private handleItemPropChange(): void {
     const items = this.getItems();
 
@@ -401,4 +397,6 @@ export class SegmentedControl
       items[0].tabIndex = 0;
     }
   }
+
+  private handleSlotChange = (): void => this.setUpItems();
 }

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
@@ -7,7 +7,6 @@ import {
   InteractiveContainer,
   updateHostInteraction,
 } from "../../utils/interactive";
-import { createObserver } from "../../utils/observers";
 import { HandleNudge } from "../handle/interfaces";
 import { Layout } from "../interfaces";
 import {
@@ -87,10 +86,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
 
   items: Element[] = [];
 
-  mutationObserver = createObserver("mutation", () => {
-    this.setUpSorting();
-  });
-
   sortable: Sortable;
 
   dragEnabled = true;
@@ -106,8 +101,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
       return;
     }
 
-    this.setUpSorting();
-    this.beginObserving();
     connectInteractive(this);
   }
 
@@ -118,7 +111,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
 
     disconnectInteractive(this);
     disconnectSortableComponent(this);
-    this.endObserving();
   }
 
   componentDidRender(): void {
@@ -146,14 +138,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
   //  Private Methods
   //
   // --------------------------------------------------------------------------
-
-  onGlobalDragStart(): void {
-    this.endObserving();
-  }
-
-  onGlobalDragEnd(): void {
-    this.beginObserving();
-  }
 
   onDragEnd(): void {}
 
@@ -196,8 +180,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
       }
     }
 
-    this.endObserving();
-
     if (appendInstead) {
       sortItem.parentElement.appendChild(sortItem);
     } else {
@@ -206,7 +188,6 @@ export class SortableList implements InteractiveComponent, SortableComponent {
 
     this.items = Array.from(this.el.children);
 
-    this.beginObserving();
     requestAnimationFrame(() => focusElement(handle));
 
     if ("selected" in handle) {
@@ -219,13 +200,7 @@ export class SortableList implements InteractiveComponent, SortableComponent {
     connectSortableComponent(this);
   }
 
-  beginObserving(): void {
-    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
-  }
-
-  endObserving(): void {
-    this.mutationObserver?.disconnect();
-  }
+  private handleSlotChange = (): void => this.setUpSorting();
 
   // --------------------------------------------------------------------------
   //
@@ -246,7 +221,7 @@ export class SortableList implements InteractiveComponent, SortableComponent {
             [CSS.containerHorizontal]: horizontal,
           }}
         >
-          <slot />
+          <slot onSlotchange={this.handleSlotChange} />
         </div>
       </InteractiveContainer>
     );

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -15,7 +15,6 @@ import {
 } from "@stencil/core";
 import { focusElementInGroup, slotChangeGetAssignedElements } from "../../utils/dom";
 import { Position, Scale } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { guid } from "../../utils/guid";
 import {
   connectLocalized,
@@ -139,8 +138,6 @@ export class Stepper implements LocalizedComponent, T9nComponent {
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
-    this.mutationObserver?.observe(this.el, { childList: true });
-    this.updateItems();
     connectMessages(this);
     connectLocalized(this);
   }
@@ -167,7 +164,6 @@ export class Stepper implements LocalizedComponent, T9nComponent {
   disconnectedCallback(): void {
     disconnectMessages(this);
     disconnectLocalized(this);
-    this.mutationObserver?.disconnect();
   }
 
   render(): VNode {
@@ -360,8 +356,6 @@ export class Stepper implements LocalizedComponent, T9nComponent {
 
   private items: HTMLCalciteStepperItemElement[] = [];
 
-  private mutationObserver = createObserver("mutation", () => this.updateItems());
-
   /** Specifies if the user is viewing one `stepper-item` at a time when the page width is less than sum of min-width of each item. */
   private multipleViewMode = false;
 
@@ -376,7 +370,7 @@ export class Stepper implements LocalizedComponent, T9nComponent {
   //--------------------------------------------------------------------------
 
   private updateItems(): void {
-    this.el.querySelectorAll("calcite-stepper-item").forEach((item) => {
+    this.items.forEach((item) => {
       item.icon = this.icon;
       item.numbered = this.numbered;
       item.layout = this.layout;
@@ -503,5 +497,6 @@ export class Stepper implements LocalizedComponent, T9nComponent {
     this.containerEl.style.gridTemplateAreas = spacing;
     this.containerEl.style.gridTemplateColumns = spacing;
     this.setStepperItemNumberingSystem();
+    this.updateItems();
   };
 }

--- a/packages/calcite-components/src/components/tabs/tabs.tsx
+++ b/packages/calcite-components/src/components/tabs/tabs.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, Fragment, h, Listen, Prop, State, VNode, Watch } from "@stencil/core";
 import { Scale } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { TabLayout, TabPosition } from "./interfaces";
 import { SLOTS } from "./resources";
 
@@ -52,25 +51,12 @@ export class Tabs {
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.mutationObserver.observe(this.el, { childList: true });
-    this.updateItems();
-  }
-
-  async componentWillLoad(): Promise<void> {
-    this.updateItems();
-  }
-
-  disconnectedCallback(): void {
-    this.mutationObserver?.disconnect();
-  }
-
   render(): VNode {
     return (
       <Fragment>
-        <slot name={SLOTS.titleGroup} />
+        <slot name={SLOTS.titleGroup} onSlotchange={this.handleTitleGroupSlotChange} />
         <section>
-          <slot />
+          <slot onSlotchange={this.handleSlotChange} />
         </section>
       </Fragment>
     );
@@ -153,19 +139,6 @@ export class Tabs {
    */
   @State() tabs: HTMLCalciteTabElement[] = [];
 
-  mutationObserver = createObserver("mutation", (mutationsList: MutationRecord[]) => {
-    for (const mutation of mutationsList) {
-      const target = mutation.target as HTMLElement;
-      if (
-        target.nodeName === "CALCITE-TAB-NAV" ||
-        target.nodeName === "CALCITE-TAB-TITLE" ||
-        target.nodeName === "CALCITE-TAB"
-      ) {
-        this.updateItems();
-      }
-    }
-  });
-
   private updateItems(): void {
     const { position, scale } = this;
 
@@ -240,4 +213,8 @@ export class Tabs {
     this.tabs.forEach((el) => el.updateAriaInfo(tabIds, titleIds));
     this.titles.forEach((el) => el.updateAriaInfo(tabIds, titleIds));
   }
+
+  private handleSlotChange = (): void => this.updateItems();
+
+  private handleTitleGroupSlotChange = (): void => this.updateItems();
 }

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -17,7 +17,6 @@ import {
   updateHostInteraction,
 } from "../../utils/interactive";
 import { Alignment, Layout, Scale, SelectionAppearance, SelectionMode } from "../interfaces";
-import { createObserver } from "../../utils/observers";
 import { focusElementInGroup } from "../../utils/dom";
 import { SelectableGroupComponent } from "../../utils/selectableComponent";
 import { CSS } from "./resources";
@@ -62,7 +61,7 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
 
   @Watch("scale")
   scaleWatcher(): void {
-    this.updateTiles();
+    this.updateItems();
   }
 
   /**
@@ -96,7 +95,7 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
   @Watch("selectionMode")
   @Watch("selectionAppearance")
   handleSelectionModeOrAppearanceChange(): void {
-    this.updateTiles();
+    this.updateItems();
   }
 
   //--------------------------------------------------------------------------
@@ -119,11 +118,9 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
 
   private getSlottedTiles = (): HTMLCalciteTileElement[] => {
     return this.slotEl
-      ?.assignedElements({ flatten: true })
-      .filter((el) => el?.matches("calcite-tile")) as HTMLCalciteTileElement[];
+      .assignedElements({ flatten: true })
+      .filter((el) => el.matches("calcite-tile")) as HTMLCalciteTileElement[];
   };
-
-  private mutationObserver = createObserver("mutation", () => this.updateTiles());
 
   private selectItem = (item: HTMLCalciteTileElement): void => {
     if (!item) {
@@ -172,9 +169,9 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
     }
   };
 
-  private updateTiles = (): void => {
+  private updateItems = (): void => {
     this.items = this.getSlottedTiles();
-    this.items?.forEach((el) => {
+    this.items.forEach((el) => {
       el.alignment = this.alignment;
       el.interactive = true;
       el.layout = this.layout;
@@ -184,6 +181,8 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
     });
     this.updateSelectedItems();
   };
+
+  private handleSlotChange = (): void => this.updateItems();
 
   //--------------------------------------------------------------------------
   //
@@ -202,8 +201,6 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
 
   connectedCallback(): void {
     connectInteractive(this);
-    this.mutationObserver?.observe(this.el, { childList: true });
-    this.updateTiles();
   }
 
   componentDidRender(): void {
@@ -212,7 +209,6 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
 
   disconnectedCallback(): void {
     disconnectInteractive(this);
-    this.mutationObserver?.disconnect();
   }
 
   //--------------------------------------------------------------------------
@@ -265,7 +261,7 @@ export class TileGroup implements InteractiveComponent, SelectableGroupComponent
     return (
       <InteractiveContainer disabled={this.disabled}>
         <div aria-label={this.label} class={CSS.container} role={role}>
-          <slot onSlotchange={this.updateTiles} ref={this.setSlotEl} />
+          <slot onSlotchange={this.handleSlotChange} ref={this.setSlotEl} />
         </div>
       </InteractiveContainer>
     );

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -63,12 +63,12 @@ export interface SortableComponent {
   /**
    * Called when any sortable component drag starts. For internal use only. Any public drag events should emit within `onDragStart()`.
    */
-  onGlobalDragStart: () => void;
+  onGlobalDragStart?: () => void;
 
   /**
    * Called when any sortable component drag ends. For internal use only. Any public drag events should emit within `onDragEnd()`.
    */
-  onGlobalDragEnd: () => void;
+  onGlobalDragEnd?: () => void;
 
   /**
    * Called when a component's dragging ends.
@@ -132,12 +132,12 @@ export function connectSortableComponent(component: SortableComponent): void {
     filter: `${handle}[disabled]`,
     onStart: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       dragState.active = true;
-      onGlobalDragStart();
+      onGlobalDragStart?.();
       component.onDragStart({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
     onEnd: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
       dragState.active = false;
-      onGlobalDragEnd();
+      onGlobalDragEnd?.();
       component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
     onSort: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
@@ -171,9 +171,9 @@ export function dragActive(component: SortableComponent): boolean {
 }
 
 function onGlobalDragStart(): void {
-  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragStart());
+  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragStart?.());
 }
 
 function onGlobalDragEnd(): void {
-  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragEnd());
+  Array.from(sortableComponentSet).forEach((component) => component.onGlobalDragEnd?.());
 }


### PR DESCRIPTION
Replaces `MutationObserver` + `childList: true` usage with `slotchange` event for simplification and performance reasons ([slots already leverage mutation observer](https://dom.spec.whatwg.org/#mutation-observers)). Another benefit is that using `slotchange` eliminates conditions where callbacks may be invoked before the element has rendered.