### PR TITLE
docs(a11y): add reference to a11y guidance to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -8,7 +8,7 @@ body:
       label: Check existing issues
       description: If someone has already opened an issue for what you are experiencing, please add a 👍 reaction to the existing issue instead of creating a new one. For support, please check the [community forum](https://developers.arcgis.com/calcite-design-system/community/).
       options:
-        - label: I have [checked for existing issues](https://github.com/Esri/calcite-design-system/issues) to avoid duplicates
+        - label: I have [checked for existing issues](https://github.com/Esri/calcite-design-system/issues) to avoid duplicates and reviewed the [Accessibility page](https://developers.arcgis.com/calcite-design-system/foundations/accessibility) for guidance.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/8724

## Summary
Adds a reference to the foundational [accessibility page](https://developers.arcgis.com/calcite-design-system/foundations/accessibility) to the accessibility issue template, where additional a11y guidance, including new context to focus, visible focus and no keyboard trap will be provided to developers.

![image](https://github.com/user-attachments/assets/ef827d27-91a5-4613-9862-23d0fbc11cc6)
