### PR TITLE
feat(extras): add web types to provide Intellisense for components in HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6977,6 +6977,12 @@
         "@stencil/core": ">=2.0.0 || >=3.0.0 || >=4.0.0"
       }
     },
+    "node_modules/@stencil-community/web-types-output-target": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@stencil-community/web-types-output-target/-/web-types-output-target-0.3.1.tgz",
+      "integrity": "sha512-+Xz/NQ+kYXvqzSU8G/EsDkoCSZqkmiXjaYz8r0KNG11RNQaz/J4K6Aa7XyAO+cB7BN7iHjFKYPWY6rLpJ7v4PA==",
+      "dev": true
+    },
     "node_modules/@stencil/angular-output-target": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.8.4.tgz",
@@ -36704,6 +36710,7 @@
         "@esri/eslint-plugin-calcite-components": "^1.2.1-next.0",
         "@stencil-community/eslint-plugin": "0.7.2",
         "@stencil-community/postcss": "2.2.0",
+        "@stencil-community/web-types-output-target": "0.3.1",
         "@stencil/angular-output-target": "0.8.4",
         "@stencil/react-output-target": "0.5.3",
         "@stencil/sass": "3.0.11",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -80,6 +80,7 @@
     "@esri/eslint-plugin-calcite-components": "^1.2.1-next.0",
     "@stencil-community/eslint-plugin": "0.7.2",
     "@stencil-community/postcss": "2.2.0",
+    "@stencil-community/web-types-output-target": "0.3.1",
     "@stencil/angular-output-target": "0.8.4",
     "@stencil/react-output-target": "0.5.3",
     "@stencil/sass": "3.0.11",

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -6,6 +6,7 @@ import { reactOutputTarget } from "@stencil/react-output-target";
 import { angularOutputTarget } from "@stencil/angular-output-target";
 import tailwindcss, { Config as TailwindConfig } from "tailwindcss";
 import stylelint from "stylelint";
+import { webTypesOutputTarget } from "@stencil-community/web-types-output-target";
 import tailwindConfig from "./tailwind.config";
 import { generatePreactTypes } from "./support/preact";
 import { version } from "./package.json";
@@ -100,6 +101,9 @@ export const create: () => Config = () => ({
       proxiesFile: "../calcite-components-react/src/components.ts",
       excludeComponents: ["context-consumer"],
       customElementsDir: "dist/components",
+    }),
+    webTypesOutputTarget({
+      outFile: "dist/extras/web-types.json",
     }),
     { type: "dist-hydrate-script" },
     { type: "dist-custom-elements", customElementsExportBehavior: "auto-define-custom-elements" },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Wires up [`@stencil-community/web-types-output-target`](https://github.com/stencil-community/stencil-web-types) to provide Intellisense to additional IDEs (e.g., WebStorm/IntelliJ).
