### PR TITLE
refactor: avoid and prevent spread attribute usage

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -140,6 +140,7 @@ module.exports = {
         ],
       },
     ],
+    "react/jsx-props-no-spreading": "error",
     "react/jsx-sort-props": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -3335,6 +3335,10 @@ export namespace Components {
     }
     interface CalciteLoader {
         /**
+          * Indicates whether the component is in a loading state.
+         */
+        "complete": boolean;
+        /**
           * When `true`, displays smaller and appears to the left of the text.
          */
         "inline": boolean;
@@ -11464,6 +11468,10 @@ declare namespace LocalJSX {
         "onCalciteInternalListItemGroupDefaultSlotChange"?: (event: CalciteListItemGroupCustomEvent<DragEvent>) => void;
     }
     interface CalciteLoader {
+        /**
+          * Indicates whether the component is in a loading state.
+         */
+        "complete"?: boolean;
         /**
           * When `true`, displays smaller and appears to the left of the text.
          */

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
@@ -85,20 +85,14 @@ export class ColorPickerSwatch {
     const borderRadius = active ? "100%" : "0";
     const theme = getModeName(el);
     const borderColor = theme === "light" ? COLORS.borderLight : COLORS.borderDark;
+    const isEmpty = !internalColor;
     const commonSwatchProps = {
       height: "100%",
       rx: borderRadius,
       stroke: borderColor,
-
-      // stroke-width and clip-path are needed to hide overflowing portion of stroke
-      // see https://stackoverflow.com/a/7273346/194216
-
-      // using attribute to work around Stencil using the prop name vs the attribute when rendering
-      ["stroke-width"]: "2",
+      strokeWidth: "2",
       width: "100%",
     };
-
-    const isEmpty = !internalColor;
 
     if (isEmpty) {
       return (
@@ -106,11 +100,10 @@ export class ColorPickerSwatch {
           <clipPath id="shape">
             <rect height="100%" rx={borderRadius} width="100%" />
           </clipPath>
-          <rect
-            clip-path={`inset(0 round ${borderRadius})`}
-            rx={borderRadius}
-            {...commonSwatchProps}
-          />
+          {this.renderSwatchRect({
+            clipPath: `inset(0 round ${borderRadius})`,
+            ...commonSwatchProps,
+          })}
           <line clip-path="url(#shape)" stroke-width="3" x1="100%" x2="0" y1="0" y2="100%" />
         </Fragment>
       );
@@ -148,24 +141,63 @@ export class ColorPickerSwatch {
             />
           </pattern>
         </defs>
-        <rect fill="url(#checker)" height="100%" rx={borderRadius} width="100%" />
-        <rect
-          fill={hex}
-          style={{
-            "clip-path":
-              alpha < 1 ? "polygon(100% 0, 0 0, 0 100%)" : `inset(0 round ${borderRadius})`,
-          }}
-          {...commonSwatchProps}
-        />
-        {alpha < 1 ? (
-          <rect
-            fill={hexa}
-            key="opacity-fill"
-            style={{ "clip-path": "polygon(100% 0, 100% 100%, 0 100%)" }}
-            {...commonSwatchProps}
-          />
-        ) : null}
+        {this.renderSwatchRect({
+          fill: "url(#checker)",
+          rx: commonSwatchProps.rx,
+          height: commonSwatchProps.height,
+          width: commonSwatchProps.width,
+        })}
+        {this.renderSwatchRect({
+          clipPath: alpha < 1 ? "polygon(100% 0, 0 0, 0 100%)" : `inset(0 round ${borderRadius})`,
+          fill: hex,
+          ...commonSwatchProps,
+        })}
+        {alpha < 1
+          ? this.renderSwatchRect({
+              clipPath: "polygon(100% 0, 100% 100%, 0 100%)",
+              fill: hexa,
+              key: "opacity-fill",
+              ...commonSwatchProps,
+            })
+          : null}
       </Fragment>
+    );
+  }
+
+  renderSwatchRect({
+    clipPath,
+    fill,
+    height,
+    key,
+    rx,
+    stroke,
+    strokeWidth,
+    width,
+  }: {
+    clipPath?: string;
+    fill?: string;
+    height: string;
+    key?: string;
+    rx: string;
+
+    // note: stroke-width and clip-path are needed to hide overflowing portion of stroke
+    // see https://stackoverflow.com/a/7273346/194216
+    stroke?: string;
+    strokeWidth?: string;
+
+    width: string;
+  }): VNode {
+    return (
+      <rect
+        clip-path={clipPath}
+        fill={fill}
+        height={height}
+        key={key}
+        rx={rx}
+        stroke={stroke}
+        stroke-width={strokeWidth}
+        width={width}
+      />
     );
   }
 }

--- a/packages/calcite-components/src/components/functional/Heading.tsx
+++ b/packages/calcite-components/src/components/functional/Heading.tsx
@@ -3,7 +3,7 @@ import { JSXBase } from "@stencil/core/internal";
 
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
-interface HeadingProps extends JSXBase.HTMLAttributes {
+interface HeadingProps extends Pick<JSXBase.HTMLAttributes, "class" | "key"> {
   level?: HeadingLevel;
 }
 
@@ -16,5 +16,9 @@ export const Heading: FunctionalComponent<HeadingProps> = (props, children): VNo
 
   delete props.level;
 
-  return <HeadingTag {...props}>{children}</HeadingTag>;
+  return (
+    <HeadingTag class={props.class} key={props.key} level={props.level}>
+      {children}
+    </HeadingTag>
+  );
 };

--- a/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
+++ b/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
@@ -25,7 +25,9 @@ interface ListProps extends DOMAttributes {
   storeAssistiveEl?: (el: HTMLSpanElement) => void;
 }
 
-export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = ({
+export const List: FunctionalComponent<
+  { props: ListProps } & Pick<DOMAttributes, "onBlur" | "onFocusin" | "onKeyDown">
+> = ({
   props: {
     disabled,
     loading,
@@ -38,10 +40,19 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
     dragEnabled,
     storeAssistiveEl,
   },
+  onBlur,
+  onFocusin,
+  onKeyDown,
 }): VNode => {
   const defaultSlot = <slot />;
   return (
-    <Host aria-busy={toAriaBoolean(loading)} role="menu">
+    <Host
+      aria-busy={toAriaBoolean(loading)}
+      onBlur={onBlur}
+      onFocusin={onFocusin}
+      onKeyDown={onKeyDown}
+      role="menu"
+    >
       <InteractiveContainer disabled={disabled}>
         <section>
           {dragEnabled ? (

--- a/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
+++ b/packages/calcite-components/src/components/pick-list/shared-list-render.tsx
@@ -38,11 +38,10 @@ export const List: FunctionalComponent<{ props: ListProps } & DOMAttributes> = (
     dragEnabled,
     storeAssistiveEl,
   },
-  ...rest
 }): VNode => {
   const defaultSlot = <slot />;
   return (
-    <Host aria-busy={toAriaBoolean(loading)} role="menu" {...rest}>
+    <Host aria-busy={toAriaBoolean(loading)} role="menu">
       <InteractiveContainer disabled={disabled}>
         <section>
           {dragEnabled ? (

--- a/packages/calcite-components/src/components/rating/functional/star.tsx
+++ b/packages/calcite-components/src/components/rating/functional/star.tsx
@@ -3,10 +3,8 @@ import { StarIconProps } from "../interfaces";
 
 export const StarIcon: FunctionalComponent<StarIconProps> = ({ full, scale, partial }): VNode => (
   <calcite-icon
-    {...{
-      class: partial ? undefined : "icon",
-      icon: full ? "star-f" : "star",
-      scale,
-    }}
+    class={partial ? undefined : "icon"}
+    icon={full ? "star-f" : "star"}
+    scale={scale}
   />
 );


### PR DESCRIPTION
**Related Issue:** #10236

## Summary

Moves away from JSX attribute spreading pattern.

This also enables [`react/jsx-props-no-spreading`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md) to prevent the spread of future spreading (🥁🐍)

