### PR TITLE
chore: add license to npm package

### DIFF
--- a/packages/calcite-design-tokens/LICENSE.md
+++ b/packages/calcite-design-tokens/LICENSE.md
@@ -1,0 +1,13 @@
+# Licensing
+
+COPYRIGHT © 2024 Esri
+
+All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
+
+This material is licensed for use under the Esri Master License Agreement (MLA), and is bound by the terms of that agreement. You may redistribute and use this code without modification, provided you adhere to the terms of the MLA and include this copyright notice.
+
+See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
+
+For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+
+email: <contracts@esri.com>

--- a/packages/calcite-design-tokens/package.json
+++ b/packages/calcite-design-tokens/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Esri/calcite-design-system.git"
+    "url": "git://github.com/Esri/calcite-design-system.git",
+    "directory": "packages/calcite-design-tokens"
   },
   "author": {
     "name": "Esri"
@@ -24,6 +25,7 @@
   "bugs": {
     "url": "https://github.com/Esri/calcite-design-system/issues"
   },
+  "license": "SEE LICENSE.md",
   "scripts": {
     "build": "tsx support/run.ts",
     "clean": "rimraf dist",


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/pull/9835#discussion_r1688646094

## Summary

Add license to `@esri/calcite-design-tokens`.
