### PR TITLE
fix(carousel): Prevent duplicate animation when navigating via keyboard

### DIFF
--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -494,6 +494,8 @@ export class Carousel
       return;
     }
 
+    const lastItem = this.items.length - 1;
+
     switch (event.key) {
       case " ":
       case "Enter":
@@ -512,13 +514,19 @@ export class Carousel
         break;
       case "Home":
         event.preventDefault();
+        if (this.selectedIndex === 0) {
+          return;
+        }
         this.direction = "backward";
         this.setSelectedItem(0, true);
         break;
       case "End":
         event.preventDefault();
+        if (this.selectedIndex === lastItem) {
+          return;
+        }
         this.direction = "forward";
-        this.setSelectedItem(this.items.length - 1, true);
+        this.setSelectedItem(lastItem, true);
         break;
     }
   };


### PR DESCRIPTION
**Related Issue:** #9471

## Summary
When using `home` and `end` while focused on the Container, prevent "re-navigating" to the currently active Carousel Item and showing a duplicate animation. This matches the behavior when a user selects an individual Carousel Item "dot", both with mouse or via keyboard.