### PR TITLE
ci: bump version in icon docs

### DIFF
--- a/packages/calcite-ui-icons/docs/index.html
+++ b/packages/calcite-ui-icons/docs/index.html
@@ -47,7 +47,9 @@
           <div class="column-24">
             <div class="column-12">
               <p class="trailer-half">
-                Version <span class="js-version margin-right-2">1.1.2</span>
+                <!-- x-release-please-start-version -->
+                Version <span class="js-version margin-right-2">3.30.0</span>
+                <!-- x-release-please-end -->
                 <a href="https://github.com/esri/calcite-ui-icons/" class="link-white"
                   >View on GitHub
                   <svg

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
       "component": "@esri/calcite-design-tokens"
     },
     "packages/calcite-ui-icons": {
-      "component": "@esri/calcite-ui-icons"
+      "component": "@esri/calcite-ui-icons",
+      "extra-files": ["docs/index.html"]
     },
     "packages/eslint-plugin-calcite-components": {
       "component": "@esri/eslint-plugin-calcite-components"


### PR DESCRIPTION
## Summary

Bump the version in the UI Icons reference doc via release-please.
