### PR TITLE
docs(shell-center-row): add logger + component deprecation context

### DIFF
--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
@@ -1,9 +1,17 @@
 import { Component, Element, Fragment, h, Prop, State, VNode } from "@stencil/core";
 import { Position, Scale } from "../interfaces";
 import { slotChangeGetAssignedElements } from "../../utils/dom";
+import { logger } from "../../utils/logger";
 import { CSS, SLOTS } from "./resources";
 
+logger.deprecated("component", {
+  name: "shell-center-row",
+  removalVersion: 4,
+  suggested: "shell-panel",
+});
+
 /**
+ * @deprecated Use the `calcite-shell-panel` component instead.
  * @slot - A slot for adding content to the `calcite-shell-panel`.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the `calcite-shell-panel`.
  */


### PR DESCRIPTION
**Related Issue:** #10506 

## Summary
Adds deprecation context to `shell-center-row` with our logger messaging and a `@deprecated` reference in the component's .tsx file.