### PR TITLE
fix(action-group, input, menu): fix `setFocus` issues in Chrome 128+

### DIFF
--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -17,7 +17,7 @@ import {
 import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { Layout, Scale } from "../interfaces";
 import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
-import { slotChangeHasAssignedElement } from "../../utils/dom";
+import { focusFirstTabbable, slotChangeHasAssignedElement } from "../../utils/dom";
 import { Columns } from "./interfaces";
 import { ActionGroupMessages } from "./assets/action-group/t9n";
 import { ICONS, SLOTS, CSS } from "./resources";
@@ -145,7 +145,7 @@ export class ActionGroup implements LoadableComponent, LocalizedComponent, T9nCo
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);
-    this.el.focus();
+    focusFirstTabbable(this.el);
   }
   // --------------------------------------------------------------------------
   //

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -13,6 +13,7 @@ import {
   Watch,
 } from "@stencil/core";
 import {
+  focusFirstTabbable,
   getElementDir,
   isPrimaryPointerButton,
   setRequestedIcon,
@@ -610,11 +611,7 @@ export class Input
   async setFocus(): Promise<void> {
     await componentFocusable(this);
 
-    if (this.type === "number") {
-      this.childNumberEl?.focus();
-    } else {
-      this.childEl?.focus();
-    }
+    focusFirstTabbable(this.type === "number" ? this.childNumberEl : this.childEl);
   }
 
   /** Selects the text of the component's `value`. */

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -11,7 +11,12 @@ import {
   VNode,
   forceUpdate,
 } from "@stencil/core";
-import { focusElement, focusElementInGroup, slotChangeGetAssignedElements } from "../../utils/dom";
+import {
+  focusElement,
+  focusElementInGroup,
+  focusFirstTabbable,
+  slotChangeGetAssignedElements,
+} from "../../utils/dom";
 import {
   componentFocusable,
   LoadableComponent,
@@ -145,7 +150,7 @@ export class CalciteMenu implements LocalizedComponent, T9nComponent, LoadableCo
   @Method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);
-    this.el.focus();
+    focusFirstTabbable(this.menuItems[0]);
   }
   //--------------------------------------------------------------------------
   //


### PR DESCRIPTION
**Related Issue:** #10394

## Summary

This uses `focusFirstTabbable` to ensure focus works properly.
