### PR TITLE
chore: avoid deleting untracked, non-generated files on npm run clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "postinstall": "patch-package",
     "build": "turbo run build --log-order=stream",
-    "clean": "turbo run clean --log-order=stream && git clean -fdx",
+    "clean": "turbo run clean --log-order=stream && git clean -fd",
     "lint": "concurrently \"npm:lint:*\" \"turbo run lint --log-order=stream\"",
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"{,documentation}/*.md\" --fix --dot --ignore-path .gitignore",
     "lint:yml": "prettier --write \".github/**/*.yml\" >/dev/null",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Prevents `git clean` from removing untracked, non-generated files/dirs from `.gitignore` (e.g., `.idea` 😉)

