### PR TITLE
ci: upload dist to github releases

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -58,5 +58,6 @@ jobs:
           git commit -m "build: update types and package-lock" || true
 
           npm run publish:latest
+          npm run util:upload-release-assets -- "${{ steps.release.outputs.paths_released }}"
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "turbo run test --log-order=stream",
     "util:is-next-deployable": "tsx support/isNextDeployable.ts",
     "util:push-tags": "git push origin main --follow-tags",
+    "util:upload-release-assets": "tsx support/uploadReleaseAssets.ts",
     "util:remove-prerelease-changelog-entries": "tsx support/removePrereleaseChangelogEntries.ts",
     "util:sync-linked-package-versions": "tsx support/syncLinkedPackageVersions.ts"
   },

--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -1,27 +1,31 @@
 {
   "name": "@esri/calcite-components-angular",
   "version": "2.9.0-next.23",
-  "sideEffects": false,
-  "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "A set of Angular components that wrap Esri's Calcite Components.",
-  "author": {
-    "name": "Esri"
+  "homepage": "https://developers.arcgis.com/calcite-design-system/",
+  "bugs": {
+    "url": "https://github.com/Esri/calcite-design-system/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/Esri/calcite-design-system.git",
     "directory": "packages/calcite-components-angular/projects/component-library"
   },
-  "bugs": {
-    "url": "https://github.com/Esri/calcite-design-system/issues"
+  "license": "SEE LICENSE.md",
+  "author": {
+    "name": "Esri"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@esri/calcite-components": "^2.9.0-next.23",
+    "tslib": "2.6.2"
   },
   "peerDependencies": {
     "@angular/common": ">=16.0.0",
     "@angular/core": ">=16.0.0"
-  },
-  "dependencies": {
-    "@esri/calcite-components": "^2.9.0-next.23",
-    "tslib": "2.6.2"
   },
   "lerna": {
     "command": {
@@ -29,6 +33,5 @@
         "directory": "./dist"
       }
     }
-  },
-  "license": "SEE LICENSE.md"
+  }
 }

--- a/support/uploadReleaseAssets.ts
+++ b/support/uploadReleaseAssets.ts
@@ -27,8 +27,8 @@
       const tagName = `${packageName}@${packageVersion}`;
       const assetName = `${packageName.replace("@", "").replace("/", "-")}-${packageVersion}.tgz`;
 
-      await exec(`cd ${packagePath} && tar -czvf ${assetName} ${distFiles.join(" ")}`);
-      await exec(`gh release upload ${tagName} ${packagePath}/${assetName}`);
+      await exec(`npm pack --workspace ${packagePath}`);
+      await exec(`gh release upload ${tagName} ${assetName}`);
     }
   } catch (error) {
     console.error(error);

--- a/support/uploadReleaseAssets.ts
+++ b/support/uploadReleaseAssets.ts
@@ -27,7 +27,7 @@
       const tagName = `${packageName}@${packageVersion}`;
       const assetName = `${packageName.replace("@", "").replace("/", "-")}-${packageVersion}.tgz`;
 
-      await exec(`npm pack --workspace ${packagePath}`);
+      await exec(`npm pack --workspace ${packagePath} >/dev/null 2>&1`);
       await exec(`gh release upload ${tagName} ${assetName}`);
     }
   } catch (error) {

--- a/support/uploadReleaseAssets.ts
+++ b/support/uploadReleaseAssets.ts
@@ -15,15 +15,14 @@
 
     for (const packagePath of releasedPackages) {
       const packageJson = JSON.parse(await fs.readFile(resolve(packagePath, "package.json"), "utf8"));
-      const distFiles = packageJson?.files;
       const packageName = packageJson?.name;
+      const packageVersion = packageJson?.version;
 
-      if (!distFiles?.length) {
-        console.warn("Skipping", packageName, "because it does not have the `files` field in its package.json");
+      if (!packageName || !packageVersion) {
+        console.warn(`Skipping "${packagePath}" because a package.json could not be found/parsed"`);
         continue;
       }
 
-      const packageVersion = packageJson?.version;
       const tagName = `${packageName}@${packageVersion}`;
       const assetName = `${packageName.replace("@", "").replace("/", "-")}-${packageVersion}.tgz`;
 

--- a/support/uploadReleaseAssets.ts
+++ b/support/uploadReleaseAssets.ts
@@ -1,0 +1,37 @@
+(async function (): Promise<void> {
+  try {
+    const childProcess = await import("child_process");
+    const { promisify } = await import("util");
+    const { promises: fs } = await import("fs");
+    const { resolve } = await import("path");
+    const exec = promisify(childProcess.exec);
+
+    // https://github.com/googleapis/release-please-action#outputs
+    const releasedPackages = JSON.parse(process.argv[2]);
+
+    if (!releasedPackages || !releasedPackages?.length) {
+      throw new Error("Unable to parse the list of released packages");
+    }
+
+    for (const packagePath of releasedPackages) {
+      const packageJson = JSON.parse(await fs.readFile(resolve(packagePath, "package.json"), "utf8"));
+      const distFiles = packageJson?.files;
+      const packageName = packageJson?.name;
+
+      if (!distFiles?.length) {
+        console.warn("Skipping", packageName, "because it does not have the `files` field in its package.json");
+        continue;
+      }
+
+      const packageVersion = packageJson?.version;
+      const tagName = `${packageName}@${packageVersion}`;
+      const assetName = `${packageName.replace("@", "").replace("/", "-")}-${packageVersion}.tgz`;
+
+      await exec(`cd ${packagePath} && tar -czvf ${assetName} ${distFiles.join(" ")}`);
+      await exec(`gh release upload ${tagName} ${packagePath}/${assetName}`);
+    }
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

Upload dist files to the GitHub Releases after publishing to npm. I'm not sure why I thought release-please was already doing this. I tested locally with the following script, which correctly uploaded the dists, e.g. for release [`@esri/calcite-components: v2.8.0`](https://github.com/Esri/calcite-design-system/releases/tag/%40esri%2Fcalcite-components%402.8.0).

```sh
#!/usr/bin/env bash

mv support/uploadReleaseAssets.ts /tmp
git clean -fdx && git reset --hard
git checkout @esri/calcite-components@2.8.0
npm install
npm run build
mv /tmp/uploadReleaseAssets.ts support/
npx tsx support/uploadReleaseAssets.ts '["packages/calcite-components","packages/calcite-components-react","packages/calcite-components-angular/projects/component-library"]'
```

It might be time to recreate a VM so I can iterate through all the tags with missing dists and add them with the script.
