### PR TITLE
docs(shell): modify panel-named slots to reflect shell-panel

### DIFF
--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -13,12 +13,12 @@ import { CSS, SLOTS } from "./resources";
  * @slot footer - A slot for adding footer content. This content will be positioned at the bottom of the component.
  * @slot panel-start - A slot for adding the starting `calcite-shell-panel`.
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
- * @slot panel-top - A slot for adding the top `calcite-shell-center-row`.
- * @slot panel-bottom - A slot for adding the bottom `calcite-shell-center-row`.
- * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-shell-center-row`.
- * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the shell.
- * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the shell.
- * @slot sheets - A slot for adding `calcite-sheet` components. When placed in this slot, the sheet position will be constrained to the extent of the shell.
+ * @slot panel-top - A slot for adding the top `calcite-shell-panel`.
+ * @slot panel-bottom - A slot for adding the bottom `calcite-shell-panel`.
+ * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-panel`.
+ * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the `calcite-shell`.
+ * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the `calcite-shell`.
+ * @slot sheets - A slot for adding `calcite-sheet` components. When placed in this slot, the sheet position will be constrained to the extent of the `calcite-shell`.
  */
 
 @Component({

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -15,7 +15,7 @@ import { CSS, SLOTS } from "./resources";
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
  * @slot panel-top - A slot for adding the top `calcite-shell-panel`.
  * @slot panel-bottom - A slot for adding the bottom `calcite-shell-panel`.
- * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-panel`.
+ * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-shell-panel`.
  * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the `calcite-shell`.
  * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the `calcite-shell`.
  * @slot sheets - A slot for adding `calcite-sheet` components. When placed in this slot, the sheet position will be constrained to the extent of the `calcite-shell`.

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -15,7 +15,7 @@ import { CSS, SLOTS } from "./resources";
  * @slot panel-end - A slot for adding the ending `calcite-shell-panel`.
  * @slot panel-top - A slot for adding the top `calcite-shell-panel`.
  * @slot panel-bottom - A slot for adding the bottom `calcite-shell-panel`.
- * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-shell-panel`.
+ * @slot center-row - [Deprecated] Use the `"panel-bottom"` slot instead. A slot for adding the bottom `calcite-shell-center-row`.
  * @slot modals - A slot for adding `calcite-modal` components. When placed in this slot, the modal position will be constrained to the extent of the `calcite-shell`.
  * @slot alerts - A slot for adding `calcite-alert` components. When placed in this slot, the alert position will be constrained to the extent of the `calcite-shell`.
  * @slot sheets - A slot for adding `calcite-sheet` components. When placed in this slot, the sheet position will be constrained to the extent of the `calcite-shell`.


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/9275

## Summary
Updates the `shell` slots to reflect `shell-panel` placement, as we move towards deprecation of the `shell-center-row`, anticipated for June/July 2024.

Also, includes a minor doc consistency improvement for the `"modals"`, `"alerts"`, and `"sheets"` slots to reflect `calcite-shell`.
