### PR TITLE
ci(release-please): try setting bootstrap-sha to 2.10

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "bootstrap-sha": "dc9c6ad669336599ae51bf7e23b08f8fb2114ec6",
   "tag-separator": "@",
   "label": "skip visual snapshots",
   "draft-pull-request": true,


### PR DESCRIPTION
## Summary

This is the last release-please escape hatch I haven't tried yet.
