### PR TITLE
feat(accordion-item): custom header and content spacing tokens

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -193,7 +193,7 @@
 }
 
 .content {
-  @apply hidden pt-0;
+  @apply hidden;
   text-align: initial;
 }
 


### PR DESCRIPTION
**Related Issue:** #4012 

## Summary

### Add spacing

Removes pt-0 from .content to allow spacing between the header-content and content.

#### Before

<img width="268" alt="Screenshot 2024-11-13 at 11 30 49 AM" src="https://github.com/user-attachments/assets/aef62811-5a09-43e1-8328-330cb2c46bc2">

#### After

<img width="267" alt="Screenshot 2024-11-13 at 11 30 59 AM" src="https://github.com/user-attachments/assets/dd92b276-259e-400b-9fcb-f048b5858426">




