### PR TITLE
ci(release-please): fix hotfix weirdness by hardcoding sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "6f7d90935fef0a1fe9bc2570c8b97266a19b128a",
   "release-type": "node",
   "tag-separator": "@",
   "label": "skip visual snapshots",
@@ -13,7 +14,6 @@
     "packages/calcite-components-react": {
       "component": "@esri/calcite-components-react"
     },
-
     "packages/calcite-components-angular/projects/component-library": {
       "component": "@esri/calcite-components-angular"
     },


### PR DESCRIPTION
## Summary

Releasing the `2.8.x` hotfix patches after `2.9.0` has caused a lot of issues with release-please. This hardcodes the `2.9.0` release commit so release-please doesn't try to figure things out itself.

https://github.com/googleapis/release-please/blob/ace2bd5dc778f83c33ad5dee6807db5d0afdba36/docs/manifest-releaser.md?plain=1#L134-L147
