### PR TITLE
refactor: prevent mixed Sass mixed declaration warnings

### DIFF
--- a/packages/calcite-components/src/assets/styles/_host.scss
+++ b/packages/calcite-components/src/assets/styles/_host.scss
@@ -1,10 +1,11 @@
 %component-host {
   /* Base ":host" styles for the component */
   box-sizing: border-box;
-  * {
-    box-sizing: border-box;
-  }
   background-color: var(--calcite-color-foreground-1);
   color: var(--calcite-color-text-2);
   font-size: var(--calcite-font-size--1);
+
+  * {
+    box-sizing: border-box;
+  }
 }

--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -97,11 +97,11 @@
     flex-row
     flex-nowrap
     rounded;
+  color: var(--calcite-popover-text-color, var(--calcite-color-text-1));
+
   &.has-header {
     @apply flex-col;
   }
-
-  color: var(--calcite-popover-text-color, var(--calcite-color-text-1));
 }
 
 .content {

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.scss
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.scss
@@ -14,11 +14,11 @@
   box-border
   block;
 
+  --calcite-tip-manager-height: 19vh;
+
   * {
     @apply box-border;
   }
-
-  --calcite-tip-manager-height: 19vh;
 }
 
 :host([closed]) {


### PR DESCRIPTION
**Related Issue:** #10347

## Summary

Updates styles to avoid [mixed declaration](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) warnings that will show up after #10310.
