### PR TITLE
chore(linting): enable `scss/function-no-unknown` rule

### DIFF
--- a/packages/calcite-components/.stylelintrc.json
+++ b/packages/calcite-components/.stylelintrc.json
@@ -68,6 +68,13 @@
         "message": "Name should be kebab-cased.",
         "severity": "error"
       }
+    ],
+    "scss/function-no-unknown": [
+      true,
+      {
+        "ignoreFunctions": ["get-trailing-text-input-padding", "scale-duration", "theme", "var"],
+        "severity": "error"
+      }
     ]
   }
 }


### PR DESCRIPTION
**Related Issue:** #10188 

## Summary

The Sass compiler does not error on unknown functions, but we can use Stylelint's [`function-no-unknown`](https://github.com/stylelint-scss/stylelint-scss/tree/master/src/rules/function-no-unknown) to ensure function names are properly referenced. 