### PR TITLE
ci(provenance): add missing options from setup doc

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -8,7 +8,9 @@ permissions:
   pull-requests: write
 jobs:
   release-please:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: google-github-actions/release-please-action@v3.7.13
         id: release

--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -8,7 +8,9 @@ on:
     branches: [main]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**Related Issue:** #9429

## Summary

Update the deployment GitHub Actions according to steps in the [npm provenance doc](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions), which I missed because I was looking at the 3rd party section below it.

The [GitHub provenance doc](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) doesn't mention permissions, so it might not be required.

We had originally hardcoded an older version of Ubuntu in #5942 due to errors, but it was resolved in Stencil v4.
