### PR TITLE
refactor(date-picker-month-header, sort-handle): fix imports

### DIFF
--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.e2e.ts
@@ -2,7 +2,7 @@ import { E2EPage } from "@stencil/core/testing";
 import { DateLocaleData } from "../date-picker/utils";
 import { renders } from "../../tests/commonTests";
 import { newProgrammaticE2EPage } from "../../tests/utils";
-import { DatePickerMessages } from "../../components";
+import { DatePickerMessages } from "../date-picker/assets/date-picker/t9n";
 
 describe("calcite-date-picker-month-header", () => {
   const localeDataFixture = {

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -30,8 +30,12 @@ import {
   updateHostInteraction,
 } from "../../utils/interactive";
 import { Scale } from "../interfaces";
-import { FlipPlacement, MenuPlacement, OverlayPositioning } from "../../components";
-import { defaultMenuPlacement } from "../../utils/floating-ui";
+import {
+  FlipPlacement,
+  MenuPlacement,
+  OverlayPositioning,
+  defaultMenuPlacement,
+} from "../../utils/floating-ui";
 import { SortHandleMessages } from "./assets/sort-handle/t9n";
 import { CSS, ICONS, REORDER_VALUES, SUBSTITUTIONS } from "./resources";
 import { MoveEventDetail, MoveTo, Reorder, ReorderEventDetail } from "./interfaces";


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Avoids imports from `components.d.ts`
