### PR TITLE
feat(stepper-item): update component's active state background color

### DIFF
--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -73,6 +73,10 @@
 // .stepper-item-header / content
 :host .stepper-item-header {
   @apply flex cursor-pointer items-start;
+
+  &:active {
+    @apply bg-foreground-3;
+  }
 }
 
 :host .stepper-item-content,


### PR DESCRIPTION
**Related Issue:** [#10000](https://github.com/Esri/calcite-design-system/issues/10000)

## Summary

Add `bg-foreground-3` to the component's `active` state.
