### PR TITLE
ci: add contributors action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,16 @@
+name: Update Contributors
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update-readme-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Update Contributor List
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,11 @@ This is a monorepo containing Calcite Design System packages. Please see the pac
 
 We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.md) for an overview of contribution guidelines.
 
+### Contributors
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
 ## License
 
 COPYRIGHT © 2024 Esri


### PR DESCRIPTION
**Related Issue:** #8010

## Summary

Sets up [akhilmhdh/contributors-readme-action](https://github.com/akhilmhdh/contributors-readme-action) to display contributors in the readme.
