### PR TITLE
feat(pagination): remove gap at start and end of component.

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -4568,6 +4568,9 @@ export namespace Components {
          */
         "contentBehind": boolean;
     }
+    /**
+     * @deprecated Use the `calcite-shell-panel` component instead.
+     */
     interface CalciteShellCenterRow {
         /**
           * When `true`, the content area displays like a floating panel.
@@ -7553,6 +7556,9 @@ declare global {
         prototype: HTMLCalciteShellElement;
         new (): HTMLCalciteShellElement;
     };
+    /**
+     * @deprecated Use the `calcite-shell-panel` component instead.
+     */
     interface HTMLCalciteShellCenterRowElement extends Components.CalciteShellCenterRow, HTMLStencilElement {
     }
     var HTMLCalciteShellCenterRowElement: {
@@ -12764,6 +12770,9 @@ declare namespace LocalJSX {
          */
         "contentBehind"?: boolean;
     }
+    /**
+     * @deprecated Use the `calcite-shell-panel` component instead.
+     */
     interface CalciteShellCenterRow {
         /**
           * When `true`, the content area displays like a floating panel.
@@ -14428,6 +14437,9 @@ declare module "@stencil/core" {
             "calcite-select": LocalJSX.CalciteSelect & JSXBase.HTMLAttributes<HTMLCalciteSelectElement>;
             "calcite-sheet": LocalJSX.CalciteSheet & JSXBase.HTMLAttributes<HTMLCalciteSheetElement>;
             "calcite-shell": LocalJSX.CalciteShell & JSXBase.HTMLAttributes<HTMLCalciteShellElement>;
+            /**
+             * @deprecated Use the `calcite-shell-panel` component instead.
+             */
             "calcite-shell-center-row": LocalJSX.CalciteShellCenterRow & JSXBase.HTMLAttributes<HTMLCalciteShellCenterRowElement>;
             "calcite-shell-panel": LocalJSX.CalciteShellPanel & JSXBase.HTMLAttributes<HTMLCalciteShellPanelElement>;
             "calcite-slider": LocalJSX.CalciteSlider & JSXBase.HTMLAttributes<HTMLCalciteSliderElement>;

--- a/packages/calcite-components/src/components/pagination/pagination.e2e.ts
+++ b/packages/calcite-components/src/components/pagination/pagination.e2e.ts
@@ -344,4 +344,24 @@ describe("calcite-pagination", () => {
       expect(item).toEqual(1);
     });
   });
+
+  describe("chevrons", () => {
+    it("hides first and last chevrons when width is not xxsmall", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<calcite-pagination total-items="123456789" page-size="10" scale="l"></calcite-pagination>`,
+      );
+      const hiddenChevrons = await page.findAll(`calcite-pagination >>> .${CSS.hiddenItem}`);
+      expect(hiddenChevrons.length).toBe(2);
+    });
+
+    it("does not hide first and last chevrons when width is xxsmall", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        `<div style="width: 100px;"><calcite-pagination total-items="123456789" page-size="10" scale="l"></calcite-pagination></div>`,
+      );
+      const hiddenChevrons = await page.findAll(`calcite-pagination >>> .${CSS.hiddenItem}`);
+      expect(hiddenChevrons.length).toBe(0);
+    });
+  });
 });

--- a/packages/calcite-components/src/components/pagination/pagination.scss
+++ b/packages/calcite-components/src/components/pagination/pagination.scss
@@ -12,6 +12,10 @@
   @apply flex m-0 p-0;
 }
 
+.hidden-item {
+  display: none;
+}
+
 :host([scale="s"]) {
   & .chevron,
   & .page,

--- a/packages/calcite-components/src/components/pagination/pagination.tsx
+++ b/packages/calcite-components/src/components/pagination/pagination.tsx
@@ -548,11 +548,25 @@ export class Pagination
   render(): VNode {
     return (
       <ul class={CSS.list}>
-        <li class={CSS.listItem}>{this.renderFirstChevron()}</li>
+        <li
+          class={{
+            [CSS.listItem]: true,
+            [CSS.hiddenItem]: !this.renderFirstChevron(),
+          }}
+        >
+          {this.renderFirstChevron()}
+        </li>
         <li class={CSS.listItem}>{this.renderPreviousChevron()}</li>
         {this.renderItems()}
         <li class={CSS.listItem}>{this.renderNextChevron()}</li>
-        <li class={CSS.listItem}>{this.renderLastChevron()}</li>
+        <li
+          class={{
+            [CSS.listItem]: true,
+            [CSS.hiddenItem]: !this.renderLastChevron(),
+          }}
+        >
+          {this.renderLastChevron()}
+        </li>
       </ul>
     );
   }

--- a/packages/calcite-components/src/components/pagination/resources.ts
+++ b/packages/calcite-components/src/components/pagination/resources.ts
@@ -1,6 +1,7 @@
 export const CSS = {
   list: "list",
   listItem: "list-item",
+  hiddenItem: "hidden-item",
   page: "page",
   selected: "selected",
   chevron: "chevron",


### PR DESCRIPTION
**Related Issue:** [#10513](https://github.com/Esri/calcite-design-system/issues/10513)

## Summary

Remove the 2px gap at the start and end of component.