### PR TITLE
chore: add 'start:components' npm script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ npm install
 Next, start the local Stencil development server on localhost:
 
 ```sh
-npm start
+npm run start:components
 ```
 
 The demos will open in the browser after building. Edit the pages in [`packages/calcite-components/src/demos`](.packages/calcite-components/src/demos) to modify the component demos, such as changing attributes or adding content to slots. When adding a new demo page, make sure to add a link in [`packages/calcite-components/src/index.html`](./packages/calcite-components/src/index.html) so others can find it. You can also edit the component code in [`packages/calcite-components/src/components`](packages/calcite-components/src/components`./src/components), and the changes will be reflected in the demos.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish:hotfix": "./support/release.sh publish hotfix",
     "prepare": "husky",
     "start": "turbo run start --log-order=stream",
+    "start:components": "turbo run start --log-order=stream --filter=@esri/calcite-components",
     "test": "turbo run test --log-order=stream",
     "util:is-next-deployable": "tsx support/isNextDeployable.ts",
     "util:push-tags": "git push origin HEAD --follow-tags",


### PR DESCRIPTION
**Related Issue:** #9938

## Summary

Running `npm start` from the root of the monorepo will run `npm start` for all of the packages that have a `start` script. Therefore, `npm start` will launch the icon browser in addition to the component demos, now that the `@esri/calcite-ui-components` lives in the monorepo.

This seems to cause timing issues on Windows where the icons are copied to the components before they are all built.

To only launch the component demos, use `npm run start:components`.
