### PR TITLE
fix: defer floating-ui updating until component is connected and open

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -452,7 +452,7 @@ export class Combobox
   //
   // --------------------------------------------------------------------------
 
-  connectedCallback(): void {
+  async connectedCallback(): Promise<void> {
     connectInteractive(this);
     connectLocalized(this);
     connectMessages(this);
@@ -472,7 +472,9 @@ export class Combobox
       onToggleOpenCloseComponent(this);
     }
 
+    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
+    afterConnectDefaultValueSet(this, this.getValue());
   }
 
   async componentWillLoad(): Promise<void> {
@@ -482,8 +484,6 @@ export class Combobox
   }
 
   componentDidLoad(): void {
-    afterConnectDefaultValueSet(this, this.getValue());
-    connectFloatingUI(this, this.referenceEl, this.floatingEl);
     setComponentLoaded(this);
   }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -43,6 +43,7 @@ import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { RequestedItem } from "../dropdown-group/interfaces";
 import { Scale } from "../interfaces";
+import { componentOnReady } from "../../utils/component";
 import { ItemKeyboardEvent } from "./interfaces";
 import { SLOTS } from "./resources";
 
@@ -196,7 +197,7 @@ export class Dropdown
   //
   //--------------------------------------------------------------------------
 
-  connectedCallback(): void {
+  async connectedCallback(): Promise<void> {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.setFilteredPlacements();
     if (this.open) {
@@ -205,6 +206,8 @@ export class Dropdown
     }
     connectInteractive(this);
     this.updateItems();
+
+    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
@@ -214,7 +217,6 @@ export class Dropdown
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   componentDidRender(): void {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -79,7 +79,7 @@ import {
   FocusTrapComponent,
 } from "../../utils/focusTrapComponent";
 import { guid } from "../../utils/guid";
-import { getIconScale } from "../../utils/component";
+import { componentOnReady, getIconScale } from "../../utils/component";
 import { Status } from "../interfaces";
 import { Validation } from "../functional/Validation";
 import { normalizeToCurrentCentury, isTwoDigitYear } from "./utils";
@@ -459,7 +459,7 @@ export class InputDatePicker
   //
   // --------------------------------------------------------------------------
 
-  connectedCallback(): void {
+  async connectedCallback(): Promise<void> {
     connectInteractive(this);
     connectLocalized(this);
 
@@ -506,7 +506,9 @@ export class InputDatePicker
       onToggleOpenCloseComponent(this);
     }
 
+    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
+    this.localizeInputValues();
   }
 
   async componentWillLoad(): Promise<void> {
@@ -518,8 +520,6 @@ export class InputDatePicker
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    this.localizeInputValues();
-    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -55,7 +55,7 @@ import {
 } from "../../utils/loadable";
 import { createObserver } from "../../utils/observers";
 import { FloatingArrow } from "../functional/FloatingArrow";
-import { getIconScale } from "../../utils/component";
+import { componentOnReady, getIconScale } from "../../utils/component";
 import PopoverManager from "./PopoverManager";
 import { PopoverMessages } from "./assets/popover/t9n";
 import { ARIA_CONTROLS, ARIA_EXPANDED, CSS, defaultPopoverPlacement } from "./resources";
@@ -278,8 +278,6 @@ export class Popover
 
   transitionEl: HTMLDivElement;
 
-  hasLoaded = false;
-
   focusTrap: FocusTrap;
 
   // --------------------------------------------------------------------------
@@ -288,16 +286,19 @@ export class Popover
   //
   // --------------------------------------------------------------------------
 
-  connectedCallback(): void {
+  async connectedCallback(): Promise<void> {
     this.setFilteredPlacements();
     connectLocalized(this);
     connectMessages(this);
-    this.setUpReferenceElement(this.hasLoaded);
+
+    await componentOnReady(this.el);
+    this.setUpReferenceElement();
     connectFocusTrap(this);
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
+
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
   }
 
   async componentWillLoad(): Promise<void> {
@@ -307,11 +308,6 @@ export class Popover
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    if (this.referenceElement && !this.effectiveReferenceElement) {
-      this.setUpReferenceElement();
-    }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
-    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -294,7 +294,6 @@ export class Popover
     await componentOnReady(this.el);
     this.setUpReferenceElement();
     connectFocusTrap(this);
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
 
     if (this.open) {
       onToggleOpenCloseComponent(this);

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -27,6 +27,7 @@ import {
 import { guid } from "../../utils/guid";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { FloatingArrow } from "../functional/FloatingArrow";
+import { componentOnReady } from "../../utils/component";
 import { ARIA_DESCRIBED_BY, CSS } from "./resources";
 import TooltipManager from "./TooltipManager";
 import { getEffectiveReferenceElement } from "./utils";
@@ -146,8 +147,6 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
 
   guid = `calcite-tooltip-${guid()}`;
 
-  hasLoaded = false;
-
   openTransitionProp = "opacity";
 
   transitionEl: HTMLDivElement;
@@ -158,26 +157,20 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
   //
   // --------------------------------------------------------------------------
 
-  connectedCallback(): void {
-    this.setUpReferenceElement(this.hasLoaded);
+  async connectedCallback(): Promise<void> {
+    await componentOnReady(this.el);
+    this.setUpReferenceElement(true);
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
+
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
   }
 
   async componentWillLoad(): Promise<void> {
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
-  }
-
-  componentDidLoad(): void {
-    if (this.referenceElement && !this.effectiveReferenceElement) {
-      this.setUpReferenceElement();
-    }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
-    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -507,25 +507,24 @@ async function runAutoUpdate(
   // we set initial state here to make it available for `reposition` calls
   autoUpdatingComponentMap.set(component, { state: "pending" });
 
-  const rep = component.reposition();
+  let repositionPromise: Promise<void>;
 
-  // define callback function that return s `rep` on the first call and then returns component.reposition();
-  const callback = () => {
-    let first = true;
-    return () => {
-      if (first) {
-        first = false;
-        return rep;
+  const cleanUp = effectiveAutoUpdate(
+    referenceEl,
+    floatingEl,
+    // callback is invoked immediately
+    () => {
+      const promise = component.reposition();
+
+      if (!repositionPromise) {
+        repositionPromise = promise;
       }
+    },
+  );
 
-      return component.reposition();
-    };
-  };
-
-  const cleanUp = effectiveAutoUpdate(referenceEl, floatingEl, callback);
   autoUpdatingComponentMap.set(component, { state: "active", cleanUp });
 
-  return rep;
+  return repositionPromise;
 }
 
 /**

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -427,13 +427,19 @@ export async function reposition(
   options: Parameters<typeof positionFloatingUI>[1],
   delayed = false,
 ): Promise<void> {
-  if (!component.open) {
+  if (!component.open || !options.floatingEl || !options.referenceEl) {
     return;
+  }
+
+  const trackedState = autoUpdatingComponentMap.get(component);
+
+  if (!trackedState) {
+    return runAutoUpdate(component, options.referenceEl, options.floatingEl);
   }
 
   const positionFunction = delayed ? getDebouncedReposition(component) : positionFloatingUI;
 
-  return positionFunction(component, options);
+  await positionFunction(component, options);
 }
 
 function getDebouncedReposition(component: FloatingUIComponent): DebouncedFunc<typeof positionFloatingUI> {
@@ -460,14 +466,67 @@ const ARROW_CSS_TRANSFORM = {
   right: "rotate(90deg)",
 };
 
+type PendingFloatingUIState = {
+  state: "pending";
+};
+
+type ActiveFloatingUIState = {
+  state: "active";
+  cleanUp: () => void;
+};
+
+type TrackedFloatingUIState = PendingFloatingUIState | ActiveFloatingUIState;
+
 /**
  * Exported for testing purposes only
  *
  * @internal
  */
-export const cleanupMap = new WeakMap<FloatingUIComponent, () => void>();
+export const autoUpdatingComponentMap = new WeakMap<FloatingUIComponent, TrackedFloatingUIState>();
 
 const componentToDebouncedRepositionMap = new WeakMap<FloatingUIComponent, DebouncedFunc<typeof positionFloatingUI>>();
+
+async function runAutoUpdate(
+  component: FloatingUIComponent,
+  referenceEl: ReferenceElement,
+  floatingEl: HTMLElement,
+): Promise<void> {
+  if (!floatingEl.isConnected) {
+    return;
+  }
+
+  const effectiveAutoUpdate = Build.isBrowser
+    ? autoUpdate
+    : (_refEl: HTMLElement, _floatingEl: HTMLElement, updateCallback: () => void): (() => void) => {
+        updateCallback();
+        return () => {
+          /* noop */
+        };
+      };
+
+  // we set initial state here to make it available for `reposition` calls
+  autoUpdatingComponentMap.set(component, { state: "pending" });
+
+  const rep = component.reposition();
+
+  // define callback function that return s `rep` on the first call and then returns component.reposition();
+  const callback = () => {
+    let first = true;
+    return () => {
+      if (first) {
+        first = false;
+        return rep;
+      }
+
+      return component.reposition();
+    };
+  };
+
+  const cleanUp = effectiveAutoUpdate(referenceEl, floatingEl, callback);
+  autoUpdatingComponentMap.set(component, { state: "active", cleanUp });
+
+  return rep;
+}
 
 /**
  * Helper to set up floating element interactions on connectedCallback.
@@ -476,11 +535,11 @@ const componentToDebouncedRepositionMap = new WeakMap<FloatingUIComponent, Debou
  * @param referenceEl - The `referenceElement` used to position the component according to its `placement` value.
  * @param floatingEl - The `floatingElement` containing the floating ui.
  */
-export function connectFloatingUI(
+export async function connectFloatingUI(
   component: FloatingUIComponent,
   referenceEl: ReferenceElement,
   floatingEl: HTMLElement,
-): void {
+): Promise<void> {
   if (!floatingEl || !referenceEl) {
     return;
   }
@@ -495,19 +554,11 @@ export function connectFloatingUI(
     position: component.overlayPositioning,
   });
 
-  const runAutoUpdate = Build.isBrowser
-    ? autoUpdate
-    : (_refEl: HTMLElement, _floatingEl: HTMLElement, updateCallback: () => void): (() => void) => {
-        updateCallback();
-        return () => {
-          /* noop */
-        };
-      };
+  if (!component.open) {
+    return;
+  }
 
-  cleanupMap.set(
-    component,
-    runAutoUpdate(referenceEl, floatingEl, () => component.reposition()),
-  );
+  return runAutoUpdate(component, referenceEl, floatingEl);
 }
 
 /**
@@ -526,8 +577,13 @@ export function disconnectFloatingUI(
     return;
   }
 
-  cleanupMap.get(component)?.();
-  cleanupMap.delete(component);
+  const trackedState = autoUpdatingComponentMap.get(component);
+
+  if (trackedState?.state === "active") {
+    trackedState.cleanUp();
+  }
+
+  autoUpdatingComponentMap.delete(component);
 
   componentToDebouncedRepositionMap.get(component)?.cancel();
   componentToDebouncedRepositionMap.delete(component);


### PR DESCRIPTION
**Related Issue:** #9397

## Summary

This updates the `FloatingUIComponent` implementation to defer calling `autoUpdate` until the component is open and connected (following `floating-ui` [usage notes](https://floating-ui.com/docs/autoupdate#usage)).

