### PR TITLE
fix(sort-handle): adjust icon color

### DIFF
--- a/packages/calcite-components/src/components/sort-handle/sort-handle.scss
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.scss
@@ -5,6 +5,7 @@
 .handle {
   @apply cursor-move;
   --calcite-internal-action-padding-inline: var(--calcite-spacing-xxs);
+  --calcite-action-text-color: var(--calcite-color-border-input);
 }
 
 .dropdown {


### PR DESCRIPTION
**Related Issue:** #7537

## Summary

- adjust icon color to use border-input color.