### PR TITLE
fix(block): remove top padding when no heading is defined

### DIFF
--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -194,7 +194,8 @@ calcite-action-menu {
   }
 }
 
-:host([heading]) {
+:host([heading]),
+:host([description]) {
   .header {
     padding: var(--calcite-spacing-md);
   }

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -21,7 +21,6 @@
 
 .header {
   @apply justify-start;
-  padding: var(--calcite-spacing-md);
 }
 
 .header,
@@ -192,6 +191,12 @@ calcite-action-menu {
 
   .header .title .heading {
     @apply text-color-1;
+  }
+}
+
+:host([heading]) {
+  .header {
+    padding: var(--calcite-spacing-md);
   }
 }
 


### PR DESCRIPTION
**Related Issue:** [#9753](https://github.com/Esri/calcite-design-system/issues/9753)

## Summary
Updates component to have no top padding when `heading` is not defined.
