### PR TITLE
fix(tooltip): allow focusing on a reference element and then clicking a tooltip

### DIFF
--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -140,22 +140,29 @@ export default class TooltipManager {
     this.toggleTooltip(tooltip, true);
   };
 
-  private focusInHandler = (event: FocusEvent): void => {
-    this.queryFocusedTooltip(event, true);
+  private blurHandler = (): void => {
+    this.closeActiveTooltip();
   };
 
-  private focusOutHandler = (event: FocusEvent): void => {
-    this.queryFocusedTooltip(event, false);
+  private focusInHandler = (event: FocusEvent): void => {
+    const composedPath = event.composedPath();
+    const tooltip = this.queryTooltip(composedPath);
+
+    this.closeTooltipIfNotActive(tooltip);
+
+    if (!tooltip) {
+      return;
+    }
+
+    this.toggleFocusedTooltip(tooltip, true);
   };
 
   private addShadowListeners(shadowRoot: ShadowRoot): void {
     shadowRoot.addEventListener("focusin", this.focusInHandler, { capture: true });
-    shadowRoot.addEventListener("focusout", this.focusOutHandler, { capture: true });
   }
 
   private removeShadowListeners(shadowRoot: ShadowRoot): void {
     shadowRoot.removeEventListener("focusin", this.focusInHandler, { capture: true });
-    shadowRoot.removeEventListener("focusout", this.focusOutHandler, { capture: true });
   }
 
   private addListeners(): void {
@@ -163,7 +170,7 @@ export default class TooltipManager {
     window.addEventListener("pointermove", this.pointerMoveHandler, { capture: true });
     window.addEventListener("click", this.clickHandler, { capture: true });
     window.addEventListener("focusin", this.focusInHandler, { capture: true });
-    window.addEventListener("focusout", this.focusOutHandler, { capture: true });
+    window.addEventListener("blur", this.blurHandler, { capture: true });
   }
 
   private removeListeners(): void {
@@ -171,7 +178,7 @@ export default class TooltipManager {
     window.removeEventListener("pointermove", this.pointerMoveHandler, { capture: true });
     window.removeEventListener("click", this.clickHandler, { capture: true });
     window.removeEventListener("focusin", this.focusInHandler, { capture: true });
-    window.removeEventListener("focusout", this.focusOutHandler, { capture: true });
+    window.removeEventListener("blur", this.blurHandler, { capture: true });
   }
 
   private clearHoverOpenTimeout(): void {
@@ -241,19 +248,6 @@ export default class TooltipManager {
       this.closeActiveTooltip();
     }, TOOLTIP_CLOSE_DELAY_MS);
   };
-
-  private queryFocusedTooltip(event: FocusEvent, open: boolean): void {
-    const composedPath = event.composedPath();
-    const tooltip = this.queryTooltip(composedPath);
-
-    this.closeTooltipIfNotActive(tooltip);
-
-    if (!tooltip) {
-      return;
-    }
-
-    this.toggleFocusedTooltip(tooltip, open);
-  }
 
   private registerShadowRoot(shadowRoot: ShadowRoot): void {
     const { registeredShadowRootCounts } = this;

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -140,10 +140,6 @@ export default class TooltipManager {
     this.toggleTooltip(tooltip, true);
   };
 
-  private blurHandler = (): void => {
-    this.closeActiveTooltip();
-  };
-
   private focusInHandler = (event: FocusEvent): void => {
     const composedPath = event.composedPath();
     const tooltip = this.queryTooltip(composedPath);
@@ -170,7 +166,6 @@ export default class TooltipManager {
     window.addEventListener("pointermove", this.pointerMoveHandler, { capture: true });
     window.addEventListener("click", this.clickHandler, { capture: true });
     window.addEventListener("focusin", this.focusInHandler, { capture: true });
-    window.addEventListener("blur", this.blurHandler, { capture: true });
   }
 
   private removeListeners(): void {
@@ -178,7 +173,6 @@ export default class TooltipManager {
     window.removeEventListener("pointermove", this.pointerMoveHandler, { capture: true });
     window.removeEventListener("click", this.clickHandler, { capture: true });
     window.removeEventListener("focusin", this.focusInHandler, { capture: true });
-    window.removeEventListener("blur", this.blurHandler, { capture: true });
   }
 
   private clearHoverOpenTimeout(): void {

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -143,6 +143,10 @@ export default class TooltipManager {
     this.toggleTooltip(tooltip, true);
   };
 
+  private blurHandler = (): void => {
+    this.closeActiveTooltip();
+  };
+
   private focusInHandler = (event: FocusEvent): void => {
     const composedPath = event.composedPath();
     const tooltip = this.queryTooltip(composedPath);
@@ -169,6 +173,7 @@ export default class TooltipManager {
     window.addEventListener("pointermove", this.pointerMoveHandler);
     window.addEventListener("click", this.clickHandler);
     window.addEventListener("focusin", this.focusInHandler);
+    window.addEventListener("blur", this.blurHandler);
   }
 
   private removeListeners(): void {
@@ -176,6 +181,7 @@ export default class TooltipManager {
     window.removeEventListener("pointermove", this.pointerMoveHandler);
     window.removeEventListener("click", this.clickHandler);
     window.removeEventListener("focusin", this.focusInHandler);
+    window.removeEventListener("blur", this.blurHandler);
   }
 
   private clearHoverOpenTimeout(): void {

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -1141,9 +1141,9 @@ describe("calcite-tooltip", () => {
       await page.waitForChanges();
       expect(await tooltip.getProperty("open")).toBe(true);
 
-      const other = await page.find("#other");
-      await other.click();
-      await page.waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
+      await page.$eval("#other", (el: HTMLElement) => {
+        el.dispatchEvent(new MouseEvent("click", { cancelable: true, bubbles: true }));
+      });
       await page.waitForChanges();
       expect(await tooltip.getProperty("open")).toBe(false);
     });

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -1108,4 +1108,55 @@ describe("calcite-tooltip", () => {
     expect(await tooltip1.getProperty("open")).toBe(false);
     expect(await tooltip2.getProperty("open")).toBe(true);
   });
+
+  describe("allows clicking on an open tooltip", () => {
+    const pageContent = html`
+      <calcite-tooltip placement="auto" reference-element="ref">content</calcite-tooltip>
+      <button id="ref">referenceElement</button>
+      <button id="other">other</button>
+    `;
+
+    it("should work when clicking on a reference element first", async () => {
+      const page = await newE2EPage();
+      await page.setContent(pageContent);
+      await page.waitForChanges();
+      const tooltip = await page.find("calcite-tooltip");
+      const referenceElement = await page.find("#ref");
+
+      await referenceElement.click();
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(true);
+
+      await tooltip.click();
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(true);
+
+      const other = await page.find("#other");
+      await other.click();
+      await page.waitForTimeout(TOOLTIP_CLOSE_DELAY_MS);
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(false);
+    });
+
+    it("should work when focusing on a reference element first", async () => {
+      const page = await newE2EPage();
+      await page.setContent(pageContent);
+      await page.waitForChanges();
+      const tooltip = await page.find("calcite-tooltip");
+      const referenceElement = await page.find("#ref");
+
+      await referenceElement.focus();
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(true);
+
+      await tooltip.click();
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(true);
+
+      const other = await page.find("#other");
+      await other.focus();
+      await page.waitForChanges();
+      expect(await tooltip.getProperty("open")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**Related Issue:** #9827

## Summary

- allows clicking on a tooltip while a referenceElement is focused
- adds tests
- depends on #9839