### PR TITLE
build(deps): add type-fest to prevent build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "ts-jest": "29.1.2",
         "tsx": "4.7.2",
         "turbo": "1.13.2",
-        "type-fest": "4.16.0",
         "typescript": "5.4.4",
         "updtr": "4.0.0",
         "workbox-build": "7.0.0"
@@ -33823,18 +33822,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.16.0.tgz",
-      "integrity": "sha512-z7Rf5PXxIhbI6eJBTwdqe5bO02nUUmctq4WqviFSstBAWV0YNtEQRhEnZw73WJ8sZOqgFG6Jdl8gYZu7NBJZnA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -36708,7 +36695,8 @@
         "focus-trap": "7.5.4",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.1",
-        "timezone-groups": "0.8.0"
+        "timezone-groups": "0.8.0",
+        "type-fest": "4.18.2"
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "^2.2.0",
@@ -38734,6 +38722,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/calcite-components/node_modules/type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/calcite-components/node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "ts-jest": "29.1.2",
     "tsx": "4.7.2",
     "turbo": "1.13.2",
-    "type-fest": "4.16.0",
     "typescript": "5.4.4",
     "updtr": "4.0.0",
     "workbox-build": "7.0.0"

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -71,7 +71,8 @@
     "focus-trap": "7.5.4",
     "lodash-es": "4.17.21",
     "sortablejs": "1.15.1",
-    "timezone-groups": "0.8.0"
+    "timezone-groups": "0.8.0",
+    "type-fest": "4.18.2"
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "^2.2.0",


### PR DESCRIPTION
**Related Issue:** #9307

## Summary

Add `type-fest` to the dependencies of `@esri/calcite-components` to prevent build errors. `type-fest` can also be used to simplify/remove the [preact type generator](https://github.com/Esri/calcite-design-system/blob/27a82dcaf8b091c609b3bf765d8c8617c447d8e7/packages/calcite-components/support/preact.ts#L8) in the future.