### PR TITLE
fix(shell): fix resizing a slotted shell-panel when clicking to resize

### DIFF
--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -29,18 +29,18 @@
     overflow-hidden;
 }
 
-.content,
-.content--non-interactive {
+.content {
   @apply flex
     h-full
     w-full
     flex-col
-    flex-nowrap;
+    flex-nowrap
+    overflow-auto;
+  justify-content: space-between;
 }
 
-.content {
-  @apply overflow-auto;
-  justify-content: space-between;
+.content--non-interactive {
+  @apply flex pointer-events-none;
 }
 
 .content ::slotted(calcite-shell-center-row),
@@ -56,10 +56,6 @@
     border-0;
   z-index: calc(theme("zIndex.default") - 1);
   display: initial;
-}
-
-.content--non-interactive {
-  @apply pointer-events-none;
 }
 
 ::slotted(calcite-shell-center-row) {

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -39,10 +39,6 @@
   justify-content: space-between;
 }
 
-.content--non-interactive {
-  @apply flex pointer-events-none;
-}
-
 .content ::slotted(calcite-shell-center-row),
 .content ::slotted(calcite-panel),
 .content ::slotted(calcite-flow) {
@@ -56,6 +52,10 @@
     border-0;
   z-index: calc(theme("zIndex.default") - 1);
   display: initial;
+}
+
+.content--non-interactive {
+  @apply flex pointer-events-none;
 }
 
 ::slotted(calcite-shell-center-row) {

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -198,13 +198,12 @@ export class Shell implements ConditionalSlotComponent {
   }
 
   renderContent(): VNode[] {
-    const { panelIsResizing } = this;
-    const defaultSlotNode: VNode = <slot key="default-slot" />;
-    const defaultSlotContainerNode = panelIsResizing ? (
-      <div class={CSS.contentNonInteractive}>{defaultSlotNode}</div>
-    ) : (
-      defaultSlotNode
+    const defaultSlotContainerNode = (
+      <div class={{ [CSS.contentNonInteractive]: this.panelIsResizing }}>
+        <slot key="default-slot" />
+      </div>
     );
+
     const deprecatedCenterRowSlotNode: VNode = (
       <slot key="center-row-slot" name={SLOTS.centerRow} />
     );

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -198,12 +198,13 @@ export class Shell implements ConditionalSlotComponent {
   }
 
   renderContent(): VNode[] {
-    const defaultSlotContainerNode = (
-      <div class={{ [CSS.contentNonInteractive]: this.panelIsResizing }}>
-        <slot key="default-slot" />
-      </div>
+    const { panelIsResizing } = this;
+    const defaultSlotNode: VNode = <slot key="default-slot" />;
+    const defaultSlotContainerNode = panelIsResizing ? (
+      <div class={CSS.contentNonInteractive}>{defaultSlotNode}</div>
+    ) : (
+      defaultSlotNode
     );
-
     const deprecatedCenterRowSlotNode: VNode = (
       <slot key="center-row-slot" name={SLOTS.centerRow} />
     );


### PR DESCRIPTION
**Related Issue:** #9807

## Summary

- fixes styles when resizing
  - makes non interactive container not suddenly jump full height/width.
- cleanup 
