### PR TITLE
fix(inline-editable): fix rendering tied to default slot content

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -321,8 +321,6 @@ export class InlineEditable
   };
 
   mutationObserverCallback(): void {
-    // todo: kind of odd to be setting scale based on a slotted element scale.
-    // would require a scale event to properly handle this which would be better than a mutation observer
     this.scale = this.scale || this.inputElement?.scale;
   }
 

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -24,7 +24,6 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
-import { createObserver } from "../../utils/observers";
 import {
   connectMessages,
   disconnectMessages,
@@ -130,8 +129,6 @@ export class InlineEditable
     connectLabel(this);
     connectLocalized(this);
     connectMessages(this);
-    this.mutationObserver?.observe(this.el, { childList: true });
-    this.mutationObserverCallback();
   }
 
   async componentWillLoad(): Promise<void> {
@@ -147,7 +144,6 @@ export class InlineEditable
     disconnectLabel(this);
     disconnectLocalized(this);
     disconnectMessages(this);
-    this.mutationObserver?.disconnect();
   }
 
   componentDidRender(): void {
@@ -274,8 +270,6 @@ export class InlineEditable
 
   labelEl: HTMLCalciteLabelElement;
 
-  mutationObserver = createObserver("mutation", () => this.mutationObserverCallback());
-
   @State() defaultMessages: InlineEditableMessages;
 
   @State() effectiveLocale: string;
@@ -318,11 +312,8 @@ export class InlineEditable
 
     inputElement.disabled = this.disabled;
     inputElement.label = inputElement.label || getLabelText(this);
-  };
-
-  mutationObserverCallback(): void {
     this.scale = this.scale || this.inputElement?.scale;
-  }
+  };
 
   onLabelClick(): void {
     this.setFocus();


### PR DESCRIPTION
**Related Issue:** #6059

## Summary

- remove use of `getSlotted` utility
- replace with `slotchange` event 
- existing tests should suffice