### PR TITLE
ci: enable npm provenance statements

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -60,3 +60,4 @@ jobs:
           npm run publish:latest
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -26,6 +26,7 @@ jobs:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: |
           if [ "$NEXT_RELEASE_ENABLED" == "true" ]; then
             npm install


### PR DESCRIPTION
## Summary

Enable npm provenance statements to improve supply-chain security for our users.

ref: https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
