### PR TITLE
feat(navigation): add component tokens

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,13 +1,7 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [
-  "get-trailing-text-input-padding",
-  "medium-modular-scale",
-  "modular-scale",
-  "scale-duration",
-  "small-modular-scale"
-];
+const customFunctions = [];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,7 +1,13 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [];
+const customFunctions = [
+  "get-trailing-text-input-padding",
+  "medium-modular-scale",
+  "modular-scale",
+  "scale-duration",
+  "small-modular-scale",
+];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/src/components/navigation/navigation.e2e.ts
+++ b/packages/calcite-components/src/components/navigation/navigation.e2e.ts
@@ -1,6 +1,8 @@
 import { newE2EPage } from "@stencil/core/testing";
 import { accessible, defaults, focusable, hidden, reflects, renders } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
+import { ComponentTestTokens, themed } from "../../tests/commonTests/themed";
+import { CSS } from "./resources";
 
 describe("calcite-navigation", () => {
   describe("renders", () => {
@@ -66,5 +68,68 @@ describe("calcite-navigation", () => {
 
     await hamburgerMenu.click();
     expect(eventSpy).toHaveReceivedEventTimes(3);
+  });
+
+  describe("theme", () => {
+    const navigationHtml = html`
+      <calcite-navigation>
+        <calcite-navigation-logo
+          heading="Walt's Chips"
+          description="Eastern Potato Chip Company"
+          icon="layers"
+          slot="logo"
+        >
+        </calcite-navigation-logo>
+        <calcite-navigation-user slot="user" full-name="Walt McChipson" username="waltChip"> </calcite-navigation-user>
+        <calcite-navigation slot="navigation-secondary">
+          <calcite-menu slot="content-start">
+            <calcite-menu-item breadcrumb text="All Routes" icon-start="book" text-enabled></calcite-menu-item>
+          </calcite-menu>
+        </calcite-navigation>
+        <calcite-navigation slot="navigation-tertiary">
+          <calcite-menu slot="content-end">
+            <calcite-menu-item breadcrumb text="All Routes" icon-start="book" text-enabled></calcite-menu-item>
+          </calcite-menu>
+        </calcite-navigation>
+      </calcite-navigation>
+    `;
+
+    describe("default", () => {
+      const tokens: ComponentTestTokens = {
+        "--calcite-navigation-background-color": [
+          {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "backgroundColor",
+          },
+          {
+            selector: "calcite-navigation-logo",
+            targetProp: "backgroundColor",
+          },
+          {
+            selector: "calcite-navigation-user",
+            targetProp: "backgroundColor",
+          },
+        ],
+        "--calcite-navigation-width": {
+          shadowSelector: `.${CSS.containerContent}`,
+          targetProp: "width",
+        },
+        "--calcite-navigation-border-color": [
+          {
+            shadowSelector: `.${CSS.primary}`,
+            targetProp: "borderColor",
+          },
+          {
+            shadowSelector: `.${CSS.secondary}`,
+            targetProp: "borderColor",
+          },
+          {
+            shadowSelector: `.${CSS.tertiary}`,
+            targetProp: "borderColor",
+          },
+        ],
+      };
+      themed(navigationHtml, tokens);
+    });
   });
 });

--- a/packages/calcite-components/src/components/navigation/navigation.e2e.ts
+++ b/packages/calcite-components/src/components/navigation/navigation.e2e.ts
@@ -96,20 +96,10 @@ describe("calcite-navigation", () => {
 
     describe("default", () => {
       const tokens: ComponentTestTokens = {
-        "--calcite-navigation-background-color": [
-          {
-            shadowSelector: `.${CSS.container}`,
-            targetProp: "backgroundColor",
-          },
-          {
-            selector: "calcite-navigation-logo",
-            targetProp: "backgroundColor",
-          },
-          {
-            selector: "calcite-navigation-user",
-            targetProp: "backgroundColor",
-          },
-        ],
+        "--calcite-navigation-background-color": {
+          shadowSelector: `.${CSS.container}`,
+          targetProp: "backgroundColor",
+        },
         "--calcite-navigation-width": {
           shadowSelector: `.${CSS.containerContent}`,
           targetProp: "width",
@@ -117,15 +107,15 @@ describe("calcite-navigation", () => {
         "--calcite-navigation-border-color": [
           {
             shadowSelector: `.${CSS.primary}`,
-            targetProp: "borderColor",
+            targetProp: "borderBlockEndColor",
           },
           {
             shadowSelector: `.${CSS.secondary}`,
-            targetProp: "borderColor",
+            targetProp: "borderBlockEndColor",
           },
           {
             shadowSelector: `.${CSS.tertiary}`,
-            targetProp: "borderColor",
+            targetProp: "borderBlockEndColor",
           },
         ],
       };

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -4,7 +4,8 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-navigation-width: Specifies the width of the component's content area.
- * @prop --calcite-navigation-background: Specifies the background color of the component.
+ * @prop --calcite-navigation-background:[Deprecated] Use `--calcite-navigation-background-color`. Specifies the background color of the component.
+ * @prop --calcite-navigation-background-color: Specifies component's background color.
  * @prop --calcite-navigation-border-color: Specifies the border color of the component.
  */
 
@@ -17,7 +18,10 @@
   w-full;
   margin-block: 0;
   margin-inline: auto;
-  background-color: var(--calcite-navigation-background, var(--calcite-color-foreground-1));
+  background-color: var(
+    --calcite-navigation-background-color,
+    var(--calcite-navigation-background, var(--calcite-color-foreground-1))
+  );
   &.primary,
   &.secondary,
   &.tertiary {

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -4,7 +4,7 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-navigation-width: Specifies the width of the component's content area.
- * @prop --calcite-navigation-background:[Deprecated] Use `--calcite-navigation-background-color`. Specifies the background color of the component.
+ * @prop --calcite-navigation-background: [Deprecated] Use `--calcite-navigation-background-color`. Specifies the background color of the component.
  * @prop --calcite-navigation-background-color: Specifies component's background color.
  * @prop --calcite-navigation-border-color: Specifies the border color of the component.
  */

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -36,6 +36,7 @@ import { tabs } from "./custom-theme/tabs";
 import { textArea, textAreaTokens } from "./custom-theme/text-area";
 import { avatarIcon, avatarInitials, avatarThumbnail, avatarTokens } from "./custom-theme/avatar";
 import { tileTokens, tile } from "./custom-theme/tile";
+import { navigationTokens, navigation } from "./custom-theme/navigation";
 
 const globalTokens = {
   calciteColorBrand: "#007ac2",
@@ -100,25 +101,27 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       }
     </style>
     <div class="demo">
-        <div class="demo-column">
-          ${accordion} ${actionBar} ${notices} ${segmentedControl}
-          <div style="display: flex">
-            ${actionPad}
-            <div style="width: 40px; height: 40px;">${actionMenu}</div>
-            ${icon}
-          </div>
-          ${input} ${inputNumber} ${inputText}
+      <div class="demo-column">
+        ${accordion} ${actionBar} ${notices} ${segmentedControl}
+        <div style="display: flex">
+          ${actionPad}
+          <div style="width: 40px; height: 40px;">${actionMenu}</div>
+          ${icon}
         </div>
-        <div class="demo-column">
-          <div>${card}</div>
-          ${cardThumbnail}
-          <div>${dropdown} ${buttons}</div>
-          <div>${checkbox}</div>
-          ${chips} ${pagination} ${slider}
-        </div>
-        <div class="demo-column">${datePicker} ${tabs} ${loader} ${calciteSwitch} ${avatarIcon} ${avatarInitials} ${avatarThumbnail} ${progress} ${handle} ${textArea} ${popover} ${tile}</div>
-        ${alert}
+        ${input} ${inputNumber} ${inputText}
       </div>
+      <div class="demo-column">
+        <div>${card}</div>
+        ${cardThumbnail}
+        <div>${dropdown} ${buttons}</div>
+        <div>${checkbox}</div>
+        ${chips} ${pagination} ${slider}
+      </div>
+      <div class="demo-column">
+        ${datePicker} ${tabs} ${loader} ${calciteSwitch} ${avatarIcon} ${avatarInitials} ${avatarThumbnail} ${progress}
+        ${handle} ${textArea} ${popover} ${tile}
+      </div>
+      ${alert} ${navigation}
     </div>
   </div>`;
 
@@ -142,6 +145,7 @@ const componentTokens = {
   ...inputTokens,
   ...textAreaTokens,
   ...tileTokens,
+  ...navigationTokens,
 };
 
 export default {

--- a/packages/calcite-components/src/custom-theme/navigation.ts
+++ b/packages/calcite-components/src/custom-theme/navigation.ts
@@ -1,0 +1,23 @@
+import { html } from "../../support/formatting";
+
+export const navigationTokens = {
+  calciteNavigationBackgroundColor: "",
+  calciteNavigationBorderColor: "",
+  calciteNavigationWidth: "",
+  calciteNavigationBackground: "",
+};
+export const navigation = html`<calcite-navigation>
+  <calcite-navigation-logo heading="Walt's Chips" description="Eastern Potato Chip Company" icon="layers" slot="logo">
+  </calcite-navigation-logo>
+  <calcite-navigation-user slot="user" full-name="Walt McChipson" username="waltChip"> </calcite-navigation-user>
+  <calcite-navigation slot="navigation-secondary">
+    <calcite-menu slot="content-start">
+      <calcite-menu-item breadcrumb text="All Routes" icon-start="book" text-enabled></calcite-menu-item>
+    </calcite-menu>
+  </calcite-navigation>
+  <calcite-navigation slot="navigation-tertiary">
+    <calcite-menu slot="content-end">
+      <calcite-menu-item breadcrumb text="All Routes" icon-start="book" text-enabled></calcite-menu-item>
+    </calcite-menu>
+  </calcite-navigation>
+</calcite-navigation>`;


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary

Add the following component-scoped CSS Variables to `calcite-navigation`:

 `--calcite-navigation-background-color`: Specifies component's background color.

Deprecates following component-scoped CSS variables in `calcite-navigation`:

`--calcite-navigation-background`