### PR TITLE
fix(tile): center align slot's text when alignment is equal to center

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -103,6 +103,9 @@
   .icon {
     align-self: center;
   }
+  .text-content-container {
+    justify-content: center;
+  }
   .text-content {
     text-align: center;
   }


### PR DESCRIPTION
**Related Issue:** [#9540](https://github.com/Esri/calcite-design-system/issues/9540)

## Summary
updates the `tile` component to center align the slot's text when the alignment prop is equal to "center"
