### PR TITLE
test(inline-editable): add token theme tests

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -4563,6 +4563,10 @@ export namespace Components {
          */
         "dropdownLabel": string;
         /**
+          * Defines the available placements that can be used when a flip occurs.
+         */
+        "flipPlacements": FlipPlacement[];
+        /**
           * Specifies the kind of the component, which will apply to border and background, if applicable.
          */
         "kind": Extract<"brand" | "danger" | "inverse" | "neutral", Kind>;
@@ -4574,6 +4578,11 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
+        /**
+          * Determines where the component will be positioned relative to the container element.
+          * @default "bottom-end"
+         */
+        "placement": MenuPlacement;
         /**
           * Specifies an icon to display at the end of the primary button.
          */
@@ -12510,6 +12519,10 @@ declare namespace LocalJSX {
          */
         "dropdownLabel"?: string;
         /**
+          * Defines the available placements that can be used when a flip occurs.
+         */
+        "flipPlacements"?: FlipPlacement[];
+        /**
           * Specifies the kind of the component, which will apply to border and background, if applicable.
          */
         "kind"?: Extract<"brand" | "danger" | "inverse" | "neutral", Kind>;
@@ -12529,6 +12542,11 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
+        /**
+          * Determines where the component will be positioned relative to the container element.
+          * @default "bottom-end"
+         */
+        "placement"?: MenuPlacement;
         /**
           * Specifies an icon to display at the end of the primary button.
          */

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -438,10 +438,75 @@ describe("calcite-inline-editable", () => {
         targetProp: "--calcite-button-icon-color",
         state: "hover",
       },
+      "--calcite-inline-editable-cancel-button-corner-radius": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-corner-radius",
+      },
+      "--calcite-inline-editable-edit-button-background-color": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+      },
+      "--calcite-inline-editable-edit-button-background-color-active": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+      },
+      "--calcite-inline-editable-edit-button-background-color-focus": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-edit-button-background-color-hover": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-edit-button-border-color": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+      },
+      "--calcite-inline-editable-edit-button-border-color-active": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+      },
+      "--calcite-inline-editable-edit-button-border-color-focus": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-edit-button-border-color-hover": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-edit-button-icon-color": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+      },
+      "--calcite-inline-editable-edit-button-icon-color-active": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+      },
+      "--calcite-inline-editable-edit-button-icon-color-focus": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-edit-button-icon-color-hover": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-edit-button-corner-radius": {
+        shadowSelector: `.${CSS.enableEditingButton}`,
+        targetProp: "--calcite-button-corner-radius",
+      },
     } as const;
 
     themed(
-      `<calcite-inline-editable editing-enabled controls><calcite-input></calcite-input></calcite-inline-editable>`,
+      `<calcite-inline-editable editing-enabled controls><calcite-input placeholder="My placeholder" value="Edit me"></calcite-input></calcite-inline-editable>`,
       tokens,
     );
   });

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -380,67 +380,10 @@ describe("calcite-inline-editable", () => {
   });
 
   describe("theme", () => {
-    const tokens = {
+    const preEditTokens = {
       "--calcite-inline-editable-background-color": {
         shadowSelector: `.${CSS.wrapper}`,
         targetProp: "backgroundColor",
-      },
-      "--calcite-inline-editable-cancel-button-background-color": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-      },
-      "--calcite-inline-editable-cancel-button-background-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-background-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-cancel-button-background-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-border-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-border-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-border-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-corner-radius": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-corner-radius",
       },
       "--calcite-inline-editable-edit-button-background-color": {
         shadowSelector: `.${CSS.enableEditingButton}`,
@@ -505,9 +448,137 @@ describe("calcite-inline-editable", () => {
       },
     } as const;
 
+    const postEditTokens = {
+      "--calcite-inline-editable-cancel-button-background-color": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+      },
+      "--calcite-inline-editable-cancel-button-background-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-background-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-cancel-button-background-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-cancel-button-border-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-border-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-border-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-cancel-button-icon-color": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-cancel-button-corner-radius": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-corner-radius",
+      },
+      "--calcite-inline-editable-ok-button-background-color": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-background-color",
+      },
+      "--calcite-inline-editable-ok-button-background-color-active": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+      },
+      "--calcite-inline-editable-ok-button-background-color-focus": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-ok-button-background-color-hover": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-ok-button-border-color": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-ok-button-border-color-active": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+      },
+      "--calcite-inline-editable-ok-button-border-color-focus": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-ok-button-border-color-hover": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-ok-button-icon-color": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-ok-button-icon-color-active": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+      },
+      "--calcite-inline-editable-ok-button-icon-color-focus": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-ok-button-icon-color-hover": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-ok-button-corner-radius": {
+        shadowSelector: `.${CSS.confirmChangesButton}`,
+        targetProp: "--calcite-button-corner-radius",
+      },
+    } as const;
+
+    themed(
+      `<calcite-inline-editable controls><calcite-input placeholder="My placeholder" value="Edit me"></calcite-input></calcite-inline-editable>`,
+      preEditTokens,
+    );
+
     themed(
       `<calcite-inline-editable editing-enabled controls><calcite-input placeholder="My placeholder" value="Edit me"></calcite-input></calcite-inline-editable>`,
-      tokens,
+      postEditTokens,
     );
   });
 

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -1,6 +1,7 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { accessible, disabled, labelable, renders, hidden, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
+import { ComponentTestTokens } from "../../tests/commonTests/themed";
 import { CSS } from "./resources";
 
 describe("calcite-inline-editable", () => {
@@ -380,206 +381,215 @@ describe("calcite-inline-editable", () => {
   });
 
   describe("theme", () => {
-    const preEditTokens = {
-      "--calcite-inline-editable-background-color": {
-        shadowSelector: `.${CSS.wrapper}`,
-        targetProp: "backgroundColor",
-      },
-      "--calcite-inline-editable-edit-button-background-color": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-      },
-      "--calcite-inline-editable-edit-button-background-color-active": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
-      },
-      "--calcite-inline-editable-edit-button-background-color-focus": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-edit-button-background-color-hover": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-edit-button-border-color": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-      },
-      "--calcite-inline-editable-edit-button-border-color-active": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
-      },
-      "--calcite-inline-editable-edit-button-border-color-focus": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-edit-button-border-color-hover": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-edit-button-icon-color": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-      },
-      "--calcite-inline-editable-edit-button-icon-color-active": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: { press: { attribute: "class", value: CSS.enableEditingButton } },
-      },
-      "--calcite-inline-editable-edit-button-icon-color-focus": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-edit-button-icon-color-hover": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-edit-button-corner-radius": {
-        shadowSelector: `.${CSS.enableEditingButton}`,
-        targetProp: "--calcite-button-corner-radius",
-      },
-    } as const;
-
-    const postEditTokens = {
-      "--calcite-inline-editable-cancel-button-background-color": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-      },
-      "--calcite-inline-editable-cancel-button-background-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-background-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-cancel-button-background-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-border-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-border-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-border-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-active": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-focus": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-cancel-button-icon-color-hover": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-cancel-button-corner-radius": {
-        shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "--calcite-button-corner-radius",
-      },
-      "--calcite-inline-editable-ok-button-background-color": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-background-color",
-      },
-      "--calcite-inline-editable-ok-button-background-color-active": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
-      },
-      "--calcite-inline-editable-ok-button-background-color-focus": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-ok-button-background-color-hover": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-background-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-ok-button-border-color": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-ok-button-border-color-active": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
-      },
-      "--calcite-inline-editable-ok-button-border-color-focus": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-ok-button-border-color-hover": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-border-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-ok-button-icon-color": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-ok-button-icon-color-active": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
-      },
-      "--calcite-inline-editable-ok-button-icon-color-focus": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "focus",
-      },
-      "--calcite-inline-editable-ok-button-icon-color-hover": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-icon-color",
-        state: "hover",
-      },
-      "--calcite-inline-editable-ok-button-corner-radius": {
-        shadowSelector: `.${CSS.confirmChangesButton}`,
-        targetProp: "--calcite-button-corner-radius",
-      },
-    } as const;
-
-    themed(
-      `<calcite-inline-editable controls><calcite-input placeholder="My placeholder" value="Edit me"></calcite-input></calcite-inline-editable>`,
-      preEditTokens,
-    );
-
-    themed(
-      `<calcite-inline-editable editing-enabled controls><calcite-input placeholder="My placeholder" value="Edit me"></calcite-input></calcite-inline-editable>`,
-      postEditTokens,
-    );
+    describe("default", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-inline-editable-background-color": {
+          shadowSelector: `.${CSS.wrapper}`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-inline-editable-edit-button-background-color": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+        },
+        "--calcite-inline-editable-edit-button-background-color-active": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+        },
+        "--calcite-inline-editable-edit-button-background-color-focus": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-edit-button-background-color-hover": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-edit-button-border-color": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+        },
+        "--calcite-inline-editable-edit-button-border-color-active": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+        },
+        "--calcite-inline-editable-edit-button-border-color-focus": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-edit-button-border-color-hover": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-edit-button-icon-color": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+        },
+        "--calcite-inline-editable-edit-button-icon-color-active": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: { press: { attribute: "class", value: CSS.enableEditingButton } },
+        },
+        "--calcite-inline-editable-edit-button-icon-color-focus": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-edit-button-icon-color-hover": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-edit-button-corner-radius": {
+          shadowSelector: `.${CSS.enableEditingButton}`,
+          targetProp: "--calcite-button-corner-radius",
+        },
+      };
+      themed(
+        html`
+          <calcite-inline-editable controls>
+            <calcite-input placeholder="My placeholder" value="Edit me"></calcite-input>
+          </calcite-inline-editable>
+        `,
+        tokens,
+      );
+    });
+    describe("editing enabled", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-inline-editable-cancel-button-background-color": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+        },
+        "--calcite-inline-editable-cancel-button-background-color-active": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+        },
+        "--calcite-inline-editable-cancel-button-background-color-focus": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-cancel-button-background-color-hover": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-cancel-button-border-color-active": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+        },
+        "--calcite-inline-editable-cancel-button-border-color-focus": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+        },
+        "--calcite-inline-editable-cancel-button-border-color-hover": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-cancel-button-icon-color": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+        },
+        "--calcite-inline-editable-cancel-button-icon-color-active": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+        },
+        "--calcite-inline-editable-cancel-button-icon-color-focus": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-cancel-button-icon-color-hover": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-cancel-button-corner-radius": {
+          shadowSelector: `.${CSS.cancelEditingButton}`,
+          targetProp: "--calcite-button-corner-radius",
+        },
+        "--calcite-inline-editable-ok-button-background-color": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-background-color",
+        },
+        "--calcite-inline-editable-ok-button-background-color-active": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+        },
+        "--calcite-inline-editable-ok-button-background-color-focus": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-ok-button-background-color-hover": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-background-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-ok-button-border-color": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-ok-button-border-color-active": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+        },
+        "--calcite-inline-editable-ok-button-border-color-focus": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-ok-button-border-color-hover": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-border-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-ok-button-icon-color": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-ok-button-icon-color-active": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: { press: { attribute: "class", value: CSS.confirmChangesButton } },
+        },
+        "--calcite-inline-editable-ok-button-icon-color-focus": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "focus",
+        },
+        "--calcite-inline-editable-ok-button-icon-color-hover": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-icon-color",
+          state: "hover",
+        },
+        "--calcite-inline-editable-ok-button-corner-radius": {
+          shadowSelector: `.${CSS.confirmChangesButton}`,
+          targetProp: "--calcite-button-corner-radius",
+        },
+      };
+      themed(
+        html`
+          <calcite-inline-editable editing-enabled controls>
+            <calcite-input placeholder="My placeholder" value="Edit me"></calcite-input>
+          </calcite-inline-editable>
+        `,
+        tokens,
+      );
+    });
   });
 
   describe("translation support", () => {

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -385,15 +385,39 @@ describe("calcite-inline-editable", () => {
         shadowSelector: `.${CSS.wrapper}`,
         targetProp: "backgroundColor",
       },
+      "--calcite-inline-editable-cancel-button-background-color": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+      },
       "--calcite-inline-editable-cancel-button-background-color-active": {
         shadowSelector: `.${CSS.cancelEditingButton}`,
-        targetProp: "backgroundColor",
+        targetProp: "--calcite-button-background-color",
         state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
       },
       "--calcite-inline-editable-cancel-button-background-color-focus": {
         shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
         state: "focus",
-        targetProp: "backgroundColor",
+      },
+      "--calcite-inline-editable-cancel-button-background-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-background-color",
+        state: "hover",
+      },
+      "--calcite-inline-editable-cancel-button-border-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-border-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-border-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-border-color",
+        state: "hover",
       },
     } as const;
 

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -419,6 +419,25 @@ describe("calcite-inline-editable", () => {
         targetProp: "--calcite-button-border-color",
         state: "hover",
       },
+      "--calcite-inline-editable-cancel-button-icon-color": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "focus",
+      },
+      "--calcite-inline-editable-cancel-button-icon-color-hover": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "--calcite-button-icon-color",
+        state: "hover",
+      },
     } as const;
 
     themed(

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -1,5 +1,5 @@
 import { E2EPage, newE2EPage } from "@stencil/core/testing";
-import { accessible, disabled, labelable, renders, hidden, t9n } from "../../tests/commonTests";
+import { accessible, disabled, labelable, renders, hidden, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -377,6 +377,30 @@ describe("calcite-inline-editable", () => {
         );
       });
     });
