### PR TITLE
ci: ensure all pre-release changelog sections are removed

### DIFF
--- a/.github/workflows/remove-prerelease-changelog-entries.yml
+++ b/.github/workflows/remove-prerelease-changelog-entries.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - release-please--branches--main
+      - release-please--branches--hotfix
 permissions:
   contents: write
   pull-requests: write
@@ -23,7 +24,7 @@ jobs:
         run: |
           git pull
           npm install
-          npm run util:remove-next-changelog-entries
+          npm run util:remove-prerelease-changelog-entries
       - name: Push Changes
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/documentation/monorepo.md
+++ b/documentation/monorepo.md
@@ -162,7 +162,7 @@ A `deploy-latest.yml` GitHub Action runs `release-please`, which creates the rel
 
 After installing the PR, the Action creates [git tags](#git-tags) and [GitHub releases](#github-releases) for each bumped package, and then deploys to NPM.
 
-A `remove-next-changelog-entries.yml` GitHub Action runs the `removeNextChangelogEntries.ts` script every time `release-please` pushes changes to its branch. This ensures all `next` changelog sections created by Lerna are removed before a dev installs the PR.
+A `remove-prerelease-changelog-entries.yml` GitHub Action runs the `removePrereleaseChangelogEntries.ts` script every time `release-please` pushes changes to its branch. This ensures all `next`, `hotfix`, and `rc` changelog sections created by Lerna are removed before a dev installs the PR.
 
 ### Steps to release
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "turbo run test --log-order=stream",
     "util:is-next-deployable": "tsx support/isNextDeployable.ts",
     "util:push-tags": "git push origin main --follow-tags",
-    "util:remove-next-changelog-entries": "tsx support/removeNextChangelogEntries.ts",
+    "util:remove-prerelease-changelog-entries": "tsx support/removePrereleaseChangelogEntries.ts",
     "util:sync-linked-package-versions": "tsx support/syncLinkedPackageVersions.ts"
   },
   "devDependencies": {

--- a/support/removePrereleaseChangelogEntries.ts
+++ b/support/removePrereleaseChangelogEntries.ts
@@ -6,7 +6,7 @@
     const { resolve } = await import("path");
     const exec = promisify(childProcess.exec);
 
-    const nextChangelogSectionPattern = /##\s\[?\d+\.\d+\.\d+-next\.\d+(.*?)\n(?=##\s)/gs;
+    const prereleaseChangelogSectionPattern = /##\s\[?\d+\.\d+\.\d+-(next|hotfix|rc)\.\d+(.*?)\n(?=##\s)/gs;
 
     const changedFiles = (await exec("git diff --name-only origin/main")).stdout.trim();
     const changelogs = changedFiles.split("\n").filter((file: string) => file.match("CHANGELOG.md"));
@@ -14,7 +14,7 @@
     changelogs.forEach(async (changelog: string) => {
       const changelogPath = resolve(changelog);
       const changelogContent = await fs.readFile(changelogPath, "utf8");
-      const updatedChangelogContent = changelogContent.replace(nextChangelogSectionPattern, "");
+      const updatedChangelogContent = changelogContent.replace(prereleaseChangelogSectionPattern, "");
       await fs.writeFile(changelogPath, updatedChangelogContent);
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

Ensure all pre-release changelog sections are removed before a `latest` release-please pull request is installed into the `main` or `hotfix` branches.
