### PR TITLE
fix(input-date-picker): no longer emits `calciteInputDatePickerChange` event when `valueAsDate` is set programmatically

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -320,6 +320,17 @@ describe("calcite-input-date-picker", () => {
       expect(await getDateInputValue(page)).toEqual("6/28/2023");
       expect(changeEvent).toHaveReceivedEventTimes(1);
     });
+
+    it("should not emit change event when valueAsDate is set programmatically", async () => {
+      const page = await newE2EPage();
+      await page.setContent("<calcite-input-date-picker></calcite-input-date-picker>");
+      const changeEvent = await page.spyOnEvent("calciteInputDatePickerChange");
+
+      await page.$eval("calcite-input-date-picker", (element: HTMLCalciteInputDatePickerElement) => {
+        element.valueAsDate = [new Date(1, 1, 2020), new Date(31, 1, 2020)];
+      });
+      expect(changeEvent).toHaveReceivedEventTimes(0);
+    });
   });
 
   it("should clear active date properly when deleted and committed via keyboard", async () => {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -490,9 +490,9 @@ export class InputDatePicker
         this.value = "";
       }
     } else if (this.valueAsDate) {
-      if (this.range) {
-        this.setRangeValue(this.valueAsDate as Date[]);
-      } else if (!Array.isArray(this.valueAsDate)) {
+      if (this.range && Array.isArray(this.valueAsDate)) {
+        this.value = [dateToISO(this.valueAsDate[0]), dateToISO(this.valueAsDate[1])];
+      } else if (!this.range && !Array.isArray(this.valueAsDate)) {
         this.value = dateToISO(this.valueAsDate);
       }
     }


### PR DESCRIPTION
**Related Issue:** #8368 

## Summary

`input-date-picker` no longer emits `calciteInputDatePickerChange` event when `valueAsDate` is set programmatically.
