### PR TITLE
fix(shell-center-row): ensure deprecation warning doesn’t show when using standalone `shell` or `shell-panel`

### DIFF
--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
@@ -4,12 +4,6 @@ import { slotChangeGetAssignedElements } from "../../utils/dom";
 import { logger } from "../../utils/logger";
 import { CSS, SLOTS } from "./resources";
 
-logger.deprecated("component", {
-  name: "shell-center-row",
-  removalVersion: 4,
-  suggested: "shell-panel",
-});
-
 /**
  * @deprecated Use the `calcite-shell-panel` component instead.
  * @slot - A slot for adding content to the `calcite-shell-panel`.
@@ -51,6 +45,20 @@ export class ShellCenterRow {
   @Element() el: HTMLCalciteShellCenterRowElement;
 
   @State() actionBar: HTMLCalciteActionBarElement;
+
+  //--------------------------------------------------------------------------
+  //
+  //  Lifecycle
+  //
+  //--------------------------------------------------------------------------
+
+  componentWillLoad(): void {
+    logger.deprecated("component", {
+      name: "shell-center-row",
+      removalVersion: 4,
+      suggested: "shell-panel",
+    });
+  }
 
   // --------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #10563

## Summary

Moves deprecation warnings to show when `shell-center-row` is added to the DOM and initially loaded.

This warning was being shown due to [bundling](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/stencil.config.ts#L76).