### PR TITLE
fix(dialog): fix menu positioning when when overlayPositioning is 'fixed' and menuOpen is true

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -162,6 +162,12 @@ calcite-panel {
   }
 }
 
+:host([menu-open]) .dialog {
+  transition:
+    visibility 0ms linear var(--calcite-internal-animation-timing-slow),
+    opacity var(--calcite-internal-animation-timing-slow) $easing-function;
+}
+
 .panel {
   @apply rounded;
 }


### PR DESCRIPTION
**Related Issue:** #9876

## Summary

- This corrects an issue with the transform animation on the dialog.  
  - The issue is that having a transform animation with a floating-ui element inside of it can cause positioning issues.
  - Some notes about it can be read here: https://floating-ui.com/docs/usefloating#transform
  - In our case, a wrapper won't work because the floating ui element is inside of the transform animation.
  - As a workaround, the transform animation is removed when menuOpen is true.
