### PR TITLE
refactor: handle stencil vs lumina boolean reflection differences

### DIFF
--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -505,6 +505,10 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
     }
+    /**
+     * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
+     * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
+     */
     interface CalciteAlert {
         /**
           * This internal property, managed by the AlertManager, is used to inform the component if it is the active open Alert.
@@ -723,6 +727,10 @@ export namespace Components {
          */
         "toggleDisplay": BlockSectionToggleDisplay;
     }
+    /**
+     * Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission
+     */
     interface CalciteButton {
         /**
           * Specifies the alignment of the component's elements.
@@ -3143,6 +3151,11 @@ export namespace Components {
          */
         "scale": Scale;
     }
+    /**
+     * Any attributes placed on <calcite-link> component will propagate to the rendered child
+     * Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission
+     */
     interface CalciteLink {
         /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
@@ -3768,6 +3781,12 @@ export namespace Components {
          */
         "username": string;
     }
+    /**
+     * Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
+     * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
+     * They are optionally closable - useful for keeping track of whether or not a user has closed the notice. You can also choose not
+     * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
+     */
     interface CalciteNotice {
         /**
           * When `true`, a close button is added to the component.
@@ -5022,6 +5041,9 @@ export namespace Components {
          */
         "syncId": string;
     }
+    /**
+     * Tab-titles are optionally individually closable.
+     */
     interface CalciteTabTitle {
         /**
           * This activates a tab in order for it and its associated tab-title be selected.
@@ -6203,6 +6225,10 @@ declare global {
         "calciteAlertBeforeOpen": void;
         "calciteAlertOpen": void;
     }
+    /**
+     * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
+     * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
+     */
     interface HTMLCalciteAlertElement extends Components.CalciteAlert, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteAlertElementEventMap>(type: K, listener: (this: HTMLCalciteAlertElement, ev: CalciteAlertCustomEvent<HTMLCalciteAlertElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -6261,6 +6287,10 @@ declare global {
         prototype: HTMLCalciteBlockSectionElement;
         new (): HTMLCalciteBlockSectionElement;
     };
+    /**
+     * Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission
+     */
     interface HTMLCalciteButtonElement extends Components.CalciteButton, HTMLStencilElement {
     }
     var HTMLCalciteButtonElement: {
@@ -6881,6 +6911,11 @@ declare global {
         prototype: HTMLCalciteLabelElement;
         new (): HTMLCalciteLabelElement;
     };
+    /**
+     * Any attributes placed on <calcite-link> component will propagate to the rendered child
+     * Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission
+     */
     interface HTMLCalciteLinkElement extends Components.CalciteLink, HTMLStencilElement {
     }
     var HTMLCalciteLinkElement: {
@@ -7051,6 +7086,12 @@ declare global {
         "calciteNoticeClose": void;
         "calciteNoticeOpen": void;
     }
+    /**
+     * Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
+     * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
+     * They are optionally closable - useful for keeping track of whether or not a user has closed the notice. You can also choose not
+     * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
+     */
     interface HTMLCalciteNoticeElement extends Components.CalciteNotice, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteNoticeElementEventMap>(type: K, listener: (this: HTMLCalciteNoticeElement, ev: CalciteNoticeCustomEvent<HTMLCalciteNoticeElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -7477,6 +7518,9 @@ declare global {
         "calciteInternalTabTitleRegister": TabID;
         "calciteInternalTabIconChanged": void;
     }
+    /**
+     * Tab-titles are optionally individually closable.
+     */
     interface HTMLCalciteTabTitleElement extends Components.CalciteTabTitle, HTMLStencilElement {
         addEventListener<K extends keyof HTMLCalciteTabTitleElementEventMap>(type: K, listener: (this: HTMLCalciteTabTitleElement, ev: CalciteTabTitleCustomEvent<HTMLCalciteTabTitleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
         addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8164,6 +8208,10 @@ declare namespace LocalJSX {
          */
         "scale"?: Scale;
     }
+    /**
+     * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
+     * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
+     */
     interface CalciteAlert {
         /**
           * This internal property, managed by the AlertManager, is used to inform the component if it is the active open Alert.
@@ -8410,6 +8458,10 @@ declare namespace LocalJSX {
          */
         "toggleDisplay"?: BlockSectionToggleDisplay;
     }
+    /**
+     * Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission
+     */
     interface CalciteButton {
         /**
           * Specifies the alignment of the component's elements.
@@ -10977,6 +11029,11 @@ declare namespace LocalJSX {
          */
         "scale"?: Scale;
     }
+    /**
+     * Any attributes placed on <calcite-link> component will propagate to the rendered child
+     * Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this.
+     * It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission
+     */
     interface CalciteLink {
         /**
           * When `true`, interaction is prevented and the component is displayed with lower opacity.
@@ -11632,6 +11689,12 @@ declare namespace LocalJSX {
          */
         "username"?: string;
     }
+    /**
+     * Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
+     * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
+     * They are optionally closable - useful for keeping track of whether or not a user has closed the notice. You can also choose not
+     * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
+     */
     interface CalciteNotice {
         /**
           * When `true`, a close button is added to the component.
@@ -12920,6 +12983,9 @@ declare namespace LocalJSX {
          */
         "syncId"?: string;
     }
+    /**
+     * Tab-titles are optionally individually closable.
+     */
     interface CalciteTabTitle {
         "bordered"?: boolean;
         /**
@@ -13840,10 +13906,18 @@ declare module "@stencil/core" {
             "calcite-action-group": LocalJSX.CalciteActionGroup & JSXBase.HTMLAttributes<HTMLCalciteActionGroupElement>;
             "calcite-action-menu": LocalJSX.CalciteActionMenu & JSXBase.HTMLAttributes<HTMLCalciteActionMenuElement>;
             "calcite-action-pad": LocalJSX.CalciteActionPad & JSXBase.HTMLAttributes<HTMLCalciteActionPadElement>;
+            /**
+             * Alerts are meant to provide a way to communicate urgent or important information to users, frequently as a result of an action they took in your app. Alerts are positioned
+             * at the bottom of the page. Multiple opened alerts will be added to a queue, allowing users to dismiss them in the order they are provided.
+             */
             "calcite-alert": LocalJSX.CalciteAlert & JSXBase.HTMLAttributes<HTMLCalciteAlertElement>;
             "calcite-avatar": LocalJSX.CalciteAvatar & JSXBase.HTMLAttributes<HTMLCalciteAvatarElement>;
             "calcite-block": LocalJSX.CalciteBlock & JSXBase.HTMLAttributes<HTMLCalciteBlockElement>;
             "calcite-block-section": LocalJSX.CalciteBlockSection & JSXBase.HTMLAttributes<HTMLCalciteBlockSectionElement>;
+            /**
+             * Passing a 'href' will render an anchor link, instead of a button. Role will be set to link, or button, depending on this.
+             * It is the consumers responsibility to add aria information, rel, target, for links, and any button attributes for form submission
+             */
             "calcite-button": LocalJSX.CalciteButton & JSXBase.HTMLAttributes<HTMLCalciteButtonElement>;
             "calcite-card": LocalJSX.CalciteCard & JSXBase.HTMLAttributes<HTMLCalciteCardElement>;
             "calcite-card-group": LocalJSX.CalciteCardGroup & JSXBase.HTMLAttributes<HTMLCalciteCardGroupElement>;
@@ -13882,6 +13956,11 @@ declare module "@stencil/core" {
             "calcite-input-time-picker": LocalJSX.CalciteInputTimePicker & JSXBase.HTMLAttributes<HTMLCalciteInputTimePickerElement>;
             "calcite-input-time-zone": LocalJSX.CalciteInputTimeZone & JSXBase.HTMLAttributes<HTMLCalciteInputTimeZoneElement>;
             "calcite-label": LocalJSX.CalciteLabel & JSXBase.HTMLAttributes<HTMLCalciteLabelElement>;
+            /**
+             * Any attributes placed on <calcite-link> component will propagate to the rendered child
+             * Passing a 'href' will render an anchor link, instead of a span. Role will be set to link, or link, depending on this.
+             * It is the consumers responsibility to add aria information, rel, target, for links, and any link attributes for form submission
+             */
             "calcite-link": LocalJSX.CalciteLink & JSXBase.HTMLAttributes<HTMLCalciteLinkElement>;
             /**
              * A general purpose list that enables users to construct list items that conform to Calcite styling.
@@ -13900,6 +13979,12 @@ declare module "@stencil/core" {
             "calcite-navigation": LocalJSX.CalciteNavigation & JSXBase.HTMLAttributes<HTMLCalciteNavigationElement>;
             "calcite-navigation-logo": LocalJSX.CalciteNavigationLogo & JSXBase.HTMLAttributes<HTMLCalciteNavigationLogoElement>;
             "calcite-navigation-user": LocalJSX.CalciteNavigationUser & JSXBase.HTMLAttributes<HTMLCalciteNavigationUserElement>;
+            /**
+             * Notices are intended to be used to present users with important-but-not-crucial contextual tips or copy. Because
+             * notices are displayed inline, a common use case is displaying them on page-load to present users with short hints or contextual copy.
+             * They are optionally closable - useful for keeping track of whether or not a user has closed the notice. You can also choose not
+             * to display a notice on page load and set the "active" attribute as needed to contextually provide inline messaging to users.
+             */
             "calcite-notice": LocalJSX.CalciteNotice & JSXBase.HTMLAttributes<HTMLCalciteNoticeElement>;
             "calcite-option": LocalJSX.CalciteOption & JSXBase.HTMLAttributes<HTMLCalciteOptionElement>;
             "calcite-option-group": LocalJSX.CalciteOptionGroup & JSXBase.HTMLAttributes<HTMLCalciteOptionGroupElement>;
@@ -13930,6 +14015,9 @@ declare module "@stencil/core" {
             "calcite-switch": LocalJSX.CalciteSwitch & JSXBase.HTMLAttributes<HTMLCalciteSwitchElement>;
             "calcite-tab": LocalJSX.CalciteTab & JSXBase.HTMLAttributes<HTMLCalciteTabElement>;
             "calcite-tab-nav": LocalJSX.CalciteTabNav & JSXBase.HTMLAttributes<HTMLCalciteTabNavElement>;
+            /**
+             * Tab-titles are optionally individually closable.
+             */
             "calcite-tab-title": LocalJSX.CalciteTabTitle & JSXBase.HTMLAttributes<HTMLCalciteTabTitleElement>;
             "calcite-table": LocalJSX.CalciteTable & JSXBase.HTMLAttributes<HTMLCalciteTableElement>;
             "calcite-table-cell": LocalJSX.CalciteTableCell & JSXBase.HTMLAttributes<HTMLCalciteTableCellElement>;

--- a/packages/calcite-components/src/demos/validation.html
+++ b/packages/calcite-components/src/demos/validation.html
@@ -48,16 +48,6 @@
         padding: var(--calcite-spacing-md);
       }
 
-      #when {
-        display: flex;
-      }
-
-      #whenDate,
-      #whenTime {
-        align-self: center;
-        width: 50%;
-      }
-
       /* Progress bar */
       #progress {
         position: fixed;
@@ -89,10 +79,11 @@
         padding: 0 var(--calcite-spacing-sm);
       }
 
-      /* custom styling of invalid elements */
+      /* custom styling of invalid elements
       [status="invalid"] {
         --calcite-color-foreground-1: #f4c4d3;
       }
+      */
     </style>
   </head>
 
@@ -244,7 +235,6 @@
                   max="10"
                   step="1"
                   required
-                  validation-message="Please select one of these options."
                 ></calcite-slider>
               </calcite-label>
             </li>
@@ -288,11 +278,7 @@
             <li>
               <calcite-label>
                 How many stars would you give Calcite components?
-                <calcite-rating
-                  name="rating"
-                  required
-                  validation-message="Please select one of these options."
-                ></calcite-rating>
+                <calcite-rating required name="rating"></calcite-rating>
               </calcite-label>
             </li>
           </ol>

--- a/packages/calcite-components/src/demos/validation.html
+++ b/packages/calcite-components/src/demos/validation.html
@@ -127,16 +127,16 @@
                   Your name
                   <calcite-icon tabindex="0" id="name-help" icon="question" scale="s"></calcite-icon>
                 </span>
-                <calcite-input-text
-                  pattern="^\w+\s\w+$"
-                  minlength="3"
-                  maxlength="69"
+                <calcite-input
+                  type="text"
+                  pattern="[a-zA-z]+\s[a-zA-z]+"
+                  min-length="6"
+                  max-length="69"
                   placeholder="John Doe"
                   name="fullName"
                   id="fullName"
-                  validation-message="Please enter your name."
                   required
-                ></calcite-input-text>
+                ></calcite-input>
               </calcite-label>
               <calcite-tooltip reference-element="name-help">
                 It's a pleasure to meet you! Let us know your name incase we have any further questions.
@@ -157,24 +157,11 @@
               </calcite-label>
             </li>
 
-            <!-- Date and time pickers -->
+            <!-- Date picker -->
             <li>
               <calcite-label>
                 When did you hear about Calcite components?
-                <div id="when">
-                  <calcite-input-date-picker
-                    id="whenDate"
-                    name="whenDate"
-                    max="2024-07-01"
-                    required
-                  ></calcite-input-date-picker>
-                  <calcite-input-time-picker
-                    id="whenTime"
-                    name="whenTime"
-                    max="23:11"
-                    required
-                  ></calcite-input-time-picker>
-                </div>
+                <calcite-input-date-picker id="when" name="when" required></calcite-input-date-picker>
               </calcite-label>
             </li>
 
@@ -234,8 +221,8 @@
                 <calcite-input-text
                   name="favoriteApp"
                   id="favoriteApp"
-                  pattern="^https:\/\/.+"
-                  minlength="3"
+                  pattern="https:\/\/.+"
+                  min-length="3"
                   required
                 ></calcite-input-text>
               </calcite-label>
@@ -290,8 +277,8 @@
                 <calcite-input-number
                   id="numberSeen"
                   name="numberSeen"
-                  min="0"
-                  max="100"
+                  min="21"
+                  max="108"
                   required
                 ></calcite-input-number>
               </calcite-label>
@@ -353,16 +340,20 @@
       {
         id: "fullName",
         patternMismatch: {
-          message: "First and last name are required.",
+          message: "First and last name are required using only letters.",
+          icon: "user",
         },
         tooShort: {
           message: "Please enter at least 3 characters.",
+          icon: "measure",
         },
         tooLong: {
           message: "Please enter no more than 69 characters.",
+          icon: "measure-line",
         },
         valueMissing: {
           message: "Please enter your name.",
+          icon: "user",
         },
       },
       {
@@ -407,27 +398,26 @@
           if (SHOW_VALIDATION_MESSAGES_ON_BLUR) {
             el.status = "invalid";
           }
-
           return;
         }
       }
     }
 
     window.onload = () => {
-      if (SHOW_VALIDATION_MESSAGES_ON_BLUR) {
-        /* blur event listeners to check validation constraints of elements with custom messages */
-        ELEMENT_CONSTRAINTS.forEach((data) => {
-          document
-            .querySelector(`#${data.id}`)
-            ?.addEventListener("blur", ({ target }) => checkElementConstraints(target, data));
-        });
-      } else {
-        /* use `calciteInvalid` if you only want to set custom messages on form submission */
-        document.addEventListener("calciteInvalid", ({ target }) => {
-          const constraints = ELEMENT_CONSTRAINTS.find((x) => x.id === target.id);
+      /* blur event listeners to check validation constraints of elements with custom messages */
+      ELEMENT_CONSTRAINTS.forEach((data) => {
+        document
+          .querySelector(`#${data.id}`)
+          ?.addEventListener("blur", ({ target }) => checkElementConstraints(target, data));
+      });
+
+      /* use `calciteInvalid` if you only want to set custom messages on form submission */
+      document.addEventListener("calciteInvalid", ({ target }) => {
+        const constraints = ELEMENT_CONSTRAINTS.find((x) => x.id === target.id);
+        if (constraints) {
           checkElementConstraints(target, constraints);
-        });
-      }
+        }
+      });
 
       // Mode Switcher
       document.getElementById("mode")?.addEventListener("calciteSwitchChange", () => {
@@ -477,7 +467,7 @@
       });
 
       // Date picker
-      const datePicker = document.getElementById("whenDate");
+      const datePicker = document.getElementById("when");
       datePicker.maxAsDate = new Date();
       datePicker.min = "2021-01-01";
 

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -497,6 +497,6 @@ export function formAssociated(
 
     expect(await element.getProperty("status")).toBe(testProps?.status ?? "idle");
     expect(await element.getProperty("validationMessage")).toBe(testProps?.message ?? "");
-    expect(element.getAttribute("validation-icon")).toBe(testProps?.icon ?? null);
+    expect(await element.getProperty("validationIcon")).toBe(testProps?.icon ?? false);
   }
 }

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -444,7 +444,7 @@ export function setRequestedIcon(
 ): IconNameOrString | undefined {
   if (typeof iconValue === "string" && iconValue !== "") {
     return iconValue;
-  } else if (iconValue === "") {
+  } else if (iconValue === "" || iconValue === true) {
     return iconObject[matchedValue];
   }
 }

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -290,7 +290,11 @@ function invalidHandler(event: Event) {
         formComponent.status = "idle";
       }
 
-      if ("validationIcon" in formComponent && !formComponent.validationIcon) {
+      // don't clear if a specific icon was specified
+      if (
+        "validationIcon" in formComponent &&
+        (formComponent.validationIcon === "" || formComponent.validationIcon === true)
+      ) {
         formComponent.validationIcon = false;
       }
 

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -290,7 +290,7 @@ function invalidHandler(event: Event) {
         formComponent.status = "idle";
       }
 
-      // don't clear if a specific icon was specified
+      // don't clear if an icon was specified by the user
       if (
         "validationIcon" in formComponent &&
         (formComponent.validationIcon === "" || formComponent.validationIcon === true)


### PR DESCRIPTION
**Related Issue:** #10482

## Summary

Resolve the `validationIcon` issue brought up in https://github.com/Esri/calcite-design-system/pull/10509#discussion_r1792823363

The only properties affected by the change in how boolean properties are reflected are `icon`, `validationIcon`, and `download`. This PR fixes the utils that caused issues with `icon` and `validationIcon`. The `download` property seems to already be correct, for example:

https://github.com/Esri/calcite-design-system/blob/25319998739c3af17a5438d285c5931ea656285d/packages/calcite-components/src/components/link/link.tsx#L178
