### PR TITLE
chore(angular): update example to use custom elements directly

### DIFF
--- a/examples/components/angular/.gitignore
+++ b/examples/components/angular/.gitignore
@@ -1,6 +1,7 @@
 # See https://docs.github.com/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 
 /public/assets
+/.angular
 
 # Compiled output
 /dist

--- a/examples/components/angular/angular.json
+++ b/examples/components/angular/angular.json
@@ -83,5 +83,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/examples/components/angular/package-lock.json
+++ b/examples/components/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^18.1.0",
         "@angular/platform-browser-dynamic": "^18.1.0",
         "@angular/router": "^18.1.0",
-        "@esri/calcite-components-angular": "^2.11.1",
+        "@esri/calcite-components": "^2.13.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -2713,36 +2713,24 @@
       }
     },
     "node_modules/@esri/calcite-components": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.11.1.tgz",
-      "integrity": "sha512-ICUk5cnC5fbh/laODpmSO3S5mVd046K2taNHF3p3B+VkHUncnMCRX4qzobwmZRKW5JqzwDb2E6u+Ssdz08mERA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.13.2.tgz",
+      "integrity": "sha512-90v4H8zs2wEzUXQGmZ+joHhP7ulFUHmQjDlIwXylJiDvoChhnEm38iv7eeG+X8im06biIHEDGRB8LLszlQQ7jw==",
       "dependencies": {
-        "@esri/calcite-ui-icons": "^3.30.0",
-        "@floating-ui/dom": "1.6.8",
-        "@stencil/core": "4.19.2",
+        "@esri/calcite-ui-icons": "3.32.0",
+        "@floating-ui/dom": "1.6.11",
+        "@stencil/core": "4.20.0",
         "@types/color": "3.0.6",
-        "@types/sortablejs": "1.15.7",
+        "@types/sortablejs": "1.15.8",
         "color": "4.2.3",
         "composed-offset-position": "0.0.6",
-        "dayjs": "1.11.12",
-        "focus-trap": "7.5.4",
+        "dayjs": "1.11.13",
+        "focus-trap": "7.6.0",
+        "interactjs": "1.10.27",
         "lodash-es": "4.17.21",
-        "sortablejs": "1.15.1",
-        "timezone-groups": "0.8.0",
+        "sortablejs": "1.15.3",
+        "timezone-groups": "0.10.2",
         "type-fest": "4.18.2"
-      }
-    },
-    "node_modules/@esri/calcite-components-angular": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-angular/-/calcite-components-angular-2.11.1.tgz",
-      "integrity": "sha512-0jVfN+nwonq+GqsfjI30TkemJQpDYdKLYtMf/KO4CTCotfjPv8micemL4WJhI6rYksoFdl99emekEwlBNN1E5A==",
-      "dependencies": {
-        "@esri/calcite-components": "^2.11.1",
-        "tslib": "2.6.3"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=16.0.0",
-        "@angular/core": ">=16.0.0"
       }
     },
     "node_modules/@esri/calcite-components/node_modules/type-fest": {
@@ -2757,34 +2745,34 @@
       }
     },
     "node_modules/@esri/calcite-ui-icons": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.30.0.tgz",
-      "integrity": "sha512-r6Ev82ksCT55qwK361Qm0FgsPd16s/d+to9n/nmgOdejsRvqDl5Nc64IsAtUD20y4XyKY7eyyneKm8NGI9VrFA==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-3.32.0.tgz",
+      "integrity": "sha512-2UEddEeSnpXVWp/uNrgym3mrb8lZ5+vXFbtmvXv5NiE32nQGw2MFZD52L5Z+FsxqHJ9vVrtl/X6pTIgkd0c8jA==",
       "bin": {
         "spriter": "bin/spriter.js"
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.6.tgz",
-      "integrity": "sha512-Vkvsw6EcpMHjvZZdMkSY+djMGFbt7CRssW99Ne8tar2WLnZ/l3dbxeTShbLQj+/s35h+Qb4cmnob+EzwtjrXGQ==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.6"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.8.tgz",
-      "integrity": "sha512-kx62rP19VZ767Q653wsP1XZCGIirkE09E0QUGNYTM/ttbbQHqcGPdSfWFxUyyNLc/W6aoJRBajOSXhP6GXjC0Q==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.5"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.6.tgz",
-      "integrity": "sha512-0KI3zGxIUs1KDR/pjQPdJH4Z8nGBm0yJ5WRoRfdw1Kzeh45jkIfA0rmD0kBF6fKHH+xaH7g8y4jIXyAV5MGK3g=="
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@inquirer/checkbox": {
       "version": "2.4.7",
@@ -3236,6 +3224,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@interactjs/types": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
+      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4266,9 +4259,9 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.2.tgz",
-      "integrity": "sha512-ZdnbHmHEl8E5vN0GWDtONe5w6j3CrSqqxZM4hNLBPkV/aouWKug7D5/Mi6RazfYO5U4fmHQYLwMz60rHcx0G4g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
+      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -4351,17 +4344,17 @@
       }
     },
     "node_modules/@types/color-convert": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
