### PR TITLE
feat(combobox, combobox-item): add `description`, `shortHeading` props and `content-end` slot

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1409,13 +1409,13 @@ export namespace Components {
     SelectionMode
   >;
         /**
+          * The component's short heading.  When provided, the short heading will be displayed in the component's selection.  It is recommended to use 5 characters or fewer.
+         */
+        "shortHeading": string;
+        /**
           * The component's text.
          */
         "textLabel": string;
-        /**
-          * The component's short label.  When provided, the short label will be displayed in the component's selection.  It is recommended to use 5 chars or less.
-         */
-        "textLabelShort": string;
         /**
           * The component's value.
          */
@@ -9256,13 +9256,13 @@ declare namespace LocalJSX {
     SelectionMode
   >;
         /**
+          * The component's short heading.  When provided, the short heading will be displayed in the component's selection.  It is recommended to use 5 characters or fewer.
+         */
+        "shortHeading"?: string;
+        /**
           * The component's text.
          */
         "textLabel": string;
-        /**
-          * The component's short label.  When provided, the short label will be displayed in the component's selection.  It is recommended to use 5 chars or less.
-         */
-        "textLabelShort"?: string;
         /**
           * The component's value.
          */

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1366,6 +1366,10 @@ export namespace Components {
          */
         "ancestors": ComboboxChildElement[];
         /**
+          * A description for the component, which displays below the label.
+         */
+        "description": string;
+        /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled": boolean;
@@ -1408,6 +1412,10 @@ export namespace Components {
           * The component's text.
          */
         "textLabel": string;
+        /**
+          * The component's short label.  When provided, the short label will be displayed in the component's selection.  It is recommended to use 5 chars or less.
+         */
+        "textLabelShort": string;
         /**
           * The component's value.
          */
@@ -9201,6 +9209,10 @@ declare namespace LocalJSX {
          */
         "ancestors"?: ComboboxChildElement[];
         /**
+          * A description for the component, which displays below the label.
+         */
+        "description"?: string;
+        /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
          */
         "disabled"?: boolean;
@@ -9247,6 +9259,10 @@ declare namespace LocalJSX {
           * The component's text.
          */
         "textLabel": string;
+        /**
+          * The component's short label.  When provided, the short label will be displayed in the component's selection.  It is recommended to use 5 chars or less.
+         */
+        "textLabelShort"?: string;
         /**
           * The component's value.
          */

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -6,6 +6,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-combobox-item-spacing-indent: theme("spacing.2");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
+  --calcite-combobox-item-description-font-size: var(--calcite-font-size--3);
 }
 
 .scale--m {
@@ -48,20 +49,22 @@ ul:focus {
 
 .label {
   @apply text-color-3
-    focus-base
-    relative
-    box-border
-    flex
-    w-full
-    min-w-full
-    cursor-pointer
-    items-center
-    no-underline
-    duration-150
-    ease-in-out;
+  focus-base
+  relative
+  box-border
+  flex
+  w-full
+  min-w-full
+  cursor-pointer
+  items-center
+  no-underline
+  duration-150
+  ease-in-out;
   @include word-break();
   padding-block: var(--calcite-combobox-item-spacing-unit-s);
   padding-inline: var(--calcite-combobox-item-spacing-unit-l);
+  justify-content: space-around;
+  gap: var(--calcite-combobox-item-spacing-unit-l);
 }
 
 :host([disabled]) .label {
@@ -85,11 +88,6 @@ ul:focus {
     shadow-none;
 }
 
-.title {
-  padding-block: 0;
-  padding-inline: var(--calcite-combobox-item-spacing-unit-l);
-}
-
 .icon {
   @apply inline-flex
     opacity-0
@@ -104,7 +102,6 @@ ul:focus {
 
 .icon--custom {
   margin-block-start: -1px;
-  padding-inline-start: var(--calcite-combobox-item-spacing-unit-l);
   @apply text-color-3;
 }
 
@@ -139,4 +136,26 @@ ul:focus {
   font-weight: var(--calcite-font-weight-bold);
   color: var(--calcite-color-text-1);
   background-color: var(--calcite-color-foreground-current);
+}
+
+.center-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding-block: 0;
+}
+
+.description {
+  font-size: var(--calcite-combobox-item-description-font-size);
+}
+
+:host([selected]),
+:host(:hover) {
+  .description {
+    color: var(--calcite-color-text-2);
+  }
+}
+
+.short-text {
+  color: var(--calcite-color-text-3);
 }

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -6,7 +6,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-combobox-item-spacing-indent: theme("spacing.2");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
-  --calcite-combobox-item-description-font-size: var(--calcite-font-size--3);
+  --calcite-combobox-item-description-font-size: var(--calcite-font-size-xs);
 }
 
 .scale--m {
@@ -15,6 +15,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing.2");
   --calcite-combobox-item-spacing-indent: theme("spacing.3");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
+  --calcite-combobox-item-description-font-size: var(--calcite-font-size-sm);
 }
 
 .scale--l {
@@ -23,6 +24,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing[2.5]");
   --calcite-combobox-item-spacing-indent: theme("spacing.4");
   --calcite-combobox-item-selector-icon-size: theme("spacing.6");
+  --calcite-combobox-item-description-font-size: var(--calcite-font-size);
 }
 
 .container {
@@ -143,6 +145,7 @@ ul:focus {
 
 .description {
   font-size: var(--calcite-combobox-item-description-font-size);
+  font-weight: var(--calcite-font-weight-normal);
 }
 
 :host([selected]),

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -61,10 +61,10 @@ ul:focus {
   duration-150
   ease-in-out;
   @include word-break();
-  padding-block: var(--calcite-combobox-item-spacing-unit-s);
-  padding-inline: var(--calcite-combobox-item-spacing-unit-l);
   justify-content: space-around;
   gap: var(--calcite-combobox-item-spacing-unit-l);
+  padding-block: var(--calcite-combobox-item-spacing-unit-s);
+  padding-inline: var(--calcite-combobox-item-indent-value);
 }
 
 :host([disabled]) .label {
@@ -94,10 +94,6 @@ ul:focus {
     duration-150
     ease-in-out;
   color: theme("borderColor.color.1");
-}
-
-.icon--indent {
-  padding-inline-start: var(--calcite-combobox-item-indent-value);
 }
 
 .icon--custom {

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -279,9 +279,13 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
               {this.renderIcon(iconPath)}
               <div class={CSS.centerContent}>
                 <div class={CSS.title}>{this.renderTextContent(this.textLabel)}</div>
-                <div class={CSS.description}>{this.renderTextContent(this.description)}</div>
+                {this.description ? (
+                  <div class={CSS.description}>{this.renderTextContent(this.description)}</div>
+                ) : null}
               </div>
-              <div class={CSS.shortText}>{this.renderTextContent(this.textLabelShort)}</div>
+              {this.textLabelShort ? (
+                <div class={CSS.shortText}>{this.renderTextContent(this.textLabelShort)}</div>
+              ) : null}
               <slot name={SLOTS.contentEnd} />
             </li>
             {this.renderChildren()}

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -204,7 +204,6 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
         class={{
           [CSS.custom]: !!this.icon,
           [CSS.iconActive]: this.icon && this.selected,
-          [CSS.iconIndent]: true,
         }}
         flipRtl={this.iconFlipRtl}
         icon={this.icon || iconPath}
@@ -222,7 +221,6 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
         class={{
           [CSS.icon]: true,
           [CSS.dot]: true,
-          [CSS.iconIndent]: true,
         }}
       />
     ) : (
@@ -230,7 +228,6 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
         class={{
           [CSS.icon]: true,
           [CSS.iconActive]: this.selected,
-          [CSS.iconIndent]: true,
         }}
         flipRtl={this.iconFlipRtl}
         icon={iconPath}
@@ -265,13 +262,16 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
       [CSS.active]: this.active,
       [CSS.single]: isSingleSelect,
     };
-    const depth = getDepth(this.el);
+    const depth = getDepth(this.el) + 1;
 
     return (
       <Host aria-hidden="true">
         <InteractiveContainer disabled={disabled}>
           <div
-            class={`container scale--${this.scale}`}
+            class={{
+              [CSS.container]: true,
+              [CSS.scale(this.scale)]: true,
+            }}
             style={{ "--calcite-combobox-item-spacing-indent-multiplier": `${depth}` }}
           >
             <li class={classes} id={this.guid} onClick={this.itemClickHandler}>

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -83,28 +83,23 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   @Prop({ reflect: true }) textLabel!: string;
 
   /**
-   * The component's short label.
-   *
-   * When provided, the short label will be displayed in the component's selection.
-   *
-   * It is recommended to use 5 chars or less.
-   */
-  @Prop({ reflect: true }) textLabelShort: string;
-
-  /**
    * Pattern for highlighting filter text matches.
    *
    * @internal
    */
   @Prop({ reflect: true }) filterTextMatchPattern: RegExp;
 
-  /** The component's value. */
-  @Prop() value!: any;
-
   /**
    * When `true`, omits the component from the `calcite-combobox` filtered search results.
    */
   @Prop({ reflect: true }) filterDisabled: boolean;
+
+  /**
+   * Specifies the size of the component inherited from the `calcite-combobox`, defaults to `m`.
+   *
+   * @internal
+   */
+  @Prop() scale: Scale = "m";
 
   /**
    * Specifies the selection mode of the component, where:
@@ -125,11 +120,16 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   > = "multiple";
 
   /**
-   * Specifies the size of the component inherited from the `calcite-combobox`, defaults to `m`.
+   * The component's short heading.
    *
-   * @internal
+   * When provided, the short heading will be displayed in the component's selection.
+   *
+   * It is recommended to use 5 characters or fewer.
    */
-  @Prop() scale: Scale = "m";
+  @Prop({ reflect: true }) shortHeading: string;
+
+  /** The component's value. */
+  @Prop() value!: any;
 
   // --------------------------------------------------------------------------
   //
@@ -283,8 +283,8 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
                   <div class={CSS.description}>{this.renderTextContent(this.description)}</div>
                 ) : null}
               </div>
-              {this.textLabelShort ? (
-                <div class={CSS.shortText}>{this.renderTextContent(this.textLabelShort)}</div>
+              {this.shortHeading ? (
+                <div class={CSS.shortText}>{this.renderTextContent(this.shortHeading)}</div>
               ) : null}
               <slot name={SLOTS.contentEnd} />
             </li>

--- a/packages/calcite-components/src/components/combobox-item/resources.ts
+++ b/packages/calcite-components/src/components/combobox-item/resources.ts
@@ -1,14 +1,17 @@
+import { Scale } from "../interfaces";
+
 export const CSS = {
   active: "label--active",
   centerContent: "center-content",
+  container: "container",
   custom: "icon--custom",
   description: "description",
   dot: "icon--dot",
   filterMatch: "filter-match",
   icon: "icon",
   iconActive: "icon--active",
-  iconIndent: "icon--indent",
   label: "label",
+  scale: (scale: Scale) => `scale--${scale}` as const,
   selected: "label--selected",
   shortText: "short-text",
   single: "label--single",

--- a/packages/calcite-components/src/components/combobox-item/resources.ts
+++ b/packages/calcite-components/src/components/combobox-item/resources.ts
@@ -1,14 +1,21 @@
 export const CSS = {
+  active: "label--active",
+  centerContent: "center-content",
+  custom: "icon--custom",
+  description: "description",
+  dot: "icon--dot",
+  filterMatch: "filter-match",
   icon: "icon",
   iconActive: "icon--active",
   iconIndent: "icon--indent",
-  custom: "icon--custom",
-  dot: "icon--dot",
-  single: "label--single",
   label: "label",
-  active: "label--active",
   selected: "label--selected",
-  title: "title",
+  shortText: "short-text",
+  single: "label--single",
   textContainer: "text-container",
-  filterMatch: "filter-match",
+  title: "title",
+};
+
+export const SLOTS = {
+  contentEnd: "content-end",
 };

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -888,7 +888,7 @@ export const filterHighlighting = (): string => html`
         value="Black Eyed Susan"
         description="The Black Eyed Susan is a yellow flower with a dark center."
         text-label="Black Eyed Susan"
-        text-label-short="Susan"
+        short-heading="Susan"
       ></calcite-combobox-item>
       <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
     </calcite-combobox-item>
@@ -905,27 +905,27 @@ export const filterHighlighting = (): string => html`
 
 export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
   <calcite-combobox-item
-    value="one"
-    text-label="1ne"
-    selected
-    text-label-short="#1"
     description="the first installment in this thrilling series"
+    selected
+    short-heading="#1"
+    text-label="1ne"
+    value="one"
   >
     <calcite-icon icon="number-circle-1" slot="content-end"></calcite-icon>
   </calcite-combobox-item>
   <calcite-combobox-item
-    value="two"
-    text-label="2woo"
-    text-label-short="#2"
     description="the sequel to the smash hit 'one'"
+    short-heading="#2"
+    text-label="2woo"
+    value="two"
   >
     <calcite-icon icon="number-circle-2" slot="content-end"></calcite-icon>
   </calcite-combobox-item>
   <calcite-combobox-item
-    value="three"
-    text-label="Thr333"
-    text-label-short="#3"
     description="the thrilling conclusion to the number series"
+    short-heading="#3"
+    text-label="Thr333"
+    value="three"
   >
     <calcite-icon icon="number-circle-3" slot="content-end"></calcite-icon>
   </calcite-combobox-item>

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -1,5 +1,66 @@
 import { modesDarkDefault } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
+import type { Scale } from "../interfaces";
+import type { Combobox } from "./combobox";
+
+/**
+ * This decorator takes HTML for items and will create a composite story for all scales for each specified selection mode.
+ *
+ * @param itemsStory - the HTML story template for items
+ * @param context - the context object
+ * @param context.args - the args object
+ * @param context.args.selectionMode - the selection mode(s) to use for the combobox
+ *
+ * @returns the composite story for all scales for each specified selection mode
+ */
+function allScaleComboboxBuilder(
+  itemsStory: () => string,
+  context: { args: { selectionMode: Combobox["selectionMode"] | Combobox["selectionMode"][] } },
+): string {
+  const items = itemsStory();
+  const { selectionMode } = context.args;
+  const selectionModes = Array.isArray(selectionMode) ? selectionMode : [selectionMode];
+  const scales: Scale[] = ["s", "m", "l"];
+
+  return html`
+    <style>
+      calcite-combobox {
+        margin-bottom: 250px;
+      }
+      .selection-mode-group {
+        display: flex;
+        justify-content: space-between;
+      }
+      .combobox-container {
+        flex: 1;
+        margin-right: 10px;
+      }
+    </style>
+
+    ${selectionModes.map(
+      (selectionMode) => html`
+        <div class="selection-mode-group">
+          ${scales.map(
+            (scale) => html`
+              <div class="combobox-container">
+                <h3>${selectionMode} selection mode + ${scale} scale</h3>
+                <calcite-combobox
+                  placeholder="select element"
+                  max-items="6"
+                  selection-mode="${selectionMode}"
+                  open
+                  scale="${scale}"
+                >
+                  ${items}
+                </calcite-combobox>
+              </div>
+            `,
+          )}
+        </div>
+      `,
+    )}
+  `;
+}
 
 export default {
   title: "Components/Controls/Combobox",
@@ -836,3 +897,35 @@ export const filterHighlighting = (): string => html`
     <calcite-combobox-item value="Rivers" text-label="Rivers"></calcite-combobox-item>
   </calcite-combobox>
 `;
+
+export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
+  <calcite-combobox-item
+    value="one"
+    text-label="1ne"
+    selected
+    text-label-short="#1"
+    description="the first installment in this thrilling series"
+  >
+    <calcite-icon icon="number-circle-1" slot="content-end"></calcite-icon>
+  </calcite-combobox-item>
+  <calcite-combobox-item
+    value="two"
+    text-label="2woo"
+    text-label-short="#2"
+    description="the sequel to the smash hit 'one'"
+  >
+    <calcite-icon icon="number-circle-2" slot="content-end"></calcite-icon>
+  </calcite-combobox-item>
+  <calcite-combobox-item
+    value="three"
+    text-label="Thr333"
+    text-label-short="#3"
+    description="the thrilling conclusion to the number series"
+  >
+    <calcite-icon icon="number-circle-3" slot="content-end"></calcite-icon>
+  </calcite-combobox-item>
+`;
+withDescriptionShortLabelAndContentEndSlot.decorators = [allScaleComboboxBuilder];
+withDescriptionShortLabelAndContentEndSlot.args = {
+  selectionMode: ["single", "multiple"],
+};

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -884,7 +884,12 @@ export const filterHighlighting = (): string => html`
     </calcite-combobox-item>
     <calcite-combobox-item value="Flowers" text-label="Flowers">
       <calcite-combobox-item value="Daffodil" text-label="Daffodil"></calcite-combobox-item>
-      <calcite-combobox-item value="Black Eyed Susan" text-label="Black Eyed Susan"></calcite-combobox-item>
+      <calcite-combobox-item
+        value="Black Eyed Susan"
+        description="The Black Eyed Susan is a yellow flower with a dark center."
+        text-label="Black Eyed Susan"
+        text-label-short="Susan"
+      ></calcite-combobox-item>
       <calcite-combobox-item value="Nasturtium" text-label="Nasturtium"></calcite-combobox-item>
     </calcite-combobox-item>
     <calcite-combobox-item value="Animals" text-label="Animals">

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -81,7 +81,7 @@ import {
 
 interface ItemData {
   label: string;
-  labelShort: string;
+  shortHeading: string;
   description: string;
   value: string;
 }
@@ -1253,7 +1253,7 @@ export class Combobox
       description: item.description,
       filterDisabled: item.filterDisabled,
       label: item.textLabel,
-      labelShort: item.textLabelShort,
+      shortHeading: item.shortHeading,
       value: item.value,
     }));
   }

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -71,10 +71,18 @@ import { IconName } from "../icon/interfaces";
 import { ComboboxMessages } from "./assets/combobox/t9n";
 import { ComboboxChildElement, SelectionDisplay } from "./interfaces";
 import { ComboboxChildSelector, ComboboxItem, ComboboxItemGroup, CSS } from "./resources";
-import { getItemAncestors, getItemChildren, hasActiveChildren, isSingleLike } from "./utils";
+import {
+  getItemAncestors,
+  getItemChildren,
+  getLabel,
+  hasActiveChildren,
+  isSingleLike,
+} from "./utils";
 
 interface ItemData {
   label: string;
+  labelShort: string;
+  description: string;
   value: string;
 }
 
@@ -577,7 +585,7 @@ export class Combobox
 
   textInput: HTMLInputElement = null;
 
-  data: ItemData[];
+  private data: ItemData[];
 
   mutationObserver = createObserver("mutation", () => this.updateItems());
 
@@ -1153,7 +1161,7 @@ export class Combobox
       this.emitComboboxChange();
 
       if (this.textInput) {
-        this.textInput.value = item.textLabel;
+        this.textInput.value = getLabel(item);
       }
       this.open = false;
       this.updateActiveItemIndex(-1);
@@ -1242,9 +1250,11 @@ export class Combobox
 
   getData(): ItemData[] {
     return this.items.map((item) => ({
+      description: item.description,
       filterDisabled: item.filterDisabled,
-      value: item.value,
       label: item.textLabel,
+      labelShort: item.textLabelShort,
+      value: item.value,
     }));
   }
 
@@ -1404,8 +1414,9 @@ export class Combobox
         "chip--active": activeChipIndex === i,
       };
       const ancestors = [...getItemAncestors(item)].reverse();
-      const pathLabel = [...ancestors, item].map((el) => el.textLabel);
-      const label = selectionMode !== "ancestors" ? item.textLabel : pathLabel.join(" / ");
+      const itemLabel = getLabel(item);
+      const pathLabel = [...ancestors, item].map((el) => getLabel(el));
+      const label = selectionMode !== "ancestors" ? itemLabel : pathLabel.join(" / ");
 
       return (
         <calcite-chip
@@ -1416,7 +1427,7 @@ export class Combobox
           icon={item.icon}
           iconFlipRtl={item.iconFlipRtl}
           id={item.guid ? `${chipUidPrefix}${item.guid}` : null}
-          key={item.textLabel}
+          key={itemLabel}
           messageOverrides={{ dismissLabel: messages.removeTag }}
           onCalciteChipClose={() => this.calciteChipCloseHandler(item)}
           onFocusin={() => (this.activeChipIndex = i)}
@@ -1607,7 +1618,7 @@ export class Combobox
             }}
             key="label"
           >
-            {selectedItem.textLabel}
+            {getLabel(selectedItem)}
           </span>
         )}
         <input

--- a/packages/calcite-components/src/components/combobox/utils.ts
+++ b/packages/calcite-components/src/components/combobox/utils.ts
@@ -44,3 +44,7 @@ export function getDepth(element: HTMLElement): number {
 export function isSingleLike(selectionMode: Combobox["selectionMode"]): boolean {
   return selectionMode.includes("single");
 }
+
+export function getLabel(item: HTMLCalciteComboboxItemElement): string {
+  return item.textLabelShort || item.textLabel;
+}

--- a/packages/calcite-components/src/components/combobox/utils.ts
+++ b/packages/calcite-components/src/components/combobox/utils.ts
@@ -46,5 +46,5 @@ export function isSingleLike(selectionMode: Combobox["selectionMode"]): boolean 
 }
 
 export function getLabel(item: HTMLCalciteComboboxItemElement): string {
-  return item.textLabelShort || item.textLabel;
+  return item.shortHeading || item.textLabel;
 }


### PR DESCRIPTION
**Related Issue:** #3695

## Summary

This adds the following enhancements to `combobox`/`combobox-item`:

* `description` prop - displays description below label
* `shortHeading` prop - displays short version of the heading (label) in selection
* `content-end` slot - enables slotting non-interactive elements after the item's content

**Note**: the new props are filterable and also participate in visual matching

