### PR TITLE
chore: temporarily disable broken icon diff check

### DIFF
--- a/.github/workflows/icons-diff-check.yml
+++ b/.github/workflows/icons-diff-check.yml
@@ -1,9 +1,10 @@
 name: Icon Team Diff Check
 on:
-  pull_request:
-    branches: [main, rc, dev]
-  pull_request_review:
-    types: [submitted]
+  workflow_call:
+  # pull_request:
+  #   branches: [main, rc, dev]
+  # pull_request_review:
+  #   types: [submitted]
 jobs:
   check-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Temporarily disable the "Icon Team Diff Check" workflow, which is currently broken. I will re-enable it once I have time to fix it in the next few days.
