### PR TITLE
fix(input-date-picker): prevent console error when using a lang

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -527,6 +527,7 @@ export class InputDatePicker
 
   componentDidLoad(): void {
     setComponentLoaded(this);
+    this.handleDateTimeFormatChange();
     this.localizeInputValues();
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }
@@ -1089,8 +1090,11 @@ export class InputDatePicker
         )
       : null;
 
-    this.setInputValue((date && this.dateTimeFormat.format(date)) ?? "", "start");
-    this.setInputValue((this.range && endDate && this.dateTimeFormat.format(endDate)) ?? "", "end");
+    this.setInputValue((date && this.dateTimeFormat?.format(date)) ?? "", "start");
+    this.setInputValue(
+      (this.range && endDate && this.dateTimeFormat?.format(endDate)) ?? "",
+      "end",
+    );
   }
 
   private setInputValue = (newValue: string, input: "start" | "end" = "start"): void => {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -468,6 +468,7 @@ export class InputDatePicker
   connectedCallback(): void {
     connectInteractive(this);
     connectLocalized(this);
+    this.handleDateTimeFormatChange();
 
     const { open } = this;
     open && this.openHandler();
@@ -527,7 +528,6 @@ export class InputDatePicker
 
   componentDidLoad(): void {
     setComponentLoaded(this);
-    this.handleDateTimeFormatChange();
     this.localizeInputValues();
     connectFloatingUI(this, this.referenceEl, this.floatingEl);
   }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -1090,11 +1090,8 @@ export class InputDatePicker
         )
       : null;
 
-    this.setInputValue((date && this.dateTimeFormat?.format(date)) ?? "", "start");
-    this.setInputValue(
-      (this.range && endDate && this.dateTimeFormat?.format(endDate)) ?? "",
-      "end",
-    );
+    this.setInputValue((date && this.dateTimeFormat.format(date)) ?? "", "start");
+    this.setInputValue((this.range && endDate && this.dateTimeFormat.format(endDate)) ?? "", "end");
   }
 
   private setInputValue = (newValue: string, input: "start" | "end" = "start"): void => {


### PR DESCRIPTION
**Related Issue:** #9387

## Summary

- creates `dateTimeFormat` on connectedCallback to prevent console error from occurring.
