### PR TITLE
fix(action): prefer `disabled` in favor of `aria-disabled`

### DIFF
--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -315,7 +315,6 @@ export class Action
           <button
             aria-busy={toAriaBoolean(loading)}
             aria-controls={indicator ? indicatorId : null}
-            aria-disabled={toAriaBoolean(disabled)}
             aria-label={ariaLabel}
             aria-pressed={toAriaBoolean(active)}
             class={buttonClasses}


### PR DESCRIPTION
**Related Issue:** #7775

## Summary

- only set `disabled` on action, not `aria-disabled` since it is redundant.