### PR TITLE
feat(stepper-item): update component's active state background color.

### DIFF
--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -56,6 +56,10 @@
     border-solid
     no-underline
     outline-none;
+
+  &:active {
+    @apply bg-foreground-3;
+  }
 }
 
 // focus styles


### PR DESCRIPTION
**Related Issue:** [#10000](https://github.com/Esri/calcite-design-system/issues/10000)

## Summary

-Add `bg-foreground-3` to the component's `active` state.
