### PR TITLE
build(deps): drop unnecessary @types/prettier dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@types/jsdom": "21.1.7",
         "@types/lodash-es": "4.17.12",
         "@types/node": "^20.12.7",
-        "@types/prettier": "3.0.0",
         "@types/react": "^16.7.6",
         "@types/react-dom": "^16.0.9",
         "@types/semver": "7.5.8",
@@ -7577,15 +7576,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/prettier": {
-      "version": "3.0.0",
-      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier": "*"
-      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/jsdom": "21.1.7",
     "@types/lodash-es": "4.17.12",
     "@types/node": "^20.12.7",
-    "@types/prettier": "3.0.0",
     "@types/react": "^16.7.6",
     "@types/react-dom": "^16.0.9",
     "@types/semver": "7.5.8",
@@ -135,7 +134,7 @@
   },
   "optionalDependencies": {
     "@nx/nx-darwin-arm64": "19.5.1",
-    "@nx/nx-win32-x64-msvc": "19.5.1",
-    "@nx/nx-linux-x64-gnu": "18.3.5"
+    "@nx/nx-linux-x64-gnu": "18.3.5",
+    "@nx/nx-win32-x64-msvc": "19.5.1"
   }
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

[`@types/prettier`](https://www.npmjs.com/package/@types/prettier) is deprecated and no longer needed as Prettier includes types.

