### PR TITLE
ci(prerelease): use absolute path to publish script

### DIFF
--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -33,7 +33,7 @@ jobs:
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           BRANCH: ${{ github.base_ref || github.ref_name }}
-        run: ../scripts/publishPrerelease.sh
+        run: "${{ github.workspace }}/.github/scripts/publishPrerelease.sh"
       - name: notify teams
         uses: toko-bifrost/ms-teams-deploy-card@3.1.2
         if: ${{ !cancelled() && github.event_name == 'push' }}


### PR DESCRIPTION
Use an absolute path to the pre-release publishing script, because I'm not sure where relative paths start from.