### PR TITLE
chore: refactor user defined priority selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -91,11 +91,10 @@ body:
       multiple: false
       description: What is the impact to you, your team, or organization? Use discretion and only select "need" or "emergency" priorities for high user impact and quality issues. For instance, would someone notice, in a bad way, if this issue were present in the release?
       options:
-        - p4 - not time sensitive
-        - p3 - want for upcoming milestone
-        - p2 - want for current milestone
-        - p1 - need for current milestone
-        - p0 - emergency
+        - impact - p3 - not time sensitive
+        - impact - p2 - want for an upcoming milestone
+        - impact - p1 - need for current milestone
+        - impact - p0 - emergency
   - type: checkboxes
     id: packages
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -78,11 +78,10 @@ body:
       multiple: false
       description: What is the impact to you, your team, or organization? Use discretion and only select "need" or "emergency" priorities for high user impact and quality issues. For instance, would someone notice, in a bad way, if this issue were present in the release?
       options:
-        - p4 - not time sensitive
-        - p3 - want for upcoming milestone
-        - p2 - want for current milestone
-        - p1 - need for current milestone
-        - p0 - emergency
+        - impact - p3 - not time sensitive
+        - impact - p2 - want for an upcoming milestone
+        - impact - p1 - need for current milestone
+        - impact - p0 - emergency
   - type: textarea
     id: impact
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -54,10 +54,10 @@ body:
       multiple: false
       description: What is the impact of the enhancement to you, your team, or organization? Use discretion and only select the "need" priority for high user impact and quality issues in the component(s).
       options:
-        - p4 - not time sensitive
-        - p3 - want for upcoming milestone
-        - p2 - want for current milestone
-        - p1 - need for current milestone
+        - impact - p3 - not time sensitive
+        - impact - p2 - want for an upcoming milestone
+        - impact - p1 - need for current milestone
+        - impact - p0 - emergency
   - type: checkboxes
     id: packages
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -51,10 +51,10 @@ body:
       multiple: false
       description: How important is the new component request to you, your team, or organization? Use discretion and only select the "need" priority for high user impact.
       options:
-        - p4 - not time sensitive
-        - p3 - want for upcoming milestone
-        - p2 - want for current milestone
-        - p1 - need for current milestone
+        - impact - p3 - not time sensitive
+        - impact - p2 - want for an upcoming milestone
+        - impact - p1 - need for current milestone
+        - impact - p0 - emergency
   - type: dropdown
     id: esri-team
     validations:


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/9133

## Summary
Updates the user impact dropdown selections to make the labels more clear using `"impact"`:
- `impact - p3 - not time sensitive`
- `impact - p2 - want for an upcoming milestone`
- `impact - p1 - need for current milestone`
- `impact - p0 - emergency`

Once approved and the PR has been merged, will modify the existing labels to reflect the above.