### PR TITLE
fix(action-pad): fix horizontal action group alignment

### DIFF
--- a/packages/calcite-components/src/components/action-pad/action-pad.scss
+++ b/packages/calcite-components/src/components/action-pad/action-pad.scss
@@ -20,8 +20,10 @@
   max-inline-size: var(--calcite-action-pad-expanded-max-width, auto);
 }
 
-::slotted(calcite-action-group:not(:last-of-type)) {
-  @apply border-b;
+:host([layout="vertical"]) {
+  ::slotted(calcite-action-group:not(:last-of-type)) {
+    @apply border-b;
+  }
 }
 
 .container {

--- a/packages/calcite-components/src/components/action-pad/action-pad.stories.ts
+++ b/packages/calcite-components/src/components/action-pad/action-pad.stories.ts
@@ -42,7 +42,7 @@ export const simple = (args: ActionPadStoryArgs): string => html`
   </calcite-action-pad>
 `;
 
-export const withGroups_TestOnly = (): string =>
+export const withGroups = (): string =>
   html`<calcite-action-pad layout="horizontal">
     <calcite-action-group>
       <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>

--- a/packages/calcite-components/src/components/action-pad/action-pad.stories.ts
+++ b/packages/calcite-components/src/components/action-pad/action-pad.stories.ts
@@ -42,6 +42,27 @@ export const simple = (args: ActionPadStoryArgs): string => html`
   </calcite-action-pad>
 `;
 
+export const withGroups_TestOnly = (): string =>
+  html`<calcite-action-pad layout="horizontal">
+    <calcite-action-group>
+      <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Layers" icon="layers" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Basemaps" icon="layer-basemap" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-tooltip
+      slot="expand-tooltip"
+      id="calcite-tooltip-c19274e3-ff3b-6168-ef1e-8a700b056e1c"
+      role="tooltip"
+      overlay-positioning="absolute"
+      placement="auto"
+      style="visibility: hidden; pointer-events: none; position: absolute;"
+      >Toggle Action Pad</calcite-tooltip
+    >
+  </calcite-action-pad>`;
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-action-pad position="start" dir="rtl" class="calcite-mode-dark">
     <calcite-action-group>


### PR DESCRIPTION
**Related Issue:** #10307

## Summary

Removes an extra border-block-end which was causing a layout bug