### PR TITLE
chore: adds priority context to tooling issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tooling.yml
+++ b/.github/ISSUE_TEMPLATE/tooling.yml
@@ -7,6 +7,18 @@ body:
       value: |
         - Please [check for existing issues](https://github.com/Esri/calcite-design-system/issues) to avoid duplicates. If someone has already opened an issue for what you are experiencing, please add a 👍 reaction to the existing issue instead of creating a new one.
         - For support, please check the [community forum](https://developers.arcgis.com/calcite-design-system/community/).
+  - type: dropdown
+    id: priority-impact
+    validations:
+      required: true
+    attributes:
+      label: Priority impact
+      multiple: false
+      description: What is the impact of the requested improvement? If the need is blocking release, the priority may be high, where a new improvement may have a low or medium priority.
+      options:
+        - p - low
+        - p - medium
+        - p - high
   - type: textarea
     id: summary
     attributes:


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/9258

## Summary
Adds a priority option to the tooling issue template, which will add a priority label upon creation. Sets the default priority to `p - low`.