### PR TITLE
chore: token jam session cleanup

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -1012,6 +1012,7 @@ describe("calcite-input-time-picker", () => {
       };
       themed(`calcite-input-time-picker`, tokens);
     });
+
     describe("popover", () => {
       const tokens: ComponentTestTokens = {
         "--calcite-input-popover-border-color": {
@@ -1023,8 +1024,8 @@ describe("calcite-input-time-picker", () => {
           targetProp: "--calcite-popover-shadow",
         },
         "--calcite-input-time-picker-background-color-hover": {
-          shadowSelector: "calcite-popover",
-          targetProp: "--calcite-popover-border-color",
+          shadowSelector: "calcite-time-picker",
+          targetProp: "--calcite-time-picker-background-color-hover",
           state: "hover",
         },
         "--calcite-input-time-picker-background-color": [

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -3,28 +3,29 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-input-background-color: defines the background color of the component.
- * @prop --calcite-input-border-color: defines the border color of the component.
- * @prop --calcite-input-button-background-color-hover: defines the background color of a button in the component when it's hovered.
- * @prop --calcite-input-button-background-color: defines the background color of a button in the component.
- * @prop --calcite-input-button-border-color: defines the border color of a button in the component.
- * @prop --calcite-input-button-icon-color-active: defines the icon color of a button in the component when it's active.
- * @prop --calcite-input-button-icon-color-hover: defines the icon color of a button in the component when it's hovered.
- * @prop --calcite-input-button-icon-color: defines the icon color of a button in the component.
- * @prop --calcite-input-corner-radius: defines the corner radius of the component.
- * @prop --calcite-input-icon-color:  defines the icon color of the component.
- * @prop --calcite-input-popover-border-color: defines the border color of the popover sub component.
- * @prop --calcite-input-text-color: defines the text color of the component.
- * @prop --calcite-input-time-picker-background-color-active: defines the background color of the time picker sub component when active.
- * @prop --calcite-input-time-picker-background-color-hover: defines the background color of the time picker sub component when hovered.
- * @prop --calcite-input-time-picker-background-color: defines the background color of the time picker sub component.
- * @prop --calcite-input-time-picker-shadow-focus: defines the box shadow around the numbers inside the open component when focused.
- * @prop --calcite-input-time-picker-shadow: defines the box shadow around the numbers inside the open component.
- * @prop --calcite-input-time-picker-icon-color: defines the icon color of the time picker sub component.
- * @prop --calcite-input-time-picker-text-color: defines the text color of the time picker sub component.
+ * @prop --calcite-input-background-color: Specifies the background color of the component.
+ * @prop --calcite-input-border-color: Specifies the border color of the component.
+ * @prop --calcite-input-button-background-color-hover: Specifies the background color of a button in the component when it's hovered.
+ * @prop --calcite-input-button-background-color: Specifies the background color of a button in the component.
+ * @prop --calcite-input-button-border-color: Specifies the border color of a button in the component.
+ * @prop --calcite-input-button-icon-color-active: Specifies the icon color of a button in the component when it's active.
+ * @prop --calcite-input-button-icon-color-hover: Specifies the icon color of a button in the component when it's hovered.
+ * @prop --calcite-input-button-icon-color: Specifies the icon color of a button in the component.
+ * @prop --calcite-input-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-input-icon-color:  Specifies the icon color of the component.
+ * @prop --calcite-input-popover-border-color: Specifies the border color of the popover sub-component.
+ * @prop --calcite-input-popover-shadow: Specifies the shadow of the popover sub-component.
+ * @prop --calcite-input-text-color: Specifies the text color of the component.
+ * @prop --calcite-input-time-picker-background-color-active: Specifies the background color of the time picker sub-component when active.
+ * @prop --calcite-input-time-picker-background-color-hover: Specifies the background color of the time picker sub-component when hovered.
+ * @prop --calcite-input-time-picker-background-color: Specifies the background color of the time picker sub-component.
+ * @prop --calcite-input-time-picker-shadow-focus: Specifies the box shadow around the numbers inside the open component when focused.
+ * @prop --calcite-input-time-picker-shadow: Specifies the box shadow around the numbers inside the open component.
+ * @prop --calcite-input-time-picker-icon-color: Specifies the icon color of the time picker sub-component.
+ * @prop --calcite-input-time-picker-text-color: Specifies the text color of the time picker sub-component.
  * @prop --calcite-input-time-picker-toggle-icon-color-hover: Specifies the icon color of the toggle when hovered.
  * @prop --calcite-input-time-picker-toggle-icon-color: Specifies the icon color of the toggle.
- * @prop --calcite-input-shadow: defines the shadow of the component.
+ * @prop --calcite-input-shadow: Specifies the shadow of the component.
  *
  */
 

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -590,7 +590,7 @@ describe("calcite-input-time-zone", () => {
         },
         "--calcite-input-combobox-item-background-color-active": {
           shadowSelector: "calcite-combobox-item",
-          targetProp: "--calcite-input-combobox-item-background-color-active",
+          targetProp: "--calcite-combobox-item-background-color-active",
         },
         "--calcite-input-combobox-item-background-color": {
           shadowSelector: "calcite-combobox-item",
@@ -614,11 +614,11 @@ describe("calcite-input-time-zone", () => {
         },
         "--calcite-input-combobox-item-text-color-active": {
           shadowSelector: "calcite-combobox-item",
-          targetProp: "--calcite-input-combobox-item-text-color-active",
+          targetProp: "--calcite-combobox-item-text-color-active",
         },
         "--calcite-input-combobox-item-text-color": {
           shadowSelector: "calcite-combobox-item",
-          targetProp: "--calcite-input-combobox-item-text-color",
+          targetProp: "--calcite-combobox-item-text-color",
         },
       };
 

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.scss
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.scss
@@ -1,17 +1,17 @@
 /**
  *
- * @prop --calcite-input-combobox-border-color: defines the border color of the combobox sub-component.
- * @prop --calcite-input-combobox-background-color: defines the background color of the combobox sub-component.
- * @prop --calcite-input-combobox-text-color: defines the text color of the combobox sub-component.
- * @prop --calcite-input-combobox-chip-background-color-active: defines the color of a chip in the comobox sub-component when active.
- * @prop --calcite-input-combobox-item-background-color-active: defines the background color of a combobox-item sub-component when active.
- * @prop --calcite-input-combobox-item-background-color: defines the background color of a combobox-item sub-component.
- * @prop --calcite-input-combobox-item-icon-color: defines the icon color of a combobox-item sub-component.
- * @prop --calcite-input-combobox-item-indicator-icon-color-active: defines the indicator color of a combobox-item sub-component when active.
- * @prop --calcite-input-combobox-item-indicator-icon-color: defines the indicator color of a combobox-item sub-component.
- * @prop --calcite-input-combobox-item-shadow: defines the shadow of a combobox-item sub-component.
- * @prop --calcite-input-combobox-item-text-color-active: defines the text color of a combobox-item sub-component when active.
- * @prop --calcite-input-combobox-item-text-color: defines the text color of a combobox-item sub-component.
+ * @prop --calcite-input-combobox-border-color: Specifies the border color of the combobox sub-component.
+ * @prop --calcite-input-combobox-background-color: Specifies the background color of the combobox sub-component.
+ * @prop --calcite-input-combobox-text-color: Specifies the text color of the combobox sub-component.
+ * @prop --calcite-input-combobox-chip-background-color-active: Specifies the color of a chip in the comobox sub-component when active.
+ * @prop --calcite-input-combobox-item-background-color-active: Specifies the background color of a combobox-item sub-component when active.
+ * @prop --calcite-input-combobox-item-background-color: Specifies the background color of a combobox-item sub-component.
+ * @prop --calcite-input-combobox-item-icon-color: Specifies the icon color of a combobox-item sub-component.
+ * @prop --calcite-input-combobox-item-indicator-icon-color-active: Specifies the indicator color of a combobox-item sub-component when active.
+ * @prop --calcite-input-combobox-item-indicator-icon-color: Specifies the indicator color of a combobox-item sub-component.
+ * @prop --calcite-input-combobox-item-shadow: Specifies the shadow of a combobox-item sub-component.
+ * @prop --calcite-input-combobox-item-text-color-active: Specifies the text color of a combobox-item sub-component when active.
+ * @prop --calcite-input-combobox-item-text-color: Specifies the text color of a combobox-item sub-component.
  *
  */
 

--- a/packages/calcite-components/src/components/label/label.scss
+++ b/packages/calcite-components/src/components/label/label.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-label-margin-bottom: **[Deprecated]** Use `--calcite-label-space-y-end` -  The spacing below the component.
+ * @prop --calcite-label-margin-bottom: **[Deprecated]** Use `--calcite-label-space-y-end` -  Specifies the spacing below the component.
  * @prop --calcite-label-space-y-end: Specifies the space below the component.
  * @prop --calcite-label-text-color: Specifies the text color of the component.
  */

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -1,18 +1,19 @@
 /*
  *
- * --calcite-list-item-background-color-active: Specifies the background color of the component when active.
- * --calcite-list-item-background-color-hover: Specifies the background color of the component when hovered.
- * --calcite-list-item-background-color: Specifies the background color of the component.
- * --calcite-list-item-border-color: Specifies the border color of nested items.
- * --calcite-list-item-description-text-color-selected: Specifies the text color of the description when selected.
- * --calcite-list-item-description-text-color: Specifies the text color of the description.
- * --calcite-list-item-indicator-color-hover: Specifies the color of the nested container or selector icon when the component is hovered.
- * --calcite-list-item-indicator-color-selected: Specifies the color of the nested container or selector icon when the component is selected.
- * --calcite-list-item-indicator-color: Specifies the default color of the nested container or selector icon.   
- * --calcite-list-item-label-text-color: Specifies the text color of the label.
- * --calcite-list-item-nested-text-color-hover: Specifies the text color of nested items when hovered.
- * --calcite-list-item-nested-text-color: Specifies the text color of nested items.
- * --calcite-list-item-spacing-indent: Specifies the indented spacing of nested items.
+ * @prop --calcite-list-text-color: Specifies the component text color.
+ * @prop --calcite-list-item-background-color-active: Specifies the background color of the component when active.
+ * @prop --calcite-list-item-background-color-hover: Specifies the background color of the component when hovered.
+ * @prop --calcite-list-item-background-color: Specifies the background color of the component.
+ * @prop --calcite-list-item-border-color: Specifies the border color of nested items.
+ * @prop --calcite-list-item-description-text-color-selected: Specifies the text color of the description when selected.
+ * @prop --calcite-list-item-description-text-color: Specifies the text color of the description.
+ * @prop --calcite-list-item-indicator-color-hover: Specifies the color of the nested container or selector icon when the component is hovered.
+ * @prop --calcite-list-item-indicator-color-selected: Specifies the color of the nested container or selector icon when the component is selected.
+ * @prop --calcite-list-item-indicator-color: Specifies the default color of the nested container or selector icon.
+ * @prop --calcite-list-item-label-text-color: Specifies the text color of the label.
+ * @prop --calcite-list-item-nested-text-color-hover: Specifies the text color of nested items when hovered.
+ * @prop --calcite-list-item-nested-text-color: Specifies the text color of nested items.
+ * @prop --calcite-list-item-spacing-indent: Specifies the indented spacing of nested items.
 */
 
 :host {

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -3,14 +3,14 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-loader-color:  defines the color of the component.
- * @prop --calcite-loader-font-size: Specifies the font size of the loading percentage when type is `"determinate"`.
+ * @prop --calcite-loader-color: Specifies the color of the component.
+ * @prop --calcite-loader-font-size: Specifies the font size of the loading percentage when type is "determinate".
  * @prop --calcite-loader-padding: [Deprecated] Use --calcite-loader-space instead. Specifies the padding of the loader.
  * @prop --calcite-loader-space: Specifies the padding of the loader.
- * @prop --calcite-loader-size-inline: [Deprecated] Use --calcite-loader-size. The width and height of an inline loader.
- * @prop --calcite-loader-size: The width and height of a loader.
- * @prop --calcite-loader-text-color: defines the text color of a loader.
- * @prop --calcite-loader-track-color-determinate: defines the track color of a "determinate" loader
+ * @prop --calcite-loader-size-inline: [Deprecated] Use --calcite-loader-size. Specifies the width and height of an inline loader.
+ * @prop --calcite-loader-size: Specifies the width and height of a loader.
+ * @prop --calcite-loader-text-color: Specifies the text color of a loader.
+ * @prop --calcite-loader-track-color-determinate: Specifies the track color of a "determinate" loader.
  *
  */
 @import "../../assets/styles/animation";

--- a/packages/calcite-components/src/components/menu-item/menu-item.e2e.ts
+++ b/packages/calcite-components/src/components/menu-item/menu-item.e2e.ts
@@ -153,6 +153,10 @@ describe("theme", () => {
         shadowSelector: `calcite-action`,
         targetProp: "--calcite-action-background-color",
       },
+      "--calcite-menu-item-action-text-color": {
+        shadowSelector: `calcite-action`,
+        targetProp: "--calcite-action-text-color",
+      },
       "--calcite-menu-item-sub-menu-corner-radius": {
         shadowSelector: `.dropdown--vertical`,
         targetProp: "borderRadius",

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -3,9 +3,9 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-menu-item-action-background-color-active: defines the background color of an action sub-component when active.
- * @prop --calcite-menu-item-action-background-color-hover: defines the background color of an action sub-component when hovered or focused.
- * @prop --calcite-menu-item-action-background-color: defines the background color of an action sub-component inside a menu-item.
+ * @prop --calcite-menu-item-action-background-color-active: Specifies the background color of an action sub-component when active.
+ * @prop --calcite-menu-item-action-background-color-hover: Specifies the background color of an action sub-component when hovered or focused.
+ * @prop --calcite-menu-item-action-background-color: Specifies the background color of an action sub-component inside a menu-item.
  * @prop --calcite-menu-item-action-border-color: Specifies the border inline start color of an action sub-component.
  * @prop --calcite-menu-item-action-text-color: Specifies the text color of an action sub component.
  * @prop --calcite-menu-item-background-color: Specifies the background color of the component.
@@ -175,7 +175,7 @@ calcite-action {
   --calcite-action-background-color: var(--calcite-menu-item-action-background-color);
   @apply relative h-auto;
   border-inline-start: 1px solid var(--calcite-color-foreground-1);
-  &:after {
+  &::after {
     @apply block absolute;
     content: "";
     inline-size: var(--calcite-spacing-px);
@@ -183,7 +183,7 @@ calcite-action {
     inset-block: theme("spacing.3");
     background-color: var(--calcite-menu-item-action-border-color, var(--calcite-color-border-3));
   }
-  &:hover:after {
+  &:hover::after {
     @apply h-full;
     inset-block: 0;
   }


### PR DESCRIPTION
## Summary

### Input Time Picker

- [x] The documentation is missing `--calcite-input-popover-shadow`
- [x] The shadowSelector/targetProp for the `--calcite-input-time-picker-background-color-hover` test may be incorrect, I think it should be for popover

### Input Time Zone

- [x] The targetProp for the `--calcite-input-combobox-item-background-color-active` may be incorrect

### Label

### Link

- [ ] The `--calcite-link-underline-color-start` and `--calcite-link-underline-color-end` are not tested

### List

- [x] `--calcite-list-text-color` is documented but I don't see it used in the styles

### List Item

- [x] `--calcite-list-text-color` is used in the component but not documented.
- [ ] `--calcite-list-item-nested-text-color` and `--calcite-list-item-nested-text-color-hover` are in the documentation but not used in the styles or tested

### List Item Group

LGTM

### Loader

- [ ] Missing the theme test

### Menu

LGTM

### Menu Item

- [ ] `--calcite-menu-item-action-border-color` is not tested. Also should it be [used](https://github.com/Esri/calcite-design-system/blob/ea430599daa9fb7b762de60219945853fc8ca1ef/packages/calcite-components/src/components/menu-item/menu-item.scss#L184) for `border-color` instead of `background-color`?  
- [x] `--calcite-menu-item-action-text-color` is not tested

### Meter

LGTM
