### PR TITLE
refactor(slider): rename internal function to avoid collision with `HTMLElement.translate`

### DIFF
--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -561,7 +561,7 @@ export class Slider
     }
 
     const x = event.clientX || event.pageX;
-    const position = this.translate(x);
+    const position = this.mapToRange(x);
     let prop: ActiveSliderProperty = "value";
     if (isRange(this.value)) {
       const inRange = position >= this.minValue && position <= this.maxValue;
@@ -803,7 +803,7 @@ export class Slider
 
     event.preventDefault();
     if (this.dragProp) {
-      const value = this.translate(event.clientX || event.pageX);
+      const value = this.mapToRange(event.clientX || event.pageX);
       if (isRange(this.value) && this.dragProp === "minMaxValue") {
         if (this.minValueDragRange && this.maxValueDragRange && this.minMaxValueRange) {
           const newMinValue = value - this.minValueDragRange;
@@ -942,7 +942,7 @@ export class Slider
    * @param x
    * @internal
    */
-  private translate(x: number): number {
+  private mapToRange(x: number): number {
     const range = this.max - this.min;
     const { left, width } = this.trackEl.getBoundingClientRect();
     const percent = (x - left) / width;


### PR DESCRIPTION
**Related Issue:** #10235

## Summary

[`HTMLElement.translate`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/translate) is a newly available baseline property, so this renames an existing function to avoid any conflicts.

