### PR TITLE
chore(font): mark tokens for deprecation.

### DIFF
--- a/packages/calcite-design-tokens/src/semantic/font.json
+++ b/packages/calcite-design-tokens/src/semantic/font.json
@@ -668,6 +668,7 @@
         "tight": {
           "value": "{core.size.default.none} - .4 ",
           "type": "letterSpacing",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -692,6 +693,7 @@
         "normal": {
           "value": "{core.size.default.none}",
           "type": "letterSpacing",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -716,6 +718,7 @@
         "wide": {
           "value": "{core.size.default.none} + .4 ",
           "type": "letterSpacing",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -742,6 +745,7 @@
         "normal": {
           "value": "{core.size.default.4}",
           "type": "paragraphSpacing",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -768,6 +772,7 @@
         "none": {
           "value": "{core.font.text-decoration.none}",
           "type": "textDecoration",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -818,6 +823,7 @@
         "none": {
           "value": "{core.font.text-case.none}",
           "type": "textCase",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -842,6 +848,7 @@
         "uppercase": {
           "value": "{core.font.text-case.uppercase}",
           "type": "textCase",
+          "description": "deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",

--- a/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
@@ -367,7 +367,6 @@ exports[`generated tokens CSS dark should match 1`] = `
   --calcite-color-foreground-2: #202020;
   --calcite-color-foreground-1: #2b2b2b;
   --calcite-color-background: #353535;
-  --calcite-color-focus: #009af2;
 }
 "
 `;
@@ -441,7 +440,7 @@ exports[`generated tokens CSS global should match 1`] = `
   --calcite-font-size: 14px;
   --calcite-font-size-sm: 12px;
   --calcite-font-size-xs: 10px;
-  --calcite-font-weight-bold: 700;
+  --calcite-font-weight-bold: 600;
   --calcite-font-weight-semibold: 600;
   --calcite-font-weight-medium: 500;
   --calcite-font-weight-regular: 400;
@@ -516,7 +515,6 @@ exports[`generated tokens CSS light should match 1`] = `
   --calcite-color-foreground-2: #f3f3f3;
   --calcite-color-foreground-1: #ffffff;
   --calcite-color-background: #f8f8f8;
-  --calcite-color-focus: #007ac2;
 }
 "
 `;
@@ -848,7 +846,6 @@ export const calciteBorderWidthMd = "2px";
 export const calciteBorderWidthLg = "4px";
 export const calciteColorBackground = {"light":"#f8f8f8","dark":"#353535"};
 export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)";
-export const calciteColorFocus = {"light":"#007ac2","dark":"#009af2"};
 export const calciteColorForeground1 = {"light":"#ffffff","dark":"#2b2b2b"};
 export const calciteColorForeground2 = {"light":"#f3f3f3","dark":"#202020"};
 export const calciteColorForeground3 = {"light":"#eaeaea","dark":"#151515"};
@@ -915,7 +912,7 @@ export const calciteFontWeightNormal = "400"; // For backwards compatibility onl
 export const calciteFontWeightRegular = "400";
 export const calciteFontWeightMedium = "500";
 export const calciteFontWeightSemibold = "600";
-export const calciteFontWeightBold = "700";
+export const calciteFontWeightBold = "600";
 export const calciteFontSizeXs = "10px";
 export const calciteFontSizeSm = "12px";
 export const calciteFontSize = "14px";
@@ -1028,7 +1025,7 @@ export const calciteTypographyHierarchyHeading4 = {"fontWeight":"500","lineHeigh
 export const calciteTypographyHierarchyHeading5 = {"fontWeight":"500","lineHeight":"137.5%"};
 export const calciteTypographyHierarchyBodySnug = {"lineHeight":"137.5%"};
 export const calciteTypographyHierarchyBody = {"fontFamily":["Avenir Next","Avenir","Helvetica Neue","sans-serif"],"fontSize":"14px","fontWeight":"400","letterSpacing":"0","lineHeight":"16px","paragraphSpacing":"4px","textCase":"none","textDecoration":"none"};
-export const calciteTypographyHierarchyOverline = {"lineHeight":"12px","textCase":"uppercase","fontWeight":"700"};
+export const calciteTypographyHierarchyOverline = {"lineHeight":"12px","textCase":"uppercase","fontWeight":"600"};
 export const calciteTypographyHierarchyCaption = {"lineHeight":"137.5%","fontSize":"12px"};
 export const calciteZIndexDeep = "-999999";
 export const calciteZIndex = "1";
@@ -1052,7 +1049,6 @@ export const calciteBorderWidthMd : string;
 export const calciteBorderWidthLg : string;
 export const calciteColorBackground : { light: string, dark: string };
 export const calciteColorBackgroundNone : string;
-export const calciteColorFocus : { light: string, dark: string };
 export const calciteColorForeground1 : { light: string, dark: string };
 export const calciteColorForeground2 : { light: string, dark: string };
 export const calciteColorForeground3 : { light: string, dark: string };
@@ -1964,7 +1960,6 @@ $calcite-color-foreground-3: #151515;
 $calcite-color-foreground-2: #202020;
 $calcite-color-foreground-1: #2b2b2b;
 $calcite-color-background: #353535;
-$calcite-color-focus: #009af2;
 "
 `;
 
@@ -2036,7 +2031,7 @@ $calcite-font-size-md: 16px;
 $calcite-font-size: 14px;
 $calcite-font-size-sm: 12px;
 $calcite-font-size-xs: 10px;
-$calcite-font-weight-bold: 700;
+$calcite-font-weight-bold: 600;
 $calcite-font-weight-semibold: 600;
 $calcite-font-weight-medium: 500;
 $calcite-font-weight-regular: 400;
@@ -2111,6 +2106,5 @@ $calcite-color-foreground-3: #eaeaea;
 $calcite-color-foreground-2: #f3f3f3;
 $calcite-color-foreground-1: #ffffff;
 $calcite-color-background: #f8f8f8;
-$calcite-color-focus: #007ac2;
 "
 `;

--- a/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/support/tests/__snapshots__/index.spec.ts.snap
@@ -367,6 +367,7 @@ exports[`generated tokens CSS dark should match 1`] = `
   --calcite-color-foreground-2: #202020;
   --calcite-color-foreground-1: #2b2b2b;
   --calcite-color-background: #353535;
+  --calcite-color-focus: #009af2;
 }
 "
 `;
@@ -515,6 +516,7 @@ exports[`generated tokens CSS light should match 1`] = `
   --calcite-color-foreground-2: #f3f3f3;
   --calcite-color-foreground-1: #ffffff;
   --calcite-color-background: #f8f8f8;
+  --calcite-color-focus: #007ac2;
 }
 "
 `;
@@ -846,6 +848,7 @@ export const calciteBorderWidthMd = "2px";
 export const calciteBorderWidthLg = "4px";
 export const calciteColorBackground = {"light":"#f8f8f8","dark":"#353535"};
 export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)";
+export const calciteColorFocus = {"light":"#007ac2","dark":"#009af2"};
 export const calciteColorForeground1 = {"light":"#ffffff","dark":"#2b2b2b"};
 export const calciteColorForeground2 = {"light":"#f3f3f3","dark":"#202020"};
 export const calciteColorForeground3 = {"light":"#eaeaea","dark":"#151515"};
@@ -1049,6 +1052,7 @@ export const calciteBorderWidthMd : string;
 export const calciteBorderWidthLg : string;
 export const calciteColorBackground : { light: string, dark: string };
 export const calciteColorBackgroundNone : string;
+export const calciteColorFocus : { light: string, dark: string };
 export const calciteColorForeground1 : { light: string, dark: string };
 export const calciteColorForeground2 : { light: string, dark: string };
 export const calciteColorForeground3 : { light: string, dark: string };
@@ -1960,6 +1964,7 @@ $calcite-color-foreground-3: #151515;
 $calcite-color-foreground-2: #202020;
 $calcite-color-foreground-1: #2b2b2b;
 $calcite-color-background: #353535;
+$calcite-color-focus: #009af2;
 "
 `;
 
@@ -2106,5 +2111,6 @@ $calcite-color-foreground-3: #eaeaea;
 $calcite-color-foreground-2: #f3f3f3;
 $calcite-color-foreground-1: #ffffff;
 $calcite-color-background: #f8f8f8;
+$calcite-color-focus: #007ac2;
 "
 `;


### PR DESCRIPTION
**Related Issue:** #9524

## Summary

Per Franco's request we are just going to mark these tokens for deprecation for now.
https://github.com/Esri/calcite-design-system/pull/9551#pullrequestreview-2383002956

Marks the following token groups for deprecation

- letter-spacing
- paragraph-spacing
- text-decoration
- text-case