### PR TITLE
fix(tooltip): closed tooltips should not reappear

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -394,10 +394,6 @@ export namespace Components {
          */
         "expanded": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * Accessible name for the component.
          */
         "label": string;
@@ -407,9 +403,17 @@ export namespace Components {
          */
         "layout": Extract<"horizontal" | "vertical" | "grid", Layout>;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
           * When `true`, the `calcite-action-menu` is open.
          */
         "menuOpen": boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -422,10 +426,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Specifies the size of the `calcite-action-menu`.
          */
@@ -633,10 +633,6 @@ export namespace Components {
          */
         "dragHandle": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -661,6 +657,14 @@ export namespace Components {
          */
         "loading": boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
+        /**
           * Use this property to override individual strings used by the component.
          */
         "messageOverrides": Partial<BlockMessages>;
@@ -676,10 +680,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Sets focus on the component's first tabbable element.
          */
@@ -3881,10 +3881,6 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements": FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -3897,9 +3893,17 @@ export namespace Components {
          */
         "loading": boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements": FlipPlacement[];
+        /**
           * When `true`, the action menu items in the `header-menu-actions` slot are open.
          */
         "menuOpen": boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement": LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -3912,10 +3916,6 @@ export namespace Components {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning": OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement": LogicalPlacement;
         /**
           * Specifies the size of the component.
          */
@@ -8350,10 +8350,6 @@ declare namespace LocalJSX {
          */
         "expanded"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * Accessible name for the component.
          */
         "label"?: string;
@@ -8363,9 +8359,17 @@ declare namespace LocalJSX {
          */
         "layout"?: Extract<"horizontal" | "vertical" | "grid", Layout>;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
           * When `true`, the `calcite-action-menu` is open.
          */
         "menuOpen"?: boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -8378,10 +8382,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout. `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Specifies the size of the `calcite-action-menu`.
          */
@@ -8596,10 +8596,6 @@ declare namespace LocalJSX {
          */
         "dragHandle"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading": string;
@@ -8623,6 +8619,14 @@ declare namespace LocalJSX {
           * When `true`, a busy indicator is displayed.
          */
         "loading"?: boolean;
+        /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -8660,10 +8664,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Displays a status-related indicator icon.
           * @deprecated Use `icon-start` instead.
@@ -12033,10 +12033,6 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
-         */
-        "flipPlacements"?: FlipPlacement[];
-        /**
           * The component header text.
          */
         "heading"?: string;
@@ -12049,9 +12045,17 @@ declare namespace LocalJSX {
          */
         "loading"?: boolean;
         /**
+          * Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available.
+         */
+        "menuFlipPlacements"?: FlipPlacement[];
+        /**
           * When `true`, the action menu items in the `header-menu-actions` slot are open.
          */
         "menuOpen"?: boolean;
+        /**
+          * Determines where the action menu will be positioned.
+         */
+        "menuPlacement"?: LogicalPlacement;
         /**
           * Use this property to override individual strings used by the component.
          */
@@ -12076,10 +12080,6 @@ declare namespace LocalJSX {
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
         "overlayPositioning"?: OverlayPositioning;
-        /**
-          * Determines where the action menu will be positioned.
-         */
-        "placement"?: LogicalPlacement;
         /**
           * Specifies the size of the component.
          */

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -22,6 +22,8 @@ export default class TooltipManager {
 
   private registeredElementCount = 0;
 
+  private clickedTooltip: HTMLCalciteTooltipElement = null;
+
   // --------------------------------------------------------------------------
   //
   //  Public Methods
@@ -100,11 +102,17 @@ export default class TooltipManager {
       return;
     }
 
+    if (tooltip === this.clickedTooltip) {
+      return;
+    }
+
     if (tooltip) {
       this.openHoveredTooltip(tooltip);
     } else if (activeTooltip?.open) {
       this.closeHoveredTooltip();
     }
+
+    this.clickedTooltip = null;
   };
 
   private pathHasOpenTooltip(tooltip: HTMLCalciteTooltipElement, composedPath: EventTarget[]): boolean {
@@ -116,6 +124,7 @@ export default class TooltipManager {
   }
 
   private clickHandler = (event: Event): void => {
+    this.clickedTooltip = null;
     const composedPath = event.composedPath();
     const tooltip = this.queryTooltip(composedPath);
 
@@ -133,6 +142,7 @@ export default class TooltipManager {
     this.clearHoverTimeout();
 
     if (tooltip.closeOnClick) {
+      this.clickedTooltip = tooltip;
       this.toggleTooltip(tooltip, false);
       return;
     }

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -661,6 +661,14 @@ describe("calcite-tooltip", () => {
     await page.waitForChanges();
 
     expect(await tooltip.getProperty("open")).toBe(false);
+
+    await referenceElement.hover();
+
+    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
+
+    await page.waitForChanges();
+
+    expect(await tooltip.getProperty("open")).toBe(false);
   });
 
   it("should close tooltip when closeOnClick is true and referenceElement is clicked quickly", async () => {


### PR DESCRIPTION
**Related Issue:** #10416

## Summary

- track clicked tooltip to stop hovering until the tooltip is hovered off of
- add e2e test
