### PR TITLE
build(deps): resolve husky deprecation warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,6 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
-
 
 types_path="packages/calcite-components/src/components.d.ts"
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish:rc": "./support/release.sh publish rc",
     "version:hotfix": "./support/release.sh version hotfix",
     "publish:hotfix": "./support/release.sh publish hotfix",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "turbo run start --log-order=stream",
     "test": "turbo run test --log-order=stream",
     "util:is-next-deployable": "tsx support/isNextDeployable.ts",


### PR DESCRIPTION
## Summary

Resolve husky deprecation warnings following their [v9 release notes](https://github.com/typicode/husky/releases/tag/v9.0.1).
