### PR TITLE
ci(actions): fix adding labels action failing on issues without "Esri team" line

### DIFF
--- a/.github/scripts/addEsriProductLabel.js
+++ b/.github/scripts/addEsriProductLabel.js
@@ -28,22 +28,27 @@ module.exports = async ({ github, context }) => {
 
   const productRegexMatch = body.match(productRegex);
 
-  const product = (productRegexMatch && productRegexMatch[0] ? productRegexMatch[0] : "").trim();
+  // If issue includes "Esri team" line then create label, otherwise log message.
+  if (productRegexMatch) {
+    const product = (productRegexMatch && productRegexMatch[0] ? productRegexMatch[0] : "").trim();
 
-  if (product !== "N/A") {
-    await createLabelIfMissing({
-      github,
-      context,
-      label: product,
-      color: "006B75",
-      description: `Issues logged by ${product} team members.`,
-    });
+    if (product !== "N/A") {
+      await createLabelIfMissing({
+        github,
+        context,
+        label: product,
+        color: "006B75",
+        description: `Issues logged by ${product} team members.`,
+      });
 
-    await github.rest.issues.addLabels({
-      issue_number,
-      owner,
-      repo,
-      labels: [product],
-    });
+      await github.rest.issues.addLabels({
+        issue_number,
+        owner,
+        repo,
+        labels: [product],
+      });
+    }
+  } else {
+    console.log(`No Esri team listed on issue #${issue_number}`);
   }
 };


### PR DESCRIPTION
**Related Issue:** #10011 

## Summary
The original issue was for fixing the action not successfully adding the priority label to a newly created issue. It looks like the reason that wasn't working was because the action would fail before getting to that step. 

The failure was caused by the `addEsriProductLabel` step of the action expecting there to always be an "Esri team" line in the issue body but that's not the case for all issue types.

This is just a small change to stop the failure and instead log a message when the "Esri team" is not present on an issue and continue to the next steps. 