### PR TITLE
feat(tip-manager): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/tip-manager/tip-manager.e2e.ts
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from "@stencil/core/testing";
-import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";
+import { accessible, defaults, hidden, renders, themed, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, TEXT } from "./resources";
 
@@ -251,5 +251,49 @@ describe("calcite-tip-manager", () => {
 
   describe("translation support", () => {
     t9n("calcite-tip-manager");
+  });
+
+  describe("theme", () => {
+    const testHTML = html`
+      <calcite-tip-manager>
+        <calcite-tip id="one"><p>first</p></calcite-tip>
+        <calcite-tip id="two"><p>second</p></calcite-tip>
+      </calcite-tip-manager>
+    `;
+
+    describe("default", () => {
+      themed(testHTML, {
+        "--calcite-tip-manager-background-color": {
+          targetProp: "backgroundColor",
+        },
+        "--calcite-tip-manager-border-color": {
+          shadowSelector: `.${CSS.header}`,
+          targetProp: "borderColor",
+        },
+        "--calcite-tip-manager-content-height": {
+          shadowSelector: `.${CSS.tipContainer}`,
+          targetProp: "blockSize",
+        },
+        "--calcite-tip-manager-heading-text-color": {
+          shadowSelector: `.${CSS.heading}`,
+          targetProp: "color",
+        },
+        "--calcite-tip-manager-text-color": {
+          targetProp: "color",
+        },
+      });
+    });
+    describe("deprecated", () => {
+      themed(testHTML, {
+        "--calcite-tip-manager-height": {
+          shadowSelector: `.${CSS.tipContainer}`,
+          targetProp: "blockSize",
+        },
+        "--calcite-tip-max-width": {
+          selector: "calcite-tip",
+          targetProp: "maxInlineSize",
+        },
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -72,6 +72,7 @@
   animation-name: none;
   animation-duration: var(--calcite-animation-timing);
   block-size: var(--calcite-tip-manager-height, var(--calcite-tip-manager-content-height, 19vh));
+
   &:focus {
     @apply focus-outset;
   }

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -3,14 +3,17 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tip-manager-height: The maximum height of the component.
- * @prop --calcite-tip-max-width: The maximum width of a slotted `calcite-tip` within the component.
+ * @prop --calcite-tip-manager-background-color: The background color of the component.
+ * @prop --calcite-tip-manager-border-color: The border color of the component.
+ * @prop --calcite-tip-manager-content-height: The height of the content area.
+ * @prop --calcite-tip-manager-heading-text-color: The heading text color of the component.
+ * @prop --calcite-tip-manager-height: [Deprecated] use `--calcite-tip-manager-content-height` instead - Specifies the maximum height of a slotted `calcite-tip` within the component.
+ * @prop --calcite-tip-manager-text-color: The text color of the component.
+ * @prop --calcite-tip-max-width: [Deprecated] in favor of setting `max-width` on tips directly - Specifies the maximum width of a slotted `calcite-tip` within the component.
  */
 
 :host {
-  @apply bg-foreground-1
-  text-color-2
-  text-n1h
+  @apply text-n1h
   box-border
   block;
 
@@ -19,6 +22,8 @@
   }
 
   --calcite-tip-manager-height: 19vh;
+  background-color: var(--calcite-tip-manager-background-color, var(--calcite-color-foreground-1));
+  color: var(--calcite-tip-manager-text-color, var(--calcite-color-text-2));
 }
 
 :host([closed]) {
@@ -28,20 +33,21 @@
 @import "../../assets/styles/header";
 
 .header {
-  @apply border-color-3
-    border-0
+  @apply border-0
     border-b
     border-solid
     py-0;
 
   padding-inline-end: theme("padding.0");
   padding-inline-start: theme("padding.4");
+  border-color: var(--calcite-tip-manager-border-color, var(--calcite-color-border-3));
 
   .heading {
-    @apply text-color-1
-      text-1h
+    @apply text-1h
       p-0
       font-bold;
+
+    color: var(--calcite-tip-manager-heading-text-color, var(--calcite-color-text-1));
   }
 }
 
@@ -65,7 +71,7 @@
     p-4;
   animation-name: none;
   animation-duration: var(--calcite-animation-timing);
-  block-size: var(--calcite-tip-manager-height);
+  block-size: var(--calcite-tip-manager-height, var(--calcite-tip-manager-content-height, 19vh));
   &:focus {
     @apply focus-outset;
   }

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -23,6 +23,7 @@ import { notices } from "./custom-theme/notice";
 import { pagination } from "./custom-theme/pagination";
 import { segmentedControl } from "./custom-theme/segmented-control";
 import { slider } from "./custom-theme/slider";
+import { tipManager, tipManagerTokens } from "./custom-theme/tip-manager";
 import { calciteSwitch } from "./custom-theme/switch";
 import { tabs } from "./custom-theme/tabs";
 
@@ -104,7 +105,9 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
           <div>${checkbox}</div>
           ${chips} ${pagination} ${slider}
         </div>
-        <div class="demo-column">${datePicker} ${tabs} ${loader} ${calciteSwitch}</div>
+        <div class="demo-column">${datePicker} ${tabs} ${loader} ${calciteSwitch}
+        <div style="margin-top: 40px">${tipManager}</div>
+        </div>
       </div>
     </div>
   </div>`;
@@ -119,6 +122,7 @@ export default {
     ...actionPadTokens,
     ...actionGroupTokens,
     ...cardTokens,
+    ...tipManagerTokens,
   },
 };
 
@@ -135,6 +139,7 @@ export const theming_TestOnly = (): string => {
       ...actionPadTokens,
       ...actionGroupTokens,
       ...cardTokens,
+      ...tipManagerTokens,
     },
     true,
   );

--- a/packages/calcite-components/src/custom-theme/tip-manager.ts
+++ b/packages/calcite-components/src/custom-theme/tip-manager.ts
@@ -1,0 +1,28 @@
+import { html } from "../../support/formatting";
+
+export const tipManagerTokens = {
+  calciteTipManagerBackgroundColor: "",
+  calciteTipManagerBorderColor: "",
+  calciteTipManagerContentHeight: "",
+  calciteTipManagerHeadingTextColor: "",
+  calciteTipManagerHeight: "",
+  calciteTipManagerTextColor: "",
+  calciteTipMaxWidth: "",
+};
+
+export const tipManager = html`
+  <calcite-tip-manager
+    <calcite-tip-group group-title="Astronomy">
+      <calcite-tip heading="The Red Rocks and Blue Water">
+          This tip is how a tip should really look. This paragraph is in an "info" slot.
+        </p>
+        <a href="http://www.esri.com">This is the "link" slot.</a>
+      </calcite-tip>
+      <calcite-tip heading="The Long Trees">
+        <p>This tip has an image that is a pretty tall. And the text will run out before the end of the image.</p>
+        <p>In astronomy, the terms object and body are often used interchangeably.</p>
+        <a href="http://www.esri.com">View Esri</a>
+      </calcite-tip>
+    </calcite-tip-group>
+  </calcite-tip-manager>
+`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary
`--calcite-tip-manager-background-color`: The background color of the component.
`--calcite-tip-manager-border-color`: The border color of the component.
`--calcite-tip-manager-content-height`: The height of the content area.
`--calcite-tip-manager-heading-text-color`: The heading text color of the component.
`--calcite-tip-manager-text-color`: The text color of the component.

**Deprecated**

`--calcite-tip-manager-height`: [Deprecated] use `--calcite-tip-manager-content-height` instead - Specifies the maximum height of a slotted `calcite-tip` within the component.
`--calcite-tip-max-width`: [Deprecated] in favor of setting `max-width` on tips directly - Specifies the maximum width of a slotted `calcite-tip` within the component.
 
 