### PR TITLE
ci(release-please): bump to v4

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -12,14 +12,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: google-github-actions/release-please-action@v3.7.13
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{ secrets.ADMIN_TOKEN }}
-          default-branch: ${{ github.ref_name }}
-          extra-files: |
-            packages/calcite-components/readme.md
+          target-branch: ${{ github.ref_name }}
       - name: Checkout Repository
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Switch from the deprecated release-please-action repo to the new one
- Bump to v4
