### PR TITLE
ci(next): install deps before release scripts execute

### DIFF
--- a/.github/scripts/publishPrerelease.sh
+++ b/.github/scripts/publishPrerelease.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+npm install
+
 if [ "$BRANCH" = "dev" ]; then
     if [ "$NEXT_RELEASE_ENABLED" != "true" ]; then
         echo "Next release is disabled"
@@ -11,8 +13,6 @@ if [ "$BRANCH" = "dev" ]; then
         exit 0
     fi
 fi
-
-npm install
 
 # version the packages with lerna before building to ensure the version in
 # Calcite components' source code preamble is correct for deployment


### PR DESCRIPTION
**Related Issue:** #9578

## Summary

Resolve [an error](https://github.com/Esri/calcite-design-system/actions/runs/9563619774/job/26362509309#step:4:16) in the prerelease deployment script where an npm package is used before it is installed.
