### PR TITLE
fix(tip): fix rendering tied to named-slot content

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,7 +1,13 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [];
+const customFunctions = [
+  "get-trailing-text-input-padding",
+  "medium-modular-scale",
+  "modular-scale",
+  "scale-duration",
+  "small-modular-scale"
+];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,13 +1,7 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [
-  "get-trailing-text-input-padding",
-  "medium-modular-scale",
-  "modular-scale",
-  "scale-duration",
-  "small-modular-scale"
-];
+const customFunctions = [];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/src/components/tip/resources.ts
+++ b/packages/calcite-components/src/components/tip/resources.ts
@@ -6,6 +6,7 @@ export const CSS = {
   imageFrame: "image-frame",
   content: "content",
   info: "info",
+  infoNoThumbnail: "info--no-thumbnail",
 };
 
 export const ICONS = {

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -49,9 +49,10 @@
 .info {
   @apply py-0 px-4;
   inline-size: 70%;
-  &:only-child {
-    @apply w-full px-0;
-  }
+}
+
+.info--no-thumbnail {
+  @apply w-full px-0;
 }
 
 ::slotted(p) {

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -203,7 +203,7 @@ export class Tip implements LocalizedComponent, T9nComponent {
 
   renderInfoNode(): VNode {
     return (
-      <div class={CSS.info}>
+      <div class={{ [CSS.info]: true, [CSS.infoNoThumbnail]: !this.hasThumbnail }}>
         <slot />
       </div>
     );

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -10,12 +10,6 @@ import {
   VNode,
   Watch,
 } from "@stencil/core";
-import {
-  ConditionalSlotComponent,
-  connectConditionalSlotComponent,
-  disconnectConditionalSlotComponent,
-} from "../../utils/conditionalSlot";
-import { getSlotted } from "../../utils/dom";
 import { connectLocalized, disconnectLocalized, LocalizedComponent } from "../../utils/locale";
 import {
   connectMessages,
@@ -26,6 +20,7 @@ import {
 } from "../../utils/t9n";
 import { constrainHeadingLevel, Heading, HeadingLevel } from "../functional/Heading";
 import { logger } from "../../utils/logger";
+import { slotChangeHasAssignedElement } from "../../utils/dom";
 import { TipMessages } from "./assets/tip/t9n";
 import { CSS, ICONS, SLOTS } from "./resources";
 
@@ -46,7 +41,7 @@ logger.deprecated("component", {
   shadow: true,
   assetsDirs: ["assets"],
 })
-export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nComponent {
+export class Tip implements LocalizedComponent, T9nComponent {
   // --------------------------------------------------------------------------
   //
   //  Properties
@@ -108,6 +103,8 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
 
   @State() defaultMessages: TipMessages;
 
+  @State() hasThumbnail = false;
+
   @State() effectiveLocale = "";
 
   @Watch("effectiveLocale")
@@ -122,7 +119,6 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
   // --------------------------------------------------------------------------
 
   connectedCallback(): void {
-    connectConditionalSlotComponent(this);
     connectLocalized(this);
     connectMessages(this);
   }
@@ -132,7 +128,6 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
   }
 
   disconnectedCallback(): void {
-    disconnectConditionalSlotComponent(this);
     disconnectLocalized(this);
     disconnectMessages(this);
   }
@@ -158,6 +153,10 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
     this.closed = true;
 
     this.calciteTipDismiss.emit();
+  };
+
+  private handleThumbnailSlotChange = (event: Event): void => {
+    this.hasThumbnail = slotChangeHasAssignedElement(event);
   };
 
   // --------------------------------------------------------------------------
@@ -195,13 +194,11 @@ export class Tip implements ConditionalSlotComponent, LocalizedComponent, T9nCom
   }
 
   renderImageFrame(): VNode {
-    const { el } = this;
-
-    return getSlotted(el, SLOTS.thumbnail) ? (
-      <div class={CSS.imageFrame} key="thumbnail">
-        <slot name={SLOTS.thumbnail} />
+    return (
+      <div class={CSS.imageFrame} hidden={!this.hasThumbnail} key="thumbnail">
+        <slot name={SLOTS.thumbnail} onSlotchange={this.handleThumbnailSlotChange} />
       </div>
-    ) : null;
+    );
   }
 
   renderInfoNode(): VNode {

--- a/packages/calcite-components/src/demos/tip-manager.html
+++ b/packages/calcite-components/src/demos/tip-manager.html
@@ -50,7 +50,7 @@
             <img
               slot="thumbnail"
               width="1000"
-              height="600"
+              height="200"
               src="./_assets/images/placeholder.svg"
               alt="This is an image of nature."
             />
@@ -89,7 +89,7 @@
             <img
               slot="thumbnail"
               width="1000"
-              height="600"
+              height="200"
               src="./_assets/images/placeholder.svg"
               alt="This is an image of nature."
             />
@@ -125,7 +125,7 @@
                 <img
                   slot="thumbnail"
                   width="1000"
-                  height="600"
+                  height="200"
                   src="./_assets/images/placeholder.svg"
                   alt="This is an image of nature."
                 />
@@ -145,7 +145,7 @@
                 <img
                   slot="thumbnail"
                   width="1000"
-                  height="600"
+                  height="200"
                   src="./_assets/images/placeholder.svg"
                   alt="This is an image of nature."
                 />
@@ -160,7 +160,7 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
+                height="200"
                 src="./_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />

--- a/packages/calcite-components/src/demos/tip/basic.html
+++ b/packages/calcite-components/src/demos/tip/basic.html
@@ -20,8 +20,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>
@@ -51,8 +51,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>This tip is how a tip should appear without a dismissible button as well as without a heading.</p>
@@ -67,8 +67,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>This tip is how a tip should appear without a dismissible button as well as without a heading.</p>
@@ -103,8 +103,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>
@@ -118,8 +118,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>
@@ -137,8 +137,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>
@@ -152,8 +152,8 @@
               <img
                 slot="thumbnail"
                 width="1000"
-                height="600"
-                src="./_assets/images/placeholder.svg"
+                height="200"
+                src="../_assets/images/placeholder.svg"
                 alt="This is an image of nature."
               />
               <p>


### PR DESCRIPTION
**Related Issue:** #6059

## Summary

- remove use of `getSlotted` utility
- replace with `slotchange` event and `@State` variables to update the display of elements.
- existing tests should suffice