### PR TITLE
chore: add cssrem VSCode extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,10 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "stylelint.vscode-stylelint",
-    "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss",
+    "cipchk.cssrem",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "stylelint.vscode-stylelint",
     "visualstudioexptteam.vscodeintellicode"
   ]
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Adds the [`cssrem`](https://marketplace.visualstudio.com/items?itemName=cipchk.cssrem) extension to display unit conversions within the editor. This will help avoid adding comments for unit conversions (see https://github.com/Esri/calcite-design-system/pull/10179#discussion_r1752943775).

