### PR TITLE
fix(panel): prevent menu actions from being clipped in Safari

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -43,7 +43,7 @@
 }
 
 .container {
-  @apply bg-background m-0 flex w-full flex-auto flex-col items-stretch p-0;
+  @apply relative bg-background m-0 flex w-full flex-auto flex-col items-stretch p-0;
 
   transition:
     max-block-size var(--calcite-animation-timing),


### PR DESCRIPTION
**Related Issue:** #8028

## Summary

- do not cut off menu actions
- `position:relative` on the container class within the panel seems to fix the safari issue. Not sure how we can test this without manual testing or getting different browser screenshots setup.

@geospatialem @DitwanP could one of you help test this fix?
