### PR TITLE
fix(combobox): fix selection of items that were previously disabled

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -6574,6 +6574,7 @@ declare global {
     };
     interface HTMLCalciteComboboxItemElementEventMap {
         "calciteComboboxItemChange": void;
+        "calciteInternalComboboxItemChange": void;
     }
     interface HTMLCalciteComboboxItemElement extends Components.CalciteComboboxItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteComboboxItemElementEventMap>(type: K, listener: (this: HTMLCalciteComboboxItemElement, ev: CalciteComboboxItemCustomEvent<HTMLCalciteComboboxItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -9363,6 +9364,7 @@ declare namespace LocalJSX {
           * Fires whenever the component is selected or unselected.
          */
         "onCalciteComboboxItemChange"?: (event: CalciteComboboxItemCustomEvent<void>) => void;
+        "onCalciteInternalComboboxItemChange"?: (event: CalciteComboboxItemCustomEvent<void>) => void;
         /**
           * Specifies the size of the component inherited from the `calcite-combobox`, defaults to `m`.
          */

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -9364,6 +9364,9 @@ declare namespace LocalJSX {
           * Fires whenever the component is selected or unselected.
          */
         "onCalciteComboboxItemChange"?: (event: CalciteComboboxItemCustomEvent<void>) => void;
+        /**
+          * Fires whenever a property the parent combobox needs to know about is changed.
+         */
         "onCalciteInternalComboboxItemChange"?: (event: CalciteComboboxItemCustomEvent<void>) => void;
         /**
           * Specifies the size of the component inherited from the `calcite-combobox`, defaults to `m`.

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -60,6 +60,11 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @Prop({ reflect: true }) disabled = false;
 
+  @Watch("disabled")
+  handleDisabledChange(): void {
+    this.calciteInternalComboboxItemChange.emit();
+  }
+
   /**
    * When `true`, omits the component from the `calcite-combobox` filtered search results.
    */
@@ -176,6 +181,13 @@ export class ComboboxItem implements ConditionalSlotComponent, InteractiveCompon
    *
    */
   @Event({ cancelable: false }) calciteComboboxItemChange: EventEmitter<void>;
+
+  /**
+   * Fires whenever a property the parent combobox needs to know about is changed.
+   *
+   * @internal
+   */
+  @Event({ cancelable: false }) calciteInternalComboboxItemChange: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -2374,4 +2374,29 @@ describe("calcite-combobox", () => {
     });
     await page.waitForChanges();
   });
+
+  it("allow selecting an item that was previously disabled", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-combobox>
+        <calcite-combobox-item text-label="Item 1" value="one"></calcite-combobox-item>
+        <calcite-combobox-item text-label="Item 2" value="two"></calcite-combobox-item>
+        <calcite-combobox-item id="tres" text-label="Item 3" value="three" disabled></calcite-combobox-item>
+      </calcite-combobox>
+    `);
+    const combobox = await page.find("calcite-combobox");
+
+    await combobox.click();
+    const item3 = await page.find("calcite-combobox-item[disabled]");
+    await item3.click();
+
+    expect(await combobox.getProperty("value")).toBe("");
+
+    await item3.setProperty("disabled", false);
+    await page.waitForChanges();
+
+    await item3.click();
+
+    expect(await combobox.getProperty("value")).toBe("three");
+  });
 });

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -397,6 +397,14 @@ export class Combobox
     this.toggleSelection(target, target.selected);
   }
 
+  @Listen("calciteInternalComboboxItemChange")
+  calciteInternalComboboxItemChangeHandler(
+    event: CustomEvent<HTMLCalciteComboboxItemElement>,
+  ): void {
+    event.stopPropagation();
+    this.updateItems();
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Public Methods


### PR DESCRIPTION
**Related Issue:** #9719

## Summary

Ensures the combobox updates items internally when an item's `disabled` property is modified.
