### PR TITLE
fix(combobox-item): tweak center content font-weight and spacing

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -12,7 +12,7 @@
 .scale--m {
   @apply text-n1h;
   --calcite-combobox-item-spacing-unit-l: theme("spacing.3");
-  --calcite-combobox-item-spacing-unit-s: theme("spacing.2");
+  --calcite-combobox-item-spacing-unit-s: theme("spacing[1.5]");
   --calcite-combobox-item-spacing-indent: theme("spacing.3");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
   --calcite-combobox-item-description-font-size: var(--calcite-font-size-sm);
@@ -75,7 +75,11 @@ ul:focus {
 
 // selected state
 .label--selected {
-  @apply text-color-1 font-medium;
+  @apply text-color-1;
+
+  .title {
+    @apply font-medium;
+  }
 }
 
 .label--active {
@@ -145,7 +149,6 @@ ul:focus {
 
 .description {
   font-size: var(--calcite-combobox-item-description-font-size);
-  font-weight: var(--calcite-font-weight-normal);
 }
 
 :host([selected]),
@@ -157,4 +160,10 @@ ul:focus {
 
 .short-text {
   color: var(--calcite-color-text-3);
+}
+
+.title,
+.description,
+.short-text {
+  line-height: var(--calcite-font-line-height-relative-snug);
 }

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -66,7 +66,8 @@ ul:focus {
   justify-content: space-around;
   gap: var(--calcite-combobox-item-spacing-unit-l);
   padding-block: var(--calcite-combobox-item-spacing-unit-s);
-  padding-inline: var(--calcite-combobox-item-indent-value);
+  padding-inline: var(--calcite-combobox-item-spacing-unit-l);
+  padding-inline-start: var(--calcite-combobox-item-indent-value);
 }
 
 :host([disabled]) .label {

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -6,7 +6,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-combobox-item-spacing-indent: theme("spacing.2");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
-  --calcite-combobox-item-description-font-size: var(--calcite-font-size-xs);
+  --calcite-internal-combobox-item-description-font-size: var(--calcite-font-size-xs);
 }
 
 .scale--m {
@@ -15,7 +15,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing[1.5]");
   --calcite-combobox-item-spacing-indent: theme("spacing.3");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
-  --calcite-combobox-item-description-font-size: var(--calcite-font-size-sm);
+  --calcite-internal-combobox-item-description-font-size: var(--calcite-font-size-sm);
 }
 
 .scale--l {
@@ -24,7 +24,7 @@
   --calcite-combobox-item-spacing-unit-s: theme("spacing[2.5]");
   --calcite-combobox-item-spacing-indent: theme("spacing.4");
   --calcite-combobox-item-selector-icon-size: theme("spacing.6");
-  --calcite-combobox-item-description-font-size: var(--calcite-font-size);
+  --calcite-internal-combobox-item-description-font-size: var(--calcite-font-size);
 }
 
 .container {
@@ -148,7 +148,7 @@ ul:focus {
 }
 
 .description {
-  font-size: var(--calcite-combobox-item-description-font-size);
+  font-size: var(--calcite-internal-combobox-item-description-font-size);
 }
 
 :host([selected]),

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -161,6 +161,7 @@ ul:focus {
 
 .short-text {
   color: var(--calcite-color-text-3);
+  white-space: nowrap;
 }
 
 .title,

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -480,10 +480,8 @@ describe("calcite-combobox", () => {
   });
 
   it("should control max items displayed", async () => {
-    const page = await newE2EPage();
-
     const maxItems = 7;
-
+    const page = await newE2EPage();
     await page.setContent(`
       <calcite-combobox max-items="${maxItems}">
         <calcite-combobox-item id="item-0" value="item-0" text-label="item-0">
@@ -501,7 +499,6 @@ describe("calcite-combobox", () => {
         </calcite-combobox-item>
       </calcite-combobox>
     `);
-    await page.waitForChanges();
 
     const element = await page.find("calcite-combobox");
     await element.click();

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1044,8 +1044,8 @@ export class Combobox
 
     if (items.length > maxItems) {
       items.forEach((item) => {
-        if (itemsToProcess < maxItems && maxItems > 0) {
-          const height = this.calculateSingleItemHeight(item);
+        if (itemsToProcess < maxItems) {
+          const height = this.calculateScrollerHeight(item);
           if (height > 0) {
             maxScrollerHeight += height;
             itemsToProcess++;
@@ -1057,20 +1057,18 @@ export class Combobox
     return maxScrollerHeight;
   }
 
-  private calculateSingleItemHeight(item: ComboboxChildElement): number {
+  private calculateScrollerHeight(item: ComboboxChildElement): number {
     if (!item) {
       return;
     }
 
-    let height = item.offsetHeight;
     // if item has children items, don't count their height twice
-    const children = Array.from(item.querySelectorAll<ComboboxChildElement>(ComboboxChildSelector));
-    children
-      .map((child) => child?.offsetHeight)
-      .forEach((offsetHeight) => {
-        height -= offsetHeight;
-      });
-    return height;
+    const parentHeight = item.getBoundingClientRect().height;
+    const childrenTotalHeight = Array.from(
+      item.querySelectorAll<ComboboxChildElement>(ComboboxChildSelector),
+    ).reduce((total, child) => total + child.getBoundingClientRect().height, 0);
+
+    return parentHeight - childrenTotalHeight;
   }
 
   inputHandler = (event: Event): void => {
@@ -1351,7 +1349,7 @@ export class Combobox
       return;
     }
 
-    const height = this.calculateSingleItemHeight(activeItem);
+    const height = this.calculateScrollerHeight(activeItem);
     const { offsetHeight, scrollTop } = this.listContainerEl;
     if (offsetHeight + scrollTop < activeItem.offsetTop + height) {
       this.listContainerEl.scrollTop = activeItem.offsetTop - offsetHeight + height;


### PR DESCRIPTION
**Related Issue:** #3695 

## Summary

This fixes spacing and font-weight to follow the updated spec.

### Notes

* updates previous internal CSS prop to follow conventions (will follow suit for others in a separate PR)
* ensures selected font weight is only applied to the title/heading
* fixes trailing indent padding
* prevents wrapping of `short-heading`