### PR TITLE
chore(tree-item): fix mutable warning `indeterminate` prop

### DIFF
--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -119,7 +119,8 @@ export class TreeItem implements ConditionalSlotComponent, InteractiveComponent 
    *
    * @internal
    */
-  @Prop({ reflect: true }) indeterminate = false;
+  // eslint-disable-next-line @stencil-community/strict-mutable -- ignoring until https://github.com/stencil-community/stencil-eslint/issues/111 is fixed
+  @Prop({ reflect: true, mutable: true }) indeterminate = false;
 
   /**
    * @internal


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Marks `indeterminate` as mutable and suppresses `@stencil-eslint/strict-mutable` class until https://github.com/stencil-community/stencil-eslint/issues/111 is fixed.

