### PR TITLE
feat: provide info message on stamped version instead of warning

### DIFF
--- a/packages/calcite-components/src/tests/setupTests.ts
+++ b/packages/calcite-components/src/tests/setupTests.ts
@@ -1,15 +1,20 @@
 let globalError: jest.SpyInstance;
+let globalLog: jest.SpyInstance;
 
 beforeAll(() => {
   globalError = jest.spyOn(global.console, "error");
+  globalLog = jest.spyOn(global.console, "info").mockImplementation(() => null);
 });
 
-beforeEach(() => globalError.mockClear());
+beforeEach(() => {
+  globalError.mockClear();
+  globalLog.mockClear();
+});
 
 // eslint-disable-next-line jest/no-standalone-expect
 afterEach(() => expect(globalError).not.toHaveBeenCalled());
 
 afterAll(() => {
-  globalError.mockClear();
   globalError.mockRestore();
+  globalLog.mockRestore();
 });

--- a/packages/calcite-components/src/utils/config.spec.ts
+++ b/packages/calcite-components/src/utils/config.spec.ts
@@ -30,6 +30,8 @@ describe("config", () => {
   describe("stampVersion", () => {
     const calciteVersionPreBuildPlaceholder = "__CALCITE_VERSION__";
 
+    beforeEach(() => delete globalThis.calciteConfig);
+
     it("creates global config and stamps the version onto it", async () => {
       config = await loadConfig();
       config.stampVersion();
@@ -43,12 +45,19 @@ describe("config", () => {
       expect(globalThis.calciteConfig.version).toBe(calciteVersionPreBuildPlaceholder);
     });
 
-    it("warns if the version is already set", async () => {
-      globalThis.calciteConfig = { version: "1.33.7" };
+    it("bails if version is already stamped onto existing config", async () => {
+      const testVersion = "1.33.7";
+      globalThis.calciteConfig = { version: testVersion };
       config = await loadConfig();
-      const warnSpy = jest.spyOn(console, "warn");
       config.stampVersion();
-      expect(warnSpy).toHaveBeenCalled();
+      expect(globalThis.calciteConfig.version).toBe(testVersion);
+    });
+
+    it("logs info with registered version", async () => {
+      expect(console.info).not.toHaveBeenCalled();
+      config = await loadConfig();
+      config.stampVersion();
+      expect(console.info).toHaveBeenCalled();
     });
   });
 });

--- a/packages/calcite-components/src/utils/config.ts
+++ b/packages/calcite-components/src/utils/config.ts
@@ -22,26 +22,26 @@ export interface CalciteConfig {
   version?: string;
 }
 
-const customConfig: CalciteConfig = globalThis["calciteConfig"];
+const existingConfig: CalciteConfig = globalThis["calciteConfig"];
 
-export const focusTrapStack: FocusTrap[] = customConfig?.focusTrapStack || [];
+export const focusTrapStack: FocusTrap[] = existingConfig?.focusTrapStack || [];
 
-const version = "__CALCITE_VERSION__"; // version number is set by build
+// the following placeholders are replaced by the build
+const version = "__CALCITE_VERSION__";
+const buildDate = "__CALCITE_BUILD_DATE__";
+const revision = "__CALCITE_REVISION__";
 
 /**
  * Stamp the version onto the global config.
  */
 export function stampVersion(): void {
-  if (customConfig && customConfig.version) {
-    console.warn(
-      customConfig.version === version
-        ? `[calcite-components] while initializing v${version}, an existing configuration with the same version was found. This may be caused by the initialization script running more than once.`
-        : `[calcite-components] while initializing v${version}, an existing configuration with version "${customConfig.version}" was found. This may cause unexpected behavior. The version will not be added to the existing global configuration.`,
-    );
+  if (existingConfig && existingConfig.version) {
     return;
   }
 
-  const target = customConfig || globalThis["calciteConfig"] || {};
+  console.info(`Using Calcite Components ${version} [Date: ${buildDate}, Revision: ${revision}]`);
+
+  const target = existingConfig || globalThis["calciteConfig"] || {};
 
   Object.defineProperty(target, "version", {
     value: version,

--- a/packages/calcite-components/src/utils/config.ts
+++ b/packages/calcite-components/src/utils/config.ts
@@ -34,7 +34,9 @@ const version = "__CALCITE_VERSION__"; // version number is set by build
 export function stampVersion(): void {
   if (customConfig && customConfig.version) {
     console.warn(
-      `[calcite-components] while initializing v${version}, an existing configuration with version "${customConfig.version}" was found. This may cause unexpected behavior. The version will not be added to the existing global configuration.`,
+      customConfig.version === version
+        ? `[calcite-components] while initializing v${version}, an existing configuration with the same version was found. This may be caused by the initialization script running more than once.`
+        : `[calcite-components] while initializing v${version}, an existing configuration with version "${customConfig.version}" was found. This may cause unexpected behavior. The version will not be added to the existing global configuration.`,
     );
     return;
   }

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { Config } from "@stencil/core";
 import { postcss } from "@stencil-community/postcss";
 import { sass } from "@stencil/sass";
@@ -147,6 +148,8 @@ export const create: () => Config = () => ({
       replace({
         values: {
           __CALCITE_VERSION__: version,
+          __CALCITE_BUILD_DATE__: () => new Date().toISOString().split("T")[0],
+          __CALCITE_REVISION__: execSync("git rev-parse HEAD").toString().trim().slice(0, 7),
         },
         include: ["src/utils/config.ts"],
         preventAssignment: true,

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -147,9 +147,9 @@ export const create: () => Config = () => ({
     before: [
       replace({
         values: {
-          __CALCITE_VERSION__: version,
           __CALCITE_BUILD_DATE__: () => new Date().toISOString().split("T")[0],
-          __CALCITE_REVISION__: execSync("git rev-parse HEAD").toString().trim().slice(0, 7),
+          __CALCITE_REVISION__: execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim(),
+          __CALCITE_VERSION__: version,
         },
         include: ["src/utils/config.ts"],
         preventAssignment: true,


### PR DESCRIPTION
**Related Issue:** #9721

## Summary

This updates the message displayed when components load to show the version, build date and revision (similar to Maps SDK). It will log an info message instead of a warning as it could be misinterpreted and would also show up multiple times when a bundled `calcite-components` version would be overridden.

**Note**: `console.info` messages will be omitted by default across all tests to avoid noise
