### PR TITLE
chore: fix code scanning alert no. 47: DOM text reinterpreted as HTML

### DIFF
--- a/packages/calcite-ui-icons/docs/app.js
+++ b/packages/calcite-ui-icons/docs/app.js
@@ -78,7 +78,7 @@
       .join("");
 
     window.location.hash = key;
-    document.querySelector(".js-detail-name").innerHTML = key;
+    document.querySelector(".js-detail-name").textContent = key;
     document.querySelector(".js-detail-aliases").innerHTML = (tags && tags) || "---";
     document.querySelector(".js-detail-category").innerHTML = (icon.category && icon.category) || "---";
     document.querySelector(".js-detail-release").innerHTML = (icon.release && icon.release) || "---";


### PR DESCRIPTION
Fixes [https://github.com/Esri/calcite-design-system/security/code-scanning/47](https://github.com/Esri/calcite-design-system/security/code-scanning/47)

To fix the problem, we need to ensure that any user-controlled data assigned to `innerHTML` is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue is to use `textContent` instead of `innerHTML` for setting plain text content. This will ensure that any special characters in the `key` variable are treated as text and not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
