### PR TITLE
chore(icons): ensure UI icons follow naming convention

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,7 +10,7 @@ ensure_types_are_up_to_date() {
 }
 
 check_ui_icon_name_consistency() {
-  SVG_ICON_DIR="packages/calcite-ui-icons/icons"
+  svg_icon_dir="packages/calcite-ui-icons/icons"
 
   # this pattern checks for `<iconName>-<size>.svg` or `<iconName>-<size>-f.svg` for filled icons
   # where `<iconName>` is kebab-case, `<size>` is 16, 24, or 32
@@ -19,10 +19,10 @@ check_ui_icon_name_consistency() {
   # this pattern will check for invalid use of "-f-" anywhere except right before the size
   invalid_pattern="-[a-z0-9]+-f-"
 
-  STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+  staged_files=$(git diff --cached --name-only --diff-filter=ACM)
 
-  for file in $STAGED_FILES; do
-    if [[ $file == "$SVG_ICON_DIR"* ]]; then
+  for file in $staged_files; do
+    if [[ $file == "$svg_icon_dir"* ]]; then
       if [[ $file == *.svg ]]; then
         filename=$(basename "$file")
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,49 @@
 #!/usr/bin/env sh
 
-lint-staged
+ensure_types_are_up_to_date() {
+  types_path="packages/calcite-components/src/components.d.ts"
 
-types_path="packages/calcite-components/src/components.d.ts"
-
-# make sure the types are always up to date
-if [ -n "$(git diff --name-only -- "$types_path")" ]; then
+  if [ -n "$(git diff --name-only -- "$types_path")" ]; then
     echo "Automatically staging changes to \"$types_path\""
     git add "$types_path"
-fi
+  fi
+}
+
+check_ui_icon_name_consistency() {
+  SVG_ICON_DIR="packages/calcite-ui-icons/icons"
+
+  # this pattern checks for `<iconName>-<size>.svg` or `<iconName>-<size>-f.svg` for filled icons
+  # where `<iconName>` is kebab-case, `<size>` is 16, 24, or 32
+  valid_pattern="^[a-z0-9-]+-(16|24|32)(-f)?\\.svg$"
+
+  # this pattern will check for invalid use of "-f-" anywhere except right before the size
+  invalid_pattern="-[a-z0-9]+-f-"
+
+  STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+  for file in $STAGED_FILES; do
+    if [[ $file == "$SVG_ICON_DIR"* ]]; then
+      if [[ $file == *.svg ]]; then
+        filename=$(basename "$file")
+
+        # first, ensure the filename follows the valid pattern
+        if ! [[ $filename =~ $valid_pattern ]]; then
+          echo "Error: File '$file' does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
+          exit 1
+        fi
+
+        # then, ensure there's no invalid use of "-f-" anywhere except right before the size
+        if [[ $filename =~ $invalid_pattern ]]; then
+          echo "Error: File '$file' has an invalid '-f-' and does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
+          exit 1
+        fi
+      fi
+    fi
+  done
+}
+
+lint-staged
+ensure_types_are_up_to_date
+check_ui_icon_name_consistency
+
+exit 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -19,21 +19,21 @@ check_ui_icon_name_consistency() {
   # this pattern will check for invalid use of "-f-" anywhere except right before the size
   invalid_pattern="-[a-z0-9]+-f-"
 
-  staged_files=$(git diff --cached --name-only --diff-filter=ACM)
+  staged_files="$(git diff --cached --name-only --diff-filter=ACM)"
 
   for file in $staged_files; do
-    if [[ $file == "$svg_icon_dir"* ]]; then
-      if [[ $file == *.svg ]]; then
-        filename=$(basename "$file")
+    if [[ "$file" == "$svg_icon_dir"* ]]; then
+      if [[ "$file" == *.svg ]]; then
+        filename="$(basename "$file")"
 
         # first, ensure the filename follows the valid pattern
-        if ! [[ $filename =~ $valid_pattern ]]; then
+        if ! [[ "$filename" =~ $valid_pattern ]]; then
           echo "Error: File '$file' does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
           exit 1
         fi
 
         # then, ensure there's no invalid use of "-f-" anywhere except right before the size
-        if [[ $filename =~ $invalid_pattern ]]; then
+        if [[ "$filename" =~ $invalid_pattern ]]; then
           echo "Error: File '$file' has an invalid '-f-' and does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
           exit 1
         fi


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This updates our pre-commit hook to check SVG icons to make sure they follow the icon naming convention:

* `<iconName>-<size>.svg`.
* `<iconName>-<size>-f.svg`.

If an icon about to be committed does not match this format, the commit will fail and be canceled.