-      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
       "dependencies": {
-        "@types/color-name": "*"
+        "@types/color-name": "^1.1.0"
       }
     },
     "node_modules/@types/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-hulKeREDdLFesGQjl96+4aoJSHY5b2GRjagzzcqCfIrWhe5vkCqIvrLbqzBaI1q94Vg8DNJZZqTR5ocdWmWclg=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg=="
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -4565,9 +4558,9 @@
       }
     },
     "node_modules/@types/sortablejs": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.7.tgz",
-      "integrity": "sha512-PvgWCx1Lbgm88FdQ6S7OGvLIjWS66mudKPlfdrWil0TjsO5zmoZmzoKiiwRShs1dwPgrlkr0N4ewuy0/+QUXYQ=="
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg=="
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -6227,9 +6220,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
-      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -7123,9 +7116,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
+      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -7847,6 +7840,14 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/interactjs": {
+      "version": "1.10.27",
+      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
+      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
+      "dependencies": {
+        "@interactjs/types": "1.10.27"
       }
     },
     "node_modules/ip-address": {
@@ -11794,9 +11795,9 @@
       }
     },
     "node_modules/sortablejs": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
-      "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.3.tgz",
+      "integrity": "sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg=="
     },
     "node_modules/source-map": {
       "version": "0.7.4",
@@ -12322,11 +12323,11 @@
       "dev": true
     },
     "node_modules/timezone-groups": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
-      "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
-      "bin": {
-        "timezone-groups": "dist/cli.cjs"
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.10.2.tgz",
+      "integrity": "sha512-01G9JdlIybA9Njp0wJcGenXKWAw+woWbv6W/oMexWyPs7Nr/S2p2n1NRrMHbHaFzdf+PNNStQp1WILdnAGjYXQ==",
+      "engines": {
+        "node": ">=18.12.0"
       }
     },
     "node_modules/tmp": {

--- a/examples/components/angular/package.json
+++ b/examples/components/angular/package.json
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.1.0",
     "@angular/platform-browser-dynamic": "^18.1.0",
     "@angular/router": "^18.1.0",
-    "@esri/calcite-components-angular": "2.13.2",
+    "@esri/calcite-components": "^2.13.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"

--- a/examples/components/angular/src/app/app.component.spec.ts
+++ b/examples/components/angular/src/app/app.component.spec.ts
@@ -1,31 +1,41 @@
-import { TestBed } from '@angular/core/testing';
-import { CalciteComponentsModule } from '@esri/calcite-components-angular';
+import {
+  ComponentFixtureAutoDetect,
+  ComponentFixture,
+  TestBed,
+} from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { AppComponent } from './app.component';
+import { defineCustomElements } from '@esri/calcite-components/dist/loader';
+
+let component: AppComponent;
+let fixture: ComponentFixture<AppComponent>;
 
 describe('AppComponent', () => {
-  beforeEach(() =>
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CalciteComponentsModule],
-      declarations: [AppComponent],
-    }).compileComponents(),
-  );
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [{ provide: ComponentFixtureAutoDetect, useValue: true }],
+      imports: [AppComponent],
+    });
 
-  it('should create the app', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    defineCustomElements(window, {
+      resourcesUrl: './assets',
+    });
   });
 
-  it(`should have as title 'calcite-components-angular-example'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('calcite-components-angular-example');
+  it('should create the app', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it(`should have 'calcite-components-angular-example' as title`, () => {
+    expect(component.title).toEqual('calcite-components-angular-example');
   });
 
   it('should render calcite-loader with label', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('calcite-loader')?.label).toBe('Loading...');
+    const loaderElement: HTMLCalciteLoaderElement =
+      fixture.nativeElement.querySelector('calcite-loader')!;
+    expect(loaderElement?.label).toBe('Loading...');
   });
 });

--- a/examples/components/angular/src/app/app.component.ts
+++ b/examples/components/angular/src/app/app.component.ts
@@ -1,14 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, Component, OnInit, OnDestroy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { CalciteComponentsModule } from '@esri/calcite-components-angular';
 
 @Component({
   selector: 'app-root',
   standalone: true,
+  imports: [CommonModule, RouterOutlet],
   templateUrl: './app.component.html',
-  imports: [CommonModule, CalciteComponentsModule, RouterOutlet],
   styleUrls: ['./app.component.css'],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AppComponent implements OnInit, OnDestroy {
   title = 'calcite-components-angular-example';

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,11 @@
         "readme.md",
         {
           "type": "json",
+          "path": "/examples/components/angular/package.json",
+          "jsonpath": "$.dependencies['@esri/calcite-components']"
+        },
+        {
+          "type": "json",
           "path": "/examples/components/preact/package.json",
           "jsonpath": "$.dependencies['@esri/calcite-components']"
         },


### PR DESCRIPTION
**Related Issue:** #10674

## Summary

Update the Angular example to use `@esri/calcite-components` directly, instead of the now removed `@esri/calcite-components-angular` wrapper.
