### PR TITLE
chore(segmented-control): remove empty and irrelevant `describe` block

### DIFF
--- a/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
@@ -452,8 +452,4 @@ describe("calcite-segmented-control", () => {
       );
     });
   });
-
-  describe("updates items when children are modified after initialization", () => {
-    // TODO:
-  });
 });


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

`describe` block was unintentionally added in https://github.com/Esri/calcite-design-system/pull/7584.