### PR TITLE
ci: resolve husky pre-push and pre-commit errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,32 +1,28 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ensure_types_are_up_to_date() {
   types_path="packages/calcite-components/src/components.d.ts"
 
   if [ -n "$(git diff --name-only -- "$types_path")" ]; then
     echo "Automatically staging changes to \"$types_path\""
-    git add "$types_path"
+    git add "$types_path" >/dev/null 2>&1 || true
   fi
 }
 
 update_stylelint_config_if_sass_file_edited() {
-  staged_files="$(git diff --cached --name-only --diff-filter=ACM)"
+  staged_files="$(
+    git diff --cached --name-only --diff-filter=ACM -- packages/**/*.scss
+  )" 
 
-  for file in $staged_files; do
-    if [[ "$file" == *.scss ]]; then
-      npm run util:update-stylelint-custom-sass-functions
-      break
-    fi
-  done
-
-  if [ -n "$(git diff --name-only -- "packages/calcite-components/.stylelintrc.json")" ]; then
-    git add "packages/calcite-components/.stylelintrc.json"
+  if [ -n "$staged_files" ]; then
+    npm run util:update-stylelint-custom-sass-functions
+    git add "packages/calcite-components/.stylelintrc.cjs" >/dev/null 2>&1 || true
   fi
+
+  unset staged_files
 }
 
 check_ui_icon_name_consistency() {
-  svg_icon_dir="packages/calcite-ui-icons/icons"
-
   # this pattern checks for `<iconName>-<size>.svg` or `<iconName>-<size>-f.svg` for filled icons
   # where `<iconName>` is kebab-case, `<size>` is 16, 24, or 32
   valid_pattern="^[a-z0-9-]+-(16|24|32)(-f)?\\.svg$"
@@ -34,27 +30,33 @@ check_ui_icon_name_consistency() {
   # this pattern will check for invalid use of "-f-" anywhere except right before the size
   invalid_pattern="-[a-z0-9]+-f-"
 
-  staged_files="$(git diff --cached --name-only --diff-filter=ACM)"
+  staged_files="$(
+    git diff --cached --name-only --diff-filter=ACM -- packages/calcite-ui-icons/icons/*.svg
+  )"
 
-  for file in $staged_files; do
-    if [[ "$file" == "$svg_icon_dir"* ]]; then
-      if [[ "$file" == *.svg ]]; then
-        filename="$(basename "$file")"
+  if [ -n "$staged_files" ]; then
+    for file in $staged_files; do
+      filename="$(basename "$file")"
 
-        # first, ensure the filename follows the valid pattern
-        if ! [[ "$filename" =~ $valid_pattern ]]; then
-          echo "Error: File '$file' does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
-          exit 1
-        fi
-
-        # then, ensure there's no invalid use of "-f-" anywhere except right before the size
-        if [[ "$filename" =~ $invalid_pattern ]]; then
-          echo "Error: File '$file' has an invalid '-f-' and does not follow the naming convention (<iconName>-<size>.svg or <iconName>-<size>-f.svg)."
-          exit 1
-        fi
+      # first, ensure the filename follows the valid pattern
+      if ! echo "$filename" | grep -qE "$valid_pattern"; then
+        printf "%s\n%s" \
+          "error: file '$file' does not follow the naming convention:" \
+          "(<iconname>-<size>.svg | <iconname>-<size>-f.svg)"
+        exit 1
       fi
-    fi
-  done
+
+      # then, ensure there's no invalid use of "-f-" anywhere except right before the size
+      if echo "$filename" | grep -qE "$invalid_pattern"; then
+        printf '%s\n%s' \
+          "error: file '$file' has an invalid '-f-' and does not follow the naming convention:" \
+          "(<iconname>-<size>.svg | <iconname>-<size>-f.svg)"
+        exit 1
+      fi
+    done
+  fi
+
+  unset staged_files
 }
 
 lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,14 +1,20 @@
-#!/usr/bin/env bash
-# from https://riptutorial.com/git/example/16164/pre-push
+#!/usr/bin/env sh
 
-protected_branch="main"
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-
-if [ "$protected_branch" = "$current_branch" ] && bash -c ': >/dev/tty'; then
-    read -p "You're about to push main, is that what you intended? [y|n] " -n 1 -r </dev/tty
-    echo
-    if echo "$REPLY" | grep -E "^[Yy]$" >/dev/null; then
-        exit 0
-    fi
-    exit 1
+if ! bash -c ': >/dev/tty'; then
+    exit 0
 fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+case "$current_branch" in
+    dev | main | rc)
+        printf "You're about to push a protected branch, is that what you intended? [y|n] "
+        read -r response
+
+        case "$response" in
+            y | Y) exit 0 ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac

--- a/support/updateStylelintCustomSassFunctions.ts
+++ b/support/updateStylelintCustomSassFunctions.ts
@@ -15,7 +15,7 @@ function collectSassFiles(dir: string): string[] {
 
   try {
     fs.readdirSync(dir, { recursive: true, withFileTypes: true }).forEach(dirent => {
-      const fullPath = path.join(dir, dirent.name);
+      const fullPath = path.join(dirent.parentPath, dirent.name);
 
       if (dirent.isFile() && fullPath.endsWith('.scss')) {
         sassFiles.push(fullPath);


### PR DESCRIPTION
## Summary

Resolve a few errors in our `pre-commit` and `pre-push` hooks:

1. The `support/updateStylelintCustomSassFunctions.ts` script was trying to open scss files in the root directory.

   ```text
   Error reading file: /home/jamin/dev/work/calcite-design-system/dev/ComponentWithSass.scss
   Error: ENOENT: no such file or directory, open '/home/jamin/dev/work/calcite-design-system/dev/ComponentWithSass.scss'
       at Object.readFileSync (node:fs:448:20)
       at <anonymous> (/home/jamin/dev/work/calcite-design-system/dev/support/updateStylelintCustomSassFunctions.ts:37:24)
       at Array.forEach (<anonymous>)
       at sassFiles (/home/jamin/dev/work/calcite-design-system/dev/support/updateStylelintCustomSassFunctions.ts:35:11)
       at Object.<anonymous> (/home/jamin/dev/work/calcite-design-system/dev/support/updateStylelintCustomSassFunctions.ts:63:1)
       at Module._compile (node:internal/modules/cjs/loader:1358:14)
       at Object.transformer (/home/jamin/dev/work/calcite-design-system/dev/node_modules/tsx/dist/register-C1urN2EO.cjs:2:1122)
       at Module.load (node:internal/modules/cjs/loader:1208:32)
       at Module._load (node:internal/modules/cjs/loader:1024:12)
       at cjsLoader (node:internal/modules/esm/translators:348:17) {
   errno: -2,
   code: 'ENOENT',
   syscall: 'open',
   path: '/home/jamin/dev/work/calcite-design-system/dev/ComponentWithSass.scss'
   }
   ```

2. The stylelint config file extension was incorrect.
   ```text
   Stylelint configuration updated successfully
   fatal: pathspec 'packages/calcite-components/.stylelintrc.json' did not match any files
   ```
3. The `pre-push` hook was only protecting `main` when it should protect `rc` and `dev` too.

4. [Husky requires scripts to be POSIX compliant](https://typicode.github.io/husky/how-to.html#bash), which means we can't use bash features.

   - Replace the `read` prompt's `-p` and `-n` flags with a printf and case statement
   - Replace double bracket conditionals used for pattern matching with `grep -qE` in the `pre-commit` hook

     ```text
     .husky/pre-commit: 40: [[: not found
     .husky/pre-commit: 16: [[: not found
     ```
