### PR TITLE
fix(action): only set aria-busy and aria-pressed when necessary

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -394,10 +394,6 @@ export namespace Components {
          */
         "expanded": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * Accessible name for the component.
          */
         "label": string;
@@ -407,9 +403,17 @@ export namespace Components {
          */
         "layout": Extract<"horizontal" | "vertical" | "grid", Layout>;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
           * When `true`, the `calcite-action-menu` is open.
          */
         "menuOpen": boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -422,10 +426,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Specifies the size of the `calcite-action-menu`.
          */
@@ -633,10 +633,6 @@ export namespace Components {
          */
         "dragHandle": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -661,6 +657,14 @@ export namespace Components {
          */
         "loading": boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
+        /**
           * Use this property to override individual strings used by the component.
          */
         "messageOverrides": Partial<BlockMessages>;
@@ -676,10 +680,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Sets focus on the component's first tabbable element.
          */
@@ -3881,10 +3881,6 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -3897,9 +3893,17 @@ export namespace Components {
          */
         "loading": boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
           * When `true`, the action menu items in the `header-menu-actions` slot are open.
          */
         "menuOpen": boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -3912,10 +3916,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Specifies the size of the component.
          */
@@ -8350,10 +8350,6 @@ declare namespace LocalJSX {
          */
         "expanded"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * Accessible name for the component.
          */
         "label"?: string;
@@ -8363,9 +8359,17 @@ declare namespace LocalJSX {
          */
         "layout"?: Extract<"horizontal" | "vertical" | "grid", Layout>;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
           * When `true`, the `calcite-action-menu` is open.
          */
         "menuOpen"?: boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -8378,10 +8382,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Specifies the size of the `calcite-action-menu`.
          */
@@ -8596,10 +8596,6 @@ declare namespace LocalJSX {
          */
         "dragHandle"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -8623,6 +8619,14 @@ declare namespace LocalJSX {
           * When `true`, a busy indicator is displayed.
          */
         "loading"?: boolean;
+        /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -8660,10 +8664,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Displays a status-related indicator icon.
           * @deprecated Use `icon-start` instead.
@@ -12033,10 +12033,6 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading"?: string;
@@ -12049,9 +12045,17 @@ declare namespace LocalJSX {
          */
         "loading"?: boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
           * When `true`, the action menu items in the `header-menu-actions` slot are open.
          */
         "menuOpen"?: boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -12076,10 +12080,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Specifies the size of the component.
          */

--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -133,6 +133,23 @@ describe("calcite-action", () => {
     expect(iconContainer).not.toBeNull();
   });
 
+  it("should set aria-attributes attributes when necessary", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-action text="hello world"></calcite-action>`);
+
+    const button = await page.find(`calcite-action >>> .${CSS.button}`);
+    expect(button.getAttribute("aria-busy")).toBe(null);
+    expect(button.getAttribute("aria-pressed")).toBe(null);
+
+    const action = await page.find("calcite-action");
+    action.setProperty("active", true);
+    action.setProperty("loading", true);
+    await page.waitForChanges();
+
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
   it("should use text prop for a11y attributes when text is not enabled", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-action text="hello world"></calcite-action>`);

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -313,10 +313,10 @@ export class Action
       <Host>
         <InteractiveContainer disabled={disabled}>
           <button
-            aria-busy={toAriaBoolean(loading)}
+            aria-busy={loading ? toAriaBoolean(loading) : null}
             aria-controls={indicator ? indicatorId : null}
             aria-label={ariaLabel}
-            aria-pressed={toAriaBoolean(active)}
+            aria-pressed={active ? toAriaBoolean(active) : null}
             class={buttonClasses}
             disabled={disabled}
             id={buttonId}


### PR DESCRIPTION
**Related Issue:** #

## Summary

- Only set `aria-busy` and `aria-pressed` when necessary
- add tests
