### PR TITLE
docs(action): deprecates the compact property

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -277,7 +277,8 @@ export namespace Components {
          */
         "appearance": Extract<"solid" | "transparent", Appearance>;
         /**
-          * When `true`, the side padding of the component is reduced. Compact mode is used internally by components, e.g. `calcite-block-section`.
+          * When `true`, the side padding of the component is reduced.
+          * @deprecated No longer necessary.
          */
         "compact": boolean;
         /**
@@ -8051,7 +8052,8 @@ declare namespace LocalJSX {
          */
         "appearance"?: Extract<"solid" | "transparent", Appearance>;
         /**
-          * When `true`, the side padding of the component is reduced. Compact mode is used internally by components, e.g. `calcite-block-section`.
+          * When `true`, the side padding of the component is reduced.
+          * @deprecated No longer necessary.
          */
         "compact"?: boolean;
         /**

--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -14,7 +14,7 @@ describe("calcite-action", () => {
         defaultValue: "solid",
       },
       {
-        propertyName: "compact",
+        propertyName: "compact", // (deprecated)
         defaultValue: false,
       },
       {

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -135,7 +135,7 @@
   }
 }
 
-// Compact
+/* [Deprecated]  Compact */
 :host([scale="s"][compact]) .button,
 :host([scale="m"][compact]) .button,
 :host([scale="l"][compact]) .button {

--- a/packages/calcite-components/src/components/action/action.stories.ts
+++ b/packages/calcite-components/src/components/action/action.stories.ts
@@ -10,7 +10,6 @@ type ActionStoryArgs = Pick<
   | "active"
   | "alignment"
   | "appearance"
-  | "compact"
   | "disabled"
   | "icon"
   | "indicator"
@@ -27,7 +26,6 @@ export default {
     active: false,
     alignment: alignment.defaultValue,
     appearance: appearance.defaultValue,
-    compact: false,
     disabled: false,
     icon: "banana",
     indicator: false,
@@ -63,7 +61,6 @@ export const simple = (args: ActionStoryArgs): string => html`
       ${boolean("active", args.active)}
       alignment="${args.alignment}"
       appearance="${args.appearance}"
-      ${boolean("compact", args.compact)}
       ${boolean("disabled", args.disabled)}
       icon="${args.icon}"
       ${boolean("indicator", args.indicator)}
@@ -76,7 +73,7 @@ export const simple = (args: ActionStoryArgs): string => html`
   </div>
 `;
 
-export const disabledAndCompactAndTextOnly_TestOnly = (): string => html`
+export const disabledAndTextOnly_TestOnly = (): string => html`
   <div>
     <calcite-action
       icon="banana"
@@ -84,7 +81,6 @@ export const disabledAndCompactAndTextOnly_TestOnly = (): string => html`
       appearance="solid"
       label="Label"
       scale="m"
-      compact
       disabled
       text="Text"
       text-enabled

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -74,7 +74,9 @@ export class Action
   @Prop({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> = "solid";
 
   /**
-   * When `true`, the side padding of the component is reduced. Compact mode is used internally by components, e.g. `calcite-block-section`.
+   * When `true`, the side padding of the component is reduced.
+   *
+   * @deprecated No longer necessary.
    */
   @Prop({ reflect: true }) compact = false;
 


### PR DESCRIPTION
**Related Issue:** #3859

## Summary

- deprecates the compact property