### PR TITLE
refactor(list): use roles instead of table elements

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,13 +1,7 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [
-  "get-trailing-text-input-padding",
-  "medium-modular-scale",
-  "modular-scale",
-  "scale-duration",
-  "small-modular-scale"
-];
+const customFunctions = [];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
@@ -80,11 +80,11 @@ export class ListItemGroup implements InteractiveComponent {
     return (
       <Host>
         <InteractiveContainer disabled={disabled}>
-          <tr class={CSS.container}>
-            <td class={CSS.heading} colSpan={MAX_COLUMNS}>
+          <div class={CSS.container} role="row">
+            <div aria-colspan={MAX_COLUMNS} class={CSS.heading} role="cell">
               {heading}
-            </td>
-          </tr>
+            </div>
+          </div>
           <slot onSlotchange={this.handleDefaultSlotChange} />
         </InteractiveContainer>
       </Host>

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -79,17 +79,17 @@
   @apply opacity-disabled;
 }
 
-tr,
-td {
+[role="row"],
+[row="gridcell"] {
   @apply focus-base;
 }
 
-tr {
+[role="row"] {
   @apply relative;
 }
 
-tr:focus,
-td:focus {
+[role="row"]:focus,
+[row="gridcell"]:focus {
   @apply focus-inset;
 }
 
@@ -216,7 +216,7 @@ td:focus {
   }
 }
 
-tr:focus {
+[row="row"]:focus {
   .actions-start,
   .actions-end {
     inset-block: theme("spacing[0.5]");

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -79,17 +79,17 @@
   @apply opacity-disabled;
 }
 
-[role="row"],
-[row="gridcell"] {
+.row,
+.grid-cell {
   @apply focus-base;
 }
 
-[role="row"] {
+.row {
   @apply relative;
 }
 
-[role="row"]:focus,
-[row="gridcell"]:focus {
+.row:focus,
+.grid-cell:focus {
   @apply focus-inset;
 }
 
@@ -216,7 +216,7 @@
   }
 }
 
-[row="row"]:focus {
+.row:focus {
   .actions-start,
   .actions-end {
     inset-block: theme("spacing[0.5]");

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -349,15 +349,15 @@ export class ListItem
 
   @State() hasContentBottom = false;
 
-  containerEl: HTMLTableRowElement;
+  containerEl: HTMLDivElement;
 
-  contentEl: HTMLTableCellElement;
+  contentEl: HTMLDivElement;
 
-  actionsStartEl: HTMLTableCellElement;
+  actionsStartEl: HTMLDivElement;
 
-  actionsEndEl: HTMLTableCellElement;
+  actionsEndEl: HTMLDivElement;
 
-  handleGridEl: HTMLTableCellElement;
+  handleGridEl: HTMLDivElement;
 
   defaultSlotEl: HTMLSlotElement;
 
@@ -434,7 +434,7 @@ export class ListItem
     }
 
     return (
-      <td
+      <div
         class={{
           [CSS.selectionContainer]: true,
           [CSS.selectionContainerSingle]:
@@ -455,7 +455,7 @@ export class ListItem
           }
           scale="s"
         />
-      </td>
+      </div>
     );
   }
 
@@ -463,7 +463,7 @@ export class ListItem
     const { label, dragHandle, dragSelected, dragDisabled, setPosition, setSize } = this;
 
     return dragHandle ? (
-      <td
+      <div
         aria-label={label}
         class={CSS.dragContainer}
         key="drag-handle-container"
@@ -479,7 +479,7 @@ export class ListItem
           setPosition={setPosition}
           setSize={setSize}
         />
-      </td>
+      </div>
     ) : null;
   }
 
@@ -490,21 +490,21 @@ export class ListItem
     const tooltip = open ? messages.collapse : messages.expand;
 
     return openable ? (
-      <td
+      <div
         class={CSS.openContainer}
         key="open-container"
         onClick={this.handleToggleClick}
         title={tooltip}
       >
         <calcite-icon icon={icon} key={icon} scale="s" />
-      </td>
+      </div>
     ) : null;
   }
 
   renderActionsStart(): VNode {
     const { label, hasActionsStart } = this;
     return (
-      <td
+      <div
         aria-label={label}
         class={CSS.actionsStart}
         hidden={!hasActionsStart}
@@ -514,14 +514,14 @@ export class ListItem
         role="gridcell"
       >
         <slot name={SLOTS.actionsStart} onSlotchange={this.handleActionsStartSlotChange} />
-      </td>
+      </div>
     );
   }
 
   renderActionsEnd(): VNode {
     const { label, hasActionsEnd, closable, messages } = this;
     return (
-      <td
+      <div
         aria-label={label}
         class={CSS.actionsEnd}
         hidden={!(hasActionsEnd || closable)}
@@ -542,7 +542,7 @@ export class ListItem
             text={messages.close}
           />
         ) : null}
-      </td>
+      </div>
     );
   }
 
@@ -628,7 +628,7 @@ export class ListItem
     ];
 
     return (
-      <td
+      <div
         aria-label={label}
         class={{
           [CSS.contentContainer]: true,
@@ -643,7 +643,7 @@ export class ListItem
         role="gridcell"
       >
         {content}
-      </td>
+      </div>
     );
   }
 
@@ -673,7 +673,7 @@ export class ListItem
       <Host>
         <InteractiveContainer disabled={disabled}>
           <div class={{ [CSS.wrapper]: true, [CSS.wrapperBordered]: bordered }}>
-            <tr
+            <div
               aria-expanded={openable ? toAriaBoolean(open) : null}
               aria-label={label}
               aria-level={level}
@@ -701,7 +701,7 @@ export class ListItem
               {this.renderActionsStart()}
               {this.renderContentContainer()}
               {this.renderActionsEnd()}
-            </tr>
+            </div>
             {this.renderContentBottom()}
           </div>
           {this.renderDefaultContainer()}
@@ -847,7 +847,7 @@ export class ListItem
     this.calciteListItemSelect.emit();
   };
 
-  private getGridCells(): HTMLTableCellElement[] {
+  private getGridCells(): HTMLDivElement[] {
     return [this.handleGridEl, this.actionsStartEl, this.contentEl, this.actionsEndEl].filter(
       (el) => el && !el.hidden,
     );
@@ -908,13 +908,13 @@ export class ListItem
     this.focusCell(null);
   };
 
-  private handleCellFocusIn = (focusEl: HTMLTableCellElement): void => {
+  private handleCellFocusIn = (focusEl: HTMLDivElement): void => {
     this.setFocusCell(focusEl, getFirstTabbable(focusEl), true);
   };
 
   // Only one cell within a list-item should be focusable at a time. Ensures the active cell is focusable.
   private setFocusCell = (
-    focusEl: HTMLTableCellElement | null,
+    focusEl: HTMLDivElement | null,
     focusedEl: HTMLElement,
     saveFocusIndex: boolean,
   ): void => {
@@ -943,7 +943,7 @@ export class ListItem
     }
   };
 
-  private focusCell = (focusEl: HTMLTableCellElement | null, saveFocusIndex = true): void => {
+  private focusCell = (focusEl: HTMLDivElement | null, saveFocusIndex = true): void => {
     const focusedEl = getFirstTabbable(focusEl);
     this.setFocusCell(focusEl, focusedEl, saveFocusIndex);
     focusedEl?.focus();

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -465,7 +465,7 @@ export class ListItem
     return dragHandle ? (
       <div
         aria-label={label}
-        class={CSS.dragContainer}
+        class={{ [CSS.dragContainer]: true, [CSS.gridCell]: true }}
         key="drag-handle-container"
         onFocusin={this.focusCellHandle}
         ref={(el) => (this.handleGridEl = el)}
@@ -506,7 +506,7 @@ export class ListItem
     return (
       <div
         aria-label={label}
-        class={CSS.actionsStart}
+        class={{ [CSS.actionsStart]: true, [CSS.gridCell]: true }}
         hidden={!hasActionsStart}
         key="actions-start-container"
         onFocusin={this.focusCellActionsStart}
@@ -523,7 +523,7 @@ export class ListItem
     return (
       <div
         aria-label={label}
-        class={CSS.actionsEnd}
+        class={{ [CSS.actionsEnd]: true, [CSS.gridCell]: true }}
         hidden={!(hasActionsEnd || closable)}
         key="actions-end-container"
         onFocusin={this.focusCellActionsEnd}
@@ -631,6 +631,7 @@ export class ListItem
       <div
         aria-label={label}
         class={{
+          [CSS.gridCell]: true,
           [CSS.contentContainer]: true,
           [CSS.contentContainerUnavailable]: unavailable,
           [CSS.contentContainerSelectable]: selectionMode !== "none",
@@ -681,6 +682,7 @@ export class ListItem
               aria-selected={toAriaBoolean(selected)}
               aria-setsize={setSize}
               class={{
+                [CSS.row]: true,
                 [CSS.container]: true,
                 [CSS.containerHover]: true,
                 [CSS.containerBorder]: showBorder,

--- a/packages/calcite-components/src/components/list-item/resources.ts
+++ b/packages/calcite-components/src/components/list-item/resources.ts
@@ -13,6 +13,8 @@ export const CSS = {
   nestedContainer: "nested-container",
   nestedContainerOpen: "nested-container--open",
   content: "content",
+  row: "row",
+  gridCell: "grid-cell",
   customContent: "custom-content",
   actionsStart: "actions-start",
   contentStart: "content-start",

--- a/packages/calcite-components/src/components/list/list.scss
+++ b/packages/calcite-components/src/components/list/list.scss
@@ -20,7 +20,7 @@
 }
 
 .table {
-  @apply w-full border-collapse;
+  @apply w-full;
 }
 
 .stack {
@@ -33,9 +33,6 @@
   top-0
   z-sticky
   bg-foreground-1;
-  & th {
-    @apply p-0;
-  }
 }
 
 .assistive-text {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -22,7 +22,6 @@ import {
 import { createObserver } from "../../utils/observers";
 import { SelectionMode } from "../interfaces";
 import { ItemData } from "../list-item/interfaces";
-import { MAX_COLUMNS } from "../list-item/resources";
 import { getListItemChildren, updateListItemChildren } from "../list-item/utils";
 import {
   connectSortableComponent,
@@ -546,7 +545,7 @@ export class List
             {filterEnabled || hasFilterActionsStart || hasFilterActionsEnd ? (
               <div class={CSS.sticky} role="rowgroup">
                 <div role="row">
-                  <div aria-colspan={MAX_COLUMNS} role="columnheader">
+                  <div role="columnheader">
                     <calcite-stack class={CSS.stack}>
                       <slot
                         name={SLOTS.filterActionsStart}

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -536,7 +536,7 @@ export class List
           ) : null}
           {this.renderItemAriaLive()}
           {loading ? <calcite-scrim class={CSS.scrim} loading={loading} /> : null}
-          <table
+          <div
             aria-busy={toAriaBoolean(loading)}
             aria-label={label || ""}
             class={CSS.table}
@@ -544,9 +544,9 @@ export class List
             role="treegrid"
           >
             {filterEnabled || hasFilterActionsStart || hasFilterActionsEnd ? (
-              <thead class={CSS.sticky}>
-                <tr>
-                  <th colSpan={MAX_COLUMNS}>
+              <div class={CSS.sticky} role="rowgroup">
+                <div role="row">
+                  <div aria-colspan={MAX_COLUMNS} role="columnheader">
                     <calcite-stack class={CSS.stack}>
                       <slot
                         name={SLOTS.filterActionsStart}
@@ -569,14 +569,14 @@ export class List
                         slot={STACK_SLOTS.actionsEnd}
                       />
                     </calcite-stack>
-                  </th>
-                </tr>
-              </thead>
+                  </div>
+                </div>
+              </div>
             ) : null}
-            <tbody class={CSS.tableContainer}>
+            <div class={CSS.tableContainer} role="rowgroup">
               <slot onSlotchange={this.handleDefaultSlotChange} />
-            </tbody>
-          </table>
+            </div>
+          </div>
           <div
             aria-live="polite"
             data-test-id="no-results-container"


### PR DESCRIPTION
**Related Issue:** #10495

## Summary

- use aria attributes and role instead of semantic elements
- This is because table elements need to have their child elements as direct children.
- Visual changes are due to not using `td` elements anymore which shifts `1px` padding. Seems ok to me 👍  Probably shouldn't have been there. Was coming from default browser td styles.