### PR TITLE
test(navigation-logo): use sub-component token for theming test

### DIFF
--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.e2e.ts
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.e2e.ts
@@ -95,8 +95,8 @@ describe("calcite-navigation-logo", () => {
           targetProp: "color",
         },
         "--calcite-navigation-logo-icon-color": {
-          shadowSelector: `.${CSS.icon}`,
-          targetProp: "color",
+          shadowSelector: `calcite-icon`,
+          targetProp: "--calcite-icon-color",
         },
         "--calcite-navigation-logo-text-color": {
           shadowSelector: `.${CSS.icon}`,


### PR DESCRIPTION
**Related Issue:** #

## Summary

Updates theming test to use sub-component token as targetProp in `navigation-logo` component.