### PR TITLE
fix: ensure open/close events emit correctly if target element has multiple transitioned props

### DIFF
--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { focusable, renders, hidden, defaults, accessible } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, openClose, renders } from "../../tests/commonTests";
 import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils";
 import { CSS } from "./resources";
 
@@ -75,6 +75,18 @@ describe("calcite-sheet properties", () => {
     describe("focuses content by default", () => {
       focusable(createSheetHTML(focusableContentHTML), {
         focusTargetSelector: `.${focusableContentTargetClass}`,
+      });
+    });
+  });
+
+  describe("openClose", () => {
+    describe("default", () => {
+      openClose("calcite-modal");
+    });
+
+    describe("initially open", () => {
+      openClose("calcite-modal", {
+        initialToggleValue: true,
       });
     });
   });

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -178,13 +178,14 @@ export class Sheet implements OpenCloseComponent, FocusTrapComponent, LoadableCo
             [CSS.containerEmbedded]: this.embedded,
             [CSS_UTILITY.rtl]: dir === "rtl",
           }}
+          ref={this.setTransitionEl}
         >
           <calcite-scrim class={CSS.scrim} onClick={this.handleOutsideClose} />
           <div
             class={{
               [CSS.content]: true,
             }}
-            ref={this.setTransitionEl}
+            ref={this.setContentId}
           >
             <slot />
           </div>
@@ -297,9 +298,12 @@ export class Sheet implements OpenCloseComponent, FocusTrapComponent, LoadableCo
     deactivateFocusTrap(this);
   }
 
+  private setContentId = (el: HTMLDivElement): void => {
+    this.contentId = ensureId(el);
+  };
+
   private setTransitionEl = (el: HTMLDivElement): void => {
     this.transitionEl = el;
-    this.contentId = ensureId(el);
   };
 
   private openEnd = (): void => {

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -737,7 +737,7 @@ export async function whenTransitionOrAnimationDone(
   const allProps = type === "transition" ? style.transitionProperty : style.animationName;
 
   const allDurationsArray = allDurations.split(",");
-  const allPropsArray = allProps.split(",");
+  const allPropsArray = allProps.split(",").map((prop) => prop.trim());
   const propIndex = allPropsArray.indexOf(transitionPropOrAnimationName);
   const duration =
     allDurationsArray[propIndex] ??


### PR DESCRIPTION
**Related Issue:** #9641, #9315

## Summary

Fixes an issue in the openClose util that caused the incorrect duration to be used for event emitting.
