### PR TITLE
ci: fix json string escaping for release asset upload

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Build Packages and Publish to NPM
         if: steps.release.outputs.releases_created == 'true'
         env:
-          RELEASED_PATHS: ${{ toJSON(steps.release.outputs.paths_released) }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
@@ -92,7 +91,7 @@ jobs:
           git commit -m "build: update types and package-lock" || true
 
           npm run publish:latest
-          npm run util:upload-release-assets -- "$RELEASED_PATHS"
+          npm run util:upload-release-assets -- "${{toJSON(steps.release.outputs.paths_released)}}"
 
           git checkout -b ci/cherry-pick-release-commit origin/dev
 
@@ -101,7 +100,7 @@ jobs:
               ${{github.workspace}}/packages/*/CHANGELOG.md \
               ${{github.workspace}}/packages/calcite-components-angular/projects/component-library/CHANGELOG.md
 
-            git checkout --theirs
+            git checkout --theirs \
               ${{github.workspace}}/packages/*/package.json \
               ${{github.workspace}}/packages/calcite-components-angular/projects/component-library/package.json
 


### PR DESCRIPTION
## Summary

Attempt to fix the release asset uploading script, which is having errors due to invalid json string syntax. Setting the output to an intermediary env var could be messing up the quotes.
