### PR TITLE
chore(formatting): add css tagged template function to leverage Prettier formatting

### DIFF
--- a/packages/calcite-components/support/formatting.ts
+++ b/packages/calcite-components/support/formatting.ts
@@ -20,7 +20,7 @@ import dedent from "dedent";
  * ```
  *
  * ```ts
- * icon.stories.ts
+ * // select.stories.ts
  * export const simple = (): string => html`
  *   <calcite-select>
  *     <calcite-option id="1">uno</calcite-option>

--- a/packages/calcite-components/support/formatting.ts
+++ b/packages/calcite-components/support/formatting.ts
@@ -3,7 +3,7 @@ import dedent from "dedent";
 /**
  * Use this tagged template to help Prettier format any HTML template literals.
  *
- * @param strings the
+ * @param strings the input HTML text
  * @example
  *
  * ```ts
@@ -33,5 +33,31 @@ import dedent from "dedent";
 export function html(strings: string): string;
 export function html(strings: TemplateStringsArray, ...placeholders: any[]): string;
 export function html(strings: any, ...placeholders: any[]): string {
+  return dedent(strings, ...placeholders);
+}
+
+/**
+ * Use this tagged template to help Prettier format any CSS template literals.
+ *
+ * **Note**: this should only be used when the input string only contains CSS. For style tags and style attributes, use the `html` tagged template literal.
+ *
+ * @param strings the input CSS text
+ * @example
+ *
+ * ```ts
+ * const page = await newE2EPage();
+ * await page.setContent(html`...`);
+ * await page.addStyleTag({
+ *   content: css`
+ *     .my-component {
+ *        color: red;
+ *      }
+ * `
+ * });
+ * ```
+ */
+export function css(strings: string): string;
+export function css(strings: TemplateStringsArray, ...placeholders: any[]): string;
+export function css(strings: any, ...placeholders: any[]): string {
   return dedent(strings, ...placeholders);
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Adds CSS counterpart to [`html` formatting helper](https://github.com/Esri/calcite-design-system/pull/1392).

