### PR TITLE
fix(text-area): remove double transparency applied when disabled

### DIFF
--- a/packages/calcite-components/src/components/text-area/text-area.scss
+++ b/packages/calcite-components/src/components/text-area/text-area.scss
@@ -147,13 +147,6 @@ textarea {
   @apply bg-background font-medium;
 }
 
-:host([disabled]) {
-  textarea,
-  footer {
-    @apply opacity-50;
-  }
-}
-
 .border--color {
   @apply border-b border-color-input;
   &:focus {


### PR DESCRIPTION
**Related Issue:** #8374

## Summary

Removes bespoke disabled styling applied in addition to the common disabled style mixin.
