### PR TITLE
test(rating): add theme token tests

### DIFF
--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -797,7 +797,16 @@ describe("calcite-rating", () => {
           state: { press: { attribute: "class", value: "star" } },
         },
       };
-      themed(html`<calcite-rating></calcite-rating>`, tokens);
+      themed("calcite-rating", tokens);
+    });
+    describe("deprecated", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-rating-spacing-unit": {
+          shadowSelector: `.${CSS.fieldset}`,
+          targetProp: "gap",
+        },
+      };
+      themed("calcite-rating", tokens);
     });
     describe("average with chip", () => {
       const tokens: ComponentTestTokens = {

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -779,9 +779,6 @@ describe("calcite-rating", () => {
           targetProp: "gap",
         },
         "--calcite-rating-spacing-unit": {
-          targetProp: "--calcite-internal-rating-spacing",
-        },
-        "--calcite-internal-rating-spacing": {
           shadowSelector: `.${CSS.fieldset}`,
           targetProp: "gap",
         },

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -775,8 +775,14 @@ describe("calcite-rating", () => {
     describe("default", () => {
       const tokens: ComponentTestTokens = {
         "--calcite-rating-spacing": {
-          selector: `calcite-rating`,
           targetProp: "--calcite-internal-rating-spacing",
+        },
+        "--calcite-rating-spacing-unit": {
+          targetProp: "--calcite-internal-rating-spacing",
+        },
+        "--calcite-internal-rating-spacing": {
+          shadowSelector: `.${CSS.fieldset}`,
+          targetProp: "gap",
         },
         "--calcite-rating-outline-color": {
           shadowSelector: `.${CSS.star}`,
@@ -793,7 +799,7 @@ describe("calcite-rating", () => {
           state: { press: { attribute: "class", value: "star" } },
         },
       };
-      themed(async () => html`<calcite-rating></calcite-rating>`, tokens);
+      themed(html`<calcite-rating></calcite-rating>`, tokens);
     });
     describe("average with chip", () => {
       const tokens: ComponentTestTokens = {
@@ -822,7 +828,7 @@ describe("calcite-rating", () => {
           targetProp: "--calcite-chip-text-color",
         },
       };
-      themed(async () => html`<calcite-rating average="3.65" show-chip></calcite-rating>`, tokens);
+      themed(html`<calcite-rating average="3.65" show-chip></calcite-rating>`, tokens);
     });
   });
 });

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -789,12 +789,12 @@ describe("calcite-rating", () => {
           targetProp: "color",
         },
         "--calcite-rating-outline-color-hover": {
-          shadowSelector: "label",
+          shadowSelector: `.${CSS.star}`,
           targetProp: "color",
           state: "hover",
         },
         "--calcite-rating-value-fill-color": {
-          shadowSelector: "label",
+          shadowSelector: `.${CSS.star}`,
           targetProp: "color",
           state: { press: { attribute: "class", value: "star" } },
         },

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -775,7 +775,8 @@ describe("calcite-rating", () => {
     describe("default", () => {
       const tokens: ComponentTestTokens = {
         "--calcite-rating-spacing": {
-          targetProp: "--calcite-internal-rating-spacing",
+          shadowSelector: `.${CSS.fieldset}`,
+          targetProp: "gap",
         },
         "--calcite-rating-spacing-unit": {
           targetProp: "--calcite-internal-rating-spacing",

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -13,6 +13,7 @@ import {
 import { isElementFocused } from "../../tests/utils";
 import { ComponentTestTokens } from "../../tests/commonTests/themed";
 import { html } from "../../../support/formatting";
+import { CSS } from "./resources";
 
 describe("calcite-rating", () => {
   describe("common tests", () => {
@@ -778,8 +779,7 @@ describe("calcite-rating", () => {
           targetProp: "--calcite-internal-rating-spacing",
         },
         "--calcite-rating-outline-color": {
-          // TODO: add resources.ts file for storing this in a single place
-          shadowSelector: `.star`,
+          shadowSelector: `.${CSS.star}`,
           targetProp: "color",
         },
         "--calcite-rating-outline-color-hover": {
@@ -798,8 +798,7 @@ describe("calcite-rating", () => {
     describe("average with chip", () => {
       const tokens: ComponentTestTokens = {
         "--calcite-rating-average-fill-color": {
-          // TODO: add resources.ts file for storing this in a single place
-          shadowSelector: `.average`,
+          shadowSelector: `.${CSS.average}`,
           targetProp: "color",
         },
         "--calcite-rating-chip-background-color": {

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -8,8 +8,11 @@ import {
   labelable,
   renders,
   t9n,
+  themed,
 } from "../../tests/commonTests";
 import { isElementFocused } from "../../tests/utils";
+import { ComponentTestTokens } from "../../tests/commonTests/themed";
+import { html } from "../../../support/formatting";
 
 describe("calcite-rating", () => {
   describe("common tests", () => {
@@ -765,5 +768,26 @@ describe("calcite-rating", () => {
       expect(changeEvent).toHaveReceivedEventTimes(0);
       expect(element).toEqualAttribute("value", "2");
     });
+  });
+
+  describe("theme", () => {
+    const tokens: ComponentTestTokens = {
+      "--calcite-rating-spacing": {
+        selector: `calcite-rating`,
+        targetProp: "--calcite-internal-rating-spacing",
+      },
+      "--calcite-rating-outline-color": {
+        // TODO: add resources.ts file for storing this in a single place
+        shadowSelector: `.star`,
+        targetProp: "color",
+      },
+      // "--calcite-rating-outline-color-hover": {
+      //   // TODO: add resources.ts file for storing this in a single place
+      //   shadowSelector: `.hovered`,
+      //   targetProp: "color",
+      //   state: { hover: { attribute: "class", value: "hovered" } },
+      // },
+    };
+    themed(async () => html`<calcite-rating></calcite-rating>`, tokens);
   });
 });

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -771,23 +771,59 @@ describe("calcite-rating", () => {
   });
 
   describe("theme", () => {
-    const tokens: ComponentTestTokens = {
-      "--calcite-rating-spacing": {
-        selector: `calcite-rating`,
-        targetProp: "--calcite-internal-rating-spacing",
-      },
-      "--calcite-rating-outline-color": {
-        // TODO: add resources.ts file for storing this in a single place
-        shadowSelector: `.star`,
-        targetProp: "color",
-      },
-      // "--calcite-rating-outline-color-hover": {
-      //   // TODO: add resources.ts file for storing this in a single place
-      //   shadowSelector: `.hovered`,
-      //   targetProp: "color",
-      //   state: { hover: { attribute: "class", value: "hovered" } },
-      // },
-    };
-    themed(async () => html`<calcite-rating></calcite-rating>`, tokens);
+    describe("default", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-rating-spacing": {
+          selector: `calcite-rating`,
+          targetProp: "--calcite-internal-rating-spacing",
+        },
+        "--calcite-rating-outline-color": {
+          // TODO: add resources.ts file for storing this in a single place
+          shadowSelector: `.star`,
+          targetProp: "color",
+        },
+        "--calcite-rating-outline-color-hover": {
+          shadowSelector: "label",
+          targetProp: "color",
+          state: "hover",
+        },
+        "--calcite-rating-value-fill-color": {
+          shadowSelector: "label",
+          targetProp: "color",
+          state: { press: { attribute: "class", value: "star" } },
+        },
+      };
+      themed(async () => html`<calcite-rating></calcite-rating>`, tokens);
+    });
+    describe("average with chip", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-rating-average-fill-color": {
+          // TODO: add resources.ts file for storing this in a single place
+          shadowSelector: `.average`,
+          targetProp: "color",
+        },
+        "--calcite-rating-chip-background-color": {
+          shadowSelector: "calcite-chip",
+          targetProp: "--calcite-chip-background-color",
+        },
+        "--calcite-rating-chip-border-color": {
+          shadowSelector: "calcite-chip",
+          targetProp: "--calcite-chip-border-color",
+        },
+        "--calcite-rating-chip-shadow": {
+          shadowSelector: "calcite-chip",
+          targetProp: "--calcite-chip-shadow",
+        },
+        "--calcite-rating-chip-corner-radius": {
+          shadowSelector: "calcite-chip",
+          targetProp: "--calcite-chip-corner-radius",
+        },
+        "--calcite-rating-chip-text-color": {
+          shadowSelector: "calcite-chip",
+          targetProp: "--calcite-chip-text-color",
+        },
+      };
+      themed(async () => html`<calcite-rating average="3.65" show-chip></calcite-rating>`, tokens);
+    });
   });
 });

--- a/packages/calcite-components/src/components/rating/rating.scss
+++ b/packages/calcite-components/src/components/rating/rating.scss
@@ -3,8 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-rating-spacing-unit: [Deprecated] Use the `--calcite-rating-spacing` property instead.  The amount of spacing between rating items.
  * @prop --calcite-rating-spacing: Specifies the amount of spacing between rating items.
+ * @prop --calcite-rating-spacing-unit: [Deprecated] Use the `--calcite-rating-spacing` property instead.  The amount of spacing between rating items.
  * @prop --calcite-rating-outline-color: Specifies the outline color for a rating item.
  * @prop --calcite-rating-outline-color-hover: Specifies the outline color for a rating item while hovered.
  * @prop --calcite-rating-value-fill-color: Specifies the fill color for a rating item with value.

--- a/packages/calcite-components/src/components/rating/rating.tsx
+++ b/packages/calcite-components/src/components/rating/rating.tsx
@@ -39,6 +39,7 @@ import { focusFirstTabbable } from "../../utils/dom";
 import { RatingMessages } from "./assets/rating/t9n";
 import { StarIcon } from "./functional/star";
 import { Star } from "./interfaces";
+import { CSS } from "./resources";
 
 @Component({
   tag: "calcite-rating",
@@ -228,9 +229,9 @@ export class Rating
         onPointerOver={this.handleRatingPointerOver}
       >
         <InteractiveContainer disabled={this.disabled}>
-          <span class="wrapper">
-            <fieldset class="fieldset" disabled={this.disabled}>
-              <legend class="visually-hidden">{this.messages.rating}</legend>
+          <span class={CSS.wrapper}>
+            <fieldset class={CSS.fieldset} disabled={this.disabled}>
+              <legend class={CSS.visuallyHidden}>{this.messages.rating}</legend>
               {this.starsMap.map(
                 ({
                   average,
@@ -246,11 +247,11 @@ export class Rating
                   return (
                     <label
                       class={{
-                        star: true,
-                        selected,
-                        hovered,
-                        average,
-                        partial,
+                        [CSS.star]: true,
+                        [CSS.selected]: selected,
+                        [CSS.hovered]: hovered,
+                        [CSS.average]: average,
+                        [CSS.partial]: partial,
                       }}
                       data-value={value}
                       htmlFor={id}

--- a/packages/calcite-components/src/components/rating/resources.ts
+++ b/packages/calcite-components/src/components/rating/resources.ts
@@ -1,0 +1,10 @@
+export const CSS = {
+  average: "average",
+  hovered: "hovered",
+  fieldset: "fieldset",
+  partial: "partial",
+  selected: "selected",
+  star: "star",
+  wrapper: "wrapper",
+  visuallyHidden: "visually-hidden",
+};


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds token tests for theming to `calcite-rating`.