### PR TITLE
ci(release-please): use default label to identify PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "bootstrap-sha": "dc9c6ad669336599ae51bf7e23b08f8fb2114ec6",
   "tag-separator": "@",
-  "label": "skip visual snapshots",
   "draft-pull-request": true,
   "include-v-in-tag": false,
   "packages": {


### PR DESCRIPTION
## Summary

I just realized the "label" field replaces the default `autorelease: pending` one release-please uses to identify their pull requests. I'm pretty sure that was causing the issues.
