### PR TITLE
chore: release main (#9952)

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-  "packages/calcite-components": "2.11.0",
-  "packages/calcite-components-react": "2.11.0",
+  "packages/calcite-components": "2.11.1",
+  "packages/calcite-components-react": "2.11.1",
   "packages/calcite-design-tokens": "2.2.0",
   "packages/calcite-ui-icons": "3.30.0",
   "packages/eslint-plugin-calcite-components": "1.2.0",
-  "packages/calcite-components-angular/projects/component-library": "2.11.0"
+  "packages/calcite-components-angular/projects/component-library": "2.11.1"
 }

--- a/packages/calcite-components-angular/projects/component-library/CHANGELOG.md
+++ b/packages/calcite-components-angular/projects/component-library/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-angular@2.11.0...@esri/calcite-components-angular@2.11.1) (2024-08-02)
+
+### Miscellaneous Chores
+
+- **@esri/calcite-components-angular:** Synchronize components versions
+
 ## [2.12.0-next.2](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-angular@2.12.0-next.1...@esri/calcite-components-angular@2.12.0-next.2) (2024-08-02)
 
 **Note:** Version bump only for package @esri/calcite-components-angular

--- a/packages/calcite-components-react/CHANGELOG.md
+++ b/packages/calcite-components-react/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@2.11.0...@esri/calcite-components-react@2.11.1) (2024-08-02)
+
+### Miscellaneous Chores
+
+- **@esri/calcite-components-react:** Synchronize components versions
+
+### Dependencies
+
+- The following workspace dependencies were updated
+  - dependencies
+    - @esri/calcite-components bumped from ^2.11.0 to ^2.11.1
+
 ## [2.12.0-next.2](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@2.12.0-next.1...@esri/calcite-components-react@2.12.0-next.2) (2024-08-02)
 
 **Note:** Version bump only for package @esri/calcite-components-react

--- a/packages/calcite-components/CHANGELOG.md
+++ b/packages/calcite-components/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components@2.11.0...@esri/calcite-components@2.11.1) (2024-08-02)
+
+### Bug Fixes
+
+- **block:** Display correct header spacing when heading or description are present ([#9924](https://github.com/Esri/calcite-design-system/issues/9924)) ([d8f1077](https://github.com/Esri/calcite-design-system/commit/d8f1077c649f9f45f0db7e00a916a4261cd0adf2))
+- **panel, flow-item:** Fix header padding regression ([#9936](https://github.com/Esri/calcite-design-system/issues/9936)) ([90e9368](https://github.com/Esri/calcite-design-system/commit/90e93681c6926eec8480c4028f2797046ebd54f4))
+
 ## [2.12.0-next.2](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components@2.12.0-next.1...@esri/calcite-components@2.12.0-next.2) (2024-08-02)
 
 ### Bug Fixes

--- a/packages/calcite-components/readme.md
+++ b/packages/calcite-components/readme.md
@@ -17,12 +17,12 @@ The most common approach for loading Calcite Components is to use the version ho
 ```html
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.11.0/dist/calcite/calcite.esm.js"
+  src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.11.1/dist/calcite/calcite.esm.js"
 ></script>
 <link
   rel="stylesheet"
   type="text/css"
-  href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.11.0/dist/calcite/calcite.css"
+  href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.11.1/dist/calcite/calcite.css"
 />
 ```
 


### PR DESCRIPTION
**Related Issue:** #9952

## Summary

Cherry-pick the release commit from `main`.

---

<details><summary>@esri/calcite-components: 2.11.1</summary>

[2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components@2.11.0...@esri/calcite-components@2.11.1)
(2024-08-02)

* **block:** Display correct header spacing when heading or description
are present
([#9924](https://github.com/Esri/calcite-design-system/issues/9924))
([d8f1077](https://github.com/Esri/calcite-design-system/commit/d8f1077c649f9f45f0db7e00a916a4261cd0adf2))
* **panel, flow-item:** Fix header padding regression
([#9936](https://github.com/Esri/calcite-design-system/issues/9936))
([90e9368](https://github.com/Esri/calcite-design-system/commit/90e93681c6926eec8480c4028f2797046ebd54f4))
</details>

<details><summary>@esri/calcite-components-angular: 2.11.1</summary>

[2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-angular@2.11.0...@esri/calcite-components-angular@2.11.1)
(2024-08-02)

* **@esri/calcite-components-angular:** Synchronize components versions

* The following workspace dependencies were updated
  * dependencies
    * @esri/calcite-components bumped from ^2.11.0 to ^2.11.1
</details>

<details><summary>@esri/calcite-components-react: 2.11.1</summary>

[2.11.1](https://github.com/Esri/calcite-design-system/compare/@esri/calcite-components-react@2.11.0...@esri/calcite-components-react@2.11.1)
(2024-08-02)

* **@esri/calcite-components-react:** Synchronize components versions

* The following workspace dependencies were updated
  * dependencies
    * @esri/calcite-components bumped from ^2.11.0 to ^2.11.1
</details>

---
This PR was generated with [Release
Please](https://github.com/googleapis/release-please). See
[documentation](https://github.com/googleapis/release-please#release-please).
