### PR TITLE
fix(list-item): decrease horizontal spacing between selection icon and content (#9304)

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -152,8 +152,9 @@ td:focus {
 }
 
 .selection-container {
-  @apply flex px-3 py-0;
+  @apply flex py-0;
   color: theme("borderColor.color.input");
+  padding-inline: var(--calcite-spacing-md) var(--calcite-spacing-xxs);
 }
 
 .selection-container--single {


### PR DESCRIPTION
**Related Issue:** #9290

## Summary

Decreases horizontal space in selection modes that affects users
migrating from pick/value-list.
