### PR TITLE
fix(popover): prevent closing when component is connected to the DOM via a click

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -302,7 +302,7 @@ export class Popover
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    this.setUpReferenceElement();
+    this.setUpReferenceElement(true);
 
     if (this.open) {
       onToggleOpenCloseComponent(this);

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -293,6 +293,10 @@ export class Popover
     connectLocalized(this);
     connectMessages(this);
     connectFocusTrap(this);
+
+    // we set up the ref element in the next frame to ensure PopoverManager
+    // event handlers are invoked after connect (mainly for `components` output target)
+    requestAnimationFrame(() => this.setUpReferenceElement(this.hasLoaded));
   }
 
   async componentWillLoad(): Promise<void> {
@@ -302,11 +306,14 @@ export class Popover
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    this.setUpReferenceElement(true);
+    if (this.referenceElement && !this.effectiveReferenceElement) {
+      this.setUpReferenceElement();
+    }
 
     if (this.open) {
       onToggleOpenCloseComponent(this);
     }
+    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -292,12 +292,7 @@ export class Popover
     this.setFilteredPlacements();
     connectLocalized(this);
     connectMessages(this);
-    this.setUpReferenceElement(this.hasLoaded);
     connectFocusTrap(this);
-
-    if (this.open) {
-      onToggleOpenCloseComponent(this);
-    }
   }
 
   async componentWillLoad(): Promise<void> {
@@ -307,10 +302,11 @@ export class Popover
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    if (this.referenceElement && !this.effectiveReferenceElement) {
-      this.setUpReferenceElement();
+    this.setUpReferenceElement();
+
+    if (this.open) {
+      onToggleOpenCloseComponent(this);
     }
-    this.hasLoaded = true;
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
**Related Issue:** #9504

## Summary

This fixes an issue where any clicks when the popover is connected to the DOM would cause it to be immediately closed.

This would happen because `PopoverManager`'s window `click` handler was being added and invoked during `connectedCallback` and not after the component was initialized (somewhat similar to https://github.com/Esri/calcite-design-system/pull/9373).

**Note**: there are no accompanying tests as this is not reproducible in the test environment, which uses the lazy-loaded output.