### PR TITLE
feat(tabs): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/tabs/tabs.e2e.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.e2e.ts
@@ -430,7 +430,7 @@ describe("calcite-tabs", () => {
     `;
 
     describe("default", () => {
-      themed(html`<calcite-tabs position="bottom"> ${tabs}</calcite-tabs>`, {
+      themed(html`<calcite-tabs position="bottom">${tabs}</calcite-tabs>`, {
         "--calcite-tabs-border-color": [
           {
             shadowSelector: "section",
@@ -444,7 +444,7 @@ describe("calcite-tabs", () => {
       });
     });
     describe("bordered", () => {
-      themed(html`<calcite-tabs bordered> ${tabs}</calcite-tabs>`, {
+      themed(html`<calcite-tabs bordered>${tabs}</calcite-tabs>`, {
         "--calcite-tabs-background-color": {
           targetProp: "backgroundColor",
         },
@@ -458,7 +458,7 @@ describe("calcite-tabs", () => {
           },
         ],
       });
-      themed(html`<calcite-tabs bordered position="bottom"> ${tabs}</calcite-tabs>`, {
+      themed(html`<calcite-tabs bordered position="bottom">${tabs}</calcite-tabs>`, {
         "--calcite-tabs-border-color": {
           targetProp: "boxShadow",
         },

--- a/packages/calcite-components/src/components/tabs/tabs.e2e.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.e2e.ts
@@ -1,6 +1,6 @@
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, hidden, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, hidden, reflects, renders, themed } from "../../tests/commonTests";
 import { GlobalTestProps } from "../../tests/utils";
 import { Scale } from "../interfaces";
 import { TabPosition } from "../tabs/interfaces";
@@ -418,6 +418,51 @@ describe("calcite-tabs", () => {
       const selectedTitleOnEmit = await page.evaluate(() => (window as TestWindow).selectedTitleTab);
 
       expect(selectedTitleOnEmit).toBe("Tab 2 Title");
+    });
+  });
+
+  describe("theme", () => {
+    const tabs = html`
+      <calcite-tab-nav slot="title-group">
+        <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
+      </calcite-tab-nav>
+      <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
+    `;
+
+    describe("default", () => {
+      themed(html`<calcite-tabs position="bottom"> ${tabs}</calcite-tabs>`, {
+        "--calcite-tabs-border-color": [
+          {
+            shadowSelector: "section",
+            targetProp: "borderBlockStartColor",
+          },
+          {
+            shadowSelector: "section",
+            targetProp: "borderBlockEndColor",
+          },
+        ],
+      });
+    });
+    describe("bordered", () => {
+      themed(html`<calcite-tabs bordered> ${tabs}</calcite-tabs>`, {
+        "--calcite-tabs-background-color": {
+          targetProp: "backgroundColor",
+        },
+        "--calcite-tabs-border-color": [
+          {
+            targetProp: "boxShadow",
+          },
+          {
+            shadowSelector: "section",
+            targetProp: "borderColor",
+          },
+        ],
+      });
+      themed(html`<calcite-tabs bordered position="bottom"> ${tabs}</calcite-tabs>`, {
+        "--calcite-tabs-border-color": {
+          targetProp: "boxShadow",
+        },
+      });
     });
   });
 });

--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -1,20 +1,31 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-tabs-background-color: The background color of the component.
+ * @prop --calcite-tabs-border-color: The border color of the component.
+ */
+
 :host {
   @apply flex flex-col;
 }
 
 :host([bordered]) {
-  box-shadow: inset 0 1px 0 var(--calcite-color-border-1);
-  background-color: var(--calcite-color-foreground-1);
+  box-shadow: inset 0 1px 0 var(--calcite-tabs-border-color, var(--calcite-color-border-1));
+  background-color: var(--calcite-tabs-background-color, var(--calcite-color-foreground-1));
 
   section {
-    @apply border-color-1 border border-solid;
+    @apply border border-solid;
+
+    border-color: var(--calcite-tabs-border-color, var(--calcite-color-border-1));
   }
 }
 
 :host([bordered][position="bottom"]) {
   box-shadow:
-    inset 0 1px 0 var(--calcite-color-border-1),
-    inset 0 -1px 0 var(--calcite-color-border-1);
+    inset 0 1px 0 var(var(--calcite-tabs-border-color, var(--calcite-color-border-1))),
+    inset 0 -1px 0 var(var(--calcite-tabs-border-color, var(--calcite-color-border-1)));
 }
 
 :host([bordered]:not([position="bottom"])) ::slotted(calcite-tab-nav) {
@@ -38,19 +49,21 @@
 }
 
 section {
-  @apply border-t-color-1
-    flex
+  @apply flex
     flex-grow
     overflow-hidden
     border-t;
+
   border-block-start-style: solid;
+  border-block-start-color: var(--calcite-tabs-border-color, var(--calcite-color-border-1));
 }
 
 :host([position="bottom"]) section {
-  @apply border-b-color-1
-    flex-col-reverse
+  @apply flex-col-reverse
     border-t-0
     border-b;
+
+  border-block-end-color: var(--calcite-tabs-border-color, var(--calcite-color-border-1));
 }
 
 :host([position="bottom"]:not([bordered])) section {

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -24,7 +24,7 @@ import { pagination } from "./custom-theme/pagination";
 import { segmentedControl } from "./custom-theme/segmented-control";
 import { slider } from "./custom-theme/slider";
 import { calciteSwitch } from "./custom-theme/switch";
-import { tabs } from "./custom-theme/tabs";
+import { tabs, tabsTokens } from "./custom-theme/tabs";
 
 const globalTokens = {
   calciteColorBrand: "#007ac2",
@@ -119,6 +119,7 @@ export default {
     ...actionPadTokens,
     ...actionGroupTokens,
     ...cardTokens,
+    ...tabsTokens,
   },
 };
 
@@ -135,6 +136,7 @@ export const theming_TestOnly = (): string => {
       ...actionPadTokens,
       ...actionGroupTokens,
       ...cardTokens,
+      ...tabsTokens,
     },
     true,
   );

--- a/packages/calcite-components/src/custom-theme/tabs.ts
+++ b/packages/calcite-components/src/custom-theme/tabs.ts
@@ -1,10 +1,19 @@
 import { html } from "../../support/formatting";
 
-export const tabs = html`<calcite-tabs>
-  <calcite-tab-nav slot="title-group">
-    <calcite-tab-title selected>Tab 1 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 2 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 3 Title</calcite-tab-title>
-    <calcite-tab-title>Tab 4 Title</calcite-tab-title>
-  </calcite-tab-nav>
-</calcite-tabs>`;
+export const tabsTokens = {
+  calciteTabsBackgroundColor: "",
+  calciteTabsBorderColor: "",
+};
+
+export const tabs = html`
+  <calcite-tabs bordered layout="bottom">
+    <calcite-tab-nav slot="title-group">
+      <calcite-tab-title tab="tab1">Tab 1 Title</calcite-tab-title>
+      <calcite-tab-title tab="tab2" selected>Tab 2 Title</calcite-tab-title>
+      <calcite-tab-title tab="tab3">Tab 3 Title</calcite-tab-title>
+    </calcite-tab-nav>
+    <calcite-tab tab="tab1">Tab 1 Content</calcite-tab>
+    <calcite-tab tab="tab2" selected>Tab 2 Content</calcite-tab>
+    <calcite-tab tab="tab3">Tab 3 Content</calcite-tab>
+  </calcite-tabs>
+`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary
Add `tabs` component tokens.

`--calcite-tabs-background-color`: The background color of the component.
`--calcite-tabs-border-color`: The border color of the component.