### PR TITLE
fix(block): add accessible label for slotted controls

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -370,7 +370,7 @@ export class Block
           headerContent
         )}
         {hasControl ? (
-          <div class={CSS.controlContainer}>
+          <div aria-describedby={IDS.header} class={CSS.controlContainer}>
             <slot name={SLOTS.control} />
           </div>
         ) : null}

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -370,7 +370,7 @@ export class Block
           headerContent
         )}
         {hasControl ? (
-          <div aria-describedby={IDS.header} class={CSS.controlContainer}>
+          <div aria-labelledby={IDS.header} class={CSS.controlContainer}>
             <slot name={SLOTS.control} />
           </div>
         ) : null}


### PR DESCRIPTION
**Related Issue:** #8037

## Summary

- Add aria-labelledby to internal control container for enhanced accessibility.