### PR TITLE
refactor(table): refactor internals to work around HTML parser issue

### DIFF
--- a/packages/calcite-components/src/components/table-header/table-header.tsx
+++ b/packages/calcite-components/src/components/table-header/table-header.tsx
@@ -74,7 +74,7 @@ export class TableHeader extends LitElement implements LoadableComponent {
    * @notPublic
    */
   /** TODO: [MIGRATION] This component has been updated to use the useT9n() controller. Documentation: https://qawebgis.esri.com/arcgis-components/?path=/docs/references-t9n-for-components--docs */
-  messages = useT9n<typeof T9nStrings>();
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /** @notPublic */
   @property() numberCell = false;

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -336,6 +336,83 @@ export class TableRow extends LitElement implements InteractiveComponent {
 
   // #region Rendering
 
+  renderSelectionIcon(): JsxNode {
+    const icon =
+      this.selectionMode === "multiple" && this.selected
+        ? "check-square-f"
+        : this.selectionMode === "multiple"
+          ? "square"
+          : this.selected
+            ? "circle-f"
+            : "circle";
+
+    return <calcite-icon icon={icon} scale={getIconScale(this.scale)} />;
+  }
+
+  renderSelectableCell(): JsxNode {
+    return this.rowType === "head" ? (
+      <calcite-table-header
+        alignment="center"
+        bodyRowCount={this.bodyRowCount}
+        key="selection-head"
+        onClick={this.handleSelectionOfRow}
+        onKeyDown={this.handleKeyboardSelection}
+        parentRowAlignment={this.alignment}
+        selectedRowCount={this.selectedRowCount}
+        selectedRowCountLocalized={this.selectedRowCountLocalized}
+        selectionCell={true}
+        selectionMode={this.selectionMode}
+      />
+    ) : this.rowType === "body" ? (
+      <calcite-table-cell
+        alignment="center"
+        key="selection-body"
+        onClick={this.handleSelectionOfRow}
+        onKeyDown={this.handleKeyboardSelection}
+        parentRowAlignment={this.alignment}
+        parentRowIsSelected={this.selected}
+        parentRowPositionLocalized={this.positionSectionLocalized}
+        selectionCell={true}
+      >
+        {this.renderSelectionIcon()}
+      </calcite-table-cell>
+    ) : (
+      <calcite-table-cell
+        alignment="center"
+        key="selection-foot"
+        parentRowAlignment={this.alignment}
+        selectionCell={true}
+      />
+    );
+  }
+
+  renderNumberedCell(): JsxNode {
+    return this.rowType === "head" ? (
+      <calcite-table-header
+        alignment="center"
+        key="numbered-head"
+        numberCell={true}
+        parentRowAlignment={this.alignment}
+      />
+    ) : this.rowType === "body" ? (
+      <calcite-table-cell
+        alignment="center"
+        key="numbered-body"
+        numberCell={true}
+        parentRowAlignment={this.alignment}
+      >
+        {this.positionSectionLocalized}
+      </calcite-table-cell>
+    ) : (
+      <calcite-table-cell
+        alignment="center"
+        key="numbered-foot"
+        numberCell={true}
+        parentRowAlignment={this.alignment}
+      />
+    );
+  }
+
   override render(): JsxNode {
     return (
       <InteractiveContainer disabled={this.disabled}>
@@ -351,78 +428,11 @@ export class TableRow extends LitElement implements InteractiveComponent {
 
             this.tableRowEl = el;
 
-            const icon =
-              this.selectionMode === "multiple" && this.selected
-                ? "check-square-f"
-                : this.selectionMode === "multiple"
-                  ? "square"
-                  : this.selected
-                    ? "circle-f"
-                    : "circle";
-
             /* work around for https://github.com/Esri/calcite-design-system/issues/10495 */
             render(
               <>
-                {this.numbered &&
-                  (this.rowType === "head" ? (
-                    <calcite-table-header
-                      alignment="center"
-                      key="numbered-head"
-                      numberCell={true}
-                      parentRowAlignment={this.alignment}
-                    />
-                  ) : this.rowType === "body" ? (
-                    <calcite-table-cell
-                      alignment="center"
-                      key="numbered-body"
-                      numberCell={true}
-                      parentRowAlignment={this.alignment}
-                    >
-                      {this.positionSectionLocalized}
-                    </calcite-table-cell>
-                  ) : (
-                    <calcite-table-cell
-                      alignment="center"
-                      key="numbered-foot"
-                      numberCell={true}
-                      parentRowAlignment={this.alignment}
-                    />
-                  ))}
-                {this.selectionMode !== "none" &&
-                  (this.rowType === "head" ? (
-                    <calcite-table-header
-                      alignment="center"
-                      bodyRowCount={this.bodyRowCount}
-                      key="selection-head"
-                      onClick={this.handleSelectionOfRow}
-                      onKeyDown={this.handleKeyboardSelection}
-                      parentRowAlignment={this.alignment}
-                      selectedRowCount={this.selectedRowCount}
-                      selectedRowCountLocalized={this.selectedRowCountLocalized}
-                      selectionCell={true}
-                      selectionMode={this.selectionMode}
-                    />
-                  ) : this.rowType === "body" ? (
-                    <calcite-table-cell
-                      alignment="center"
-                      key="selection-body"
-                      onClick={this.handleSelectionOfRow}
-                      onKeyDown={this.handleKeyboardSelection}
-                      parentRowAlignment={this.alignment}
-                      parentRowIsSelected={this.selected}
-                      parentRowPositionLocalized={this.positionSectionLocalized}
-                      selectionCell={true}
-                    >
-                      <calcite-icon icon={icon} scale={getIconScale(this.scale)} />
-                    </calcite-table-cell>
-                  ) : (
-                    <calcite-table-cell
-                      alignment="center"
-                      key="selection-foot"
-                      parentRowAlignment={this.alignment}
-                      selectionCell={true}
-                    />
-                  ))}
+                {this.numbered && this.renderNumberedCell()}
+                {this.selectionMode !== "none" && this.renderSelectableCell()}
                 <slot ref={this.tableRowSlotEl} />
               </>,
               el,

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -110,7 +110,6 @@ export class TableRow extends LitElement implements InteractiveComponent {
 
   constructor() {
     super();
-    this.listen("slotchange", this.updateCells);
     this.listenOn<CustomEvent>(
       document,
       "calciteInternalTableRowFocusChange",
@@ -119,11 +118,7 @@ export class TableRow extends LitElement implements InteractiveComponent {
   }
 
   connectedCallback(): void {
-    this.el.shadowRoot.addEventListener("slotchange", this.handleSlotChange);
-  }
-
-  disconnectedCallback(): void {
-    this.el.shadowRoot.removeEventListener("slotchange", this.handleSlotChange);
+    this.listenOn(this.el.shadowRoot, "slotchange", this.handleSlotChange);
   }
 
   /**
@@ -169,9 +164,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
 
   // #region Private Methods
 
-  private handleSlotChange = (): void => {
+  private handleSlotChange(): void {
     this.updateCells();
-  };
+  }
 
   private handleCellChanges(): void {
     if (this.tableRowEl && this.rowCells.length > 0) {
@@ -430,7 +425,7 @@ export class TableRow extends LitElement implements InteractiveComponent {
             this.tableRowSlotEl = defaultSlot;
           }}
         >
-          {/*contents are generated programmatically to work around HTML parser issue*/}
+          {/*contents are generated dynamically to work around https://github.com/Esri/calcite-design-system/issues/10495 */}
         </tr>
       </InteractiveContainer>
     );

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -117,7 +117,7 @@ export class TableRow extends LitElement implements InteractiveComponent {
     );
   }
 
-  connectedCallback(): void {
+  load(): void {
     this.listenOn(this.el.shadowRoot, "slotchange", this.handleSlotChange);
   }
 

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -318,7 +318,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
   }
 
   private handleSelectionOfRow = (): void => {
-    this.calciteTableRowSelect.emit();
+    if (this.rowType === "body" || (this.rowType === "head" && this.selectionMode === "multiple")) {
+      this.calciteTableRowSelect.emit();
+    }
   };
 
   private handleKeyboardSelection = (event: KeyboardEvent): void => {
@@ -392,8 +394,8 @@ export class TableRow extends LitElement implements InteractiveComponent {
                       alignment="center"
                       bodyRowCount={this.bodyRowCount}
                       key="selection-head"
-                      onClick={this.selectionMode === "multiple" && this.handleSelectionOfRow}
-                      onKeyDown={this.selectionMode === "multiple" && this.handleKeyboardSelection}
+                      onClick={this.handleSelectionOfRow}
+                      onKeyDown={this.handleKeyboardSelection}
                       parentRowAlignment={this.alignment}
                       selectedRowCount={this.selectedRowCount}
                       selectedRowCountLocalized={this.selectedRowCountLocalized}

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -14,7 +14,7 @@ describe("calcite-table", () => {
   describe("renders", () => {
     renders(
       html`<calcite-table caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -97,7 +97,7 @@ describe("calcite-table", () => {
     describe("is accessible simple", () => {
       accessible(
         html`<calcite-table caption="Simple table">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -120,7 +120,7 @@ describe("calcite-table", () => {
     describe("is accessible with selection mode multiple", () => {
       accessible(
         html`<calcite-table caption="Simple table" selection-mode="multiple">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -143,7 +143,7 @@ describe("calcite-table", () => {
     describe("is accessible with selection mode multiple selected at load", () => {
       accessible(
         html`<calcite-table caption="Simple table" selection-mode="multiple">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -166,7 +166,7 @@ describe("calcite-table", () => {
     describe("is accessible with selection mode single", () => {
       accessible(
         html`<calcite-table caption="Simple table" selection-mode="single">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -189,7 +189,7 @@ describe("calcite-table", () => {
     describe("is accessible with numbered", () => {
       accessible(
         html`<calcite-table caption="Simple table" numbered>
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -212,7 +212,7 @@ describe("calcite-table", () => {
     describe("is accessible with numbered and selection", () => {
       accessible(
         html`<calcite-table caption="Simple table" numbered selection-mode="multiple">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -235,7 +235,7 @@ describe("calcite-table", () => {
     describe("is accessible with pagination", () => {
       accessible(
         html`<calcite-table page-size="4" caption="Simple table">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -274,7 +274,7 @@ describe("calcite-table", () => {
     describe("is accessible with pagination and interaction mode static", () => {
       accessible(
         html`<calcite-table page-size="4" caption="Simple table" interaction-mode="static">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -313,7 +313,7 @@ describe("calcite-table", () => {
     describe("is accessible with pagination and selection mode", () => {
       accessible(
         html`<calcite-table page-size="4" selection-mode="multiple" caption="Simple table">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
             <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           </calcite-table-row>
@@ -356,7 +356,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="single" caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -471,7 +471,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -586,7 +586,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="single" caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -696,7 +696,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -805,7 +805,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row slot=${SLOTS.tableHeader}>
+        <calcite-table-row slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -857,7 +857,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -909,7 +909,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table" page-size="1">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -961,7 +961,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1016,7 +1016,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1071,7 +1071,7 @@ describe("selection modes", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table" page-size="2" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1137,7 +1137,7 @@ describe("pagination event", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table" page-size="1" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1211,7 +1211,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Simple table" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1260,20 +1260,24 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("Home");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2a");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3b");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
   });
@@ -1282,7 +1286,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Simple table" page-size="2" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1339,12 +1343,14 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2b");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2b");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
   });
@@ -1353,7 +1359,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Simple table" page-size="2" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1410,12 +1416,14 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2b");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2b");
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
 
@@ -1461,12 +1469,14 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-4b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-4b");
 
@@ -1513,12 +1523,14 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-5b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-5b");
   });
@@ -1527,7 +1539,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1580,7 +1592,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1630,8 +1642,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("PageUp");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3b");
   });
@@ -1640,11 +1653,11 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Multiple headers using col-span table">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header id="head-1a" col-span="2" heading="Name"></calcite-table-header>
             <calcite-table-header id="head-1b" col-span="2" heading="Information"></calcite-table-header>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header id="head-2a" heading="First"></calcite-table-header>
             <calcite-table-header id="head-2b" heading="Last"></calcite-table-header>
             <calcite-table-header id="head-2c" heading="Education level"></calcite-table-header>
@@ -1666,13 +1679,13 @@ describe("keyboard navigation", () => {
             <calcite-table-cell id="cell-4a">cell</calcite-table-cell>
             <calcite-table-cell id="cell-4b" col-span="3">cell</calcite-table-cell>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableFooter}>
+          <calcite-table-row slot="${SLOTS.tableFooter}">
             <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1c">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1d">foot</calcite-table-cell>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableFooter}>
+          <calcite-table-row slot="${SLOTS.tableFooter}">
             <calcite-table-cell id="foot-2a" col-span="2">foot</calcite-table-cell>
             <calcite-table-cell id="foot-2b" col-span="2">foot</calcite-table-cell>
           </calcite-table-row>
@@ -1713,8 +1726,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-2d");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-2b");
     await page.keyboard.press("PageUp");
@@ -1729,8 +1743,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
   });
@@ -1739,11 +1754,11 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table caption="Multiple headers using col-span table" page-size="2" style="width:800px">
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header id="head-1a" col-span="2" heading="Name"></calcite-table-header>
             <calcite-table-header id="head-1b" col-span="2" heading="Information"></calcite-table-header>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableHeader}>
+          <calcite-table-row slot="${SLOTS.tableHeader}">
             <calcite-table-header id="head-2a" heading="First"></calcite-table-header>
             <calcite-table-header id="head-2b" heading="Last"></calcite-table-header>
             <calcite-table-header id="head-2c" heading="Education level"></calcite-table-header>
@@ -1765,13 +1780,13 @@ describe("keyboard navigation", () => {
             <calcite-table-cell id="cell-4a">cell</calcite-table-cell>
             <calcite-table-cell id="cell-4b" col-span="3">cell</calcite-table-cell>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableFooter}>
+          <calcite-table-row slot="${SLOTS.tableFooter}">
             <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1c">foot</calcite-table-cell>
             <calcite-table-cell id="foot-1d">foot</calcite-table-cell>
           </calcite-table-row>
-          <calcite-table-row slot=${SLOTS.tableFooter}>
+          <calcite-table-row slot="${SLOTS.tableFooter}">
             <calcite-table-cell id="foot-2a" col-span="2">foot</calcite-table-cell>
             <calcite-table-cell id="foot-2b" col-span="2">foot</calcite-table-cell>
           </calcite-table-row>
@@ -1818,8 +1833,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-2d");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-2b");
     await page.keyboard.press("Home");
@@ -1840,12 +1856,14 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-2a");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-2b");
 
@@ -1895,8 +1913,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-2d");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-2b");
     await page.keyboard.press("Home");
@@ -1920,8 +1939,9 @@ describe("keyboard navigation", () => {
     await page.keyboard.press("End");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-2b");
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("head-1a");
     await page.keyboard.press("ArrowDown");
@@ -1936,7 +1956,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table selection-mode="multiple" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -1952,7 +1972,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-3a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-3b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>
@@ -1967,10 +1987,9 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
 
     expect(
-      await page.$eval(
-        `#${rowHead.id}`,
-        (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("th").classList,
-      ),
+      await page.$eval(`#${rowHead.id}`, async (el) => {
+        return el.shadowRoot?.activeElement.shadowRoot?.querySelector("th").classList;
+      }),
     ).toEqual({ "0": CSS.selectionCell, "1": CSS.multipleSelectionCell });
 
     await page.keyboard.press("ArrowRight");
@@ -2009,13 +2028,15 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3a");
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-1b");
 
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(
       await page.$eval(
@@ -2029,7 +2050,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table numbered caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -2045,7 +2066,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-3a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-3b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>
@@ -2102,13 +2123,15 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3a");
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-1b");
 
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(
       await page.$eval(
@@ -2122,7 +2145,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table numbered selection-mode="single" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -2138,7 +2161,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-3a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-3b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>
@@ -2209,8 +2232,9 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-3a");
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(
       await page.$eval(
@@ -2224,7 +2248,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table numbered selection-mode="multiple" page-size="2" caption="Simple table">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -2244,7 +2268,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-4a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-4b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>
@@ -2307,8 +2331,9 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("cell-2a");
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-1b");
 
@@ -2321,8 +2346,9 @@ describe("keyboard navigation", () => {
       ),
     ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
 
-    page.keyboard.press("ControlLeft");
+    await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlLeft");
     await page.waitForChanges();
     expect(
       await page.$eval(
@@ -2336,7 +2362,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table numbered selection-mode="single" page-size="2" caption="Simple table" style="width:800px">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -2356,7 +2382,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-4a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-4b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>
@@ -2374,10 +2400,9 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
 
     expect(
-      await page.$eval(
-        `#${rowHead.id}`,
-        (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("th").classList,
-      ),
+      await page.$eval(`#${rowHead.id}`, (el) => {
+        return el.shadowRoot?.activeElement.shadowRoot?.querySelector("th").classList;
+      }),
     ).toEqual({ "0": CSS.numberCell });
 
     await page.keyboard.press("ArrowRight");
@@ -2436,8 +2461,9 @@ describe("keyboard navigation", () => {
       await page.$eval(`#${row2.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
     ).toEqual({ "0": CSS.selectionCell });
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-1b");
 
@@ -2450,9 +2476,9 @@ describe("keyboard navigation", () => {
       ),
     ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
 
-    page.keyboard.press("ControlRight");
-
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(
       await page.$eval(
@@ -2522,8 +2548,9 @@ describe("keyboard navigation", () => {
       await page.$eval(`#${row4.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
     ).toEqual({ "0": CSS.numberCell });
 
-    page.keyboard.press("ControlRight");
+    await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
+    await page.keyboard.up("ControlRight");
     await page.waitForChanges();
     expect(await getFocusedElementProp(page, "id")).toBe("foot-1b");
 
@@ -2541,7 +2568,7 @@ describe("keyboard navigation", () => {
     const page = await newE2EPage();
     await page.setContent(
       html`<calcite-table numbered selection-mode="multiple" caption="Simple table" interaction-mode="static">
-        <calcite-table-row id="row-head" slot=${SLOTS.tableHeader}>
+        <calcite-table-row id="row-head" slot="${SLOTS.tableHeader}">
           <calcite-table-header id="head-1a" heading="Heading" description="Description"></calcite-table-header>
           <calcite-table-header id="head-1b" heading="Heading" description="Description"></calcite-table-header>
         </calcite-table-row>
@@ -2557,7 +2584,7 @@ describe("keyboard navigation", () => {
           <calcite-table-cell id="cell-3a">cell</calcite-table-cell>
           <calcite-table-cell id="cell-3b">cell</calcite-table-cell>
         </calcite-table-row>
-        <calcite-table-row slot=${SLOTS.tableFooter} id="row-foot">
+        <calcite-table-row slot="${SLOTS.tableFooter}" id="row-foot">
           <calcite-table-cell id="foot-1a">foot</calcite-table-cell>
           <calcite-table-cell id="foot-1b">foot</calcite-table-cell>
         </calcite-table-row>

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -183,13 +183,10 @@ export class Table extends LitElement implements LoadableComponent {
     this.listen("calciteInternalTableRowFocusRequest", this.calciteInternalTableRowFocusEvent);
   }
 
-  connectedCallback(): void {
-    this.listenOn(this.el.shadowRoot, "slotchange", this.handleSlotChange);
-  }
-
   async load(): Promise<void> {
     setUpLoadableComponent(this);
     this.readCellContentsToAT = /safari/i.test(getUserAgentString());
+    this.listenOn(this.el.shadowRoot, "slotchange", this.handleSlotChange);
   }
 
   /**

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -487,6 +487,10 @@ export class Table extends LitElement implements LoadableComponent {
         >
           <table
             ariaColCount={this.colCount}
+            ariaMultiSelectable={
+              /* workaround to ensure the attr gets removed; we should be able to avoid the ternary when fixed */
+              this.selectionMode === "multiple" ? "true" : null
+            }
             ariaRowCount={this.allRows?.length}
             class={{ [CSS.tableFixed]: this.layout === "fixed" }}
             ref={(el) => {

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -184,11 +184,7 @@ export class Table extends LitElement implements LoadableComponent {
   }
 
   connectedCallback(): void {
-    this.el.shadowRoot.addEventListener("slotchange", this.handleSlotChange);
-  }
-
-  disconnectedCallback(): void {
-    this.el.shadowRoot.removeEventListener("slotchange", this.handleSlotChange);
+    this.listenOn(this.el.shadowRoot, "slotchange", this.handleSlotChange);
   }
 
   async load(): Promise<void> {
@@ -228,9 +224,9 @@ export class Table extends LitElement implements LoadableComponent {
 
   // #region Private Methods
 
-  private handleSlotChange = (): void => {
+  private handleSlotChange(): void {
     this.updateRows();
-  };
+  }
 
   private handleNumberedChange(): void {
     this.updateRows();
@@ -519,9 +515,15 @@ export class Table extends LitElement implements LoadableComponent {
             role={this.interactionMode === "interactive" ? "grid" : "table"}
           >
             <caption class={CSS.assistiveText}>{this.caption}</caption>
-            <thead>{/* slots added programmatically to work around HTML parser issue */}</thead>
-            <tbody>{/* slots added programmatically to work around HTML parser issue */}</tbody>
-            <tfoot>{/* slots added programmatically to work around HTML parser issue */}</tfoot>
+            <thead>
+              {/*contents are generated dynamically to work around https://github.com/Esri/calcite-design-system/issues/10495 */}
+            </thead>
+            <tbody>
+              {/*contents are generated dynamically to work around https://github.com/Esri/calcite-design-system/issues/10495 */}
+            </tbody>
+            <tfoot>
+              {/*contents are generated dynamically to work around https://github.com/Esri/calcite-design-system/issues/10495 */}
+            </tfoot>
           </table>
         </div>
         {this.pageSize > 0 && this.renderPaginationArea()}

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -466,6 +466,30 @@ export class Table extends LitElement implements LoadableComponent {
     );
   }
 
+  renderTHead(): JsxNode {
+    return (
+      <thead>
+        <slot name={SLOTS.tableHeader} ref={this.tableHeadSlotEl} />
+      </thead>
+    );
+  }
+
+  renderTBody(): JsxNode {
+    return (
+      <tbody>
+        <slot ref={this.tableBodySlotEl} />
+      </tbody>
+    );
+  }
+
+  renderTFoot(): JsxNode {
+    return (
+      <tfoot>
+        <slot name={SLOTS.tableFooter} ref={this.tableFootSlotEl} />
+      </tfoot>
+    );
+  }
+
   override render(): JsxNode {
     return (
       <div class={CSS.container}>
@@ -496,15 +520,9 @@ export class Table extends LitElement implements LoadableComponent {
               render(
                 <>
                   <caption class={CSS.assistiveText}>{this.caption}</caption>
-                  <thead>
-                    <slot name={SLOTS.tableHeader} ref={this.tableHeadSlotEl} />
-                  </thead>
-                  <tbody>
-                    <slot ref={this.tableBodySlotEl} />
-                  </tbody>
-                  <tfoot>
-                    <slot name={SLOTS.tableFooter} ref={this.tableFootSlotEl} />
-                  </tfoot>
+                  {this.renderTHead()}
+                  {this.renderTBody()}
+                  {this.renderTFoot()}
                 </>,
                 el,
               );

--- a/packages/calcite-components/src/tests/commonTests/accessible.ts
+++ b/packages/calcite-components/src/tests/commonTests/accessible.ts
@@ -26,6 +26,7 @@ export function accessible(componentTestSetup: ComponentTestSetup): void {
 
     await page.addScriptTag({ path: require.resolve("axe-core") });
     await page.waitForFunction(() => (window as AxeOwningWindow).axe);
+    await page.waitForTimeout(500);
 
     expect(
       await page.evaluate(async (componentTag: ComponentTag) => (window as AxeOwningWindow).axe.run(componentTag), tag),

--- a/packages/calcite-components/src/tests/commonTests/accessible.ts
+++ b/packages/calcite-components/src/tests/commonTests/accessible.ts
@@ -26,7 +26,6 @@ export function accessible(componentTestSetup: ComponentTestSetup): void {
 
     await page.addScriptTag({ path: require.resolve("axe-core") });
     await page.waitForFunction(() => (window as AxeOwningWindow).axe);
-    await page.waitForTimeout(500);
 
     expect(
       await page.evaluate(async (componentTag: ComponentTag) => (window as AxeOwningWindow).axe.run(componentTag), tag),


### PR DESCRIPTION
**Related Issue:** #10495

## Summary

Split up table rendering to bypass HTML parser corrections that would break functionality and styling.

