### PR TITLE
build: remove unnecessary dist files before publishing

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -32,6 +32,7 @@
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path .gitignore",
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\" >/dev/null",
     "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
+    "prepublish": "./support/cleanupDistFiles.sh",
     "posttest": "npm run test:prerender",
     "screenshot-tests": "storybook build",
     "screenshot-tests:preview": "npm run util:prep-storybook-build && NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_SCREENSHOT_LOCAL_BUILD=true storybook dev",

--- a/packages/calcite-components/support/cleanupDistFiles.sh
+++ b/packages/calcite-components/support/cleanupDistFiles.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Remove unnecessary files that ended up in dist before publishing to NPM.
+# This is a temporary workaround until I figure out why they are being bundled.
+#
+# The images in the demos folder first appeared in the dist in v1.4.0 after this PR:
+# https://github.com/Esri/calcite-design-system/pull/6873
+#
+# The rest of the files showed up in v2 and are likely related to the Stencil v4 bump.
+rm -rf ./dist/collection/demos ./dist/collection/tests ./dist/.storybook/ \
+    ./dist/tailwind.config.js{,.map} ./dist/stencil.config.js{,.map} \
+    ./dist/calcite-preset.js{,.map} ./dist/types/tests ./dist/types/home


### PR DESCRIPTION
## Summary

Remove unnecessary files that somehow ended up in `dist` before publishing to NPM.
