### PR TITLE
ci(actions): fix contributor list action failing

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -14,3 +14,5 @@ jobs:
         uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          readme_path: readme.md


### PR DESCRIPTION
**Related Issue:** #8010 

## Summary
Spent way too long hunting down a solution to a generic "Error: Not found" error message and found nothing, but it turned out to be just a case sensitive default path 🤦 so this should fix it. 🤞 

(Tested in my test repo)
![image](https://github.com/user-attachments/assets/bee9c595-cb97-4a84-89af-2e828d969516)
