### PR TITLE
refactor: only call getElementDir once when positioning floating-ui elements

### DIFF
--- a/packages/calcite-components/src/utils/floating-ui.spec.ts
+++ b/packages/calcite-components/src/utils/floating-ui.spec.ts
@@ -17,23 +17,19 @@ const {
 } = floatingUI;
 
 it("should set calcite placement to FloatingUI placement", () => {
-  const el = document.createElement("div");
+  expect(getEffectivePlacement(false, "leading")).toBe("left");
+  expect(getEffectivePlacement(false, "leading-start")).toBe("left-start");
+  expect(getEffectivePlacement(false, "leading-end")).toBe("left-end");
+  expect(getEffectivePlacement(false, "trailing")).toBe("right");
+  expect(getEffectivePlacement(false, "trailing-start")).toBe("right-start");
+  expect(getEffectivePlacement(false, "trailing-end")).toBe("right-end");
 
-  expect(getEffectivePlacement(el, "leading")).toBe("left");
-  expect(getEffectivePlacement(el, "leading-start")).toBe("left-start");
-  expect(getEffectivePlacement(el, "leading-end")).toBe("left-end");
-  expect(getEffectivePlacement(el, "trailing")).toBe("right");
-  expect(getEffectivePlacement(el, "trailing-start")).toBe("right-start");
-  expect(getEffectivePlacement(el, "trailing-end")).toBe("right-end");
-
-  el.dir = "rtl";
-
-  expect(getEffectivePlacement(el, "leading")).toBe("right");
-  expect(getEffectivePlacement(el, "leading-start")).toBe("right-start");
-  expect(getEffectivePlacement(el, "leading-end")).toBe("right-end");
-  expect(getEffectivePlacement(el, "trailing")).toBe("left");
-  expect(getEffectivePlacement(el, "trailing-start")).toBe("left-start");
-  expect(getEffectivePlacement(el, "trailing-end")).toBe("left-end");
+  expect(getEffectivePlacement(true, "leading")).toBe("right");
+  expect(getEffectivePlacement(true, "leading-start")).toBe("right-start");
+  expect(getEffectivePlacement(true, "leading-end")).toBe("right-end");
+  expect(getEffectivePlacement(true, "trailing")).toBe("left");
+  expect(getEffectivePlacement(true, "trailing-start")).toBe("left-start");
+  expect(getEffectivePlacement(true, "trailing-end")).toBe("left-end");
 });
 
 function createFakeFloatingUiComponent(referenceEl: HTMLElement, floatingEl: HTMLElement): FloatingUIComponent {

--- a/packages/calcite-components/src/utils/floating-ui.spec.ts
+++ b/packages/calcite-components/src/utils/floating-ui.spec.ts
@@ -17,19 +17,19 @@ const {
 } = floatingUI;
 
 it("should set calcite placement to FloatingUI placement", () => {
-  expect(getEffectivePlacement(false, "leading")).toBe("left");
-  expect(getEffectivePlacement(false, "leading-start")).toBe("left-start");
-  expect(getEffectivePlacement(false, "leading-end")).toBe("left-end");
-  expect(getEffectivePlacement(false, "trailing")).toBe("right");
-  expect(getEffectivePlacement(false, "trailing-start")).toBe("right-start");
-  expect(getEffectivePlacement(false, "trailing-end")).toBe("right-end");
+  expect(getEffectivePlacement("leading")).toBe("left");
+  expect(getEffectivePlacement("leading-start")).toBe("left-start");
+  expect(getEffectivePlacement("leading-end")).toBe("left-end");
+  expect(getEffectivePlacement("trailing")).toBe("right");
+  expect(getEffectivePlacement("trailing-start")).toBe("right-start");
+  expect(getEffectivePlacement("trailing-end")).toBe("right-end");
 
-  expect(getEffectivePlacement(true, "leading")).toBe("right");
-  expect(getEffectivePlacement(true, "leading-start")).toBe("right-start");
-  expect(getEffectivePlacement(true, "leading-end")).toBe("right-end");
-  expect(getEffectivePlacement(true, "trailing")).toBe("left");
-  expect(getEffectivePlacement(true, "trailing-start")).toBe("left-start");
-  expect(getEffectivePlacement(true, "trailing-end")).toBe("left-end");
+  expect(getEffectivePlacement("leading", true)).toBe("right");
+  expect(getEffectivePlacement("leading-start", true)).toBe("right-start");
+  expect(getEffectivePlacement("leading-end", true)).toBe("right-end");
+  expect(getEffectivePlacement("trailing", true)).toBe("left");
+  expect(getEffectivePlacement("trailing-start", true)).toBe("left-start");
+  expect(getEffectivePlacement("trailing-end", true)).toBe("left-end");
 });
 
 function createFakeFloatingUiComponent(referenceEl: HTMLElement, floatingEl: HTMLElement): FloatingUIComponent {

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -103,6 +103,8 @@ export const positionFloatingUI =
       return null;
     }
 
+    const isRTL = getElementDir(floatingEl) === "rtl";
+
     const {
       x,
       y,
@@ -114,11 +116,11 @@ export const positionFloatingUI =
       placement:
         placement === "auto" || placement === "auto-start" || placement === "auto-end"
           ? undefined
-          : getEffectivePlacement(floatingEl, placement),
+          : getEffectivePlacement(isRTL, placement),
       middleware: getMiddleware({
         placement,
         flipDisabled,
-        flipPlacements: flipPlacements?.map((placement) => getEffectivePlacement(floatingEl, placement)),
+        flipPlacements: flipPlacements?.map((placement) => getEffectivePlacement(isRTL, placement)),
         offsetDistance,
         offsetSkidding,
         arrowEl,
@@ -396,10 +398,10 @@ export function filterValidFlipPlacements(placements: string[], el: HTMLElement)
   return filteredPlacements;
 }
 
-export function getEffectivePlacement(floatingEl: HTMLElement, placement: LogicalPlacement): EffectivePlacement {
+export function getEffectivePlacement(isRTL: boolean, placement: LogicalPlacement): EffectivePlacement {
   const placements = ["left", "right"];
 
-  if (getElementDir(floatingEl) === "rtl") {
+  if (isRTL) {
     placements.reverse();
   }
 

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -116,11 +116,11 @@ export const positionFloatingUI =
       placement:
         placement === "auto" || placement === "auto-start" || placement === "auto-end"
           ? undefined
-          : getEffectivePlacement(isRTL, placement),
+          : getEffectivePlacement(placement, isRTL),
       middleware: getMiddleware({
         placement,
         flipDisabled,
-        flipPlacements: flipPlacements?.map((placement) => getEffectivePlacement(isRTL, placement)),
+        flipPlacements: flipPlacements?.map((placement) => getEffectivePlacement(placement, isRTL)),
         offsetDistance,
         offsetSkidding,
         arrowEl,
@@ -398,7 +398,7 @@ export function filterValidFlipPlacements(placements: string[], el: HTMLElement)
   return filteredPlacements;
 }
 
-export function getEffectivePlacement(isRTL: boolean, placement: LogicalPlacement): EffectivePlacement {
+export function getEffectivePlacement(placement: LogicalPlacement, isRTL = false): EffectivePlacement {
   const placements = ["left", "right"];
 
   if (isRTL) {

--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -158,6 +158,7 @@ export const create: () => Config = () => ({
     ],
   },
   testing: {
+    browserArgs: ["--window-size=1200,800"],
     watchPathIgnorePatterns: ["<rootDir>/../../node_modules", "<rootDir>/dist", "<rootDir>/www", "<rootDir>/hydrate"],
     moduleNameMapper: {
       "^lodash-es$": "lodash",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

chore: only call getElementDir once when positioning floating-ui elements
