### PR TITLE
chore(linting): enable @typescript-eslint/methd-signature-style for safer types

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -70,6 +70,7 @@ module.exports = {
         ],
       },
     ],
+    "@typescript-eslint/method-signature-style": ["error", "property"],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": "error",
     curly: "error",

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -298,7 +298,7 @@ export interface FloatingUIComponent {
    *
    * @param delayed – (internal) when true, it will reposition the component after a delay. the default is false. This is useful for components that have multiple watched properties that schedule repositioning.
    */
-  reposition(delayed?: boolean): Promise<void>;
+  reposition: (delayed?: boolean) => Promise<void>;
 
   /**
    * Used to store the effective floating layout for components that use arrows.

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -125,14 +125,14 @@ export interface FormComponent<T = any> extends FormOwner {
   /**
    * Hook for components to provide custom form reset behavior.
    */
-  onFormReset?(): void;
+  onFormReset?: () => void;
 
   /**
    * Hook for components to sync _extra_ props on the hidden input form element used for form-submitting.
    *
    * Note: The following props are set by default: disabled, hidden, name, required, value.
    */
-  syncHiddenFormInput?(input: HTMLInputElement): void;
+  syncHiddenFormInput?: (input: HTMLInputElement) => void;
 }
 
 /**

--- a/packages/calcite-components/src/utils/observers.ts
+++ b/packages/calcite-components/src/utils/observers.ts
@@ -2,7 +2,7 @@ import { Build } from "@stencil/core";
 
 export interface ExtendedMutationObserver extends MutationObserver {
   new: () => ExtendedMutationObserver;
-  unobserve(target: Node): void;
+  unobserve: (target: Node) => void;
 }
 
 declare const ExtendedMutationObserver: {

--- a/packages/calcite-components/src/utils/t9n.ts
+++ b/packages/calcite-components/src/utils/t9n.ts
@@ -142,7 +142,7 @@ export interface T9nComponent extends LocalizedComponent {
    *  \/* wired up by t9n util *\/
    * }
    */
-  onMessagesChange(): void;
+  onMessagesChange: () => void;
 }
 
 function defaultOnMessagesChange(this: T9nComponent): void {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Prevents method shorthand syntax to avoid potential pitfals described in https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
