### PR TITLE
fix(input-time-zone): fix inconsistent open/close events when opened programmatically

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -8,6 +8,7 @@ import {
   formAssociated,
   hidden,
   labelable,
+  openClose,
   reflects,
   renders,
   t9n,
@@ -121,6 +122,10 @@ describe("calcite-input-time-zone", () => {
     disabled(simpleTestProvider, {
       shadowAriaAttributeTargetSelector: "calcite-combobox",
     });
+  });
+
+  describe("openClose", () => {
+    openClose(simpleTestProvider);
   });
 
   describe("t9n", () => {

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -188,6 +188,11 @@ export class InputTimeZone
   /** When `true`, displays and positions the component. */
   @Prop({ mutable: true, reflect: true }) open = false;
 
+  @Watch("open")
+  openChanged(value: boolean): void {
+    this.comboboxEl.open = value;
+  }
+
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
@@ -338,6 +343,7 @@ export class InputTimeZone
 
   private setComboboxRef = (el: HTMLCalciteComboboxElement): void => {
     this.comboboxEl = el;
+    this.comboboxEl.open = this.open;
   };
 
   private onComboboxBeforeClose = (event: CustomEvent): void => {
@@ -485,7 +491,6 @@ export class InputTimeZone
             onCalciteComboboxChange={this.onComboboxChange}
             onCalciteComboboxClose={this.onComboboxClose}
             onCalciteComboboxOpen={this.onComboboxOpen}
-            open={this.open}
             overlayPositioning={this.overlayPositioning}
             placeholder={
               this.mode === "name" ? this.messages.namePlaceholder : this.messages.offsetPlaceholder

--- a/packages/calcite-components/src/tests/commonTests/openClose.ts
+++ b/packages/calcite-components/src/tests/commonTests/openClose.ts
@@ -1,6 +1,6 @@
 import { E2EPage } from "@stencil/core/testing";
 import { toHaveNoViolations } from "jest-axe";
-import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations } from "../utils";
+import { GlobalTestProps, toProgrammaticE2EPage, skipAnimations } from "../utils";
 import { getTagAndPage } from "./utils";
 import { ComponentTag, ComponentTestSetup } from "./interfaces";
 
@@ -167,15 +167,16 @@ export function openClose(componentTestSetup: ComponentTestSetup, options?: Open
 
   if (customizedOptions.initialToggleValue === true) {
     it("emits on initialization with animations enabled", async () => {
-      const page = await newProgrammaticE2EPage();
-      const { tag } = await getTagAndPage(componentTestSetup);
+      const { page, tag } = await getTagAndPage(componentTestSetup);
+      await toProgrammaticE2EPage(page);
+
       await skipAnimations(page);
       await testOpenCloseEvents(tag, page);
     });
 
     it("emits on initialization with animations disabled", async () => {
-      const page = await newProgrammaticE2EPage();
-      const { tag } = await getTagAndPage(componentTestSetup);
+      const { page, tag } = await getTagAndPage(componentTestSetup);
+      await toProgrammaticE2EPage(page);
       await page.addStyleTag({
         content: `:root { --calcite-duration-factor: 0; }`,
       });

--- a/packages/calcite-components/src/tests/commonTests/openClose.ts
+++ b/packages/calcite-components/src/tests/commonTests/openClose.ts
@@ -169,7 +169,6 @@ export function openClose(componentTestSetup: ComponentTestSetup, options?: Open
     it("emits on initialization with animations enabled", async () => {
       const { page, tag } = await getTagAndPage(componentTestSetup);
       await toProgrammaticE2EPage(page);
-
       await skipAnimations(page);
       await testOpenCloseEvents(tag, page);
     });

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -309,6 +309,20 @@ export async function newProgrammaticE2EPage(): Promise<E2EPage> {
 }
 
 /**
+ * Clears up an existing E2E page for tests that need to work with elements programmatically.
+ *
+ * **Note**: whenever possible, use `newProgrammaticE2EPage` to create a new page instead of reusing an existing one.
+ *
+ * @param page
+ * @returns {Promise<E2EPage>} an e2e page
+ */
+export async function toProgrammaticE2EPage(page: E2EPage): Promise<E2EPage> {
+  await page.setContent("");
+
+  return page;
+}
+
+/**
  * Sets CSS vars to skip animations/transitions.
  *
  * @example

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -317,7 +317,9 @@ export async function newProgrammaticE2EPage(): Promise<E2EPage> {
  * @returns {Promise<E2EPage>} an e2e page
  */
 export async function toProgrammaticE2EPage(page: E2EPage): Promise<E2EPage> {
-  await page.setContent("");
+  await page.evaluate(() => {
+    document.body.innerHTML = "";
+  });
 
   return page;
 }


### PR DESCRIPTION
**Related Issue:** #9315

## Summary

This changes how the internal combobox's state is updated to avoid inconsistent event emitting.