+  });
+
+  describe("theme", () => {
+    const tokens = {
+      "--calcite-inline-editable-background-color": {
+        shadowSelector: `.${CSS.wrapper}`,
+        targetProp: "backgroundColor",
+      },
+      "--calcite-inline-editable-cancel-button-background-color-active": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        targetProp: "backgroundColor",
+        state: { press: { attribute: "class", value: CSS.cancelEditingButton } },
+      },
+      "--calcite-inline-editable-cancel-button-background-color-focus": {
+        shadowSelector: `.${CSS.cancelEditingButton}`,
+        state: "focus",
+        targetProp: "backgroundColor",
+      },
+    } as const;
+
+    themed(
+      `<calcite-inline-editable editing-enabled controls><calcite-input></calcite-input></calcite-inline-editable>`,
+      tokens,
+    );
   });
 
   describe("translation support", () => {

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.scss
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.scss
@@ -132,7 +132,7 @@
   }
 }
 
-.confirm-editing-button {
+.confirm-changes-button {
   --calcite-button-background-color: var(--calcite-inline-editable-ok-button-background-color);
   --calcite-button-border-color: var(--calcite-inline-editable-ok-button-border-color);
   --calcite-button-icon-color: var(--calcite-inline-editable-ok-button-icon-color);


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Adds token theme tests for `calcite-inline-editable`.