### PR TITLE
fix(combobox, dropdown, input-date-picker, popover, tooltip): fix initialization logic in components output target

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -452,7 +452,7 @@ export class Combobox
   //
   // --------------------------------------------------------------------------
 
-  async connectedCallback(): Promise<void> {
+  connectedCallback(): void {
     connectInteractive(this);
     connectLocalized(this);
     connectMessages(this);
@@ -472,9 +472,7 @@ export class Combobox
       onToggleOpenCloseComponent(this);
     }
 
-    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
-    afterConnectDefaultValueSet(this, this.getValue());
   }
 
   async componentWillLoad(): Promise<void> {
@@ -484,6 +482,8 @@ export class Combobox
   }
 
   componentDidLoad(): void {
+    afterConnectDefaultValueSet(this, this.getValue());
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
     setComponentLoaded(this);
   }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -43,7 +43,6 @@ import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { RequestedItem } from "../dropdown-group/interfaces";
 import { Scale } from "../interfaces";
-import { componentOnReady } from "../../utils/component";
 import { ItemKeyboardEvent } from "./interfaces";
 import { SLOTS } from "./resources";
 
@@ -197,7 +196,7 @@ export class Dropdown
   //
   //--------------------------------------------------------------------------
 
-  async connectedCallback(): Promise<void> {
+  connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.setFilteredPlacements();
     if (this.open) {
@@ -206,8 +205,6 @@ export class Dropdown
     }
     connectInteractive(this);
     this.updateItems();
-
-    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
@@ -217,6 +214,7 @@ export class Dropdown
 
   componentDidLoad(): void {
     setComponentLoaded(this);
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   componentDidRender(): void {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -79,7 +79,7 @@ import {
   FocusTrapComponent,
 } from "../../utils/focusTrapComponent";
 import { guid } from "../../utils/guid";
-import { componentOnReady, getIconScale } from "../../utils/component";
+import { getIconScale } from "../../utils/component";
 import { Status } from "../interfaces";
 import { Validation } from "../functional/Validation";
 import { normalizeToCurrentCentury, isTwoDigitYear } from "./utils";
@@ -459,7 +459,7 @@ export class InputDatePicker
   //
   // --------------------------------------------------------------------------
 
-  async connectedCallback(): Promise<void> {
+  connectedCallback(): void {
     connectInteractive(this);
     connectLocalized(this);
 
@@ -506,9 +506,7 @@ export class InputDatePicker
       onToggleOpenCloseComponent(this);
     }
 
-    await componentOnReady(this.el);
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
-    this.localizeInputValues();
   }
 
   async componentWillLoad(): Promise<void> {
@@ -520,6 +518,8 @@ export class InputDatePicker
 
   componentDidLoad(): void {
     setComponentLoaded(this);
+    this.localizeInputValues();
+    connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -310,7 +310,6 @@ export class Popover
     if (this.referenceElement && !this.effectiveReferenceElement) {
       this.setUpReferenceElement();
     }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
     this.hasLoaded = true;
   }
 

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -55,7 +55,7 @@ import {
 } from "../../utils/loadable";
 import { createObserver } from "../../utils/observers";
 import { FloatingArrow } from "../functional/FloatingArrow";
-import { componentOnReady, getIconScale } from "../../utils/component";
+import { getIconScale } from "../../utils/component";
 import PopoverManager from "./PopoverManager";
 import { PopoverMessages } from "./assets/popover/t9n";
 import { ARIA_CONTROLS, ARIA_EXPANDED, CSS, defaultPopoverPlacement } from "./resources";
@@ -278,6 +278,8 @@ export class Popover
 
   transitionEl: HTMLDivElement;
 
+  hasLoaded = false;
+
   focusTrap: FocusTrap;
 
   // --------------------------------------------------------------------------
@@ -286,13 +288,11 @@ export class Popover
   //
   // --------------------------------------------------------------------------
 
-  async connectedCallback(): Promise<void> {
+  connectedCallback(): void {
     this.setFilteredPlacements();
     connectLocalized(this);
     connectMessages(this);
-
-    await componentOnReady(this.el);
-    this.setUpReferenceElement();
+    this.setUpReferenceElement(this.hasLoaded);
     connectFocusTrap(this);
 
     if (this.open) {
@@ -307,6 +307,11 @@ export class Popover
 
   componentDidLoad(): void {
     setComponentLoaded(this);
+    if (this.referenceElement && !this.effectiveReferenceElement) {
+      this.setUpReferenceElement();
+    }
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
+    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -175,7 +175,6 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
     if (this.referenceElement && !this.effectiveReferenceElement) {
       this.setUpReferenceElement();
     }
-    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
     this.hasLoaded = true;
   }
 

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -27,7 +27,6 @@ import {
 import { guid } from "../../utils/guid";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { FloatingArrow } from "../functional/FloatingArrow";
-import { componentOnReady } from "../../utils/component";
 import { ARIA_DESCRIBED_BY, CSS } from "./resources";
 import TooltipManager from "./TooltipManager";
 import { getEffectiveReferenceElement } from "./utils";
@@ -147,6 +146,8 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
 
   guid = `calcite-tooltip-${guid()}`;
 
+  hasLoaded = false;
+
   openTransitionProp = "opacity";
 
   transitionEl: HTMLDivElement;
@@ -157,10 +158,8 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
   //
   // --------------------------------------------------------------------------
 
-  async connectedCallback(): Promise<void> {
-    await componentOnReady(this.el);
+  connectedCallback(): void {
     this.setUpReferenceElement(true);
-
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
@@ -170,6 +169,14 @@ export class Tooltip implements FloatingUIComponent, OpenCloseComponent {
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
+  }
+
+  componentDidLoad(): void {
+    if (this.referenceElement && !this.effectiveReferenceElement) {
+      this.setUpReferenceElement();
+    }
+    connectFloatingUI(this, this.effectiveReferenceElement, this.el);
+    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
**Related Issue:** #9468

## Summary

https://github.com/Esri/calcite-design-system/pull/9443 introduced a regression caused by using the `componentOnLoad` util to consolidate initialization logic shared between `connectedCallback` and `componentDidLoad`. The util appears to resolve at a different time in the `components` output target, which messed up with initialization of certain components.

**Note**: there are no accompanying tests as this is not reproducible in the test environment, which uses the lazy-loaded output.

