### PR TITLE
chore: fix package-lock versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36908,9 +36908,9 @@
         "type-fest": "4.18.2"
       },
       "devDependencies": {
-        "@esri/calcite-design-tokens": "^2.2.1",
+        "@esri/calcite-design-tokens": "^2.2.0",
         "@esri/calcite-ui-icons": "3.28.2",
-        "@esri/eslint-plugin-calcite-components": "^1.2.1",
+        "@esri/eslint-plugin-calcite-components": "^1.2.0",
         "@stencil-community/eslint-plugin": "0.7.2",
         "@stencil-community/postcss": "2.2.0",
         "@stencil/angular-output-target": "0.8.4",
@@ -38518,7 +38518,7 @@
     },
     "packages/calcite-design-tokens": {
       "name": "@esri/calcite-design-tokens",
-      "version": "2.2.1",
+      "version": "2.2.0",
       "devDependencies": {
         "ts-jest-resolver": "2.0.1",
         "ts-node": "10.9.2"
@@ -38526,7 +38526,7 @@
     },
     "packages/eslint-plugin-calcite-components": {
       "name": "@esri/eslint-plugin-calcite-components",
-      "version": "1.2.1",
+      "version": "1.2.0",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "stencil-eslint-core": "0.4.1"


### PR DESCRIPTION
## Summary

Fix incorrect package versions in `package-lock.json` due to the manual release.
