### PR TITLE
fix(date-picker): fix setFocus method

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -1680,6 +1680,10 @@ export namespace Components {
           * Already selected date.
          */
         "selectedDate": Date;
+        /**
+          * Sets focus on the component's first focusable element.
+         */
+        "setFocus": () => Promise<void>;
     }
     interface CalciteDialog {
         /**

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
@@ -1,7 +1,9 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
 import { html } from "../../../support/formatting";
-import { renders } from "../../tests/commonTests";
+import { focusable, renders } from "../../tests/commonTests";
 import { DateLocaleData } from "../date-picker/utils";
+import { ComponentTestContent } from "../../tests/commonTests/interfaces";
+import { CSS } from "./resources";
 
 describe("calcite-date-picker-month-header", () => {
   describe("renders", () => {
@@ -38,13 +40,9 @@ describe("calcite-date-picker-month-header", () => {
     },
   } as DateLocaleData;
 
-  it("displays next/previous options", async () => {
-    const page = await newE2EPage({
-      // intentionally using calcite-date-picker to wire up supporting components to be used in `evaluate` fn below
-      html: "<calcite-date-picker></calcite-date-picker>",
-    });
-    await page.waitForChanges();
-
+  async function setUpPage(page: E2EPage): Promise<void> {
+    // intentionally using calcite-date-picker to wire up supporting components to be used in `evaluate` fn below
+    await page.setContent(html`<calcite-date-picker></calcite-date-picker>`);
     await page.evaluate((localeData) => {
       const dateMonthHeader = document.createElement("calcite-date-picker-month-header");
       const now = new Date();
@@ -63,6 +61,26 @@ describe("calcite-date-picker-month-header", () => {
       document.body.append(dateMonthHeader);
     }, localeDataFixture);
     await page.waitForChanges();
+  }
+
+  async function setUpProvider(): Promise<ComponentTestContent> {
+    const page = await newE2EPage();
+    await setUpPage(page);
+    return {
+      tag: "calcite-date-picker-month-header",
+      page,
+    };
+  }
+
+  describe("focusable", () => {
+    focusable(() => setUpProvider(), {
+      shadowFocusTargetSelector: `.${CSS.chevron}`,
+    });
+  });
+
+  it("displays next/previous options", async () => {
+    const page = await newE2EPage();
+    await setUpPage(page);
 
     const [prev, next] = await page.findAll("calcite-date-picker-month-header >>> .chevron");
 

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   Fragment,
   h,
+  Method,
   Prop,
   State,
   VNode,
@@ -18,7 +19,7 @@ import {
   prevMonth,
   formatCalendarYear,
 } from "../../utils/date";
-import { closestElementCrossShadowBoundary } from "../../utils/dom";
+import { closestElementCrossShadowBoundary, focusFirstTabbable } from "../../utils/dom";
 import { isActivationKey } from "../../utils/key";
 import { numberStringFormatter } from "../../utils/locale";
 import { DatePickerMessages } from "../date-picker/assets/date-picker/t9n";
@@ -26,6 +27,12 @@ import { DateLocaleData } from "../date-picker/utils";
 import { Heading, HeadingLevel } from "../functional/Heading";
 import { Scale } from "../interfaces";
 import { getIconScale } from "../../utils/component";
+import {
+  componentFocusable,
+  LoadableComponent,
+  setComponentLoaded,
+  setUpLoadableComponent,
+} from "../../utils/loadable";
 import { CSS, ICON } from "./resources";
 
 @Component({
@@ -33,7 +40,7 @@ import { CSS, ICON } from "./resources";
   styleUrl: "date-picker-month-header.scss",
   shadow: true,
 })
-export class DatePickerMonthHeader {
+export class DatePickerMonthHeader implements LoadableComponent {
   //--------------------------------------------------------------------------
   //
   //  Properties
@@ -87,16 +94,34 @@ export class DatePickerMonthHeader {
 
   //--------------------------------------------------------------------------
   //
+  //  Public Methods
+  //
+  //--------------------------------------------------------------------------
+
+  /** Sets focus on the component's first focusable element. */
+  @Method()
+  async setFocus(): Promise<void> {
+    await componentFocusable(this);
+    focusFirstTabbable(this.el);
+  }
+
+  //--------------------------------------------------------------------------
+  //
   //  Lifecycle
   //
   //--------------------------------------------------------------------------
 
+  connectedCallback(): void {
+    this.setNextPrevMonthDates();
+  }
+
   componentWillLoad(): void {
+    setUpLoadableComponent(this);
     this.parentDatePickerEl = closestElementCrossShadowBoundary(this.el, "calcite-date-picker");
   }
 
-  connectedCallback(): void {
-    this.setNextPrevMonthDates();
+  componentDidLoad(): void {
+    setComponentLoaded(this);
   }
 
   render(): VNode {

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -183,7 +183,7 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);
-    this.el.focus();
+    await this.datePickerMonthHeaderEl?.setFocus();
   }
 
   /**
@@ -324,11 +324,17 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
 
   @State() startAsDate: Date;
 
+  private datePickerMonthHeaderEl: HTMLCalciteDatePickerMonthHeaderElement;
+
   //--------------------------------------------------------------------------
   //
   //  Private Methods
   //
   //--------------------------------------------------------------------------
+
+  private setDatePickerMonthHeaderEl = (el: HTMLCalciteDatePickerMonthHeaderElement): void => {
+    this.datePickerMonthHeaderEl = el;
+  };
 
   keyDownHandler = (event: KeyboardEvent): void => {
     if (event.key === "Escape") {
@@ -486,6 +492,7 @@ export class DatePicker implements LocalizedComponent, LoadableComponent, T9nCom
           messages={this.messages}
           min={minDate}
           onCalciteInternalDatePickerSelect={this.monthHeaderSelectChange}
+          ref={this.setDatePickerMonthHeaderEl}
           scale={this.scale}
           selectedDate={this.activeRange === "end" ? endDate : date || new Date()}
         />,


### PR DESCRIPTION
**Related Issue:** #10243

## Summary

- update `setFocus` method on `date-picker` to focus correctly by adding `setFocus` method on `date-picker-month-header`
- add test
