### PR TITLE
fix(combobox): restores `filterText` when filtered items are empty

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -567,9 +567,9 @@ describe("calcite-combobox", () => {
       expect(await three.isVisible()).toBeFalsy();
 
       expect(await combobox.getProperty("value")).toBe("Natural Resources");
-      expect(await combobox.getProperty("filterText")).toBe("anm");
       expect((await combobox.getProperty("filteredItems")).length).toBe(0);
       expect(await input.getProperty("value")).toBe("anm");
+      expect(input).not.toHaveClass(`${CSS.inputHidden}`);
     });
   });
 

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -536,13 +536,18 @@ describe("calcite-combobox", () => {
 
     it("should restore filter text when no items are filtered", async () => {
       const page = await newE2EPage();
-      await page.setContent(`
-     <calcite-combobox placeholder="Select a field" selection-mode="single-persist">
-      <calcite-combobox-item id="one" value="Natural Resources" text-label="Natural Resources" selected></calcite-combobox-item>
-      <calcite-combobox-item id="two" value="Agriculture" text-label="Agriculture"></calcite-combobox-item>
-      <calcite-combobox-item id="three" value="Transportation" text-label="Transportation"></calcite-combobox-item>
-    </calcite-combobox>
-    `);
+      await page.setContent(html`
+        <calcite-combobox placeholder="Select a field" selection-mode="single-persist">
+          <calcite-combobox-item
+            id="one"
+            value="Natural Resources"
+            text-label="Natural Resources"
+            selected
+          ></calcite-combobox-item>
+          <calcite-combobox-item id="two" value="Agriculture" text-label="Agriculture"></calcite-combobox-item>
+          <calcite-combobox-item id="three" value="Transportation" text-label="Transportation"></calcite-combobox-item>
+        </calcite-combobox>
+      `);
 
       const combobox = await page.find("calcite-combobox");
       const input = await page.find("calcite-combobox >>> input");

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -533,6 +533,44 @@ describe("calcite-combobox", () => {
       expect(visibleItems.length).toBe(1);
       expect(await visibleItems[0].getProperty("value")).toBe("1");
     });
+
+    it("should restore filter text when no items are filtered", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+     <calcite-combobox placeholder="Select a field" selection-mode="single-persist">
+      <calcite-combobox-item id="one" value="Natural Resources" text-label="Natural Resources" selected></calcite-combobox-item>
+      <calcite-combobox-item id="two" value="Agriculture" text-label="Agriculture"></calcite-combobox-item>
+      <calcite-combobox-item id="three" value="Transportation" text-label="Transportation"></calcite-combobox-item>
+    </calcite-combobox>
+    `);
+
+      const combobox = await page.find("calcite-combobox");
+      const input = await page.find("calcite-combobox >>> input");
+      await combobox.click();
+      await page.waitForChanges();
+      await combobox.type("an");
+      await page.waitForChanges();
+      await new Promise((res) => setTimeout(() => res(true), DEBOUNCE.filter));
+      const one = await page.find("#one");
+      const two = await page.find("#two");
+      const three = await page.find("#three");
+
+      expect(await one.isVisible()).toBeFalsy();
+      expect(await two.isVisible()).toBeFalsy();
+      expect(await three.isVisible()).toBeTruthy();
+
+      await combobox.type("m");
+      await new Promise((res) => setTimeout(() => res(true), DEBOUNCE.filter));
+      await page.waitForChanges();
+      expect(await one.isVisible()).toBeFalsy();
+      expect(await two.isVisible()).toBeFalsy();
+      expect(await three.isVisible()).toBeFalsy();
+
+      expect(await combobox.getProperty("value")).toBe("Natural Resources");
+      expect(await combobox.getProperty("filterText")).toBe("anm");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(0);
+      expect(await input.getProperty("value")).toBe("anm");
+    });
   });
 
   it("should control max items displayed", async () => {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1633,7 +1633,7 @@ export class Combobox
           class={{
             [CSS.input]: true,
             "input--single": true,
-            "input--hidden": showLabel,
+            [CSS.inputHidden]: showLabel,
             "input--icon": this.showingInlineIcon && !!this.placeholderIcon,
           }}
           data-test-id="input"

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1600,7 +1600,7 @@ export class Combobox
     const { guid, disabled, placeholder, selectionMode, selectedItems, open } = this;
     const single = isSingleLike(selectionMode);
     const selectedItem = selectedItems[0];
-    const showLabel = !open && single && !!selectedItem;
+    const showLabel = !open && single && !!selectedItem && !this.filterText;
 
     return (
       <span

--- a/packages/calcite-components/src/components/combobox/resources.ts
+++ b/packages/calcite-components/src/components/combobox/resources.ts
@@ -4,6 +4,7 @@ export const ComboboxChildSelector = `${ComboboxItem}, ${ComboboxItemGroup}`;
 
 export const CSS = {
   input: "input",
+  inputHidden: "input--hidden",
   chipInvisible: "chip--invisible",
   selectionDisplayFit: "selection-display-fit",
   selectionDisplaySingle: "selection-display-single",


### PR DESCRIPTION
**Related Issue:** #10156

## Summary

Restores `filterText` when filtered items are empty. 