### PR TITLE
build(deps): update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7987,9 +7987,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
-      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "version": "20.14.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.13.tgz",
+      "integrity": "sha512-+bHoGiZb8UiQ0+WEtmph2IWQCjIqg8MDZMAV+ppRRhUZnquF5mQkP/9vpSwJClEiSM/C7fZZExPzfU0vJTyp8w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"


### PR DESCRIPTION
## Summary

Resolve `next` release [CI errors](https://github.com/Esri/calcite-design-system/actions/runs/10149756639/job/28065362229#step:4:77) due to an outdated `package-lock.json`.
