### PR TITLE
feat(alert): add 'queue' property to prioritize the ordering of alerts when opened

### DIFF
--- a/packages/calcite-components/.storybook/resources.ts
+++ b/packages/calcite-components/.storybook/resources.ts
@@ -26,6 +26,7 @@ import { TimeZoneMode } from "../src/components/input-time-zone/interfaces.ts";
 import { DisplayMode } from "../src/components/sheet/interfaces.ts";
 import { ShellDisplayMode } from "../src/components/shell/interfaces.ts";
 import { OverlayPositioning } from "../src/components";
+import { AlertDuration } from "../src/components/alert/interfaces";
 
 interface AttributeMetadata<T> {
   values: T[];
@@ -35,6 +36,7 @@ interface AttributeMetadata<T> {
 interface CommonAttributes {
   alignment: AttributeMetadata<Alignment>;
   appearance: AttributeMetadata<Appearance>;
+  duration: AttributeMetadata<AlertDuration>;
   scale: AttributeMetadata<Scale>;
   logicalFlowPosition: AttributeMetadata<LogicalFlowPosition>;
   position: AttributeMetadata<Position>;
@@ -60,11 +62,13 @@ interface CommonAttributes {
   selectionAppearance: AttributeMetadata<SelectionAppearance>;
   shellDisplayMode: AttributeMetadata<ShellDisplayMode>;
   overlayPositioning: AttributeMetadata<OverlayPositioning>;
+  numberingSystem: AttributeMetadata<string>;
 }
 
 const logicalFlowPositionOptions: LogicalFlowPosition[] = ["inline-start", "inline-end", "block-start", "block-end"];
 const positionOptions: Position[] = ["start", "end", "top", "bottom"];
 const scaleOptions: Scale[] = ["s", "m", "l"];
+const durationOptions: AlertDuration[] = ["slow", "medium", "fast"];
 const alignmentOptions: Alignment[] = ["start", "center", "end"];
 const appearanceOptions: Appearance[] = ["solid", "outline", "outline-fill", "transparent"];
 const statusOptions: Status[] = ["invalid", "valid", "idle"];
@@ -93,6 +97,7 @@ const layoutOptions: Layout[] = [
   "none",
   "horizontal-single",
 ];
+const numberingSystems = ["arab", "arabext", "latn"];
 const dirOptions: Dir[] = ["ltr", "rtl"];
 const buttonTypeOptions: TileSelectType[] = ["radio", "checkbox"];
 const interactionModeOptions: TableInteractionMode[] = ["interactive", "static"];
@@ -127,6 +132,10 @@ export const ATTRIBUTES: CommonAttributes = {
   appearance: {
     values: appearanceOptions,
     defaultValue: appearanceOptions[0],
+  },
+  duration: {
+    values: durationOptions,
+    defaultValue: durationOptions[1],
   },
   logicalFlowPosition: {
     values: logicalFlowPositionOptions,
@@ -227,5 +236,9 @@ export const ATTRIBUTES: CommonAttributes = {
   shellDisplayMode: {
     values: shellDisplayModeOptions,
     defaultValue: shellDisplayModeOptions[0],
+  },
+  numberingSystem: {
+    values: numberingSystems,
+    defaultValue: numberingSystems[2],
   },
 };

--- a/packages/calcite-components/.storybook/resources.ts
+++ b/packages/calcite-components/.storybook/resources.ts
@@ -26,7 +26,7 @@ import { TimeZoneMode } from "../src/components/input-time-zone/interfaces.ts";
 import { DisplayMode } from "../src/components/sheet/interfaces.ts";
 import { ShellDisplayMode } from "../src/components/shell/interfaces.ts";
 import { OverlayPositioning } from "../src/components";
-import { AlertDuration } from "../src/components/alert/interfaces";
+import { AlertDuration, AlertQueue } from "../src/components/alert/interfaces";
 
 interface AttributeMetadata<T> {
   values: T[];
@@ -42,6 +42,7 @@ interface CommonAttributes {
   position: AttributeMetadata<Position>;
   status: AttributeMetadata<Status>;
   kind: AttributeMetadata<Kind>;
+  queue: AttributeMetadata<AlertQueue>;
   width: AttributeMetadata<Width>;
   selectionMode: AttributeMetadata<SelectionMode>;
   arrowType: AttributeMetadata<ArrowType>;
@@ -73,6 +74,7 @@ const alignmentOptions: Alignment[] = ["start", "center", "end"];
 const appearanceOptions: Appearance[] = ["solid", "outline", "outline-fill", "transparent"];
 const statusOptions: Status[] = ["invalid", "valid", "idle"];
 const kindOptions: Kind[] = ["brand", "danger", "info", "inverse", "neutral", "warning", "success"];
+const queueOptions: AlertQueue[] = ["last", "next", "immediate"];
 const widthOptions: Width[] = ["auto", "half", "full"];
 const selectionModeOptions: SelectionMode[] = [
   "single",
@@ -156,6 +158,10 @@ export const ATTRIBUTES: CommonAttributes = {
   kind: {
     values: kindOptions,
     defaultValue: kindOptions[0],
+  },
+  queue: {
+    values: queueOptions,
+    defaultValue: queueOptions[0],
   },
   width: {
     values: widthOptions,

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -15,7 +15,7 @@ import { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n
 import { Columns } from "./components/action-group/interfaces";
 import { ActionGroupMessages } from "./components/action-group/assets/action-group/t9n";
 import { ActionPadMessages } from "./components/action-pad/assets/action-pad/t9n";
-import { AlertDuration, Sync } from "./components/alert/interfaces";
+import { AlertDuration, AlertQueue, Sync } from "./components/alert/interfaces";
 import { NumberingSystem } from "./utils/locale";
 import { AlertMessages } from "./components/alert/assets/alert/t9n";
 import { HeadingLevel } from "./components/functional/Heading";
@@ -111,7 +111,7 @@ export { ActionBarMessages } from "./components/action-bar/assets/action-bar/t9n
 export { Columns } from "./components/action-group/interfaces";
 export { ActionGroupMessages } from "./components/action-group/assets/action-group/t9n";
 export { ActionPadMessages } from "./components/action-pad/assets/action-pad/t9n";
-export { AlertDuration, Sync } from "./components/alert/interfaces";
+export { AlertDuration, AlertQueue, Sync } from "./components/alert/interfaces";
 export { NumberingSystem } from "./utils/locale";
 export { AlertMessages } from "./components/alert/assets/alert/t9n";
 export { HeadingLevel } from "./components/functional/Heading";
@@ -562,6 +562,10 @@ export namespace Components {
          */
         "placement": MenuPlacement;
         /**
+          * Specifies the urgency of the component when opened.
+         */
+        "queue": AlertQueue;
+        /**
           * Specifies the size of the component.
          */
         "scale": Scale;
@@ -569,10 +573,6 @@ export namespace Components {
           * Sets focus on the component's "close" button, the first focusable item.
          */
         "setFocus": () => Promise<void>;
-        /**
-          * Specifies the priority of the component. urgent alerts will be shown first.
-         */
-        "urgent": boolean;
     }
     interface CalciteAvatar {
         /**
@@ -8465,13 +8465,13 @@ declare namespace LocalJSX {
          */
         "placement"?: MenuPlacement;
         /**
+          * Specifies the urgency of the component when opened.
+         */
+        "queue"?: AlertQueue;
+        /**
           * Specifies the size of the component.
          */
         "scale"?: Scale;
-        /**
-          * Specifies the priority of the component. urgent alerts will be shown first.
-         */
-        "urgent"?: boolean;
     }
     interface CalciteAvatar {
         /**

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -569,6 +569,10 @@ export namespace Components {
           * Sets focus on the component's "close" button, the first focusable item.
          */
         "setFocus": () => Promise<void>;
+        /**
+          * Specifies the priority of the component. urgent alerts will be shown first.
+         */
+        "urgent": boolean;
     }
     interface CalciteAvatar {
         /**
@@ -8464,6 +8468,10 @@ declare namespace LocalJSX {
           * Specifies the size of the component.
          */
         "scale"?: Scale;
+        /**
+          * Specifies the priority of the component. urgent alerts will be shown first.
+         */
+        "urgent"?: boolean;
     }
     interface CalciteAvatar {
         /**

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -562,7 +562,7 @@ export namespace Components {
          */
         "placement": MenuPlacement;
         /**
-          * Specifies the urgency of the component when opened.
+          * Specifies the ordering priority of the component when opened.
          */
         "queue": AlertQueue;
         /**
@@ -8465,7 +8465,7 @@ declare namespace LocalJSX {
          */
         "placement"?: MenuPlacement;
         /**
-          * Specifies the urgency of the component when opened.
+          * Specifies the ordering priority of the component when opened.
          */
         "queue"?: AlertQueue;
         /**

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -249,6 +249,8 @@ describe("calcite-alert", () => {
     expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(true);
 
+    alert3.setProperty("queue", "immediate");
+    await page.waitForChanges();
     alert2.setProperty("queue", "immediate");
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
@@ -269,6 +271,25 @@ describe("calcite-alert", () => {
     // queue: [1, 3]
     expect(await alert1Container.isVisible()).toBe(true);
     expect(await alert2Container.isVisible()).toBe(false);
+    expect(await alert3Container.isVisible()).toBe(false);
+
+    alert2.setProperty("queue", "next");
+    alert2.setProperty("open", true);
+    await page.waitForChanges();
+    await page.waitForTimeout(animationDurationInMs);
+
+    // queue: [1, 2, 3]
+    expect(await alert1Container.isVisible()).toBe(true);
+    expect(await alert2Container.isVisible()).toBe(false);
+    expect(await alert3Container.isVisible()).toBe(false);
+
+    alert1.setProperty("open", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(animationDurationInMs);
+
+    // queue: [2, 3]
+    expect(await alert1Container.isVisible()).toBe(false);
+    expect(await alert2Container.isVisible()).toBe(true);
     expect(await alert3Container.isVisible()).toBe(false);
   });
 

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -1,6 +1,6 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, hidden, HYDRATED_ATTR, renders, t9n } from "../../tests/commonTests";
+import { accessible, defaults, hidden, HYDRATED_ATTR, reflects, renders, t9n } from "../../tests/commonTests";
 import { getElementXY } from "../../tests/utils";
 import { openClose } from "../../tests/commonTests";
 import { CSS, DURATIONS } from "./resources";
@@ -14,6 +14,19 @@ describe("defaults", () => {
     {
       propertyName: "embedded",
       defaultValue: false,
+    },
+    {
+      propertyName: "urgent",
+      defaultValue: false,
+    },
+  ]);
+});
+
+describe("reflects", () => {
+  reflects("calcite-alert", [
+    {
+      propertyName: "urgent",
+      value: true,
     },
   ]);
 });
@@ -153,6 +166,7 @@ describe("calcite-alert", () => {
     <calcite-button id="button-1" onclick="document.querySelector('#alert-1').setAttribute('open', '')">open alert-1</calcite-button>
     <calcite-button id="button-2" onclick="document.querySelector('#alert-2').setAttribute('open', '')">open alert-2</calcite-button>
     <calcite-button id="button-3" onclick="document.querySelector('#alert-3').setAttribute('open', '')">open alert-3</calcite-button>
+     <calcite-button id="button-4" onclick="document.querySelector('#alert-4').setAttribute('open', '')">open alert-4</calcite-button>
     <calcite-alert id="alert-1">
     ${alertContent}
     </calcite-alert>
@@ -162,14 +176,19 @@ describe("calcite-alert", () => {
     <calcite-alert id="alert-3">
     ${alertContent}
     </calcite-alert>
+    <calcite-alert urgent id="alert-4">
+    ${alertContent}
+    </calcite-alert>
     </div>`);
 
     const alert1 = await page.find("#alert-1");
     const alert2 = await page.find("#alert-2");
     const alert3 = await page.find("#alert-3");
+    const alert4 = await page.find("#alert-4");
     const button1 = await page.find("#button-1");
     const button2 = await page.find("#button-2");
     const button3 = await page.find("#button-3");
+    const button4 = await page.find("#button-4");
     const alertClose1 = await page.find(`#alert-1 >>> .${CSS.close}`);
     const alertClose2 = await page.find(`#alert-2 >>> .${CSS.close}`);
 
@@ -187,6 +206,15 @@ describe("calcite-alert", () => {
     expect(await alert1.isVisible()).not.toBe(true);
     expect(await alert2.isVisible()).not.toBe(true);
     expect(await alert3.isVisible()).toBe(true);
+    expect(await alert4.isVisible()).not.toBe(true);
+
+    await button4.click();
+    await page.waitForTimeout(animationDurationInMs);
+
+    expect(await alert1.isVisible()).not.toBe(true);
+    expect(await alert2.isVisible()).not.toBe(true);
+    expect(await alert3.isVisible()).not.toBe(true);
+    expect(await alert4.isVisible()).toBe(true);
   });
 
   it("correctly assigns a default placement class", async () => {

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -205,18 +205,11 @@ describe("calcite-alert", () => {
   it("should queue alerts", async () => {
     const page = await newE2EPage();
     await skipAnimations(page);
-    await page.setContent(`
-    <div>
-    <calcite-alert id="alert-1">
-    ${alertContent}
-    </calcite-alert>
-    <calcite-alert id="alert-2">
-    ${alertContent}
-    </calcite-alert>
-    <calcite-alert id="alert-3">
-    ${alertContent}
-    </calcite-alert>
-    </div>`);
+    await page.setContent(html`
+      <calcite-alert id="alert-1"> ${alertContent} </calcite-alert>
+      <calcite-alert id="alert-2"> ${alertContent} </calcite-alert>
+      <calcite-alert id="alert-3"> ${alertContent} </calcite-alert>
+    `);
 
     const alert1 = await page.find("#alert-1");
     const alert2 = await page.find("#alert-2");
@@ -244,7 +237,6 @@ describe("calcite-alert", () => {
     const alert2Container = await page.find(`#alert-2 >>> .${CSS.container}`);
     const alert3Container = await page.find(`#alert-3 >>> .${CSS.container}`);
 
-    // queue: [3, 1, 2]
     expect(await alert1Container.isVisible()).toBe(false);
     expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(true);
@@ -255,7 +247,6 @@ describe("calcite-alert", () => {
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
 
-    // queue: [2, 3, 1]
     expect(await alert1Container.isVisible()).toBe(false);
     expect(await alert2Container.isVisible()).toBe(true);
     expect(await alert3Container.isVisible()).toBe(false);
@@ -268,7 +259,6 @@ describe("calcite-alert", () => {
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
 
-    // queue: [1, 3]
     expect(await alert1Container.isVisible()).toBe(true);
     expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(false);
@@ -278,7 +268,6 @@ describe("calcite-alert", () => {
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
 
-    // queue: [1, 2, 3]
     expect(await alert1Container.isVisible()).toBe(true);
     expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(false);
@@ -287,7 +276,6 @@ describe("calcite-alert", () => {
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
 
-    // queue: [2, 3]
     expect(await alert1Container.isVisible()).toBe(false);
     expect(await alert2Container.isVisible()).toBe(true);
     expect(await alert3Container.isVisible()).toBe(false);

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -16,8 +16,8 @@ describe("defaults", () => {
       defaultValue: false,
     },
     {
-      propertyName: "urgent",
-      defaultValue: false,
+      propertyName: "queue",
+      defaultValue: "last",
     },
   ]);
 });
@@ -25,8 +25,8 @@ describe("defaults", () => {
 describe("reflects", () => {
   reflects("calcite-alert", [
     {
-      propertyName: "urgent",
-      value: true,
+      propertyName: "queue",
+      value: "last",
     },
   ]);
 });
@@ -202,7 +202,7 @@ describe("calcite-alert", () => {
     expect(await alert3.isVisible()).toBe(true);
   });
 
-  it("should handle urgent alerts", async () => {
+  it("should queue alerts", async () => {
     const page = await newE2EPage();
     await skipAnimations(page);
     await page.setContent(`
@@ -230,7 +230,7 @@ describe("calcite-alert", () => {
     await page.waitForChanges();
     alert2.setProperty("open", true);
     await page.waitForChanges();
-    alert3.setProperty("urgent", true);
+    alert3.setProperty("queue", "immediate");
     await page.waitForChanges();
     alert3.setProperty("open", true);
     await page.waitForChanges();
@@ -244,16 +244,31 @@ describe("calcite-alert", () => {
     const alert2Container = await page.find(`#alert-2 >>> .${CSS.container}`);
     const alert3Container = await page.find(`#alert-3 >>> .${CSS.container}`);
 
+    // queue: [3, 1, 2]
     expect(await alert1Container.isVisible()).toBe(false);
     expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(true);
 
-    alert2.setProperty("urgent", true);
+    alert2.setProperty("queue", "immediate");
     await page.waitForChanges();
     await page.waitForTimeout(animationDurationInMs);
 
+    // queue: [2, 3, 1]
     expect(await alert1Container.isVisible()).toBe(false);
     expect(await alert2Container.isVisible()).toBe(true);
+    expect(await alert3Container.isVisible()).toBe(false);
+
+    alert1.setProperty("queue", "next");
+    await page.waitForChanges();
+    await page.waitForTimeout(animationDurationInMs);
+
+    alert2.setProperty("open", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(animationDurationInMs);
+
+    // queue: [1, 3]
+    expect(await alert1Container.isVisible()).toBe(true);
+    expect(await alert2Container.isVisible()).toBe(false);
     expect(await alert3Container.isVisible()).toBe(false);
   });
 

--- a/packages/calcite-components/src/components/alert/alert.stories.ts
+++ b/packages/calcite-components/src/components/alert/alert.stories.ts
@@ -4,7 +4,7 @@ import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
 import { menuPlacements } from "../../utils/floating-ui";
 import { Alert } from "./Alert";
-const { scale, duration, kind, numberingSystem } = ATTRIBUTES;
+const { scale, duration, kind, numberingSystem, queue } = ATTRIBUTES;
 
 interface AlertStoryArgs
   extends Pick<
@@ -19,7 +19,7 @@ interface AlertStoryArgs
     | "open"
     | "placement"
     | "scale"
-    | "urgent"
+    | "queue"
   > {}
 
 export default {
@@ -35,7 +35,7 @@ export default {
     open: true,
     placement: menuPlacements[4],
     scale: "m",
-    urgent: false,
+    queue: "last",
   },
   argTypes: {
     autoCloseDuration: {
@@ -56,6 +56,10 @@ export default {
     },
     placement: {
       options: menuPlacements,
+      control: { type: "select" },
+    },
+    queue: {
+      options: queue.values,
       control: { type: "select" },
     },
     scale: {
@@ -89,7 +93,7 @@ export const simple = (args: AlertStoryArgs): string => html`
       ${boolean("auto-close", args.autoClose)}
       ${boolean("open", args.open)}
       ${boolean("icon-flip-rtl", args.iconFlipRtl)}
-      ${boolean("urgent", args.urgent)}
+      queue="${args.queue}"
       auto-close-duration="${args.autoCloseDuration}"
       scale="${args.scale}"
       kind="${args.kind}"
@@ -283,15 +287,15 @@ export const textAlignDoesNotAffectComponentAlignment_TestOnly = (): string => h
   </div>
 `;
 
-export const withUrgent = (): string => html`
+export const withQueue = (): string => html`
   ${wrapperStyles}
   <div class="wrapper">
     <calcite-alert id="one" kind="brand" open>
       <div slot="title">Open by default</div>
       <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
-    <calcite-alert id="two" urgent kind="danger">
-      <div slot="title">Urgent Alert</div>
+    <calcite-alert id="two" queue="immediate" kind="danger">
+      <div slot="title">Immediate Alert</div>
       <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
     <calcite-alert id="three" kind="success">

--- a/packages/calcite-components/src/components/alert/alert.stories.ts
+++ b/packages/calcite-components/src/components/alert/alert.stories.ts
@@ -260,7 +260,7 @@ export const actionsEndQueued_TestOnly = (): string => html`
     <script>
       setTimeout(() => {
         document.querySelector("#two").open = true;
-      }, "1000");
+      }, 250);
     </script>
   </div>
 `;
@@ -286,17 +286,25 @@ export const textAlignDoesNotAffectComponentAlignment_TestOnly = (): string => h
 export const withUrgent = (): string => html`
   ${wrapperStyles}
   <div class="wrapper">
-    <calcite-alert kind="brand" open label="A normal alert">
-      <div slot="title">Normal Alert</div>
+    <calcite-alert id="one" kind="brand" open>
+      <div slot="title">Open by default</div>
       <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
-    <calcite-alert urgent kind="danger" open label="An urgent alert">
+    <calcite-alert id="two" urgent kind="danger">
       <div slot="title">Urgent Alert</div>
       <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
-    <calcite-alert kind="brand" open label="A normal alert">
-      <div slot="title">Normal Alert</div>
+    <calcite-alert id="three" kind="success">
+      <div slot="title">Third Alert</div>
       <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
+    <script>
+      setTimeout(() => {
+        document.querySelector("#two").open = true;
+      }, 100);
+      setTimeout(() => {
+        document.querySelector("#three").open = true;
+      }, 250);
+    </script>
   </div>
 `;

--- a/packages/calcite-components/src/components/alert/alert.stories.ts
+++ b/packages/calcite-components/src/components/alert/alert.stories.ts
@@ -1,9 +1,68 @@
 import { iconNames } from "../../../.storybook/helpers";
-import { modesDarkDefault } from "../../../.storybook/utils";
+import { boolean, modesDarkDefault } from "../../../.storybook/utils";
 import { html } from "../../../support/formatting";
+import { ATTRIBUTES } from "../../../.storybook/resources";
+import { menuPlacements } from "../../utils/floating-ui";
+import { Alert } from "./Alert";
+const { scale, duration, kind, numberingSystem } = ATTRIBUTES;
+
+interface AlertStoryArgs
+  extends Pick<
+    Alert,
+    | "autoClose"
+    | "autoCloseDuration"
+    | "icon"
+    | "iconFlipRtl"
+    | "kind"
+    | "label"
+    | "numberingSystem"
+    | "open"
+    | "placement"
+    | "scale"
+    | "urgent"
+  > {}
 
 export default {
   title: "Components/Alert",
+  args: {
+    autoClose: false,
+    autoCloseDuration: duration.defaultValue,
+    icon: "",
+    iconFlipRtl: false,
+    kind: kind.defaultValue,
+    label: "Alert",
+    numberingSystem: numberingSystem[2],
+    open: true,
+    placement: menuPlacements[4],
+    scale: "m",
+    urgent: false,
+  },
+  argTypes: {
+    autoCloseDuration: {
+      options: duration.values,
+      control: { type: "select" },
+    },
+    icon: {
+      options: iconNames,
+      control: { type: "select" },
+    },
+    kind: {
+      options: kind.values.filter((option) => option !== "inverse" && option !== "neutral"),
+      control: { type: "select" },
+    },
+    numberingSystem: {
+      options: numberingSystem,
+      control: { type: "select" },
+    },
+    placement: {
+      options: menuPlacements,
+      control: { type: "select" },
+    },
+    scale: {
+      options: scale.values,
+      control: { type: "select" },
+    },
+  },
   parameters: {
     chromatic: {
       delay: 500,
@@ -21,6 +80,29 @@ const wrapperStyles = html`
       max-width: 100%;
     }
   </style>
+`;
+
+export const simple = (args: AlertStoryArgs): string => html`
+  ${wrapperStyles}
+  <div class="wrapper">
+    <calcite-alert
+      ${boolean("auto-close", args.autoClose)}
+      ${boolean("open", args.open)}
+      ${boolean("icon-flip-rtl", args.iconFlipRtl)}
+      ${boolean("urgent", args.urgent)}
+      auto-close-duration="${args.autoCloseDuration}"
+      scale="${args.scale}"
+      kind="${args.kind}"
+      icon="${args.icon}"
+      label="${args.label}"
+      numbering-system="${args.numberingSystem}"
+      placement="${args.placement}"
+    >
+      <div slot="title">Here's a general bit of information</div>
+      <div slot="message">Some kind of contextually relevant content</div>
+      <calcite-link slot="link" title="my action">Take action</calcite-link>
+    </calcite-alert>
+  </div>
 `;
 
 export const titleMessageLink = (): string => html`
@@ -197,6 +279,24 @@ export const textAlignDoesNotAffectComponentAlignment_TestOnly = (): string => h
       <div slot="title">Trail Camera Report</div>
       <div slot="message">We thought you might want to take a look</div>
       <calcite-link slot="link">Take action</calcite-link>
+    </calcite-alert>
+  </div>
+`;
+
+export const withUrgent = (): string => html`
+  ${wrapperStyles}
+  <div class="wrapper">
+    <calcite-alert kind="brand" open label="A normal alert">
+      <div slot="title">Normal Alert</div>
+      <div slot="message">We thought you might want to take a look</div>
+    </calcite-alert>
+    <calcite-alert urgent kind="danger" open label="An urgent alert">
+      <div slot="title">Urgent Alert</div>
+      <div slot="message">We thought you might want to take a look</div>
+    </calcite-alert>
+    <calcite-alert kind="brand" open label="A normal alert">
+      <div slot="title">Normal Alert</div>
+      <div slot="message">We thought you might want to take a look</div>
     </calcite-alert>
   </div>
 `;

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -232,7 +232,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
             [CSS.containerQueued]: queued,
             [`${CSS.container}--${placement}`]: true,
             [CSS.containerEmbedded]: this.embedded,
-            [CSS.focused]: this.keyBoardFocus,
+            [CSS.focused]: this.isFocused,
           }}
           onPointerEnter={this.autoClose && this.autoCloseTimeoutId ? this.handleMouseOver : null}
           onPointerLeave={this.autoClose ? this.handleMouseLeave : null}
@@ -258,13 +258,13 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   }
 
   private handleKeyBoardFocus = (): void => {
-    this.keyBoardFocus = true;
+    this.isFocused = true;
     this.handleFocus();
   };
 
   private handleKeyBoardBlur = (): void => {
-    this.keyBoardFocus = false;
-    if (!this.mouseFocus) {
+    this.isFocused = false;
+    if (!this.isHovered) {
       this.handleBlur();
     }
   };
@@ -460,7 +460,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   /** is the alert queued */
   @State() queued = false;
 
-  @State() keyBoardFocus = false;
+  @State() isFocused = false;
 
   private autoCloseTimeoutId: number = null;
 
@@ -476,11 +476,11 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   private totalHoverTime = 0;
 
+  private isHovered: boolean;
+
   openTransitionProp = "opacity";
 
   transitionEl: HTMLDivElement;
-
-  mouseFocus: boolean;
 
   //--------------------------------------------------------------------------
   //
@@ -570,13 +570,13 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   };
 
   private handleMouseOver = (): void => {
-    this.mouseFocus = true;
+    this.isHovered = true;
     this.handleFocus();
   };
 
   private handleMouseLeave = (): void => {
-    this.mouseFocus = false;
-    if (!this.keyBoardFocus) {
+    this.isHovered = false;
+    if (!this.isFocused) {
       this.handleBlur();
     }
   };

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -152,7 +152,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   @Watch("autoCloseDuration")
   updateDuration(): void {
     if (this.autoClose && this.autoCloseTimeoutId) {
-      window.clearTimeout(this.autoCloseTimeoutId);
+      this.clearAutoCloseTimeout();
       this.autoCloseTimeoutId = window.setTimeout(
         () => this.closeAlert(),
         DURATIONS[this.autoCloseDuration],
@@ -470,7 +470,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   private lastMouseOverBegin: number;
 
-  private queueTimeout: number;
+  private queueTimeoutId: number = null;
 
   private totalOpenTime = 0;
 
@@ -488,6 +488,16 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   //
   //--------------------------------------------------------------------------
 
+  private clearAutoCloseTimeout = (): void => {
+    window.clearTimeout(this.autoCloseTimeoutId);
+    this.autoCloseTimeoutId = null;
+  };
+
+  private clearQueueTimeout = (): void => {
+    window.clearTimeout(this.queueTimeoutId);
+    this.queueTimeoutId = null;
+  };
+
   private unregisterAlert = (): void => {
     this.queued = false;
 
@@ -497,9 +507,8 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
       }),
     );
 
-    window.clearTimeout(this.autoCloseTimeoutId);
-    this.autoCloseTimeoutId = null;
-    window.clearTimeout(this.queueTimeout);
+    this.clearAutoCloseTimeout();
+    this.clearQueueTimeout();
   };
 
   private setTransitionEl = (el: HTMLDivElement): void => {
@@ -518,7 +527,8 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
         );
       }
     } else {
-      window.clearTimeout(this.queueTimeout);
+      this.clearAutoCloseTimeout();
+      this.clearQueueTimeout();
       this.queued = this.open;
     }
   }
@@ -551,8 +561,8 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   /** remove queued class after animation completes */
   private openAlert(): void {
-    window.clearTimeout(this.queueTimeout);
-    this.queueTimeout = window.setTimeout(() => (this.queued = false), 300);
+    this.clearQueueTimeout();
+    this.queueTimeoutId = window.setTimeout(() => (this.queued = false), 300);
   }
 
   private actionsEndSlotChangeHandler = (event: Event): void => {
@@ -572,8 +582,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   };
 
   private handleFocus = (): void => {
-    window.clearTimeout(this.autoCloseTimeoutId);
-    this.autoCloseTimeoutId = null;
+    this.clearAutoCloseTimeout();
     this.totalOpenTime = Date.now() - this.initialOpenTime;
     this.lastMouseOverBegin = Date.now();
   };

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -93,6 +93,17 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   /** Specifies the duration before the component automatically closes - only use with `autoClose`. */
   @Prop({ reflect: true }) autoCloseDuration: AlertDuration = "medium";
 
+  @Watch("autoCloseDuration")
+  updateDuration(): void {
+    if (this.autoClose && this.autoCloseTimeoutId) {
+      this.clearAutoCloseTimeout();
+      this.autoCloseTimeoutId = window.setTimeout(
+        () => this.closeAlert(),
+        DURATIONS[this.autoCloseDuration],
+      );
+    }
+  }
+
   /**
    * This internal property, managed by a containing calcite-shell, is used
    * to inform the component if special configuration or styles are needed
@@ -147,17 +158,6 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   @Watch("messageOverrides")
   onMessagesChange(): void {
     /* wired up by t9n util */
-  }
-
-  @Watch("autoCloseDuration")
-  updateDuration(): void {
-    if (this.autoClose && this.autoCloseTimeoutId) {
-      this.clearAutoCloseTimeout();
-      this.autoCloseTimeoutId = window.setTimeout(
-        () => this.closeAlert(),
-        DURATIONS[this.autoCloseDuration],
-      );
-    }
   }
 
   /** Specifies the priority of the component. urgent alerts will be shown first. */

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -160,7 +160,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     /* wired up by t9n util */
   }
 
-  /** Specifies the urgency of the component when opened. */
+  /** Specifies the ordering priority of the component when opened. */
   @Prop({ reflect: true }) queue: AlertQueue = "last";
 
   @Watch("queue")

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -486,17 +486,17 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   //
   //--------------------------------------------------------------------------
 
-  private clearAutoCloseTimeout = (): void => {
+  private clearAutoCloseTimeout(): void {
     window.clearTimeout(this.autoCloseTimeoutId);
     this.autoCloseTimeoutId = null;
-  };
+  }
 
-  private clearQueueTimeout = (): void => {
+  private clearQueueTimeout(): void {
     window.clearTimeout(this.queueTimeoutId);
     this.queueTimeoutId = null;
-  };
+  }
 
-  private unregisterAlert = (): void => {
+  private unregisterAlert(): void {
     this.queued = false;
 
     window.dispatchEvent(
@@ -507,7 +507,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
     this.clearAutoCloseTimeout();
     this.clearQueueTimeout();
-  };
+  }
 
   private setTransitionEl = (el: HTMLDivElement): void => {
     this.transitionEl = el;

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -449,11 +449,9 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   @State() hasEndActions = false;
 
-  // todo: this queue stack is maintained as a state on every alert instance? Should we refactor this?
   /** the list of queued alerts */
   @State() queue: HTMLCalciteAlertElement[] = [];
 
-  // todo: this queue length is maintained on every alert instance?
   /** the count of queued alerts */
   @State() queueLength = 0;
 

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -160,6 +160,14 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
     }
   }
 
+  /** Specifies the priority of the component. urgent alerts will be shown first. */
+  @Prop({ reflect: true }) urgent = false;
+
+  @Watch("urgent")
+  handleUrgentChange(): void {
+    // todo
+  }
+
   //--------------------------------------------------------------------------
   //
   //  Lifecycle
@@ -365,7 +373,11 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
   alertRegister(): void {
     if (this.open && !this.queue.includes(this.el as HTMLCalciteAlertElement)) {
       this.queued = true;
-      this.queue.push(this.el as HTMLCalciteAlertElement);
+      if (this.urgent) {
+        this.queue.unshift(this.el as HTMLCalciteAlertElement);
+      } else {
+        this.queue.push(this.el as HTMLCalciteAlertElement);
+      }
     }
     this.calciteInternalAlertSync.emit({ queue: this.queue });
     this.determineActiveAlert();
@@ -441,9 +453,11 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
 
   @State() hasEndActions = false;
 
+  // todo: this queue stack is maintained as a state on every alert instance? Should we refactor this?
   /** the list of queued alerts */
   @State() queue: HTMLCalciteAlertElement[] = [];
 
+  // todo: this queue length is maintained on every alert instance?
   /** the count of queued alerts */
   @State() queueLength = 0;
 
@@ -494,6 +508,7 @@ export class Alert implements OpenCloseComponent, LoadableComponent, T9nComponen
         );
       }
     } else {
+      this.queued = this.open;
       return;
     }
   }

--- a/packages/calcite-components/src/components/alert/interfaces.ts
+++ b/packages/calcite-components/src/components/alert/interfaces.ts
@@ -1,7 +1,8 @@
 export type AlertDuration = "fast" | "medium" | "slow";
+export type AlertQueue = "immediate" | "next" | "last";
 
 export interface Sync {
-  queue: HTMLCalciteAlertElement[];
+  queueList: HTMLCalciteAlertElement[];
 }
 
 export interface Unregister {


### PR DESCRIPTION
**Related Issue:** #8705 #8316

## Summary

- add `queue` property to order an open alert `immediate`, `next` or `last` (default).
  - When a `queue="immediate"` alert is opened it is displayed immediately.
  - When a `queue="next"` alert is opened it will be displayed after the currently opened one is closed.
  - By default, alerts are queued to be `last` when opened.
  - When an alert is set to `queue="immediate"` after already being opened it will be presented first.
    - Done by unregistering and registering the alert again
    - All open alerts not at the top of the stack will be queued and auto close timeout reset
  - All other alerts remain in their place.
- cleanup private var names
- add simple story
- add urgent story
- add e2e test
