### PR TITLE
ci: new version of husky no longer need npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-npx lint-staged
+lint-staged
 
 types_path="packages/calcite-components/src/components.d.ts"
 


### PR DESCRIPTION
## Summary

Husky adds `node_modules/.bin` to path starting in `v9`, so `npx` is no longer required in the hook scripts.

ref: https://github.com/typicode/husky/releases/tag/v9.0.1#how-to-migrate
