### PR TITLE
ci: add repo url to package.json files for provenance

### DIFF
--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -1,13 +1,24 @@
 {
   "name": "@esri/calcite-components-react",
-  "sideEffects": false,
   "version": "2.9.0-next.23",
-  "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "description": "A set of React components that wrap calcite components",
+  "homepage": "https://developers.arcgis.com/calcite-design-system/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Esri/calcite-design-system.git",
+    "directory": "packages/calcite-components-react"
+  },
   "license": "SEE LICENSE.md",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
-    "build": "rimraf dist && npm run compile",
     "prebuild": "npm run patch:jsx-import",
+    "build": "rimraf dist && npm run compile",
     "clean": "rimraf dist node_modules .turbo",
     "compile": "npm run tsc",
     "lint": "concurrently npm:lint:*",
@@ -16,12 +27,6 @@
     "patch:jsx-import": "tsx support/patchJSXImport.ts",
     "tsc": "tsc"
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist/"
-  ],
   "dependencies": {
     "@esri/calcite-components": "^2.9.0-next.23"
   },

--- a/packages/eslint-plugin-calcite-components/package.json
+++ b/packages/eslint-plugin-calcite-components/package.json
@@ -2,6 +2,12 @@
   "name": "@esri/eslint-plugin-calcite-components",
   "version": "1.2.1-next.0",
   "description": "ESLint rules for @esri/calcite-components",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Esri/calcite-design-system.git",
+    "directory": "packages/eslint-plugin-calcite-components"
+  },
+  "license": "SEE LICENSE.md",
   "main": "dist/index.js",
   "files": [
     "dist/index.js"
@@ -16,15 +22,14 @@
   "dependencies": {
     "stencil-eslint-core": "0.4.1"
   },
+  "devDependencies": {
+    "ts-node": "10.9.2"
+  },
   "peerDependencies": {
     "eslint": ">=8.0.0"
   },
-  "license": "SEE LICENSE.md",
   "packageManager": "npm@8.19.4",
   "volta": {
     "extends": "../../package.json"
-  },
-  "devDependencies": {
-    "ts-node": "10.9.2"
   }
 }


### PR DESCRIPTION
## Summary

- Add repository URL to package.json files that were missing the field, which is [required for provenance](https://github.com/Esri/calcite-design-system/actions/runs/9279905717/job/25533608990#step:4:16776).
- Sort the package.json files with `npx sort-package-json`.

This is the last missing configuration for provenance; Calcite components and the angular wrapper already published successfully:

https://www.npmjs.com/package/@esri/calcite-components/v/2.9.0-next.24#provenance
