### PR TITLE
feat(stepper, stepper-item): add separate change events to stepper and items (deprecates `calciteStepperItemChange` on the parent)

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -7344,6 +7344,7 @@ declare global {
         new (): HTMLCalciteStackElement;
     };
     interface HTMLCalciteStepperElementEventMap {
+        "calciteStepperChange": void;
         "calciteStepperItemChange": void;
         "calciteInternalStepperItemChange": StepperItemChangeEventDetail;
     }
@@ -7364,8 +7365,8 @@ declare global {
     interface HTMLCalciteStepperItemElementEventMap {
         "calciteInternalStepperItemKeyEvent": StepperItemKeyEventDetail;
         "calciteInternalStepperItemSelect": StepperItemEventDetail;
-        "calciteInternalUserRequestedStepperItemSelect": StepperItemChangeEventDetail;
         "calciteInternalStepperItemRegister": StepperItemEventDetail;
+        "calciteStepperItemSelect": void;
     }
     interface HTMLCalciteStepperItemElement extends Components.CalciteStepperItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteStepperItemElementEventMap>(type: K, listener: (this: HTMLCalciteStepperItemElement, ev: CalciteStepperItemCustomEvent<HTMLCalciteStepperItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -12579,6 +12580,11 @@ declare namespace LocalJSX {
         /**
           * Fires when the active `calcite-stepper-item` changes.
          */
+        "onCalciteStepperChange"?: (event: CalciteStepperCustomEvent<void>) => void;
+        /**
+          * Fires when the active `calcite-stepper-item` changes.
+          * @deprecated use `calciteStepperChange` instead.
+         */
         "onCalciteStepperItemChange"?: (event: CalciteStepperCustomEvent<void>) => void;
         /**
           * Specifies the size of the component.
@@ -12639,7 +12645,10 @@ declare namespace LocalJSX {
         "onCalciteInternalStepperItemKeyEvent"?: (event: CalciteStepperItemCustomEvent<StepperItemKeyEventDetail>) => void;
         "onCalciteInternalStepperItemRegister"?: (event: CalciteStepperItemCustomEvent<StepperItemEventDetail>) => void;
         "onCalciteInternalStepperItemSelect"?: (event: CalciteStepperItemCustomEvent<StepperItemEventDetail>) => void;
-        "onCalciteInternalUserRequestedStepperItemSelect"?: (event: CalciteStepperItemCustomEvent<StepperItemChangeEventDetail>) => void;
+        /**
+          * Fires when the active `calcite-stepper-item` changes.
+         */
+        "onCalciteStepperItemSelect"?: (event: CalciteStepperItemCustomEvent<void>) => void;
         /**
           * Specifies the size of the component inherited from the `calcite-stepper`, defaults to `m`.
          */

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -12583,7 +12583,7 @@ declare namespace LocalJSX {
         "onCalciteStepperChange"?: (event: CalciteStepperCustomEvent<void>) => void;
         /**
           * Fires when the active `calcite-stepper-item` changes.
-          * @deprecated use `calciteStepperChange` instead.
+          * @deprecated use `calciteStepperChange` instead or `calciteStepperItemChange` on items instead.
          */
         "onCalciteStepperItemChange"?: (event: CalciteStepperCustomEvent<void>) => void;
         /**

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.e2e.ts
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.e2e.ts
@@ -1,4 +1,6 @@
+import { newE2EPage } from "@stencil/core/testing";
 import { disabled, renders, hidden, t9n } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 
 describe("calcite-stepper-item", () => {
   describe("renders", () => {
@@ -14,6 +16,24 @@ describe("calcite-stepper-item", () => {
   });
 
   describe("translation support", () => {
-    t9n(`<calcite-stepper-item heading="Step 1" id="step-1"></calcite-stepper-item>`);
+    t9n(html`<calcite-stepper-item heading="Step 1" id="step-1"></calcite-stepper-item>`);
+  });
+
+  it("emits selection event on user interaction", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-stepper-item heading="heading"></calcite-stepper-item>`);
+    const stepperItem = await page.find("calcite-stepper-item");
+    const stepperItemSelect = await page.spyOnEvent("calciteStepperItemSelect");
+
+    await stepperItem.setProperty("selected", true);
+    await page.waitForChanges();
+    expect(stepperItemSelect).toHaveReceivedEventTimes(0);
+
+    await stepperItem.setProperty("selected", false);
+    await page.waitForChanges();
+    expect(stepperItemSelect).toHaveReceivedEventTimes(0);
+
+    await stepperItem.click();
+    expect(stepperItemSelect).toHaveReceivedEventTimes(1);
   });
 });

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -199,13 +199,12 @@ export class StepperItem
    * @internal
    */
   @Event({ cancelable: false })
-  calciteInternalUserRequestedStepperItemSelect: EventEmitter<StepperItemChangeEventDetail>;
+  calciteInternalStepperItemRegister: EventEmitter<StepperItemEventDetail>;
 
   /**
-   * @internal
+   * Fires when the active `calcite-stepper-item` changes.
    */
-  @Event({ cancelable: false })
-  calciteInternalStepperItemRegister: EventEmitter<StepperItemEventDetail>;
+  @Event({ cancelable: false }) calciteStepperItemSelect: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //
@@ -404,11 +403,7 @@ export class StepperItem
   private emitUserRequestedItem = (): void => {
     this.emitRequestedItem();
     if (!this.disabled) {
-      const position = this.itemPosition;
-
-      this.calciteInternalUserRequestedStepperItemSelect.emit({
-        position,
-      });
+      this.calciteStepperItemSelect.emit();
     }
   };
 

--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -501,12 +501,13 @@ describe("calcite-stepper", () => {
     });
   });
 
-  describe("should emit calciteStepperItemChange on user interaction", () => {
+  describe("should emit calciteStepperChange/calciteStepperItemChange on user interaction", () => {
     let layout: HTMLCalciteStepperElement["layout"];
 
     async function assertEmitting(page: E2EPage, hasContent: boolean): Promise<void> {
       const element = await page.find("calcite-stepper");
-      const eventSpy = await element.spyOnEvent("calciteStepperItemChange");
+      const itemChangeSpy = await element.spyOnEvent("calciteStepperItemChange");
+      const changeSpy = await element.spyOnEvent("calciteStepperChange");
       const firstItem = await page.find("#step-1");
 
       const getSelectedItemId = async (): Promise<string> => {
@@ -520,10 +521,12 @@ describe("calcite-stepper", () => {
       // non user interaction
       firstItem.setProperty("selected", true);
       await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
 
       await page.$eval("#step-2", itemClicker);
-      expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
       expect(await getSelectedItemId()).toBe("step-2");
 
       if (hasContent) {
@@ -532,29 +535,35 @@ describe("calcite-stepper", () => {
         );
 
         if (layout === "vertical") {
-          expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
+          expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
+          expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
           expect(await getSelectedItemId()).toBe("step-1");
         } else {
           // no events since horizontal layout moves content outside of item selection hit area
-          expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
+          expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
+          expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
         }
       }
 
       // disabled item
       await page.$eval("#step-3", itemClicker);
-      expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
 
       await page.$eval("#step-4", itemClicker);
-      expect(eventSpy).toHaveReceivedEventTimes(++expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(++expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
       expect(await getSelectedItemId()).toBe("step-4");
 
       await element.callMethod("prevStep");
       await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
 
       await element.callMethod("nextStep");
       await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(expectedEvents);
+      expect(changeSpy).toHaveReceivedEventTimes(expectedEvents);
     }
 
     describe("horizontal layout", () => {

--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -846,26 +846,28 @@ describe("calcite-stepper", () => {
 
       const stepper = await page.find("calcite-stepper");
       const [actionStart, actionEnd] = await page.findAll("calcite-stepper >>> calcite-action");
-      const eventSpy = await stepper.spyOnEvent("calciteStepperItemChange");
-      expect(eventSpy).toHaveReceivedEventTimes(0);
+      const changeSpy = await stepper.spyOnEvent("calciteStepperChange");
+      const itemChangeSpy = await stepper.spyOnEvent("calciteStepperItemChange");
+      expect(changeSpy).toHaveReceivedEventTimes(0);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(0);
 
       // shouldn't emit change event when disabled element is visible
       await actionEnd.click();
-      await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(0);
+      expect(changeSpy).toHaveReceivedEventTimes(0);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(0);
 
       await actionEnd.click();
-      await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(1);
+      expect(changeSpy).toHaveReceivedEventTimes(1);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(1);
 
       // shouldn't emit change event when disabled element is visible
       await actionStart.click();
-      await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(1);
+      expect(changeSpy).toHaveReceivedEventTimes(1);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(1);
 
       await actionStart.click();
-      await page.waitForChanges();
-      expect(eventSpy).toHaveReceivedEventTimes(2);
+      expect(changeSpy).toHaveReceivedEventTimes(2);
+      expect(itemChangeSpy).toHaveReceivedEventTimes(2);
     });
 
     it(`switching to layout="horizontal-single" dynamically from another option should display a single item (#8931)`, async () => {

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -122,6 +122,13 @@ export class Stepper implements LocalizedComponent, T9nComponent {
    * Fires when the active `calcite-stepper-item` changes.
    *
    */
+  @Event({ cancelable: false }) calciteStepperChange: EventEmitter<void>;
+
+  /**
+   * Fires when the active `calcite-stepper-item` changes.
+   *
+   * @deprecated use `calciteStepperChange` instead or `calciteStepperItemChange` on items instead.
+   */
   @Event({ cancelable: false }) calciteStepperItemChange: EventEmitter<void>;
 
   /**
@@ -255,9 +262,10 @@ export class Stepper implements LocalizedComponent, T9nComponent {
     });
   }
 
-  @Listen("calciteInternalUserRequestedStepperItemSelect")
-  handleUserRequestedStepperItemSelect(): void {
+  @Listen("calciteStepperItemSelect")
+  handleItemSelect(): void {
     this.calciteStepperItemChange.emit();
+    this.calciteStepperChange.emit();
   }
 
   //--------------------------------------------------------------------------

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -264,8 +264,7 @@ export class Stepper implements LocalizedComponent, T9nComponent {
 
   @Listen("calciteStepperItemSelect")
   handleItemSelect(): void {
-    this.calciteStepperItemChange.emit();
-    this.calciteStepperChange.emit();
+    this.emitItemSelect();
   }
 
   //--------------------------------------------------------------------------
@@ -383,6 +382,11 @@ export class Stepper implements LocalizedComponent, T9nComponent {
   //
   //--------------------------------------------------------------------------
 
+  private emitItemSelect(): void {
+    this.calciteStepperItemChange.emit();
+    this.calciteStepperChange.emit();
+  }
+
   private updateItems(): void {
     this.el.querySelectorAll("calcite-stepper-item").forEach((item) => {
       item.icon = this.icon;
@@ -485,7 +489,7 @@ export class Stepper implements LocalizedComponent, T9nComponent {
       currentActivePosition !== this.currentActivePosition &&
       !this.items[this.currentActivePosition].disabled
     ) {
-      this.calciteStepperItemChange.emit();
+      this.emitItemSelect();
     }
   };
 


### PR DESCRIPTION
**Related Issue:** #2094 

## Summary

Adds the following events:

* `calciteStepperChange` on `calcite-stepper`
* `calciteStepperItemChange` on `calcite-stepper-item`

Deprecates `calciteStepperItemChange` on `calcite-stepper`.
