### PR TITLE
ci(release-please): fix conditional that checks if releases were created

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -40,28 +40,25 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: google-github-actions/release-please-action@v3.7.13
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{ secrets.ADMIN_TOKEN }}
-          default-branch: ${{ github.ref_name }}
-          extra-files: |
-            packages/calcite-components/readme.md
+          target-branch: ${{ github.ref_name }}
       - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
+        if: steps.release.outputs.releases_created == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.ADMIN_TOKEN }}
       - name: Setup Node
-        if: ${{ steps.release.outputs.releases_created }}
+        if: steps.release.outputs.releases_created == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
+        if: steps.release.outputs.releases_created == 'true'
         env:
           RELEASED_PATHS: ${{ toJSON(steps.release.outputs.paths_released) }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -40,11 +40,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: google-github-actions/release-please-action@v3.7.13
         id: release
         with:
+          command: manifest
           token: ${{ secrets.ADMIN_TOKEN }}
-          target-branch: ${{ github.ref_name }}
+          default-branch: ${{ github.ref_name }}
+          extra-files: |
+            packages/calcite-components/readme.md
       - name: Checkout Repository
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fix a bug in release-please-action v4 that changes how the `releases_created` [output](https://github.com/googleapis/release-please-action?tab=readme-ov-file#outputs) needs to be checked in conditionals.

ref: https://github.com/googleapis/release-please-action/issues/912