### PR TITLE
chore: update patch for jsdom@21.1.7

### DIFF
--- a/patches/@types+jsdom+21.1.7.patch
+++ b/patches/@types+jsdom+21.1.7.patch
@@ -1,14 +1,14 @@
 diff --git a/node_modules/@types/jsdom/base.d.ts b/node_modules/@types/jsdom/base.d.ts
-index 96400e7..fd26b36 100644
+index 420870f..25ac10c 100644
 --- a/node_modules/@types/jsdom/base.d.ts
 +++ b/node_modules/@types/jsdom/base.d.ts
 @@ -196,7 +196,9 @@ declare module "jsdom" {
  
          /* ECMAScript Globals */
          globalThis: DOMWindow;
-+      // @ts-ignore
++        // @ts-ignore
          readonly ["Infinity"]: number;
-+      // @ts-ignore
++        // @ts-ignore
          readonly ["NaN"]: number;
          readonly undefined: undefined;
  


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This resolves the following warning:

```bash
> calcite-design-system@0.0.0 postinstall
> patch-package

patch-package 8.0.0
Applying patches...
@types/jsdom@21.1.6 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @types/jsdom@21.1.6

  applied to

    @types/jsdom@21.1.7

  At path

    node_modules/@types/jsdom

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @types/jsdom

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 1 warning(s).
```