### PR TITLE
deprecate: deprecate `require-event-emitter-type` rule

### DIFF
--- a/packages/eslint-plugin-calcite-components/docs/require-event-emitter-type.md
+++ b/packages/eslint-plugin-calcite-components/docs/require-event-emitter-type.md
@@ -1,5 +1,7 @@
 # require-event-emitter-type
 
+**Deprecated** This rule is deprecated and will be removed in a future release. Event typing has been improved and is no longer needed.
+
 This rule helps enforce the payload type to `EventEmitter`s to avoid misleading `any` type on the `CustomEvent` detail object.
 
 ## Config

--- a/packages/eslint-plugin-calcite-components/src/rules/require-event-emitter-type.ts
+++ b/packages/eslint-plugin-calcite-components/src/rules/require-event-emitter-type.ts
@@ -3,6 +3,7 @@ import { stencilComponentContext } from "stencil-eslint-core";
 
 const rule: Rule.RuleModule = {
   meta: {
+    deprecated: true,
     docs: {
       description:
         "This rule helps enforce the payload type to EventEmitters to avoid misleading `any` type on the CustomEvent detail object.",


### PR DESCRIPTION
**Related Issue:** #10398

## Summary

Deprecates this rule for 3.x removal as it is no longer needed after #10310.


