### PR TITLE
ci(assets): stringify list of paths for released packages

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -60,7 +60,8 @@ jobs:
           git commit -m "build: update types and package-lock" || true
 
           npm run publish:latest
-          npm run util:upload-release-assets -- "${{ steps.release.outputs.paths_released }}"
+          npm run util:upload-release-assets -- "$RELEASED_PATHS"
         env:
+          RELEASED_PATHS: ${{ toJSON(steps.release.outputs.paths_released) }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
**Related Issue:** #9428

## Summary

The new [script](https://github.com/Esri/calcite-design-system/blob/main/support/uploadReleaseAssets.ts) for uploading release assets failed after `2.9.0` was deployed:

```sh
> calcite-design-system@0.0.0 util:upload-release-assets
﻿2024-05-29T06:43:20.4633461Z > tsx support/uploadReleaseAssets.ts [packages/calcite-components,packages/calcite-components-react,packages/calcite-components-angular/projects/component-library]

SyntaxError: Unexpected token 'p', "[packages/c"... is not valid JSON
    at JSON.parse (<anonymous>)
    at <anonymous> (/home/runner/work/calcite-design-system/calcite-design-system/support/uploadReleaseAssets.ts:10:35)
```

The quotes were removed from the [`paths_released`](https://github.com/googleapis/release-please-action#outputs) value, which should be valid, stringified JSON.

After some digging I came across a solution on [stack overflow](https://stackoverflow.com/a/72955840).
