### PR TITLE
fix(angular): resolve empty dist

### DIFF
--- a/packages/calcite-components-angular/projects/component-library/package.json
+++ b/packages/calcite-components-angular/projects/component-library/package.json
@@ -16,9 +16,6 @@
     "name": "Esri"
   },
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
   "dependencies": {
     "@esri/calcite-components": "^2.10.0-next.12",
     "tslib": "2.6.2"


### PR DESCRIPTION
## Summary

Unfortunately, the `2.10.0` release didn't fix the empty Angular dist. After some digging, it started in `2.9.0-next.24`. These are the suspicious commits:

```sh
git log @esri/calcite-components-angular@2.9.0-next.23...@esri/calcite-components-angular@2.9.0-next.24^ -- packages/calcite-components-angular
```

In #9428 I added the `files` field to the `package.json` so the dist files could be added to the GitHub releases. It seems like that broke the actual releases, because Angular has really strange workflow where they copy the `package.json` into the `dist` and release from there.
