### PR TITLE
refactor(tests): reduce TypeScript errors

### DIFF
--- a/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
+++ b/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
@@ -520,7 +520,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
 
-      await chip5.setAttribute("selected", true);
+      await chip5.toggleAttribute("selected", true);
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -569,7 +569,7 @@ describe("calcite-chip-group", () => {
       expect(await element.getProperty("selectedItems")).toHaveLength(0);
       await selectedItemAsserter([]);
 
-      chip5.setAttribute("selected", true);
+      chip5.toggleAttribute("selected", true);
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -577,7 +577,7 @@ describe("calcite-chip-group", () => {
       expect(await element.getProperty("selectedItems")).toHaveLength(1);
       await selectedItemAsserter([chip5.id]);
 
-      chip4.setAttribute("selected", true);
+      chip4.toggleAttribute("selected", true);
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
@@ -617,7 +617,7 @@ describe("calcite-chip-group", () => {
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy2).toHaveReceivedEventTimes(0);
 
-      chip5.setAttribute("selected", true);
+      chip5.toggleAttribute("selected", true);
       await page.waitForChanges();
       expect(chipGroupSelectSpy).toHaveReceivedEventTimes(0);
       expect(chipSelectSpy1).toHaveReceivedEventTimes(0);

--- a/packages/calcite-components/src/components/chip/chip.e2e.ts
+++ b/packages/calcite-components/src/components/chip/chip.e2e.ts
@@ -214,7 +214,7 @@ describe("calcite-chip", () => {
       await page.setContent(`<div class="calcite-mode-dark">${chipSnippet}</div>`);
 
       const chipEl = await page.find(`calcite-chip`);
-      chipEl.setAttribute("closed", true);
+      chipEl.toggleAttribute("closed", true);
       await page.waitForChanges();
 
       expect(await chipEl.isVisible()).toBe(false);

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1632,7 +1632,7 @@ describe("calcite-combobox", () => {
     let element: E2EElement;
     let comboboxItem: E2EElement;
     let itemNestedLi: E2EElement;
-    let closeEvent: Promise<void>;
+    let closeEvent: Promise<unknown>;
 
     beforeEach(async () => {
       page = await newE2EPage();

--- a/packages/calcite-components/src/components/functional/XButton.tsx
+++ b/packages/calcite-components/src/components/functional/XButton.tsx
@@ -3,7 +3,7 @@ import { JSXAttributes, JSXBase } from "@stencil/core/internal";
 import { Scale } from "../interfaces";
 import { getIconScale } from "../../utils/component";
 
-export interface XButtonProps extends JSXAttributes {
+export interface XButtonProps extends JSXAttributes<HTMLButtonElement> {
   disabled: boolean;
   label: string;
   scale: Scale;

--- a/packages/calcite-components/src/components/functional/XButton.tsx
+++ b/packages/calcite-components/src/components/functional/XButton.tsx
@@ -3,7 +3,7 @@ import { JSXAttributes, JSXBase } from "@stencil/core/internal";
 import { Scale } from "../interfaces";
 import { getIconScale } from "../../utils/component";
 
-export interface XButtonProps extends JSXAttributes<HTMLButtonElement> {
+export interface XButtonProps extends JSXAttributes {
   disabled: boolean;
   label: string;
   scale: Scale;
@@ -18,8 +18,6 @@ export const XButton: FunctionalComponent<XButtonProps> = ({
   disabled,
   key,
   label,
-  onClick,
-  ref,
   scale,
 }): VNode => (
   <button
@@ -27,8 +25,6 @@ export const XButton: FunctionalComponent<XButtonProps> = ({
     class={CSS.button}
     disabled={disabled}
     key={key}
-    onClick={onClick}
-    ref={ref}
     tabIndex={-1}
     type="button"
   >

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
@@ -49,7 +49,7 @@ export class ListItemGroup implements InteractiveComponent {
    * Fires when changes occur in the default slot, notifying parent lists of the changes.
    */
   @Event({ cancelable: false })
-  calciteInternalListItemGroupDefaultSlotChange: EventEmitter<DragEvent>;
+  calciteInternalListItemGroupDefaultSlotChange: EventEmitter<void>;
 
   // --------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -304,7 +304,7 @@ export class ListItem
 
   @Listen("calciteInternalListItemGroupDefaultSlotChange")
   @Listen("calciteInternalListDefaultSlotChange")
-  handleCalciteInternalListDefaultSlotChanges(event: CustomEvent<void>): void {
+  handleCalciteInternalListDefaultSlotChanges(event: CustomEvent): void {
     event.stopPropagation();
     this.handleOpenableChange(this.defaultSlotEl);
   }

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -304,7 +304,7 @@ export class ListItem
 
   @Listen("calciteInternalListItemGroupDefaultSlotChange")
   @Listen("calciteInternalListDefaultSlotChange")
-  handleCalciteInternalListDefaultSlotChanges(event: CustomEvent): void {
+  handleCalciteInternalListDefaultSlotChanges(event: CustomEvent<void>): void {
     event.stopPropagation();
     this.handleOpenableChange(this.defaultSlotEl);
   }
@@ -710,7 +710,7 @@ export class ListItem
   //
   // --------------------------------------------------------------------------
 
-  private dragHandleSelectedChangeHandler = (event: CustomEvent): void => {
+  private dragHandleSelectedChangeHandler = (event: CustomEvent<void>): void => {
     this.dragSelected = (event.target as HTMLCalciteHandleElement).selected;
     this.calciteListItemDragHandleChange.emit();
     event.stopPropagation();

--- a/packages/calcite-components/src/components/loader/loader.tsx
+++ b/packages/calcite-components/src/components/loader/loader.tsx
@@ -90,9 +90,9 @@ export class Loader implements LocalizedComponent {
     return (
       <Host
         aria-label={label}
-        aria-valuemax={isDeterminate ? 100 : undefined}
-        aria-valuemin={isDeterminate ? 0 : undefined}
-        aria-valuenow={isDeterminate ? valueNow : undefined}
+        aria-valuemax={isDeterminate ? "100" : undefined}
+        aria-valuemin={isDeterminate ? "0" : undefined}
+        aria-valuenow={isDeterminate ? valueNow.toString() : undefined}
         id={id}
         role="progressbar"
       >

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
@@ -292,7 +292,7 @@ describe("calcite-segmented-control", () => {
 
       async function cycleThroughItemsAndAssertValue(keys: "left-right" | "up-down"): Promise<void> {
         const [moveBeforeArrowKey, moveAfterArrowKey] =
-          keys === "left-right" ? ["ArrowLeft", "ArrowRight"] : ["ArrowUp", "ArrowDown"];
+          keys === "left-right" ? (["ArrowLeft", "ArrowRight"] as const) : (["ArrowUp", "ArrowDown"] as const);
 
         await element.press(moveAfterArrowKey);
         await page.waitForChanges();

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -250,11 +250,11 @@ export class Table implements LocalizedComponent, LoadableComponent, T9nComponen
   }
 
   @Listen("calciteInternalTableRowFocusRequest")
-  calciteInternalTableRowFocusEvent(event: TableRowFocusEvent): void {
-    const cellPosition = event["detail"].cellPosition;
-    const rowPos = event["detail"].rowPosition;
-    const destination = event["detail"].destination;
-    const lastCell = event["detail"].lastCell;
+  calciteInternalTableRowFocusEvent(event: CustomEvent<TableRowFocusEvent>): void {
+    const cellPosition = event.detail.cellPosition;
+    const rowPos = event.detail.rowPosition;
+    const destination = event.detail.destination;
+    const lastCell = event.detail.lastCell;
 
     const visibleBody = this.bodyRows?.filter((row) => !row.hidden);
     const visibleAll = this.allRows?.filter((row) => !row.hidden);

--- a/packages/calcite-components/src/components/text-area/text-area.e2e.ts
+++ b/packages/calcite-components/src/components/text-area/text-area.e2e.ts
@@ -151,7 +151,7 @@ describe("calcite-text-area", () => {
     await page.setContent("<calcite-text-area></calcite-text-area>");
 
     const element = await page.find("calcite-text-area");
-    element.setAttribute("max-length", 5);
+    element.setAttribute("max-length", "5");
     await page.waitForChanges();
 
     await page.keyboard.press("Tab");

--- a/packages/calcite-components/src/components/time-picker/time-picker.tsx
+++ b/packages/calcite-components/src/components/time-picker/time-picker.tsx
@@ -202,7 +202,7 @@ export class TimePicker
   /**
    * @internal
    */
-  @Event({ cancelable: false }) calciteInternalTimePickerChange: EventEmitter<string>;
+  @Event({ cancelable: false }) calciteInternalTimePickerChange: EventEmitter<void>;
 
   //--------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/tests/commonTests/t9n.ts
+++ b/packages/calcite-components/src/tests/commonTests/t9n.ts
@@ -82,7 +82,7 @@ export async function t9n(componentTestSetup: ComponentTestSetup): Promise<void>
             return new Response(new Blob([JSON.stringify(fakeEsMessages, null, 2)], { type: "application/json" }));
           }
 
-          return orig.call(input, init);
+          return orig.call(window, input, init);
         };
       },
       enMessages,

--- a/packages/calcite-components/src/utils/dom.spec.ts
+++ b/packages/calcite-components/src/utils/dom.spec.ts
@@ -665,8 +665,8 @@ describe("dom", () => {
 
     let element: HTMLDivElement;
     let dispatchTransitionEvent: TransitionEventDispatcher;
-    let onStartCallback: jest.Mock<any, any, any>;
-    let onEndCallback: jest.Mock<any, any, any>;
+    let onStartCallback: jest.Mock;
+    let onEndCallback: jest.Mock;
 
     beforeEach(() => {
       dispatchTransitionEvent = createTransitionEventDispatcher();
@@ -766,8 +766,8 @@ describe("dom", () => {
 
     let element: HTMLDivElement;
     let dispatchAnimationEvent: AnimationEventDispatcher;
-    let onStartCallback: jest.Mock<any, any, any>;
-    let onEndCallback: jest.Mock<any, any, any>;
+    let onStartCallback: jest.Mock;
+    let onEndCallback: jest.Mock;
 
     beforeEach(() => {
       dispatchAnimationEvent = createAnimationEventDispatcher();

--- a/packages/calcite-components/src/utils/interactive.tsx
+++ b/packages/calcite-components/src/utils/interactive.tsx
@@ -111,7 +111,7 @@ function removeInteractionListeners(element: HTMLElement): void {
   );
 }
 
-export interface InteractiveContainerProps extends JSXAttributes<HTMLDivElement> {
+export interface InteractiveContainerProps extends JSXAttributes {
   disabled: boolean;
 }
 

--- a/packages/calcite-components/src/utils/interactive.tsx
+++ b/packages/calcite-components/src/utils/interactive.tsx
@@ -111,7 +111,7 @@ function removeInteractionListeners(element: HTMLElement): void {
   );
 }
 
-export interface InteractiveContainerProps extends JSXAttributes {
+export interface InteractiveContainerProps extends JSXAttributes<HTMLDivElement> {
   disabled: boolean;
 }
 


### PR DESCRIPTION
Run the migration script on tests.
This PR includes some small fixups that affect TypeScript typings to reduce number of TypeScript errors after the codemod.
With these changes, there are only 57 TypeScript error in the entire calcite-components package after the codemod!