### PR TITLE
ci(release): fix jsonpath syntax for updating extra files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,7 +47,7 @@
         {
           "type": "json",
           "path": "/examples/components/react/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components-react"
+          "jsonpath": "$.dependencies['@esri/calcite-components-react']"
         }
       ]
     },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,33 +11,33 @@
         "readme.md",
         {
           "type": "json",
-          "path": "../../examples/components/preact/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/preact/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         },
         {
           "type": "json",
-          "path": "../../examples/components/rollup/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/rollup/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         },
         {
           "type": "json",
-          "path": "../../examples/components/vite/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/vite/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         },
         {
           "type": "json",
-          "path": "../../examples/components/vue/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/vue/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         },
         {
           "type": "json",
-          "path": "../../examples/components/web-dev-server/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/web-dev-server/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         },
         {
           "type": "json",
-          "path": "../../examples/components/webpack/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components"
+          "path": "/examples/components/webpack/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
         }
       ]
     },
@@ -46,7 +46,7 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "../../examples/components/react/package.json",
+          "path": "/examples/components/react/package.json",
           "jsonpath": "$.dependencies.@esri/calcite-components-react"
         }
       ]
@@ -56,8 +56,8 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "../../examples/components/angular/package.json",
-          "jsonpath": "$.dependencies.@esri/calcite-components-angular"
+          "path": "/examples/components/angular/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components-angular']"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Use absolute path instead of relative as recommended in <https://github.com/googleapis/release-please/issues/2064#issuecomment-1714211105>
- Fix a syntax issue in the `jsonpath` to the extra files. The library they use is [different than the original](https://github.com/dchester/jsonpath?tab=readme-ov-file#other-minor-differences) I've used in the past. Specifically:
  > non-ascii non-word characters are no-longer valid in member identifier names; use quoted subscript strings instead (e.g., `$['$']` instead of `$.$`)
