### PR TITLE
refactor(panel): remove duplicate tailwind class

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -160,7 +160,6 @@
   flex-auto
   flex-col
   flex-nowrap
-  focus-base
   items-stretch
   bg-background
   overflow-auto


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

- focus-base is defined twice on a class.
- showed up in VSCode lint