### PR TITLE
ci: fix icon diff check failures

### DIFF
--- a/.github/workflows/icons-diff-check.yml
+++ b/.github/workflows/icons-diff-check.yml
@@ -1,10 +1,9 @@
 name: Icon Team Diff Check
 on:
-  workflow_call:
-  # pull_request:
-  #   branches: [main, rc, dev]
-  # pull_request_review:
-  #   types: [submitted]
+  pull_request:
+    branches: [dev]
+  pull_request_review:
+    types: [submitted]
 jobs:
   check-diff:
     runs-on: ubuntu-latest
@@ -18,7 +17,7 @@ jobs:
         run: |
           non_icon_changes="$(
             git diff --name-only HEAD "$(
-              git merge-base HEAD origin/${{ github.base_ref }}
+              git merge-base HEAD origin/dev
             )" -- . ':!**/calcite-ui-icons/**'
           )"
 


### PR DESCRIPTION
## Summary

The Icon Diff Check action was failing on the `pull_request_review` event, because apparently `github.base_ref` isn't defined in its context. The icon team members will only be submitting PRs to `dev`, so I hardcoded the branch name.
