### PR TITLE
fix(panel): define heading and description line height

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -39,12 +39,22 @@
 
   .header-content {
     .heading {
-      font-size: theme("fontSize.0h");
+      @apply text-0h;
     }
 
     .description {
-      font-size: theme("fontSize.n1h");
+      @apply text-n1h;
     }
+  }
+}
+
+.header-content {
+  .heading {
+    @apply text-0h mx-0 mt-0 mb-1 font-medium;
+  }
+
+  .description {
+    @apply text-color-2 text-n1h;
   }
 }
 

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -24,11 +24,11 @@
 
   .header-content {
     .heading {
-      font-size: theme("fontSize.n1h");
+      @apply text-n1h;
     }
 
     .description {
-      font-size: theme("fontSize.n2h");
+      @apply text-n2h;
     }
   }
 }
@@ -48,27 +48,17 @@
   }
 }
 
-.header-content {
-  .heading {
-    @apply text-0h mx-0 mt-0 mb-1 font-medium;
-  }
-
-  .description {
-    @apply text-color-2 text-n1h;
-  }
-}
-
 :host([scale="l"]) {
   --calcite-internal-panel-default-padding: var(--calcite-spacing-xl);
   --calcite-internal-panel-header-vertical-padding: var(--calcite-spacing-xxl);
 
   .header-content {
     .heading {
-      font-size: theme("fontSize.1h");
+      @apply text-1h;
     }
 
     .description {
-      font-size: theme("fontSize.0h");
+      @apply text-0h;
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #10042

## Summary
Fix regression where panel `heading` and `description` retain their line height. 
