### PR TITLE
test(input-time-picker): skip unstable test

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -101,7 +101,10 @@ describe("calcite-input-time-picker", () => {
 
   describe("openClose", () => {
     openClose("calcite-input-time-picker");
-    openClose.initial("calcite-input-time-picker");
+
+    describe.skip("initially open", () => {
+      openClose.initial("calcite-input-time-picker");
+    });
   });
 
   it("when set to readOnly, element still focusable but won't display the controls or allow for changing the value", async () => {


### PR DESCRIPTION
**Related Issue:** #10227

## Summary

Re-skip unstable test (see #10226).

Unfortunately, https://github.com/Esri/calcite-design-system/pull/10228 didn't stabilize this test.