### PR TITLE
test(tree): stabilize tests

### DIFF
--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -583,6 +583,7 @@ describe("calcite-tree", () => {
       const keyDownSpy = await page.spyOnEvent("keydown");
       const item = await page.find("#middle-item");
       await item.focus();
+      await page.waitForChanges();
 
       expect(keyDownSpy).toHaveReceivedEventTimes(0);
 
@@ -593,6 +594,7 @@ describe("calcite-tree", () => {
       await page.keyboard.press("Home");
       await page.keyboard.press("End");
       await page.keyboard.press("Tab");
+      await page.waitForChanges();
 
       expect(keyDownSpy).toHaveReceivedEventTimes(7);
     });
@@ -1033,11 +1035,13 @@ describe("calcite-tree", () => {
 
       await button.focus();
       await page.keyboard.press("Enter");
+      await page.waitForChanges();
 
       expect(keydownSpy).toHaveReceivedEventTimes(1);
       expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
 
       await page.keyboard.press("Space");
+      await page.waitForChanges();
 
       expect(keydownSpy).toHaveReceivedEventTimes(2);
       expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
@@ -1063,11 +1067,13 @@ describe("calcite-tree", () => {
 
       await button.focus();
       await page.keyboard.press("Enter");
+      await page.waitForChanges();
 
       expect(keydownSpy).toHaveReceivedEventTimes(1);
       expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
 
       await page.keyboard.press("Space");
+      await page.waitForChanges();
 
       expect(keydownSpy).toHaveReceivedEventTimes(2);
       expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Try to stabilize the tree tests.

Example:


```
@esri/calcite-components:test:   ● calcite-tree › keyboard support › does prevent space/enter keyboard event on actions with selectionMode of none
@esri/calcite-components:test: 
@esri/calcite-components:test:     expected event "keydown" to have been called 1 times, but was called 0 time
@esri/calcite-components:test: 
@esri/calcite-components:test:       1065 |       await page.keyboard.press("Enter");
@esri/calcite-components:test:       1066 |
@esri/calcite-components:test:     > 1067 |       expect(keydownSpy).toHaveReceivedEventTimes(1);
@esri/calcite-components:test:            |                          ^
@esri/calcite-components:test:       1068 |       expect(keydownSpy.lastEvent.defaultPrevented).toBe(true);
@esri/calcite-components:test:       1069 |
@esri/calcite-components:test:       1070 |       await page.keyboard.press("Space");
@esri/calcite-components:test: 
@esri/calcite-components:test:       at Object.<anonymous> (src/components/tree/tree.e2e.ts:1067:26)
@esri/calcite-components:test: 
@esri/calcite-components:test: 
@esri/calcite-components:test: Test Suites: 1 failed, 1 skipped, 133 passed, 134 of 135 total
```

https://github.com/Esri/calcite-design-system/actions/runs/10085510671/job/27886423203
