### PR TITLE
fix(notice): ensure closed notice does not affect layout

### DIFF
--- a/packages/calcite-components/src/components/notice/notice.e2e.ts
+++ b/packages/calcite-components/src/components/notice/notice.e2e.ts
@@ -36,7 +36,9 @@ describe("calcite-notice", () => {
   });
 
   describe("openClose", () => {
-    openClose("calcite-notice");
+    openClose("calcite-notice", {
+      collapsedOnClose: true,
+    });
   });
 
   describe("slots", () => {

--- a/packages/calcite-components/src/components/notice/notice.e2e.ts
+++ b/packages/calcite-components/src/components/notice/notice.e2e.ts
@@ -37,7 +37,7 @@ describe("calcite-notice", () => {
 
   describe("openClose", () => {
     openClose("calcite-notice", {
-      collapsedOnClose: true,
+      collapsedOnClose: "vertical",
     });
   });
 

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -78,6 +78,7 @@
     flex
     w-full
     opacity-0;
+  overflow: hidden;
   max-block-size: 0;
   transition-property: opacity, max-block-size;
   transition-duration: var(--calcite-animation-timing);
@@ -104,6 +105,7 @@
     max-h-full
     items-center
     opacity-100;
+  overflow: visible;
 }
 
 @include slotted("title", "*", ".container") {

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -1,8 +1,8 @@
 import { E2EElement, E2EPage } from "@stencil/core/testing";
 import { toHaveNoViolations } from "jest-axe";
-import { ElementHandle } from "puppeteer";
 import type { RequireExactlyOne } from "type-fest";
 import { getTokenValue } from "../utils/cssTokenValues";
+import { toElementHandle } from "../utils";
 import type { ComponentTestSetup } from "./interfaces";
 import { getTagAndPage } from "./utils";
 
@@ -266,11 +266,9 @@ async function getComputedStylePropertyValue(
   property: string,
   pseudoElement?: string,
 ): Promise<string> {
-  type E2EElementInternal = E2EElement & {
-    _elmHandle: ElementHandle;
-  };
+  const elementHandle = await toElementHandle(element);
 
-  return await (element as E2EElementInternal)._elmHandle.evaluate(
+  return await elementHandle.evaluate(
     (el, targetProp, pseudoElement): string => window.getComputedStyle(el, pseudoElement).getPropertyValue(targetProp),
     property,
     pseudoElement,

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -1,5 +1,5 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
-import { BoundingBox } from "puppeteer";
+import { BoundingBox, ElementHandle } from "puppeteer";
 import type { JSX } from "../components";
 import { ComponentTag } from "./commonTests/interfaces";
 
@@ -526,4 +526,18 @@ export async function assertCaretPosition({
       shadowInputTypeSelector,
     ),
   ).toBeTruthy();
+}
+
+/**
+ * This utils helps to get the element handle from an E2EElement.
+ *
+ * @param element - the E2E element
+ * @returns {Promise<ElementHandle>} - the element handle
+ */
+export async function toElementHandle(element: E2EElement): Promise<ElementHandle> {
+  type E2EElementInternal = E2EElement & {
+    _elmHandle: ElementHandle;
+  };
+
+  return (element as E2EElementInternal)._elmHandle;
 }


### PR DESCRIPTION
**Related Issue:** #10516

## Summary

Fixes regression introduced by https://github.com/Esri/calcite-design-system/commit/7e2764f13a95cbf6488596a1f11a9964970883c2#diff-eef7cf73b4f6571be27053eba0e491f478a9569a26f5f2571a590a18bebfc591.

### Noteworthy changes

* updates `openClose` test helper with option to assert on collapsed layout
* adds util to get `ElementHandle` and updates applicable tests

