### PR TITLE
refactor(input-date-picker): update stories to use min/max attributes

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -110,11 +110,11 @@ export const mediumIconForLargeInput_TestOnly = (): string => html`
   <div style="width: 400px">
     <calcite-input-date-picker
       open
-      value="1/1/1"
+      value="1-1-1"
       lang="zh-CN"
       scale="l"
-      start="2020-12-12"
-      end="2020-12-16"
+      min="2020-12-12"
+      max="2020-12-16"
       range
       layout="horizontal"
     ></calcite-input-date-picker>
@@ -187,8 +187,8 @@ export const scales_TestOnly = (): string => html`
       <calcite-input-date-picker
         scale="s"
         open
-        start="2020-12-12"
-        end="2020-12-16"
+        min="2020-12-12"
+        max="2020-12-16"
         range
         layout="horizontal"
         value="2020-12-12"
@@ -196,8 +196,8 @@ export const scales_TestOnly = (): string => html`
       <calcite-input-date-picker
         scale="m"
         open
-        start="2020-12-12"
-        end="2020-12-16"
+        min="2020-12-12"
+        max="2020-12-16"
         range
         layout="horizontal"
         value="2020-12-12"
@@ -205,8 +205,8 @@ export const scales_TestOnly = (): string => html`
       <calcite-input-date-picker
         scale="l"
         open
-        start="2020-12-12"
-        end="2020-12-16"
+        min="2020-12-12"
+        max="2020-12-16"
         range
         layout="horizontal"
         value="2020-12-12"


### PR DESCRIPTION
**Related Issue:** #

## Summary
Refactors `input-date-picker` stories to use `min/max` attributes instead of `start/end`.