### PR TITLE
docs(modal): restore component-level doc

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -3522,6 +3522,9 @@ export namespace Components {
          */
         "valueLabelType": MeterLabelType;
     }
+    /**
+     * @deprecated Use the `calcite-dialog` component instead.
+     */
     interface CalciteModal {
         /**
           * Passes a function to run before the component closes.
@@ -7157,6 +7160,9 @@ declare global {
         "calciteModalBeforeOpen": void;
         "calciteModalOpen": void;
     }
+    /**
+     * @deprecated Use the `calcite-dialog` component instead.
+     */
     interface HTMLCalciteModalElement extends Components.CalciteModal, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteModalElementEventMap>(type: K, listener: (this: HTMLCalciteModalElement, ev: CalciteModalCustomEvent<HTMLCalciteModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -11643,6 +11649,9 @@ declare namespace LocalJSX {
          */
         "valueLabelType"?: MeterLabelType;
     }
+    /**
+     * @deprecated Use the `calcite-dialog` component instead.
+     */
     interface CalciteModal {
         /**
           * Passes a function to run before the component closes.
@@ -14320,6 +14329,9 @@ declare module "@stencil/core" {
             "calcite-menu": LocalJSX.CalciteMenu & JSXBase.HTMLAttributes<HTMLCalciteMenuElement>;
             "calcite-menu-item": LocalJSX.CalciteMenuItem & JSXBase.HTMLAttributes<HTMLCalciteMenuItemElement>;
             "calcite-meter": LocalJSX.CalciteMeter & JSXBase.HTMLAttributes<HTMLCalciteMeterElement>;
+            /**
+             * @deprecated Use the `calcite-dialog` component instead.
+             */
             "calcite-modal": LocalJSX.CalciteModal & JSXBase.HTMLAttributes<HTMLCalciteModalElement>;
             "calcite-navigation": LocalJSX.CalciteNavigation & JSXBase.HTMLAttributes<HTMLCalciteNavigationElement>;
             "calcite-navigation-logo": LocalJSX.CalciteNavigationLogo & JSXBase.HTMLAttributes<HTMLCalciteNavigationLogoElement>;

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -56,6 +56,12 @@ import { CSS, ICONS, SLOTS } from "./resources";
 let totalOpenModals: number = 0;
 let initialDocumentOverflowStyle: string = "";
 
+logger.deprecated("component", {
+  name: "modal",
+  removalVersion: 4,
+  suggested: "dialog",
+});
+
 /**
  * @deprecated Use the `calcite-dialog` component instead.
  * @slot header - A slot for adding header text.
@@ -66,13 +72,6 @@ let initialDocumentOverflowStyle: string = "";
  * @slot secondary - A slot for adding a secondary button.
  * @slot back - A slot for adding a back button.
  */
-
-logger.deprecated("component", {
-  name: "modal",
-  removalVersion: 4,
-  suggested: "dialog",
-});
-
 @Component({
   tag: "calcite-modal",
   styleUrl: "modal.scss",


### PR DESCRIPTION
**Related Issue:** #10194

## Summary

Restores modal's component JSDoc placement to fix generated doc. #9751 placed it above the logger call, which changed the documentation target.