### PR TITLE
fix(tile): expose selected property

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -116,8 +116,6 @@ export class Tile implements InteractiveComponent, SelectableComponent {
 
   /**
    * When `true` and the parent's `selectionMode` is `"single"`, `"single-persist"', or `"multiple"`, the component is selected.
-   *
-   * @internal
    */
   @Prop({ reflect: true }) selected = false;
 


### PR DESCRIPTION
**Related Issue:** #9582

## Summary

This PR exposes `calcite-tile`'s `selected` property so that it won't throw typescript errors when compiled.  This was made internal unintentionally as other components like `calcite-chip` expose this property.