### PR TITLE
ci(release-please): hardcode target branch

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -44,7 +44,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
-          target-branch: ${{ github.ref_name }}
+          target-branch: main
       - name: Checkout Repository
         if: steps.release.outputs.releases_created == 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Maybe release-please thinks the target branch is `dev` since the commit is being rebased to `main`?
