### PR TITLE
build(deps): update dependency @esri/calcite-ui-icons to v3.28.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3831,9 +3831,9 @@
       "link": true
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.27.9",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.27.9.tgz",
-      "integrity": "sha512-bsmXAkWCI/WMr5bCOqsBp3MXu/OAGtF0pgcLWjSx29X5qKQbOIepHT1XNLYWi3ywLp+RQGy6l72Ut76IGmF9Ww==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.28.1.tgz",
+      "integrity": "sha512-nJn140va7xG01FlAbeYZiwmy1vT8Jx4eA/sJZc1Lhk3k0T9l+koB+ydIZ2HlO4YS12OTohvVO4b3PNxogUQZ+Q==",
       "dev": true,
       "bin": {
         "spriter": "bin/spriter.js"
@@ -36712,7 +36712,7 @@
       },
       "devDependencies": {
         "@esri/calcite-design-tokens": "^2.2.1-next.0",
-        "@esri/calcite-ui-icons": "3.27.9",
+        "@esri/calcite-ui-icons": "3.28.1",
         "@esri/eslint-plugin-calcite-components": "^1.2.1-next.0",
         "@stencil-community/eslint-plugin": "0.7.2",
         "@stencil-community/postcss": "2.2.0",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@esri/calcite-design-tokens": "^2.2.1-next.0",
-    "@esri/calcite-ui-icons": "3.27.9",
+    "@esri/calcite-ui-icons": "3.28.1",
     "@esri/eslint-plugin-calcite-components": "^1.2.1-next.0",
     "@stencil-community/eslint-plugin": "0.7.2",
     "@stencil-community/postcss": "2.2.0",


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Manually updates the `@esri/calcite-ui-icons` dependency to [`3.28.1`](https://github.com/Esri/calcite-ui-icons/releases/tag/v3.28.1).
