### PR TITLE
ci(release-please): limit commits scanned for releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "last-release-sha": "6f7d90935fef0a1fe9bc2570c8b97266a19b128a",
+  "commit-search-depth": 140,
   "release-type": "node",
   "tag-separator": "@",
   "label": "skip visual snapshots",


### PR DESCRIPTION
**Related Issue:** #

## Summary


Setting the last release sha didn't fix the issues. This limits the number of commits release-please scans when trying to find a release.


```sh
git rev-list --count @esri/calcite-components@2.9.0^..HEAD # => 137
```
