### PR TITLE
docs: add calcite-ui-icons package to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -98,6 +98,7 @@ body:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-react"
         - label: "@esri/calcite-design-tokens"
+        - label: "@esri/calcite-ui-icons"
         - label: "@esri/eslint-plugin-calcite-components"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -43,6 +43,7 @@ body:
         - label: "@esri/calcite-components"
         - label: "@esri/calcite-components-react"
         - label: "@esri/calcite-design-tokens"
+        - label: "@esri/calcite-ui-icons"
         - label: "@esri/eslint-plugin-calcite-components"
     validations:
       required: false


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/10634#issuecomment-2458156607

## Summary
Add the `@esri/calcite-ui-icons` package to our bug and refactor templates.
