### PR TITLE
test: fix `window.getComputedStyle` arguments

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -353,7 +353,7 @@ describe("calcite-alert", () => {
         await page.setContent(alertSnippet);
         await page.waitForTimeout(alertQueueTimeoutMs);
         alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
-        progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
+        progressBarStyles = await alertDismissProgressBar.getComputedStyle("::after");
         expect(await progressBarStyles.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.8)");
       });
     });
@@ -365,7 +365,7 @@ describe("calcite-alert", () => {
         await page.setContent(html`<div class="calcite-mode-dark">${alertSnippet}</div>`);
         await page.waitForTimeout(alertQueueTimeoutMs);
         alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
-        progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
+        progressBarStyles = await alertDismissProgressBar.getComputedStyle("::after");
         expect(await progressBarStyles.getPropertyValue("background-color")).toEqual("rgba(43, 43, 43, 0.8)");
       });
     });
@@ -384,7 +384,7 @@ describe("calcite-alert", () => {
       );
       await page.waitForTimeout(alertQueueTimeoutMs);
       alertDismissProgressBar = await page.find(`calcite-alert[open] >>> .${CSS.dismissProgress}`);
-      progressBarStyles = await alertDismissProgressBar.getComputedStyle(":after");
+      progressBarStyles = await alertDismissProgressBar.getComputedStyle("::after");
       expect(await progressBarStyles.getPropertyValue("background-color")).toEqual(overrideStyle);
     });
   });

--- a/packages/calcite-components/src/components/button/button.e2e.ts
+++ b/packages/calcite-components/src/components/button/button.e2e.ts
@@ -533,12 +533,12 @@ describe("calcite-button", () => {
         buttonEl = await page.find("calcite-button >>> button");
         await buttonEl.focus();
         await page.waitForChanges();
-        buttonFocusStyle = await buttonEl.getComputedStyle(":focus");
+        buttonFocusStyle = await buttonEl.getComputedStyle();
         expect(buttonFocusStyle.getPropertyValue("background-color")).toEqual("rgba(0, 0, 0, 0.04)");
 
         await buttonEl.hover();
         await page.waitForChanges();
-        buttonHoverStyle = await buttonEl.getComputedStyle(":hover");
+        buttonHoverStyle = await buttonEl.getComputedStyle();
         expect(buttonHoverStyle.getPropertyValue("background-color")).toEqual("rgba(0, 0, 0, 0.04)");
       });
     });
@@ -551,12 +551,12 @@ describe("calcite-button", () => {
         buttonEl = await page.find("calcite-button >>> button");
         await buttonEl.focus();
         await page.waitForChanges();
-        buttonFocusStyle = await buttonEl.getComputedStyle(":focus");
+        buttonFocusStyle = await buttonEl.getComputedStyle();
         expect(buttonFocusStyle.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.04)");
 
         await buttonEl.hover();
         await page.waitForChanges();
-        buttonHoverStyle = await buttonEl.getComputedStyle(":hover");
+        buttonHoverStyle = await buttonEl.getComputedStyle();
         expect(buttonHoverStyle.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.04)");
       });
     });
@@ -575,12 +575,12 @@ describe("calcite-button", () => {
       buttonEl = await page.find("calcite-button >>> button");
       await buttonEl.focus();
       await page.waitForChanges();
-      buttonFocusStyle = await buttonEl.getComputedStyle(":focus");
+      buttonFocusStyle = await buttonEl.getComputedStyle();
       expect(buttonFocusStyle.getPropertyValue("background-color")).toEqual(overrideStyle);
 
       await buttonEl.hover();
       await page.waitForChanges();
-      buttonHoverStyle = await buttonEl.getComputedStyle(":hover");
+      buttonHoverStyle = await buttonEl.getComputedStyle();
       expect(buttonHoverStyle.getPropertyValue("background-color")).toEqual(overrideStyle);
     });
   });

--- a/packages/calcite-components/src/components/chip/chip.e2e.ts
+++ b/packages/calcite-components/src/components/chip/chip.e2e.ts
@@ -158,12 +158,12 @@ describe("calcite-chip", () => {
         chipCloseButton = await page.find("calcite-chip >>> button");
         await chipCloseButton.focus();
         await page.waitForChanges();
-        chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle(":focus");
+        chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle();
         expect(chipCloseButtonFocusStyle.getPropertyValue("background-color")).toEqual("rgba(0, 0, 0, 0.04)");
 
         await chipCloseButton.hover();
         await page.waitForChanges();
-        chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle(":hover");
+        chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle();
         expect(chipCloseButtonHoverStyle.getPropertyValue("background-color")).toEqual("rgba(0, 0, 0, 0.04)");
       });
     });
@@ -176,12 +176,12 @@ describe("calcite-chip", () => {
         chipCloseButton = await page.find("calcite-chip >>> button");
         await chipCloseButton.focus();
         await page.waitForChanges();
-        chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle(":focus");
+        chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle();
         expect(chipCloseButtonFocusStyle.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.04)");
 
         await chipCloseButton.hover();
         await page.waitForChanges();
-        chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle(":hover");
+        chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle();
         expect(chipCloseButtonHoverStyle.getPropertyValue("background-color")).toEqual("rgba(255, 255, 255, 0.04)");
       });
     });
@@ -200,12 +200,12 @@ describe("calcite-chip", () => {
       chipCloseButton = await page.find("calcite-chip >>> button");
       await chipCloseButton.focus();
       await page.waitForChanges();
-      chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle(":focus");
+      chipCloseButtonFocusStyle = await chipCloseButton.getComputedStyle();
       expect(chipCloseButtonFocusStyle.getPropertyValue("background-color")).toEqual(overrideStyle);
 
       await chipCloseButton.hover();
       await page.waitForChanges();
-      chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle(":hover");
+      chipCloseButtonHoverStyle = await chipCloseButton.getComputedStyle();
       expect(chipCloseButtonHoverStyle.getPropertyValue("background-color")).toEqual(overrideStyle);
     });
 


### PR DESCRIPTION
**Related Issue:** #10369 

## Summary

This updates `getComputedStyle` args to:

* use `::after` vs `:after`
* remove invalid pseudoclass args (only pseudo-elements are supported)