### PR TITLE
deprecate: deprecate `enforce-ref-last-prop` rule

### DIFF
--- a/packages/eslint-plugin-calcite-components/docs/enforce-ref-last-prop.md
+++ b/packages/eslint-plugin-calcite-components/docs/enforce-ref-last-prop.md
@@ -1,5 +1,7 @@
 # enforce-ref-last-prop
 
+**Deprecated** This rule is deprecated and will be removed in a future release. It is no longer needed if you are using Stencil 4.14.1 or greater.
+
 This ensures the node passed into the `ref` callback is in sync with its JSX attributes/properties when invoked.
 
 Placing `ref` last helps work around a [Stencil bug](https://github.com/ionic-team/stencil/issues/4074) where the `ref` callback is invoked in the specified order and not after initializing the element with all its attributes/properties. This can cause attributes/properties to be outdated by the time the callback is invoked.

--- a/packages/eslint-plugin-calcite-components/src/rules/enforce-ref-last-prop.ts
+++ b/packages/eslint-plugin-calcite-components/src/rules/enforce-ref-last-prop.ts
@@ -3,6 +3,7 @@ import type { JSXAttribute, JSXOpeningElement, JSXSpreadAttribute } from "@babel
 
 const rule: Rule.RuleModule = {
   meta: {
+    deprecated: true,
     docs: {
       description: `This ensures the node passed into the ref callback is in sync with its JSX attributes/properties when invoked.`,
       recommended: true,


### PR DESCRIPTION
**Related Issue:** #10398

## Summary

Deprecates this rule for 3.x removal as it is no longer needed after Stencil 4.14.1 and will be even more obsolete after #10310.