### PR TITLE
ci(lerna): pin versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,8 @@
   "command": {
     "version": {
       "conventionalCommits": true,
-      "allowBranch": ["main", "rc", "dev"]
+      "allowBranch": ["main", "rc", "dev"],
+      "exact": true
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #9946

## Summary

Use the exact version (no semver range) when releasing `next` via Lerna to prevent Renovate from creating PRs to pin the version.
