### PR TITLE
fix(action-bar, action-pad): do not modify textEnabled on slotted actions when expandDisabled is true

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -93,8 +93,8 @@ export class ActionBar
 
   @Watch("expanded")
   expandedHandler(): void {
-    const { el, expanded } = this;
-    toggleChildActionText({ el, expanded });
+    const { el, expanded, expandDisabled } = this;
+    toggleChildActionText({ el, expanded, expandDisabled });
     this.overflowActions();
   }
 
@@ -183,8 +183,8 @@ export class ActionBar
   @Element() el: HTMLCalciteActionBarElement;
 
   mutationObserver = createObserver("mutation", () => {
-    const { el, expanded } = this;
-    toggleChildActionText({ el, expanded });
+    const { el, expanded, expandDisabled } = this;
+    toggleChildActionText({ el, expanded, expandDisabled });
     this.overflowActions();
   });
 
@@ -214,19 +214,19 @@ export class ActionBar
   // --------------------------------------------------------------------------
 
   componentDidLoad(): void {
-    const { el, expanded } = this;
+    const { el, expanded, expandDisabled } = this;
 
     setComponentLoaded(this);
-    toggleChildActionText({ el, expanded });
+    toggleChildActionText({ el, expanded, expandDisabled });
     this.overflowActions();
   }
 
   connectedCallback(): void {
-    const { el, expanded } = this;
+    const { el, expanded, expandDisabled } = this;
 
     connectLocalized(this);
     connectMessages(this);
-    toggleChildActionText({ el, expanded });
+    toggleChildActionText({ el, expanded, expandDisabled });
 
     this.mutationObserver?.observe(el, { childList: true, subtree: true });
 

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -76,7 +76,7 @@ export class ActionPad
 
   @Watch("expanded")
   expandedHandler(expanded: boolean): void {
-    toggleChildActionText({ el: this.el, expanded });
+    toggleChildActionText({ el: this.el, expanded, expandDisabled: this.expandDisabled });
   }
 
   /**
@@ -184,8 +184,8 @@ export class ActionPad
 
   async componentWillLoad(): Promise<void> {
     setUpLoadableComponent(this);
-    const { el, expanded } = this;
-    toggleChildActionText({ el, expanded });
+    const { el, expanded, expandDisabled } = this;
+    toggleChildActionText({ el, expanded, expandDisabled });
     await setUpMessages(this);
   }
 

--- a/packages/calcite-components/src/components/functional/ExpandToggle.tsx
+++ b/packages/calcite-components/src/components/functional/ExpandToggle.tsx
@@ -30,10 +30,16 @@ function getCalcitePosition(position: Position, el: HTMLElement): Position {
 export function toggleChildActionText({
   el,
   expanded,
+  expandDisabled,
 }: {
   el: HTMLElement;
   expanded: boolean;
+  expandDisabled: boolean;
 }): void {
+  if (expandDisabled) {
+    return;
+  }
+
   queryActions(el)
     .filter((el) => el.slot !== ACTION_GROUP_SLOTS.menuActions)
     .forEach((action) => (action.textEnabled = expanded));


### PR DESCRIPTION
**Related Issue:** #8886

## Summary
