### PR TITLE
refactor(action-bar, action-group, action-pad, shell, shell-panel): remove conditional slot component where not necessary

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -13,11 +13,6 @@ import {
 } from "@stencil/core";
 import { debounce } from "lodash-es";
 import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
-import {
   focusFirstTabbable,
   slotChangeGetAssignedElements,
   slotChangeHasAssignedElement,
@@ -57,9 +52,7 @@ import { geActionDimensions, getOverflowCount, overflowActions, queryActions } f
   shadow: true,
   assetsDirs: ["assets"],
 })
-export class ActionBar
-  implements ConditionalSlotComponent, LoadableComponent, LocalizedComponent, T9nComponent
-{
+export class ActionBar implements LoadableComponent, LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -228,7 +221,6 @@ export class ActionBar
     }
 
     this.overflowActions();
-    connectConditionalSlotComponent(this);
   }
 
   async componentWillLoad(): Promise<void> {
@@ -239,7 +231,6 @@ export class ActionBar
   disconnectedCallback(): void {
     this.mutationObserver?.disconnect();
     this.resizeObserver?.disconnect();
-    disconnectConditionalSlotComponent(this);
     disconnectLocalized(this);
     disconnectMessages(this);
   }

--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -1,11 +1,6 @@
 import { Component, Element, h, Method, Prop, State, VNode, Watch } from "@stencil/core";
 import { CalciteActionMenuCustomEvent } from "../../components";
 import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
-import {
   componentFocusable,
   LoadableComponent,
   setComponentLoaded,
@@ -40,9 +35,7 @@ import { ICONS, SLOTS, CSS } from "./resources";
   },
   assetsDirs: ["assets"],
 })
-export class ActionGroup
-  implements ConditionalSlotComponent, LoadableComponent, LocalizedComponent, T9nComponent
-{
+export class ActionGroup implements LoadableComponent, LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -163,13 +156,11 @@ export class ActionGroup
   connectedCallback(): void {
     connectLocalized(this);
     connectMessages(this);
-    connectConditionalSlotComponent(this);
   }
 
   disconnectedCallback(): void {
     disconnectLocalized(this);
     disconnectMessages(this);
-    disconnectConditionalSlotComponent(this);
   }
 
   async componentWillLoad(): Promise<void> {

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -11,11 +11,6 @@ import {
   VNode,
   Watch,
 } from "@stencil/core";
-import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
 import { slotChangeGetAssignedElements } from "../../utils/dom";
 import {
   componentFocusable,
@@ -50,9 +45,7 @@ import { CSS, SLOTS } from "./resources";
   },
   assetsDirs: ["assets"],
 })
-export class ActionPad
-  implements ConditionalSlotComponent, LoadableComponent, LocalizedComponent, T9nComponent
-{
+export class ActionPad implements LoadableComponent, LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -169,7 +162,6 @@ export class ActionPad
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    connectConditionalSlotComponent(this);
     connectLocalized(this);
     connectMessages(this);
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
@@ -178,7 +170,6 @@ export class ActionPad
   disconnectedCallback(): void {
     disconnectLocalized(this);
     disconnectMessages(this);
-    disconnectConditionalSlotComponent(this);
     this.mutationObserver?.disconnect();
   }
 

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -11,11 +11,6 @@ import {
   Watch,
 } from "@stencil/core";
 import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
-import {
   getElementDir,
   isPrimaryPointerButton,
   slotChangeGetAssignedElements,
@@ -46,7 +41,7 @@ import { DisplayMode } from "./interfaces";
   shadow: true,
   assetsDirs: ["assets"],
 })
-export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent, T9nComponent {
+export class ShellPanel implements LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -167,7 +162,6 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
   //--------------------------------------------------------------------------
 
   connectedCallback(): void {
-    connectConditionalSlotComponent(this);
     connectLocalized(this);
     connectMessages(this);
   }
@@ -177,7 +171,6 @@ export class ShellPanel implements ConditionalSlotComponent, LocalizedComponent,
   }
 
   disconnectedCallback(): void {
-    disconnectConditionalSlotComponent(this);
     this.disconnectSeparator();
     disconnectLocalized(this);
     disconnectMessages(this);

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -1,9 +1,4 @@
 import { Component, Element, Fragment, h, Listen, Prop, State, VNode, Watch } from "@stencil/core";
-import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
 import { slotChangeGetAssignedElements, slotChangeHasAssignedElement } from "../../utils/dom";
 import { CSS, SLOTS } from "./resources";
 
@@ -27,7 +22,7 @@ import { CSS, SLOTS } from "./resources";
   styleUrl: "shell.scss",
   shadow: true,
 })
-export class Shell implements ConditionalSlotComponent {
+export class Shell {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -89,20 +84,6 @@ export class Shell implements ConditionalSlotComponent {
   @Watch("hasPanelBottom")
   updateHasOnlyPanelBottom(): void {
     this.hasOnlyPanelBottom = !this.hasPanelTop && this.hasPanelBottom;
-  }
-
-  // --------------------------------------------------------------------------
-  //
-  //  Lifecycle
-  //
-  // --------------------------------------------------------------------------
-
-  connectedCallback(): void {
-    connectConditionalSlotComponent(this);
-  }
-
-  disconnectedCallback(): void {
-    disconnectConditionalSlotComponent(this);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
**Related Issue:** #6059

## Summary

- removes `ConditionalSlotComponent` and helpers on components that no longer need them.
- these components do not use getSlotted any longer so these should not be necessary
