### PR TITLE
revert: "chore: set default page size for E2E tests (#10219)"

### DIFF
--- a/packages/calcite-components/stencil.config.ts
+++ b/packages/calcite-components/stencil.config.ts
@@ -158,7 +158,6 @@ export const create: () => Config = () => ({
     ],
   },
   testing: {
-    browserArgs: ["--window-size=1200,800"],
     watchPathIgnorePatterns: ["<rootDir>/../../node_modules", "<rootDir>/dist", "<rootDir>/www", "<rootDir>/hydrate"],
     moduleNameMapper: {
       "^lodash-es$": "lodash",


### PR DESCRIPTION
**Related Issue:** #10219

## Summary

This reverts commit 2305cc80a1b3ea13f4033e0355813ac38e7c6596 as it did not help stabilize tests as expected (see https://github.com/Esri/calcite-design-system/pull/10232#issuecomment-2342596324).

