### PR TITLE
chore(linting): fix markdown linting error

### DIFF
--- a/examples/components/webpack/README.md
+++ b/examples/components/webpack/README.md
@@ -43,7 +43,7 @@ import "@esri/calcite-components/dist/calcite/calcite.css";
 ```
 
 > [!NOTE]
-> This requires setting up a CSS loader in your Webpack config (see [Config > CSS](#css) below)
+> This requires setting up a CSS loader in your Webpack config (see [Config > CSS](#add-css-loader) below)
 
 ### Configure Webpack
 


### PR DESCRIPTION
**Related Issue:** #N/A

## Summary
Fix the markdown linting error caused by a renamed anchor where the link was outdated.