### PR TITLE
chore: change additional instances of main to dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -99,7 +99,7 @@ body:
     id: packages
     attributes:
       label: Calcite package
-      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/main/packages) related to the request.
+      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/dev/packages) related to the request.
       options:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-angular"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -93,7 +93,7 @@ body:
     id: packages
     attributes:
       label: Calcite package
-      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/main/packages) related to the request.
+      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/dev/packages) related to the request.
       options:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-angular"

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -62,7 +62,7 @@ body:
     id: packages
     attributes:
       label: Calcite package
-      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/main/packages) related to the request.
+      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/dev/packages) related to the request.
       options:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-angular"

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -38,7 +38,7 @@ body:
     id: packages
     attributes:
       label: Calcite package
-      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/main/packages) related to the request.
+      description: Select the relevant [package(s)](https://github.com/Esri/calcite-design-system/tree/dev/packages) related to the request.
       options:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-angular"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,9 @@
 name: Chromatic
 on:
   push:
-    branches: [main, rc, dev]
+    branches: [rc, dev]
   pull_request:
-    branches: [main, rc, dev]
+    branches: [rc, dev]
     types: [labeled, synchronize]
 jobs:
   run:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           current_branch="$(git rev-parse --abbrev-ref HEAD)"
           # diff of branch excluding md
-          testable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/main) -- . ':(exclude)*.md*')
+          testable_changes=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/${{ github.base_ref }}) -- . ':(exclude)*.md*')
           echo "changed files: $testable_changes"
           # skip if there are only md changes
           if [ -z "$testable_changes" ]; then

--- a/.github/workflows/schedule-updates.yml
+++ b/.github/workflows/schedule-updates.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Commit and create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          base: main
+          base: dev
           branch: ci/update-component-docs
           delete-branch: true
           add-paths: |
@@ -50,7 +50,7 @@ jobs:
       - name: Commit and create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          base: main
+          base: dev
           branch: ci/update-browserslist-db
           delete-branch: true
           commit-message: "build: update browserslist db"

--- a/documentation/monorepo.md
+++ b/documentation/monorepo.md
@@ -76,9 +76,9 @@ Make the following changes and submit a PR:
 
 1. Move devDependencies to the root directory (besides local packages). You will need to regenerate the `package-lock.json` if you copy and paste from `package.json` files.
 1. Move GitHub Actions, git hooks, or other CI to the root directory, if applicable. GitHub Actions should follow the the naming convention of `what-it-does_scope.yml`, e.g. `pr-tests_eslint-plugin-calcite-components.yml`
