### PR TITLE
feat(loader): add `determinate-value` type

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -3304,6 +3304,10 @@ export namespace Components {
          */
         "label": string;
         /**
+          * When `true`, and when the type is `determinate`, displays the progress value as a percentage
+         */
+        "percentage": boolean;
+        /**
           * Specifies the size of the component.
          */
         "scale": Scale;
@@ -11395,6 +11399,10 @@ declare namespace LocalJSX {
           * Accessible name for the component.
          */
         "label": string;
+        /**
+          * When `true`, and when the type is `determinate`, displays the progress value as a percentage
+         */
+        "percentage"?: boolean;
         /**
           * Specifies the size of the component.
          */

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -3304,10 +3304,6 @@ export namespace Components {
          */
         "label": string;
         /**
-          * When `true`, and when the type is `determinate`, displays the progress value as a percentage
-         */
-        "percentage": boolean;
-        /**
           * Specifies the size of the component.
          */
         "scale": Scale;
@@ -3316,9 +3312,9 @@ export namespace Components {
          */
         "text": string;
         /**
-          * Specifies the component type.  Use `"indeterminate"` if finding actual progress value is impossible.
+          * Specifies the component type.  Use `"indeterminate"` if finding actual progress value is impossible. Otherwise, use `"determinate"` to have the value indicate the progress or `"determinate-value"` to have the value label displayed along the progress.
          */
-        "type": "indeterminate" | "determinate";
+        "type": "indeterminate" | "determinate" | "determinate-value";
         /**
           * The component's value. Valid only for `"determinate"` indicators. Percent complete of 100.
          */
@@ -11400,10 +11396,6 @@ declare namespace LocalJSX {
          */
         "label": string;
         /**
-          * When `true`, and when the type is `determinate`, displays the progress value as a percentage
-         */
-        "percentage"?: boolean;
-        /**
           * Specifies the size of the component.
          */
         "scale"?: Scale;
@@ -11412,9 +11404,9 @@ declare namespace LocalJSX {
          */
         "text"?: string;
         /**
-          * Specifies the component type.  Use `"indeterminate"` if finding actual progress value is impossible.
+          * Specifies the component type.  Use `"indeterminate"` if finding actual progress value is impossible. Otherwise, use `"determinate"` to have the value indicate the progress or `"determinate-value"` to have the value label displayed along the progress.
          */
-        "type"?: "indeterminate" | "determinate";
+        "type"?: "indeterminate" | "determinate" | "determinate-value";
         /**
           * The component's value. Valid only for `"determinate"` indicators. Percent complete of 100.
          */

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -78,13 +78,11 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 }
 
 .loader__percentage {
-  @apply text-color-1 absolute block text-center;
+  @apply block text-center text-color-1;
   font-size: var(--calcite-loader-font-size);
   inline-size: var(--calcite-loader-size);
-  inset-inline-start: 50%;
-  margin-inline-start: calc(var(--calcite-loader-size) / 2 * -1);
   line-height: var(--calcite-internal-loader-value-line-height);
-  transform: scale(1, 1);
+  align-self: center;
 }
 
 .loader__svgs {
@@ -97,6 +95,7 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   animation-timing-function: linear;
   animation-duration: scaleDuration(--calcite-internal-animation-timing-slow, 6.66);
   animation-name: loader-clockwise;
+  display: flex;
 }
 
 .loader__svg {

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -36,10 +36,10 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 }
 
 :host([scale="s"]) {
-  --calcite-loader-font-size: theme("fontSize.n2");
+  --calcite-loader-font-size: var(--calcite-font-size--3);
   --calcite-loader-size: theme("spacing.8");
   --calcite-loader-size-inline: theme("spacing.3");
-  --calcite-internal-loader-value-line-height: 1.03125rem; // 16.5px
+  --calcite-internal-loader-value-line-height: 0.625rem; // 10px
 }
 
 :host([scale="m"]) {
@@ -54,11 +54,6 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   --calcite-loader-size: theme("spacing.24");
   --calcite-loader-size-inline: theme("spacing.6");
   --calcite-internal-loader-value-line-height: 1.71875rem; // 27.5px
-}
-
-:host([type="determinate-value"][scale="s"]) {
-  --calcite-loader-font-size: var(--calcite-font-size--3);
-  --calcite-internal-loader-value-line-height: 0.625rem; // 10px
 }
 
 :host([no-padding]) {

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -39,18 +39,26 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   --calcite-loader-font-size: theme("fontSize.n2");
   --calcite-loader-size: theme("spacing.8");
   --calcite-loader-size-inline: theme("spacing.3");
+  --calcite-internal-loader-value-line-height: 1.03125rem; // 16.5px
 }
 
 :host([scale="m"]) {
   --calcite-loader-font-size: theme("fontSize.0");
   --calcite-loader-size: theme("spacing.16");
   --calcite-loader-size-inline: theme("spacing.4");
+  --calcite-internal-loader-value-line-height: 1.375rem; // 22px
 }
 
 :host([scale="l"]) {
   --calcite-loader-font-size: theme("fontSize.2");
   --calcite-loader-size: theme("spacing.24");
   --calcite-loader-size-inline: theme("spacing.6");
+  --calcite-internal-loader-value-line-height: 1.71875rem; // 27.5px
+}
+
+:host([type="determinate-value"][scale="s"]) {
+  --calcite-loader-font-size: var(--calcite-font-size--3);
+  --calcite-internal-loader-value-line-height: 0.625rem; // 10px
 }
 
 :host([no-padding]) {
@@ -75,7 +83,7 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   inline-size: var(--calcite-loader-size);
   inset-inline-start: 50%;
   margin-inline-start: calc(var(--calcite-loader-size) / 2 * -1);
-  line-height: 0.25;
+  line-height: var(--calcite-internal-loader-value-line-height);
   transform: scale(1, 1);
 }
 
@@ -110,7 +118,8 @@ $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
   }
 }
 
-:host([type="determinate"]) {
+:host([type="determinate"]),
+:host([type="determinate-value"]) {
   @apply animate-none;
   stroke: var(--calcite-color-border-3);
   .loader__svgs {

--- a/packages/calcite-components/src/components/loader/loader.stories.ts
+++ b/packages/calcite-components/src/components/loader/loader.stories.ts
@@ -41,10 +41,10 @@ export const inline_TestOnly = (): string => html`
 `;
 
 export const determinate = (): string => html`
-  <h1>default</h1>
+  <h1>determinate</h1>
   <calcite-loader type="determinate" value="50" /></calcite-loader>
-  <h1>percentage</h1>
-  <calcite-loader type="determinate" percentage value="50" /></calcite-loader>
+  <h1>determinate-value</h1>
+  <calcite-loader type="determinate-value" value="50" /></calcite-loader>
 `;
 
 export const customTheme_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/loader/loader.stories.ts
+++ b/packages/calcite-components/src/components/loader/loader.stories.ts
@@ -40,6 +40,13 @@ export const inline_TestOnly = (): string => html`
   </div>
 `;
 
+export const determinate = (): string => html`
+  <h1>default</h1>
+  <calcite-loader type="determinate" value="50" /></calcite-loader>
+  <h1>percentage</h1>
+  <calcite-loader type="determinate" percentage value="50" /></calcite-loader>
+`;
+
 export const customTheme_TestOnly = (): string => html`
   <calcite-loader
     type="indeterminate"

--- a/packages/calcite-components/src/components/loader/loader.stories.ts
+++ b/packages/calcite-components/src/components/loader/loader.stories.ts
@@ -41,10 +41,35 @@ export const inline_TestOnly = (): string => html`
 `;
 
 export const determinate = (): string => html`
+  <style>
+    .scales {
+      display: flex;
+      flex-direction: row;
+      gap: 50px;
+    }
+  </style>
   <h1>determinate</h1>
-  <calcite-loader type="determinate" value="50" /></calcite-loader>
+  <div class="scales">
+    <h2>s</h2>
+    <calcite-loader scale="s" type="determinate" value="50"></calcite-loader>
+    <h2>m</h2>
+    <calcite-loader scale="m" type="determinate" value="50"></calcite-loader>
+    <h2>l</h2>
+    <calcite-loader scale="l" type="determinate" value="50"></calcite-loader>
+  </div>
+  <br>
   <h1>determinate-value</h1>
-  <calcite-loader type="determinate-value" value="50" /></calcite-loader>
+  <div class="scales">
+    <h2>s</h2>
+    <calcite-loader scale="s" type="determinate-value" value="50" />
+    </calcite-loader>
+    <h2>m</h2>
+    <calcite-loader scale="m" type="determinate-value" value="50" />
+    </calcite-loader>
+    <h2>l</h2>
+    <calcite-loader scale="l" type="determinate-value" value="50" />
+    </calcite-loader>
+  </div>
 `;
 
 export const customTheme_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/loader/loader.stories.ts
+++ b/packages/calcite-components/src/components/loader/loader.stories.ts
@@ -47,6 +47,12 @@ export const determinate = (): string => html`
       flex-direction: row;
       gap: 50px;
     }
+    
+    calcite-loader {
+      /* provide dimensions for consistent screenshots */
+      height: 100px;
+      width: 100px;
+    }
   </style>
   <h1>determinate</h1>
   <div class="scales">

--- a/packages/calcite-components/src/components/loader/loader.tsx
+++ b/packages/calcite-components/src/components/loader/loader.tsx
@@ -98,9 +98,9 @@ export class Loader implements LocalizedComponent {
               <circle {...svgAttributes} />
             </svg>
           ))}
+          {isDeterminate && <div class={CSS.loaderPercentage}>{this.formatValue()}</div>}
         </div>
         {text && <div class={CSS.loaderText}>{text}</div>}
-        {isDeterminate && <div class={CSS.loaderPercentage}>{this.formatValue()}</div>}
       </Host>
     );
   }

--- a/packages/calcite-components/src/components/loader/loader.tsx
+++ b/packages/calcite-components/src/components/loader/loader.tsx
@@ -22,19 +22,16 @@ export class Loader implements LocalizedComponent {
   /** Accessible name for the component. */
   @Prop() label!: string;
 
-  /** When `true`, and when the type is `determinate`, displays the progress value as a percentage */
-  @Prop({ reflect: true }) percentage = false;
-
   /** Specifies the size of the component. */
   @Prop({ reflect: true }) scale: Scale = "m";
 
   /**
    * Specifies the component type.
    *
-   * Use `"indeterminate"` if finding actual progress value is impossible.
+   * Use `"indeterminate"` if finding actual progress value is impossible. Otherwise, use `"determinate"` to have the value indicate the progress or `"determinate-value"` to have the value label displayed along the progress.
    *
    */
-  @Prop({ reflect: true }) type: "indeterminate" | "determinate";
+  @Prop({ reflect: true }) type: "indeterminate" | "determinate" | "determinate-value";
 
   /** The component's value. Valid only for `"determinate"` indicators. Percent complete of 100. */
   @Prop() value = 0;
@@ -66,7 +63,7 @@ export class Loader implements LocalizedComponent {
     const size = inline ? this.getInlineSize(scale) : this.getSize(scale);
     const radius = size * radiusRatio;
     const viewbox = `0 0 ${size} ${size}`;
-    const isDeterminate = type === "determinate";
+    const isDeterminate = type?.startsWith("determinate");
     const circumference = 2 * radius * Math.PI;
     const progress = (value / 100) * circumference;
     const remaining = circumference - progress;
@@ -109,7 +106,7 @@ export class Loader implements LocalizedComponent {
   }
 
   private formatValue = (): string => {
-    if (!this.percentage) {
+    if (this.type !== "determinate-value") {
       return `${this.value}`;
     }
 
@@ -127,7 +124,6 @@ export class Loader implements LocalizedComponent {
   @State() effectiveLocale = "";
 
   @Watch("effectiveLocale")
-  @Watch("percentage")
   @Watch("type")
   formatterPropsChange(): void {
     this.updateFormatter();
@@ -164,8 +160,7 @@ export class Loader implements LocalizedComponent {
 
   private updateFormatter(): void {
     if (
-      this.type !== "determinate" ||
-      !this.percentage ||
+      this.type !== "determinate-value" ||
       this.formatter?.resolvedOptions().locale === this.effectiveLocale
     ) {
       return;


### PR DESCRIPTION
**Related Issue:** #8678

## Summary

Adds new determinate type to allow users to opt-into displaying the progress (percent) label.

**Note:** the current `determinate` type will no longer display a label in a future release.
