### PR TITLE
chore(linting): enable unicorn/filename-case

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -143,6 +143,7 @@ module.exports = {
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/self-closing-comp": "error",
+    "unicorn/filename-case": "error",
     "unicorn/prefer-ternary": "error",
     "unicorn/prevent-abbreviations": [
       "error",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Enables `unicorn/filename-case` rule for consistent file names across the monorepo.

