### PR TITLE
fix(dropdown): ensure `setFocus` focuses the trigger

### DIFF
--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -11,7 +11,12 @@ import {
   VNode,
   Watch,
 } from "@stencil/core";
-import { focusElement, focusElementInGroup, toAriaBoolean } from "../../utils/dom";
+import {
+  focusElement,
+  focusElementInGroup,
+  focusFirstTabbable,
+  toAriaBoolean,
+} from "../../utils/dom";
 import {
   connectFloatingUI,
   defaultMenuPlacement,
@@ -188,7 +193,7 @@ export class Dropdown
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);
-    this.el.focus();
+    focusFirstTabbable(this.referenceEl);
   }
 
   //--------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #9731

## Summary

`delegatesFocus` will only focus elements in the shadow DOM (see [example](https://codepen.io/jcfranco/pen/MWMpaOM)), so this ensures the slotted trigger gets focused.

`focusable` test was incorrectly passing with the pinned version of Puppeteer (21.5.0) for both headless and headful modes. Testing the previous implementation with `puppeteer@22.14.0` (latest) fails the test properly.  
