### PR TITLE
fix(t9n): fix error caused by disconnecting components during the setting of initial message overrides

### DIFF
--- a/packages/calcite-components/src/utils/t9n.ts
+++ b/packages/calcite-components/src/utils/t9n.ts
@@ -35,6 +35,10 @@ function mergeMessages(component: T9nComponent): void {
   };
 }
 
+function noop(): void {
+  // intentionally empty
+}
+
 /**
  * This utility sets up the messages used by the component. It should be awaited in the `componentWillLoad` lifecycle hook.
  *
@@ -94,7 +98,8 @@ export function connectMessages(component: T9nComponent): void {
  * @param component
  */
 export function disconnectMessages(component: T9nComponent): void {
-  component.onMessagesChange = undefined;
+  // we set this to noop to for watchers triggered when components are disconnected
+  component.onMessagesChange = noop;
 }
 
 /**


### PR DESCRIPTION
**Related Issue:** #9240

## Summary

This updates the `t9n` module to use a noop function (instead of undefined) for the injected watcher callback when disconnected. This change addresses an issue where a component invokes watchers during disconnection.