-1. Add the path to the package and its current version to [`.release-please-manifest.json`](https://github.com/Esri/calcite-design-system/blob/main/.release-please-manifest.json).
-1. In [`release-please-config.json`](https://github.com/Esri/calcite-design-system/blob/main/release-please-config.json) under the `packages` field, add the new package's path as well as any package-specific configurations. The only required field is the package's name, taken from the `name` field in its `package.json`.
-1. If the new package needs to be linked to Calcite Component's version, add its name to the `LINKED_VERSIONS_TRACKING_PACKAGES` array in [`support/syncLinkedPackageVersions.ts`](https://github.com/Esri/calcite-design-system/blob/main/support/syncLinkedPackageVersions.ts).
+1. Add the path to the package and its current version to [`.release-please-manifest.json`](https://github.com/Esri/calcite-design-system/blob/dev/.release-please-manifest.json).
+1. In [`release-please-config.json`](https://github.com/Esri/calcite-design-system/blob/dev/release-please-config.json) under the `packages` field, add the new package's path as well as any package-specific configurations. The only required field is the package's name, taken from the `name` field in its `package.json`.
+1. If the new package needs to be linked to Calcite Component's version, add its name to the `LINKED_VERSIONS_TRACKING_PACKAGES` array in [`support/syncLinkedPackageVersions.ts`](https://github.com/Esri/calcite-design-system/blob/dev/support/syncLinkedPackageVersions.ts).
 1. Potentially rename the new package's NPM scripts so they match the pipeline names in `turbo.json` (build, test, clean, etc.). Note: having all of the NPM scripts that are specified in `turbo.json` is not required.
 1. If present and when possible, the `test` NPM script should *not* build first. Turbo will make sure the `build` script runs first and will cache the results.
 1. Potentially rename directories for consistency with the other packages:

--- a/packages/calcite-components-angular/projects/component-library/README.md
+++ b/packages/calcite-components-angular/projects/component-library/README.md
@@ -70,7 +70,7 @@ Calcite Components can now be used in your application like any other Angular co
 
 ## Contributing
 
-We welcome contributions to this project. See [CONTRIBUTING.md](https://github.com/Esri/calcite-design-system/blob/main/CONTRIBUTING.md) for an overview of the guidelines.
+We welcome contributions to this project. See [CONTRIBUTING.md](https://github.com/Esri/calcite-design-system/blob/dev/CONTRIBUTING.md) for an overview of the guidelines.
 
 ## License
 

--- a/packages/calcite-components/conventions/Accessibility/AccessibilityDeveloper.md
+++ b/packages/calcite-components/conventions/Accessibility/AccessibilityDeveloper.md
@@ -146,7 +146,7 @@ FAIL src/components/tree/tree.e2e.ts (23.34 s)
 
 - `npm test` runs the current test suite
 - `npm run test:watch` will retest on file changes
-- [Learn more on testing](https://github.com/Esri/calcite-design-system/blob/main/CONTRIBUTING.md#running-the-tests) from our contributing docs
+- [Learn more on testing](https://github.com/Esri/calcite-design-system/blob/dev/CONTRIBUTING.md#running-the-tests) from our contributing docs
 
 [scroll to top](#developer-quick-start-guide)
 
@@ -154,7 +154,7 @@ FAIL src/components/tree/tree.e2e.ts (23.34 s)
 
 We've already added the a11y add on, [storybook-addon-a11y](https://storybook.js.org/addons/@storybook/addon-a11y) which uses `axe-core`, the same accessibility engine used for automated testing in CC. As new components and enhancements are added, **ensure stories are updated to test accessibility**. This includes as properties are added to components, to ensure we're upholding high standards to fit our audience's needs.
 
-[Learn more on writing stories](https://github.com/Esri/calcite-design-system/blob/main/CONTRIBUTING.md#writing-stories) from our contributing docs.
+[Learn more on writing stories](https://github.com/Esri/calcite-design-system/blob/dev/CONTRIBUTING.md#writing-stories) from our contributing docs.
 
 ### Adding a new story
 

--- a/packages/calcite-components/conventions/Internationalization.md
+++ b/packages/calcite-components/conventions/Internationalization.md
@@ -29,7 +29,7 @@ The following section covers how to add built-in translation support to componen
 
 This pattern enables components to support built-in translations. In order to support this, a component must:
 
-1. Add the following translation bundles as component assets under a `t9n` folder (please refer to <https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/conventions/README.md#assets> for additional info on assets)
+1. Add the following translation bundles as component assets under a `t9n` folder (please refer to <https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/conventions/README.md#assets> for additional info on assets)
    1. `messages.json` – main bundle
    2. `messages_en.json` – locale-specific bundle (kept in sync with main one via scripts)
 2. Implement the `T9nComponent` interface

--- a/packages/calcite-components/conventions/README.md
+++ b/packages/calcite-components/conventions/README.md
@@ -423,7 +423,7 @@ Watching global attributes on components is now possible with Stencil v4. Please
 
 ### BigDecimal
 
-`BigDecimal` is a [number util](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/src/utils/number.ts) that helps with [arbitrary precision arithmetic](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). The util is adopted from a [Stack Overflow answer](https://stackoverflow.com/a/66939244) with some small changes. There are some usage examples in [`number.spec.ts`](../src/utils/number.spec.ts).
+`BigDecimal` is a [number util](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/utils/number.ts) that helps with [arbitrary precision arithmetic](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic). The util is adopted from a [Stack Overflow answer](https://stackoverflow.com/a/66939244) with some small changes. There are some usage examples in [`number.spec.ts`](../src/utils/number.spec.ts).
 
 ### Custom child element support
 

--- a/packages/calcite-components/conventions/Testing.md
+++ b/packages/calcite-components/conventions/Testing.md
@@ -4,7 +4,7 @@ Components should have an automated test for any incoming features or bug fixes.
 
 We encourage writing expressive test cases and code that indicates intent. Use comments sparingly when the aforementioned can't be fully achieved. Keep it clean!
 
-Please see Stencil's doc for more info on [end-to-end](https://stenciljs.com/docs/end-to-end-testing) testing. See one of our test examples [here](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/src/components/block/block.e2e.ts).
+Please see Stencil's doc for more info on [end-to-end](https://stenciljs.com/docs/end-to-end-testing) testing. See one of our test examples [here](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/components/block/block.e2e.ts).
 
 ## Choosing which tests to write
 
@@ -51,7 +51,7 @@ darkModeRTL.parameters = { modes: modesDarkDefault };
 #### General guidelines
 
 - Story names should be camelCased
-- Update the [main custom theme](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/src/custom-theme.stories.ts) story instead of adding a specific story showing how to use a custom CSS prop
+- Update the [main custom theme](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/custom-theme.stories.ts) story instead of adding a specific story showing how to use a custom CSS prop
 - Should only have HTML for the component or use case itself (e.g., no need to wrap in calcite-label)
 - Update the `simple` story with corresponding [controls](https://storybook.js.org/docs/essentials/controls) instead of adding a story specific to a new prop with its respective control
 - Don't add or update a story if it is covered by an existing one
@@ -75,7 +75,7 @@ darkModeRTL.parameters = { modes: modesDarkDefault };
 
 ### Helpers and utilities
 
-There are helpers and utilities to make testing common workflows easier. [`commonTests.ts`](https://github.com/Esri/calcite-design-system/blob/main/src/packages/calcite-components/tests/commonTests.ts) contains common tests that you can import and use for your component. For example, every component should have an [`accessible`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/commonTests.ts#L48-L62) test. To use the test in your component, import the helper and assert that the component is accessible.
+There are helpers and utilities to make testing common workflows easier. [`commonTests.ts`](https://github.com/Esri/calcite-design-system/blob/dev/src/packages/calcite-components/tests/commonTests.ts) contains common tests that you can import and use for your component. For example, every component should have an [`accessible`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/commonTests.ts#L48-L62) test. To use the test in your component, import the helper and assert that the component is accessible.
 
 ```js
 import { accessible } from "../../tests/commonTests";
@@ -87,7 +87,7 @@ Here is an example of the helper test usage in [`accordion.e2e.ts`](https://gith
 
 There are many more useful, common tests that you should use in specific scenarios. In most IDEs or text editors, you can search the function name of a common test to find usage examples in component's end-to-end test files.
 
-In addition to the common tests, there are also test utilities in [`utils.ts`](https://github.com/Esri/calcite-design-system/blob/main/packages/calcite-components/src/tests/utils.ts). These utilities are created to avoid duplicate code in component end-to-end test files. If you find yourself creating the same test function for different components, then it should be moved to `utils.ts`. A good example is [`getElementXY`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/utils.ts#L124-L139). Determining the screen location of an element can be very important when testing interactive components. Here are some end-to-end tests where the utility is used in [`color-picker.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/color-picker/color-picker.e2e.ts#L232-L236), [`input-e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/input/input.e2e.ts#L289-L293), [`shell-panel.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/shell-panel/shell-panel.e2e.ts#L381), and [`slider.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/slider/slider.e2e.ts#L176).
+In addition to the common tests, there are also test utilities in [`utils.ts`](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/tests/utils.ts). These utilities are created to avoid duplicate code in component end-to-end test files. If you find yourself creating the same test function for different components, then it should be moved to `utils.ts`. A good example is [`getElementXY`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/tests/utils.ts#L124-L139). Determining the screen location of an element can be very important when testing interactive components. Here are some end-to-end tests where the utility is used in [`color-picker.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/color-picker/color-picker.e2e.ts#L232-L236), [`input-e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/input/input.e2e.ts#L289-L293), [`shell-panel.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/shell-panel/shell-panel.e2e.ts#L381), and [`slider.e2e.ts`](https://github.com/Esri/calcite-design-system/blob/35f5aaf165b54d3f139e1ff2978a7c0246a0bf69/src/components/slider/slider.e2e.ts#L176).
 
 ### Prevent unnecessary logging in the build
 

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -231,7 +231,7 @@ export class ColorPicker
    *
    * @default "#007ac2"
    * @see [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
-   * @see [ColorValue](https://github.com/Esri/calcite-design-system/blob/main/src/components/color-picker/interfaces.ts#L10)
+   * @see [ColorValue](https://github.com/Esri/calcite-design-system/blob/dev/src/components/color-picker/interfaces.ts#L10)
    */
   @Prop({ mutable: true }) value: ColorValue | null = normalizeHex(
     hexify(DEFAULT_COLOR, this.alphaChannel),

--- a/packages/calcite-components/src/components/functional/FloatingArrow.tsx
+++ b/packages/calcite-components/src/components/functional/FloatingArrow.tsx
@@ -25,7 +25,7 @@ const DEFAULTS = {
  * @param floatingLayout.floatingLayout
  * @param floatingLayout – The effective floating layout to render the arrow vertically or horizontally. Possible values: `vertical` or `horizontal`.
  *
- * See [floating-ui](https://github.com/Esri/calcite-design-system/blob/main/src/utils/floating-ui.ts)
+ * See [floating-ui](https://github.com/Esri/calcite-design-system/blob/dev/src/utils/floating-ui.ts)
  * @param floatingLayout.key
  * @param floatingLayout.ref
  */

--- a/packages/calcite-components/src/components/pick-list-item/pick-list-item.tsx
+++ b/packages/calcite-components/src/components/pick-list-item/pick-list-item.tsx
@@ -89,7 +89,7 @@ export class PickListItem
   /**
    * Determines the icon SVG symbol that will be shown. Options are `"circle"`, `"square"`, `"grip"` or `null`.
    *
-   * @see [ICON_TYPES](https://github.com/Esri/calcite-design-system/blob/main/src/components/pick-list/resources.ts#L5)
+   * @see [ICON_TYPES](https://github.com/Esri/calcite-design-system/blob/dev/src/components/pick-list/resources.ts#L5)
    */
   @Prop({ reflect: true }) icon: ICON_TYPES | null = null;
 

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -102,7 +102,7 @@ export class Slider
   /**
    * A list of the histogram's x,y coordinates within the component's `min` and `max`. Displays above the component's track.
    *
-   * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/main/src/components/graph/interfaces.ts#L5)
+   * @see [DataSeries](https://github.com/Esri/calcite-design-system/blob/dev/src/components/graph/interfaces.ts#L5)
    */
   @Prop() histogram: DataSeries;
 

--- a/packages/calcite-components/src/components/tab-title/tab-title.tsx
+++ b/packages/calcite-components/src/components/tab-title/tab-title.tsx
@@ -348,7 +348,7 @@ export class TabTitle implements InteractiveComponent, LocalizedComponent, T9nCo
   /**
    * Fires when a `calcite-tab` is selected (`event.details`).
    *
-   * @see [TabChangeEventDetail](https://github.com/Esri/calcite-design-system/blob/main/src/components/tab/interfaces.ts#L1)
+   * @see [TabChangeEventDetail](https://github.com/Esri/calcite-design-system/blob/dev/src/components/tab/interfaces.ts#L1)
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalTabsActivate: EventEmitter<TabChangeEventDetail>;
@@ -361,7 +361,7 @@ export class TabTitle implements InteractiveComponent, LocalizedComponent, T9nCo
   /**
    * Fires when `calcite-tab` is closed (`event.details`).
    *
-   * @see [TabChangeEventDetail](https://github.com/Esri/calcite-design-system/blob/main/src/components/tab/interfaces.ts)
+   * @see [TabChangeEventDetail](https://github.com/Esri/calcite-design-system/blob/dev/src/components/tab/interfaces.ts)
    * @internal
    */
   @Event({ cancelable: false }) calciteInternalTabsClose: EventEmitter<TabCloseEventDetail>;

--- a/packages/calcite-components/src/components/value-list-item/value-list-item.tsx
+++ b/packages/calcite-components/src/components/value-list-item/value-list-item.tsx
@@ -82,7 +82,7 @@ export class ValueListItem
   /**
    * Determines the icon SVG symbol that will be shown. Options are circle, square, grip or null.
    *
-   * @see [ICON_TYPES](https://github.com/Esri/calcite-design-system/blob/main/src/components/pick-list/resources.ts#L5)
+   * @see [ICON_TYPES](https://github.com/Esri/calcite-design-system/blob/dev/src/components/pick-list/resources.ts#L5)
    */
   @Prop({ reflect: true }) icon?: ICON_TYPES | null = null;
 

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -311,7 +311,7 @@ export interface FloatingUIComponent {
    *
    * Possible values: "vertical" or "horizontal".
    *
-   * See [FloatingArrow](https://github.com/Esri/calcite-design-system/blob/main/src/components/functional/FloatingArrow.tsx)
+   * See [FloatingArrow](https://github.com/Esri/calcite-design-system/blob/dev/src/components/functional/FloatingArrow.tsx)
    */
   floatingLayout?: FloatingLayout;
 }

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -168,7 +168,7 @@ export const create: () => Config = () => ({
     selector: "attribute",
     name: "calcite-hydrated",
   },
-  preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-design-system/blob/main/LICENSE.md for details.\nv${version}`,
+  preamble: `All material copyright ESRI, All Rights Reserved, unless otherwise specified.\nSee https://github.com/Esri/calcite-design-system/blob/dev/LICENSE.md for details.\nv${version}`,
   extras: {
     enableImportInjection: true,
     scriptDataOpts: true,


### PR DESCRIPTION
## Summary

- Remove Chromatic from `main`, since it will already have ran on `dev`.
- Fix the scheduled update jobs, which where still creating PRs targeting
  `main`. Thankfully I left the 6 approvals rule because I definitely tried to
  merge those with `gh` :sweat_smile:
- Change the branch of code URLs from `main` to `dev`. Side note: maybe we
  could use the rollup plugin from #9536 to pin the version tag in the API
  reference code links. That way docs-json will point to the actual version's
  code instead of whatever is currently on `dev` or `main`.
