### PR TITLE
chore(linting): enable selector-pseudo-element-colon-notation rule

### DIFF
--- a/packages/calcite-components/.stylelintrc.json
+++ b/packages/calcite-components/.stylelintrc.json
@@ -23,6 +23,12 @@
         "message": "selector is too complex, consider applying multiple classes dynamically during rendering"
       }
     ],
+    "selector-pseudo-element-colon-notation": [
+      "double",
+      {
+        "message": "Use double colons for pseudo-elements"
+      }
+    ],
     "selector-type-no-unknown": [
       true,
       {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Enables [`selector-pseudo-element-colon-notation`](https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation/) for consistent pseudoelement syntax (CSS3).
