### PR TITLE
deprecate: deprecate `ban-props-on-host` rule

### DIFF
--- a/packages/eslint-plugin-calcite-components/docs/ban-props-on-host.md
+++ b/packages/eslint-plugin-calcite-components/docs/ban-props-on-host.md
@@ -1,5 +1,7 @@
 # ban-props-on-host
 
+**Deprecated** This rule is deprecated and will be removed in a future release. This rule's primary use case will no longer exist after issue #10310 lands.
+
 Ensures that a Component's `tag` does not use any of the given props-on-host.
 
 ## Config

--- a/packages/eslint-plugin-calcite-components/src/rules/ban-props-on-host.ts
+++ b/packages/eslint-plugin-calcite-components/src/rules/ban-props-on-host.ts
@@ -11,6 +11,7 @@ const allowedAttributeName = (attributeName: string): boolean =>
 
 const rule: Rule.RuleModule = {
   meta: {
+    deprecated: true,
     docs: {
       description: "This rule catches usage of banned props on <Host>.",
       category: "Possible Errors",


### PR DESCRIPTION
**Related Issue:** #10398

## Summary

Deprecates this rule for 3.x removal as it is no longer needed after #10310.