### PR TITLE
ci(renovate): remove noisy sections from the PR body

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -7,6 +7,7 @@
     ":pinAllExceptPeerDependencies",
     ":widenPeerDependencies"
   ],
+  "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "platformCommit": true,
   "enabledManagers": ["npm", "github-actions"],
   "timezone": "America/Los_Angeles",


### PR DESCRIPTION
## Summary

Set [`prBodyTemplate`](https://docs.renovatebot.com/configuration-options/#prbodytemplate) to remove the noisy sections, which end up in the commit message when merging.
