### PR TITLE
docs: fixup invalid JSDoc blocks

### DIFF
--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -52,9 +52,7 @@ const manager = new AlertManager();
 /**
  * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
  * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
- */
-
-/**
+ *
  * @slot title - A slot for adding a title to the component.
  * @slot message - A slot for adding main text to the component.
  * @slot link - A slot for adding a `calcite-action` to take from the component such as: "undo", "try again", "link to page", etc.

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -40,10 +40,13 @@ import { ButtonMessages } from "./assets/button/t9n";
 import { ButtonAlignment } from "./interfaces";
 import { CSS } from "./resources";
 
-/** Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this. */
-/** It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission */
-
-/** @slot - A slot for adding text. */
+/**
+ * Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this.
+ *
+ * It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission
+ *
+ * @slot - A slot for adding text.
+ */
 @Component({
   tag: "calcite-button",
   styleUrl: "button.scss",

--- a/packages/calcite-components/src/components/link/link.tsx
+++ b/packages/calcite-components/src/components/link/link.tsx
@@ -15,11 +15,15 @@ import { CSS_UTILITY } from "../../utils/resources";
 import { FlipContext } from "../interfaces";
 import { IconNameOrString } from "../icon/interfaces";
 
-/** Any attributes placed on <calcite-link> component will propagate to the rendered child */
-/** Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this. */
-/** It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission */
-
-/** @slot - A slot for adding text. */
+/**
+ * Any attributes placed on <calcite-link> component will propagate to the rendered child
+ *
+ * Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this.
+ *
+ * It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission
+ *
+ * @slot - A slot for adding text.
+ */
 @Component({
   tag: "calcite-link",
   styleUrl: "link.scss",

--- a/packages/calcite-components/src/components/notice/notice.tsx
+++ b/packages/calcite-components/src/components/notice/notice.tsx
@@ -38,9 +38,7 @@ import { CSS, SLOTS } from "./resources";
  * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
  * They are optionally closable - useful for keeping track of whether or not a user has closed the notice. You can also choose not
  * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
- */
-
-/**
+ *
  * @slot title - A slot for adding the title.
  * @slot message - A slot for adding the message.
  * @slot link - A slot for adding a `calcite-action` to take, such as: "undo", "try again", "link to page", etc.

--- a/packages/calcite-components/src/components/tab-title/tab-title.tsx
+++ b/packages/calcite-components/src/components/tab-title/tab-title.tsx
@@ -39,9 +39,7 @@ import { CSS, ICONS } from "./resources";
 
 /**
  * Tab-titles are optionally individually closable.
- */
-
-/**
+ *
  * @slot - A slot for adding text.
  */
 @Component({


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/10658

## Summary

Combines separate JSDoc blocks into one to improve parsing in VSCode and Lumina