### PR TITLE
fix(combobox): fix error that occurs in dist-custom-elements (components) output when a click is emitted when the component is appended to the DOM

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -350,7 +350,7 @@ export class Combobox
 
     await componentOnReady(this.el);
 
-    if (!this.allowCustomValues && this.textInput.value) {
+    if (!this.allowCustomValues && this.text) {
       this.clearInputValue();
       this.filterItems("");
       this.updateActiveItemIndex(-1);


### PR DESCRIPTION
**Related Issue:** #9321

## Summary

This updates the combobox window-click listener to use an internal state property for its text instead of getting the value of the internal input. 

The `componentOnReady` util helps normalize waiting for a component to be ready in both output targets (based on [Ionic's helper](https://github.com/ionic-team/ionic-framework/blob/5cdfa1aaf47a6160cd1bd2be434dcfa8390b56e1/core/src/utils/helpers.ts#L60-L79)). This is sufficient for most scenarios, but for this particular case, it was running earlier than `connectedCallback` due to the emitted click as the component is appended and initialized, so the component is not yet rendered by the time the util resolves.

**Note**: there are no accompanying tests as this is not reproducible in the test environment, which uses the lazy-loaded output.
