### PR TITLE
feat(panel, flow-item): add beforeClose property

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1877,6 +1877,10 @@ export namespace Components {
          */
         "beforeBack": () => Promise<void>;
         /**
+          * Passes a function to run before the component closes.
+         */
+        "beforeClose": () => Promise<void>;
+        /**
           * When `true`, displays a close button in the trailing side of the component's header.
          */
         "closable": boolean;
@@ -3672,6 +3676,10 @@ export namespace Components {
         "totalItems": number;
     }
     interface CalcitePanel {
+        /**
+          * Passes a function to run before the component closes.
+         */
+        "beforeClose": () => Promise<void>;
         /**
           * When `true`, displays a close button in the trailing side of the header.
          */
@@ -9734,6 +9742,10 @@ declare namespace LocalJSX {
          */
         "beforeBack"?: () => Promise<void>;
         /**
+          * Passes a function to run before the component closes.
+         */
+        "beforeClose"?: () => Promise<void>;
+        /**
           * When `true`, displays a close button in the trailing side of the component's header.
          */
         "closable"?: boolean;
@@ -11630,6 +11642,10 @@ declare namespace LocalJSX {
         "totalItems"?: number;
     }
     interface CalcitePanel {
+        /**
+          * Passes a function to run before the component closes.
+         */
+        "beforeClose"?: () => Promise<void>;
         /**
           * When `true`, displays a close button in the trailing side of the header.
          */

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -26,6 +26,10 @@ describe("calcite-flow-item", () => {
   describe("defaults", () => {
     defaults("calcite-flow-item", [
       {
+        propertyName: "beforeClose",
+        defaultValue: undefined,
+      },
+      {
         propertyName: "closable",
         defaultValue: false,
       },
@@ -197,6 +201,24 @@ describe("calcite-flow-item", () => {
     });
 
     expect(calciteFlowItemBack).toHaveReceivedEvent();
+  });
+
+  it("sets beforeClose on internal panel", async () => {
+    const page = await newE2EPage();
+    await page.exposeFunction("beforeClose", () => Promise.reject());
+    await page.setContent("<calcite-flow-item closable></calcite-flow-item>");
+
+    await page.$eval(
+      "calcite-flow-item",
+      (el: HTMLCalciteFlowItemElement) =>
+        (el.beforeClose = (window as typeof window & Pick<typeof el, "beforeClose">).beforeClose),
+    );
+
+    await page.waitForChanges();
+
+    const panel = await page.find(`calcite-flow-item >>> calcite-panel`);
+
+    expect(await panel.getProperty("beforeClose")).toBeDefined();
   });
 
   it("sets collapsible and collapsed on internal panel", async () => {

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -99,6 +99,9 @@ export class FlowItem
    */
   @Prop() beforeBack: () => Promise<void>;
 
+  /** Passes a function to run before the component closes. */
+  @Prop() beforeClose: () => Promise<void>;
+
   /** A description for the component. */
   @Prop() description: string;
 
@@ -365,11 +368,13 @@ export class FlowItem
       menuOpen,
       messages,
       overlayPositioning,
+      beforeClose,
     } = this;
     return (
       <Host>
         <InteractiveContainer disabled={disabled}>
           <calcite-panel
+            beforeClose={beforeClose}
             closable={closable}
             closed={closed}
             collapseDirection={collapseDirection}

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -36,6 +36,10 @@ describe("calcite-panel", () => {
   describe("defaults", () => {
     defaults("calcite-panel", [
       {
+        propertyName: "beforeClose",
+        defaultValue: undefined,
+      },
+      {
         propertyName: "widthScale",
         defaultValue: undefined,
       },
@@ -127,6 +131,49 @@ describe("calcite-panel", () => {
     expect(await element.getProperty("closed")).toBe(true);
 
     expect(await container.isVisible()).toBe(false);
+  });
+
+  it("should handle rejected 'beforeClose' promise'", async () => {
+    const page = await newE2EPage();
+
+    const mockCallBack = jest.fn().mockReturnValue(() => Promise.reject());
+    await page.exposeFunction("beforeClose", mockCallBack);
+
+    await page.setContent(`<calcite-panel closable></calcite-panel>`);
+
+    await page.$eval(
+      "calcite-panel",
+      (el: HTMLCalcitePanelElement) =>
+        (el.beforeClose = (window as typeof window & Pick<typeof el, "beforeClose">).beforeClose),
+    );
+    await page.waitForChanges();
+
+    const panel = await page.find("calcite-panel");
+    expect(await panel.getProperty("closed")).toBe(false);
+    panel.setProperty("closed", true);
+    await page.waitForChanges();
+
+    expect(mockCallBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("should remain open with rejected 'beforeClose' promise'", async () => {
+    const page = await newE2EPage();
+
+    await page.exposeFunction("beforeClose", () => Promise.reject());
+    await page.setContent(`<calcite-panel closable></calcite-panel>`);
+
+    await page.$eval(
+      "calcite-panel",
+      (el: HTMLCalcitePanelElement) =>
+        (el.beforeClose = (window as typeof window & Pick<typeof el, "beforeClose">).beforeClose),
+    );
+
+    const panel = await page.find("calcite-panel");
+    panel.setProperty("closed", true);
+    await page.waitForChanges();
+
+    expect(await panel.getProperty("closed")).toBe(false);
+    expect(panel.getAttribute("closed")).toBe(null); // Makes sure attribute is added back
   });
 
   it("honors collapsed & collapsible properties", async () => {

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -85,7 +85,7 @@ export class Panel
 
   @Watch("closed")
   toggleDialog(value: boolean): void {
-    value ? this.close() : (this.isClosed = false);
+    value ? this.close() : this.open();
   }
 
   /**
@@ -308,6 +308,10 @@ export class Panel
     this.calcitePanelClose.emit();
   };
 
+  open = (): void => {
+    this.isClosed = false;
+  };
+
   close = async (): Promise<void> => {
     const beforeClose = this.beforeClose ?? (() => Promise.resolve());
 
@@ -321,7 +325,6 @@ export class Panel
       return;
     }
 
-    this.closed = true;
     this.isClosed = true;
   };
 


### PR DESCRIPTION
**Related Issue:** #9769

## Summary

- adds `beforeClose` property to `panel` and `flow-item`
- allows close to be prevented via a function returning a promise that could be rejected
- adds tests