### PR TITLE
feat(input): Add component tokens

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,13 +1,7 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [
-  "get-trailing-text-input-padding",
-  "medium-modular-scale",
-  "modular-scale",
-  "scale-duration",
-  "small-modular-scale",
-];
+const customFunctions = [];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [

--- a/packages/calcite-components/src/components.d.ts
+++ b/packages/calcite-components/src/components.d.ts
@@ -77,7 +77,6 @@ import { ScrimMessages } from "./components/scrim/assets/scrim/t9n";
 import { DisplayMode } from "./components/sheet/interfaces";
 import { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 import { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
-import { FlipPlacement as FlipPlacement1, MenuPlacement as MenuPlacement1, OverlayPositioning as OverlayPositioning1 } from "./components";
 import { SortHandleMessages } from "./components/sort-handle/assets/sort-handle/t9n";
 import { DragDetail } from "./utils/sortableComponent";
 import { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
@@ -170,7 +169,6 @@ export { ScrimMessages } from "./components/scrim/assets/scrim/t9n";
 export { DisplayMode } from "./components/sheet/interfaces";
 export { DisplayMode as DisplayMode1 } from "./components/shell-panel/interfaces";
 export { ShellPanelMessages } from "./components/shell-panel/assets/shell-panel/t9n";
-export { FlipPlacement as FlipPlacement1, MenuPlacement as MenuPlacement1, OverlayPositioning as OverlayPositioning1 } from "./components";
 export { SortHandleMessages } from "./components/sort-handle/assets/sort-handle/t9n";
 export { DragDetail } from "./utils/sortableComponent";
 export { StepperItemChangeEventDetail, StepperItemEventDetail, StepperItemKeyEventDetail, StepperLayout } from "./components/stepper/interfaces";
@@ -4736,7 +4734,7 @@ export namespace Components {
         /**
           * Specifies the component's fallback `calcite-dropdown-item` `placement` when it's initial or specified `placement` has insufficient space available.
          */
-        "flipPlacements": FlipPlacement1[];
+        "flipPlacements": FlipPlacement[];
         /**
           * Specifies the label of the component.
          */
@@ -4765,12 +4763,12 @@ export namespace Components {
         /**
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
-        "overlayPositioning": OverlayPositioning1;
+        "overlayPositioning": OverlayPositioning;
         /**
           * Determines where the component will be positioned relative to the container element.
           * @default "bottom-start"
          */
-        "placement": MenuPlacement1;
+        "placement": MenuPlacement;
         /**
           * Specifies the size of the component.
          */
@@ -12788,7 +12786,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the component's fallback `calcite-dropdown-item` `placement` when it's initial or specified `placement` has insufficient space available.
          */
-        "flipPlacements"?: FlipPlacement1[];
+        "flipPlacements"?: FlipPlacement[];
         /**
           * Specifies the label of the component.
          */
@@ -12841,12 +12839,12 @@ declare namespace LocalJSX {
         /**
           * Determines the type of positioning to use for the overlaid content.  Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.  `"fixed"` should be used to escape an overflowing parent container, or when the reference element's `position` CSS property is `"fixed"`.
          */
-        "overlayPositioning"?: OverlayPositioning1;
+        "overlayPositioning"?: OverlayPositioning;
         /**
           * Determines where the component will be positioned relative to the container element.
           * @default "bottom-start"
          */
-        "placement"?: MenuPlacement1;
+        "placement"?: MenuPlacement;
         /**
           * Specifies the size of the component.
          */

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -2051,7 +2051,7 @@ describe("calcite-input", () => {
 
   describe("theme", () => {
     themed(
-      html` <calcite-input placeholder="Placeholder text" prefix-text="prefix" suffix-text="suffix"></calcite-input> `,
+      html` <calcite-input placeholder="Placeholder text" prefix-text="prefix" suffix-text="suffix"></calcite-input>`,
       {
         "--calcite-input-prefix-size": {
           shadowSelector: `.${CSS.prefix}`,
@@ -2061,7 +2061,76 @@ describe("calcite-input", () => {
           shadowSelector: `.${CSS.suffix}`,
           targetProp: "inlineSize",
         },
+        "--calcite-input-prefix-background-color": {
+          shadowSelector: `.${CSS.prefix}`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-input-suffix-background-color": {
+          shadowSelector: `.${CSS.suffix}`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-input-prefix-text-color": {
+          shadowSelector: `.${CSS.prefix}`,
+          targetProp: "color",
+        },
+        "--calcite-input-suffix-text-color": {
+          shadowSelector: `.${CSS.suffix}`,
+          targetProp: "color",
+        },
+        "--calcite-input-background-color": {
+          shadowSelector: `input`,
+          targetProp: "backgroundColor",
+        },
+        "--calcite-input-border-color": {
+          shadowSelector: `input`,
+          targetProp: "borderColor",
+        },
+        "--calcite-input-shadow": {
+          shadowSelector: `.${CSS.inputWrapper}`,
+          targetProp: "boxShadow",
+        },
+        // not sure how to target this ::placeholder style
+        /*
+        "--calcite-input-placeholder-text": {
+          shadowSelector: `input`,
+          targetProp: "color",
+        },
+        */
       },
     );
+    themed(html` <calcite-input icon="layer" value="Forty two"></calcite-input>`, {
+      "--calcite-input-corner-radius": {
+        shadowSelector: `input`,
+        targetProp: "borderRadius",
+      },
+      "--calcite-input-icon-color": {
+        shadowSelector: `.${CSS.inputIcon}`,
+        targetProp: "color",
+      },
+      "--calcite-input-text-color": {
+        shadowSelector: `input`,
+        targetProp: "color",
+      },
+    });
+    themed(html` <calcite-input clearable icon="layer" value="Forty two"></calcite-input>`, {
+      "--calcite-input-actions-background-color": {
+        shadowSelector: `.${CSS.clearButton}`,
+        targetProp: "backgroundColor",
+      },
+      "--calcite-input-actions-icon-color": {
+        shadowSelector: `.${CSS.clearButton} calcite-icon`,
+        targetProp: "color",
+      },
+    });
+    themed(html` <calcite-input icon="layer" value="42" type="number"></calcite-input>`, {
+      "--calcite-input-actions-background-color": {
+        shadowSelector: `.${CSS.numberButtonItem}`,
+        targetProp: "backgroundColor",
+      },
+      "--calcite-input-actions-icon-color": {
+        shadowSelector: `.${CSS.numberButtonItem} calcite-icon`,
+        targetProp: "color",
+      },
+    });
   });
 });

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -5,6 +5,32 @@
  *
  * @prop --calcite-input-prefix-size: Specifies the component's prefix width.
  * @prop --calcite-input-suffix-size: Specifies the component's suffix width.
+ * 
+ * @prop --calcite-input-background-color: Specifies the background color of the component.
+ * @prop --calcite-input-border-color: Specifies the border color of the component.
+ * @prop --calcite-input-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-input-shadow: Specifies the shadow of the component.
+
+ * @prop --calcite-input-icon-color:  Specifies the icon color of the component.
+ * @prop --calcite-input-text-color: Specifies the text color of the component.
+ * @prop --calcite-input-placeholder-text-color: Specifies the color of placeholder text in the component.
+
+ * @prop --calcite-input-actions-background-color: Specifies the background color of Input's `clearable` and `number-button-type` elements.
+ * @prop --calcite-input-actions-background-color-hover: Specifies the background color of Input's `clearable` and `number-button-type` elements when hovered.
+ * @prop --calcite-input-actions-background-color-press: Specifies the background color of Input's `clearable` and `number-button-type` elements when pressed.
+ * @prop --calcite-input-actions-icon-color: Specifies the text color of Input's `clearable` and `number-button-type` elements.
+ * @prop --calcite-input-actions-icon-color-hover: Specifies the text color of Input's `clearable` and `number-button-type` elements when hovered.
+ * @prop --calcite-input-actions-icon-color-press: Specifies the text color of Input's `clearable` and `number-button-type` elements when pressed.
+ 
+ * @prop --calcite-input-loading-background-color: Specifies the background color of the `loading` element, when present.
+ * @prop --calcite-input-loading-fill-color: Specifies the fill color of the `loading` element, when present.
+ 
+ * @prop --calcite-input-prefix-background-color:  Specifies the background color of the prefix sub-component.
+ * @prop --calcite-input-prefix-text-color:  Specifies the text color of the prefix sub-component.
+
+ * @prop --calcite-input-suffix-background-color:  Specifies the background color of the suffix sub-component.
+ * @prop --calcite-input-suffix-text-color:  Specifies the text color of the suffix sub-component.
+ *
  */
 
 :host {
@@ -108,14 +134,7 @@
 
 textarea,
 input {
-  transition:
-    var(--calcite-animation-timing),
-    block-size 0,
-    outline-offset 0s;
-  -webkit-appearance: none;
   @apply font-inherit
-    text-color-1
-    bg-foreground-1
     relative
     m-0
     box-border
@@ -124,8 +143,86 @@ input {
     w-full
     max-w-full
     flex-1
-    rounded-none
-    font-normal;
+    font-normal
+    border
+    border-solid
+    text-ellipsis;
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  background-color: var(--calcite-input-background-color, var(--calcite-color-foreground-1));
+  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
+  transition:
+    var(--calcite-animation-timing),
+    block-size 0,
+    outline-offset 0s;
+  -webkit-appearance: none;
+  &::placeholder,
+  &:-ms-input-placeholder,
+  &::-ms-input-placeholder {
+    @apply font-normal;
+    color: var(--calcite-input-placeholder-text-color, var(--calcite-text-color-3));
+  }
+  &:placeholder-shown {
+    @apply text-ellipsis;
+  }
+}
+
+textarea {
+  border-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+input {
+  border-start-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  border-start-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  border-end-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  border-end-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+:host([prefix-text]) input {
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+}
+
+:host([suffix-text]) input,
+.element-wrapper:has(.clear-button) input,
+:host([number-button-type="vertical"][type="number"]) input,
+:host([suffix-text][number-button-type="horizontal"]) .suffix,
+:host([suffix-text][number-button-type="vertical"][type="number"]) .suffix,
+:host([number-button-type="vertical"][type="number"])
+  .clear-button
+  :host([number-button-type="horizontal"][type="number"])
+  .clear-button {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+:host([number-button-type="horizontal"]) input {
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
+}
+
+:host([prefix-text]) .prefix:first-child,
+:host([number-button-type="horizontal"]) .number-button-item[data-adjustment="down"] {
+  border-start-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  border-end-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+:host([suffix-text]) .suffix,
+:host([suffix-text][number-button-type="vertical"][type="number"][read-only]) .suffix,
+:host([clearable]:not([suffix-text])) .clear-button,
+:host([number-button-type="horizontal"]) .number-button-item[data-adjustment="up"] {
+  border-end-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  border-start-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+:host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"] {
+  @apply border-t-0;
+  border-end-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+:host([number-button-type="vertical"]) .number-button-item[data-adjustment="up"] {
+  border-start-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
 }
 
 input[type="search"]::-webkit-search-decoration {
@@ -133,36 +230,20 @@ input[type="search"]::-webkit-search-decoration {
 }
 
 // states
-input,
-textarea {
-  @apply border
-    border-color-input
-    border-solid
-    text-color-1
-    text-ellipsis;
-  &::placeholder,
-  &:-ms-input-placeholder,
-  &::-ms-input-placeholder {
-    @apply text-color-3 font-normal;
-  }
-  &:placeholder-shown {
-    @apply text-ellipsis;
-  }
-}
+
 input:focus,
 textarea:focus {
-  @apply border-color-brand text-color-1;
+  @apply border-color-brand;
+  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
 }
 input[readonly],
 textarea[readonly] {
-  @apply bg-background font-medium;
+  @apply font-medium;
+  background-color: var(--calcite-input-background-color, var(--calcite-color-background));
 }
 input[readonly]:focus,
 textarea[readonly]:focus {
-  @apply text-color-1;
-}
-calcite-icon {
-  @apply text-color-3;
+  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
 }
 
 //focus
@@ -230,12 +311,9 @@ input:focus {
   @apply transition-default
     pointer-events-none
     absolute
-    block;
-}
-
-.icon,
-.resize-icon-wrapper {
-  @apply z-default; // needed for firefox to display the icon properly
+    block
+    z-default;
+  color: var(--calcite-input-icon-color, var(--calcite-text-color-3));
 }
 
 // hide browser default clear
@@ -258,8 +336,6 @@ input[type="time"]::-webkit-clear-button {
 .clear-button {
   pointer-events: initial;
   @apply focus-base
-    border-color-input
-    bg-foreground-1
     order-4
     m-0
     box-border
@@ -270,20 +346,27 @@ input[type="time"]::-webkit-clear-button {
     justify-center
     self-stretch
     border
-    border-solid;
-
+    border-solid
+    transition-default;
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  background-color: var(--calcite-input-actions-background-color, var(--calcite-color-foreground-1));
   border-inline-start-width: theme("borderWidth.0");
 
+  calcite-icon {
+    @apply transition-default;
+    color: var(--calcite-input-actions-icon-color, var(--calcite-text-color-3));
+  }
+
   &:hover {
-    @apply bg-foreground-2 transition-default;
+    background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
-      @apply text-color-1 transition-default;
+      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-text-color-1));
     }
   }
   &:active {
-    @apply bg-foreground-3;
+    background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
     calcite-icon {
-      @apply text-color-1;
+      color: var(--calcite-input-actions-icon-color-press, var(--calcite-text-color-1));
     }
   }
   &:focus {
@@ -301,6 +384,8 @@ input[type="time"]::-webkit-clear-button {
   @apply pointer-events-none
     absolute
     block;
+  --calcite-progress-background-color: var(--calcite-input-loading-background-color);
+  --calcite-progress-fill-color: var(--calcite-input-loading-fill-color);
 }
 
 // slotted action
@@ -311,10 +396,7 @@ input[type="time"]::-webkit-clear-button {
 // prefix and suffix
 .prefix,
 .suffix {
-  @apply border-color-input
-    bg-background
-    text-color-2
-    box-border
+  @apply box-border
     flex
     h-auto
     min-h-full
@@ -326,17 +408,23 @@ input[type="time"]::-webkit-clear-button {
     border-solid
     font-medium
     leading-none;
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
 }
 
 .prefix {
   @apply order-2;
   border-inline-end-width: theme("borderWidth.0");
   inline-size: var(--calcite-input-prefix-size, auto);
+  background-color: var(--calcite-input-prefix-background-color, var(--calcite-color-background));
+  color: var(--calcite-input-prefix-text-color, var(--calcite-text-color-2));
 }
+
 .suffix {
   @apply order-5;
   border-inline-start-width: theme("borderWidth.0");
   inline-size: var(--calcite-input-suffix-size, auto);
+  background-color: var(--calcite-input-suffix-background-color, var(--calcite-color-background));
+  color: var(--calcite-input-suffix-text-color, var(--calcite-text-color-2));
 }
 
 // alignment type
@@ -397,12 +485,16 @@ input[type="number"] {
 }
 
 .number-button-item.number-button-item--horizontal {
-  &[data-adjustment="down"],
-  &[data-adjustment="up"] {
-    @apply order-1
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  @apply order-1
       max-h-full
       min-h-full
-      self-stretch;
+      self-stretch 
+      border 
+      border-solid;
+
+  &[data-adjustment="down"],
+  &[data-adjustment="up"] {
     & calcite-icon {
       transform: rotate(90deg);
     }
@@ -410,52 +502,19 @@ input[type="number"] {
 }
 
 .number-button-item.number-button-item--horizontal[data-adjustment="down"] {
-  @apply border-color-input
-    border
-    border-solid;
   border-inline-end-width: theme("borderWidth.0");
-  &:hover {
-    @apply bg-foreground-2;
-    calcite-icon {
-      @apply text-color-1;
-    }
-  }
 }
 
 .number-button-item.number-button-item--horizontal[data-adjustment="up"] {
+  border-inline-start-width: theme("borderWidth.0");
   @apply order-5;
-  &:hover {
-    @apply bg-foreground-2;
-    calcite-icon {
-      @apply text-color-1;
-    }
-  }
-}
-
-:host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"]:hover {
-  @apply bg-foreground-2;
-  calcite-icon {
-    @apply text-color-1;
-  }
-}
-
-:host([number-button-type="vertical"]) .number-button-item[data-adjustment="up"]:hover {
-  @apply bg-foreground-2;
-  calcite-icon {
-    @apply text-color-1;
-  }
-}
-
-:host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"] {
-  @apply border-t-0;
 }
 
 .number-button-item {
   max-block-size: 50%;
   min-block-size: 50%;
   pointer-events: initial;
-  @apply border-color-input
-    bg-foreground-1
+  @apply bg-foreground-1
     transition-default
     m-0
     box-border
@@ -467,18 +526,26 @@ input[type="number"] {
     border-solid
     py-0
     px-2;
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  background-color: var(--calcite-input-actions-background-color, var(--calcite-color-foreground-1));
+
   border-inline-start-width: theme("borderWidth.0");
   & calcite-icon {
     @apply transition-default pointer-events-none;
+    color: var(--calcite-input-actions-icon-color, var(--calcite-text-color-3));
   }
-  &:focus {
-    @apply bg-foreground-2;
+
+  &:hover {
+    background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
-      @apply text-color-1;
+      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-text-color-1));
     }
   }
   &:active {
-    @apply bg-foreground-3;
+    background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
+    calcite-icon {
+      color: var(--calcite-input-actions-icon-color-press, var(--calcite-text-color-1));
+    }
   }
   &:disabled {
     @apply pointer-events-none;
@@ -490,6 +557,8 @@ input[type="number"] {
     flex
     flex-row
     items-center;
+  border-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+  box-shadow: var(--calcite-input-shadow, var(--calcite-shadow-none));
 }
 
 // hide the default date picker
@@ -501,42 +570,6 @@ input[type="date"]::-webkit-input-placeholder {
   visibility: hidden !important;
 }
 
-// textarea resize icon
-textarea::-webkit-resizer {
-  @apply absolute
-    bottom-0
-    box-border
-    py-0
-    px-1;
-  inset-inline-end: 0;
-}
-
-.resize-icon-wrapper {
-  inset-block-end: 2px;
-  inset-inline-end: 2px;
-
-  @apply bg-foreground-1
-    text-color-3
-    pointer-events-none
-    absolute
-    h-3
-    w-3;
-
-  & calcite-icon {
-    inset-block-end: theme("spacing.1");
-    inset-inline-end: theme("spacing.1");
-    transform: rotate(-45deg);
-  }
-}
-
-.calcite--rtl {
-  .resize-icon-wrapper {
-    & calcite-icon {
-      transform: rotate(45deg);
-    }
-  }
-}
-
 :host([type="color"]) input {
   @apply p-1;
 }
@@ -544,11 +577,11 @@ textarea::-webkit-resizer {
 // file input
 :host([type="file"]) input {
   @apply bg-foreground-1
-    border-color-input
     cursor-pointer
     border
     border-dashed
     text-center;
+  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
 }
 
 :host([type="file"][scale="s"]) input {

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -3,8 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-input-prefix-size: Specifies the component's prefix width.
- * @prop --calcite-input-suffix-size: Specifies the component's suffix width.
+ * @prop --calcite-input-prefix-size: Specifies the component's prefix width, when present.
+ * @prop --calcite-input-suffix-size: Specifies the component's suffix width, when present.
  * 
  * @prop --calcite-input-background-color: Specifies the background color of the component.
  * @prop --calcite-input-border-color: Specifies the border color of the component.
@@ -18,18 +18,18 @@
  * @prop --calcite-input-actions-background-color: Specifies the background color of Input's `clearable` and `number-button-type` elements.
  * @prop --calcite-input-actions-background-color-hover: Specifies the background color of Input's `clearable` and `number-button-type` elements when hovered.
  * @prop --calcite-input-actions-background-color-press: Specifies the background color of Input's `clearable` and `number-button-type` elements when pressed.
- * @prop --calcite-input-actions-icon-color: Specifies the text color of Input's `clearable` and `number-button-type` elements.
- * @prop --calcite-input-actions-icon-color-hover: Specifies the text color of Input's `clearable` and `number-button-type` elements when hovered.
- * @prop --calcite-input-actions-icon-color-press: Specifies the text color of Input's `clearable` and `number-button-type` elements when pressed.
+ * @prop --calcite-input-actions-icon-color: Specifies the icon color of Input's `clearable` and `number-button-type` elements.
+ * @prop --calcite-input-actions-icon-color-hover: Specifies the icon color of Input's `clearable` and `number-button-type` elements when hovered.
+ * @prop --calcite-input-actions-icon-color-press: Specifies the icon color of Input's `clearable` and `number-button-type` elements when pressed.
  
  * @prop --calcite-input-loading-background-color: Specifies the background color of the `loading` element, when present.
  * @prop --calcite-input-loading-fill-color: Specifies the fill color of the `loading` element, when present.
  
- * @prop --calcite-input-prefix-background-color:  Specifies the background color of the prefix sub-component.
- * @prop --calcite-input-prefix-text-color:  Specifies the text color of the prefix sub-component.
+ * @prop --calcite-input-prefix-background-color:  Specifies the background color of the component's prefix, when present.
+ * @prop --calcite-input-prefix-text-color:  Specifies the text color of the component's prefix, when present.
 
- * @prop --calcite-input-suffix-background-color:  Specifies the background color of the suffix sub-component.
- * @prop --calcite-input-suffix-text-color:  Specifies the text color of the suffix sub-component.
+ * @prop --calcite-input-suffix-background-color:  Specifies the background color of the component's suffix, when present.
+ * @prop --calcite-input-suffix-text-color:  Specifies the text color of the component's suffix, when present.
  *
  */
 
@@ -147,7 +147,7 @@ input {
     border
     border-solid
     text-ellipsis;
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
   background-color: var(--calcite-input-background-color, var(--calcite-color-foreground-1));
   color: var(--calcite-input-text-color, var(--calcite-text-color-1));
   transition:
@@ -348,7 +348,7 @@ input[type="time"]::-webkit-clear-button {
     border
     border-solid
     transition-default;
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
   background-color: var(--calcite-input-actions-background-color, var(--calcite-color-foreground-1));
   border-inline-start-width: theme("borderWidth.0");
 
@@ -408,7 +408,7 @@ input[type="time"]::-webkit-clear-button {
     border-solid
     font-medium
     leading-none;
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
 }
 
 .prefix {
@@ -485,7 +485,7 @@ input[type="number"] {
 }
 
 .number-button-item.number-button-item--horizontal {
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
   @apply order-1
       max-h-full
       min-h-full
@@ -526,7 +526,7 @@ input[type="number"] {
     border-solid
     py-0
     px-2;
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
   background-color: var(--calcite-input-actions-background-color, var(--calcite-color-foreground-1));
 
   border-inline-start-width: theme("borderWidth.0");
@@ -581,7 +581,7 @@ input[type="date"]::-webkit-input-placeholder {
     border
     border-dashed
     text-center;
-  border-color: var(--calcite-input-border-color, var(--calcite-border-color-input));
+  border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
 }
 
 :host([type="file"][scale="s"]) input {

--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -149,7 +149,7 @@ input {
     text-ellipsis;
   border-color: var(--calcite-input-border-color, var(--calcite-color-border-input));
   background-color: var(--calcite-input-background-color, var(--calcite-color-foreground-1));
-  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
+  color: var(--calcite-input-text-color, var(--calcite-color-text-1));
   transition:
     var(--calcite-animation-timing),
     block-size 0,
@@ -159,7 +159,7 @@ input {
   &:-ms-input-placeholder,
   &::-ms-input-placeholder {
     @apply font-normal;
-    color: var(--calcite-input-placeholder-text-color, var(--calcite-text-color-3));
+    color: var(--calcite-input-placeholder-text-color, var(--calcite-color-text-3));
   }
   &:placeholder-shown {
     @apply text-ellipsis;
@@ -234,7 +234,7 @@ input[type="search"]::-webkit-search-decoration {
 input:focus,
 textarea:focus {
   @apply border-color-brand;
-  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
+  color: var(--calcite-input-text-color, var(--calcite-color-text-1));
 }
 input[readonly],
 textarea[readonly] {
@@ -243,7 +243,7 @@ textarea[readonly] {
 }
 input[readonly]:focus,
 textarea[readonly]:focus {
-  color: var(--calcite-input-text-color, var(--calcite-text-color-1));
+  color: var(--calcite-input-text-color, var(--calcite-color-text-1));
 }
 
 //focus
@@ -313,7 +313,7 @@ input:focus {
     absolute
     block
     z-default;
-  color: var(--calcite-input-icon-color, var(--calcite-text-color-3));
+  color: var(--calcite-input-icon-color, var(--calcite-color-text-3));
 }
 
 // hide browser default clear
@@ -354,19 +354,19 @@ input[type="time"]::-webkit-clear-button {
 
   calcite-icon {
     @apply transition-default;
-    color: var(--calcite-input-actions-icon-color, var(--calcite-text-color-3));
+    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
   }
 
   &:hover {
     background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-text-color-1));
+      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
     }
   }
   &:active {
     background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-press, var(--calcite-text-color-1));
+      color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
     }
   }
   &:focus {
@@ -416,7 +416,7 @@ input[type="time"]::-webkit-clear-button {
   border-inline-end-width: theme("borderWidth.0");
   inline-size: var(--calcite-input-prefix-size, auto);
   background-color: var(--calcite-input-prefix-background-color, var(--calcite-color-background));
-  color: var(--calcite-input-prefix-text-color, var(--calcite-text-color-2));
+  color: var(--calcite-input-prefix-text-color, var(--calcite-color-text-2));
 }
 
 .suffix {
@@ -424,7 +424,7 @@ input[type="time"]::-webkit-clear-button {
   border-inline-start-width: theme("borderWidth.0");
   inline-size: var(--calcite-input-suffix-size, auto);
   background-color: var(--calcite-input-suffix-background-color, var(--calcite-color-background));
-  color: var(--calcite-input-suffix-text-color, var(--calcite-text-color-2));
+  color: var(--calcite-input-suffix-text-color, var(--calcite-color-text-2));
 }
 
 // alignment type
@@ -532,19 +532,19 @@ input[type="number"] {
   border-inline-start-width: theme("borderWidth.0");
   & calcite-icon {
     @apply transition-default pointer-events-none;
-    color: var(--calcite-input-actions-icon-color, var(--calcite-text-color-3));
+    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
   }
 
   &:hover {
     background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-text-color-1));
+      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
     }
   }
   &:active {
     background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-press, var(--calcite-text-color-1));
+      color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
     }
   }
   &:disabled {

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -1173,55 +1173,46 @@ export class Input
       ) : null;
 
     const childEl =
-      this.type !== "number"
-        ? [
-            <this.childElType
-              accept={this.accept}
-              aria-errormessage={IDS.validationMessage}
-              aria-invalid={toAriaBoolean(this.status === "invalid")}
-              aria-label={getLabelText(this)}
-              autocomplete={this.autocomplete}
-              autofocus={autofocus}
-              class={{
-                [CSS.editingEnabled]: this.editingEnabled,
-                [CSS.inlineChild]: !!this.inlineEditableEl,
-              }}
-              defaultValue={this.defaultValue}
-              disabled={this.disabled ? true : null}
-              enterKeyHint={enterKeyHint}
-              inputMode={inputMode}
-              max={this.maxString}
-              maxLength={this.maxLength}
-              min={this.minString}
-              minLength={this.minLength}
-              multiple={this.multiple}
-              name={this.name}
-              onBlur={this.inputBlurHandler}
-              onChange={this.inputChangeHandler}
-              onFocus={this.inputFocusHandler}
-              onInput={this.inputInputHandler}
-              onKeyDown={this.inputKeyDownHandler}
-              onKeyUp={this.inputKeyUpHandler}
-              pattern={this.pattern}
-              placeholder={this.placeholder || ""}
-              readOnly={this.readOnly}
-              ref={this.setChildElRef}
-              required={this.required ? true : null}
-              spellcheck={this.el.spellcheck}
-              step={this.step}
-              tabIndex={
-                this.disabled || (this.inlineEditableEl && !this.editingEnabled) ? -1 : null
-              }
-              type={this.type}
-              value={this.value}
-            />,
-            this.isTextarea ? (
-              <div class={CSS.resizeIconWrapper}>
-                <calcite-icon icon="chevron-down" scale={getIconScale(this.scale)} />
-              </div>
-            ) : null,
-          ]
-        : null;
+      this.type !== "number" ? (
+        <this.childElType
+          accept={this.accept}
+          aria-errormessage={IDS.validationMessage}
+          aria-invalid={toAriaBoolean(this.status === "invalid")}
+          aria-label={getLabelText(this)}
+          autocomplete={this.autocomplete}
+          autofocus={autofocus}
+          class={{
+            [CSS.editingEnabled]: this.editingEnabled,
+            [CSS.inlineChild]: !!this.inlineEditableEl,
+          }}
+          defaultValue={this.defaultValue}
+          disabled={this.disabled ? true : null}
+          enterKeyHint={enterKeyHint}
+          inputMode={inputMode}
+          max={this.maxString}
+          maxLength={this.maxLength}
+          min={this.minString}
+          minLength={this.minLength}
+          multiple={this.multiple}
+          name={this.name}
+          onBlur={this.inputBlurHandler}
+          onChange={this.inputChangeHandler}
+          onFocus={this.inputFocusHandler}
+          onInput={this.inputInputHandler}
+          onKeyDown={this.inputKeyDownHandler}
+          onKeyUp={this.inputKeyUpHandler}
+          pattern={this.pattern}
+          placeholder={this.placeholder || ""}
+          readOnly={this.readOnly}
+          ref={this.setChildElRef}
+          required={this.required ? true : null}
+          spellcheck={this.el.spellcheck}
+          step={this.step}
+          tabIndex={this.disabled || (this.inlineEditableEl && !this.editingEnabled) ? -1 : null}
+          type={this.type}
+          value={this.value}
+        />
+      ) : null;
 
     return (
       <Host onClick={this.clickHandler} onKeyDown={this.keyDownHandler}>

--- a/packages/calcite-components/src/components/input/resources.ts
+++ b/packages/calcite-components/src/components/input/resources.ts
@@ -11,7 +11,6 @@ export const CSS = {
   wrapper: "element-wrapper",
   inputWrapper: "wrapper",
   actionWrapper: "action-wrapper",
-  resizeIconWrapper: "resize-icon-wrapper",
   numberButtonItem: "number-button-item",
 };
 

--- a/packages/calcite-components/src/custom-theme/input.ts
+++ b/packages/calcite-components/src/custom-theme/input.ts
@@ -3,6 +3,25 @@ import { html } from "../../support/formatting";
 export const inputTokens = {
   calciteInputPrefixSize: "",
   calciteInputSuffixSize: "",
+  calciteInputBackgroundColor: "",
+  calciteInputBorderColor: "",
+  calciteInputCornerRadius: "",
+  calciteInputShadow: "",
+  calciteInputIconColor: "",
+  calciteInputTextColor: "",
+  calciteInputPlaceholderTextColor: "",
+  calciteInputActionsBackgroundColor: "",
+  calciteInputActionsBackgroundColorHover: "",
+  calciteInputActionsBackgroundColorPress: "",
+  calciteInputActionsIconColor: "",
+  calciteInputActionsIconColorHover: "",
+  calciteInputActionsIconColorPress: "",
+  calciteInputLoadingBackgroundColor: "",
+  calciteInputLoadingFillColor: "",
+  calciteInputPrefixBackgroundColor: "",
+  calciteInputPrefixTextColor: "",
+  calciteInputSuffixBackgroundColor: "",
+  calciteInputSuffixTextColor: "",
 };
 
 export const input = html`<calcite-input

--- a/packages/calcite-components/src/demos/input.html
+++ b/packages/calcite-components/src/demos/input.html
@@ -55,6 +55,33 @@
       .locale {
         flex: 0 0 20%;
       }
+
+      calcite-input {
+        --calcite-input-background-color: lightyellow;
+        --calcite-input-border-color: green;
+        --calcite-input-corner-radius: 8px;
+        --calcite-input-shadow: var(--calcite-shadow-md);
+
+        --calcite-input-icon-color: orange;
+        --calcite-input-text-color: blue;
+        --calcite-input-placeholder-text-color: red;
+
+        --calcite-input-prefix-background-color: lightpink;
+        --calcite-input-prefix-text-color: red;
+
+        --calcite-input-suffix-background-color: lightblue;
+        --calcite-input-suffix-text-color: blue;
+
+        --calcite-input-actions-background-color: purple;
+        --calcite-input-actions-background-color-hover: pink;
+        --calcite-input-actions-background-color-press: red;
+        --calcite-input-actions-icon-color: pink;
+        --calcite-input-actions-icon-color-hover: purple;
+        --calcite-input-actions-icon-color-press: green;
+
+        --calcite-input-loading-background-color: black;
+        --calcite-input-loading-fill-color: pink;
+      }
     </style>
 
     <script src="./_assets/head.js"></script>
@@ -180,6 +207,126 @@
         </div>
       </div>
 
+      <!-- Standard with clearable -->
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Standard with clearable</div>
+        <div class="child-flex">
+          <calcite-label scale="s">
+            Input Label
+            <calcite-input
+              type="text"
+              placeholder="Placeholder"
+              scale="s"
+              clearable
+              value="Populated value"
+            ></calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            Input Label
+            <calcite-input
+              type="text"
+              placeholder="Placeholder"
+              scale="m"
+              clearable
+              value="Populated value"
+            ></calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label scale="l">
+            Input Label
+            <calcite-input
+              type="text"
+              placeholder="Placeholder"
+              scale="l"
+              clearable
+              value="Populated value"
+            ></calcite-input>
+          </calcite-label>
+        </div>
+      </div>
+
+      <!-- Standard with loading -->
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Standard with loading</div>
+        <div class="child-flex">
+          <calcite-label scale="s">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="s" loading></calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="m" loading></calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label scale="l">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="l" loading></calcite-input>
+          </calcite-label>
+        </div>
+      </div>
+
+      <!-- Standard Prefix/Suffix with clearable populated -->
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Standard Prefix/Suffix with clearable populated</div>
+        <div class="child-flex">
+          <calcite-label scale="s">
+            Input Label
+            <calcite-input
+              clearable
+              value="Populated value"
+              type="text"
+              placeholder="Placeholder"
+              scale="s"
+              prefix-text="Prefix"
+              suffix-text="Suffix"
+            >
+            </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            Input Label
+            <calcite-input
+              clearable
+              value="Populated value"
+              type="text"
+              placeholder="Placeholder"
+              scale="m"
+              prefix-text="Prefix"
+              suffix-text="Suffix"
+            >
+            </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label scale="l">
+            Input Label
+            <calcite-input
+              clearable
+              value="Populated value"
+              type="text"
+              placeholder="Placeholder"
+              scale="l"
+              prefix-text="Prefix"
+              suffix-text="Suffix"
+            >
+            </calcite-input>
+          </calcite-label>
+        </div>
+      </div>
+
       <!-- Standard Prefix/Suffix -->
       <div class="parent-flex">
         <div class="child-flex font right-aligned-text">Standard Prefix/Suffix</div>
@@ -204,6 +351,56 @@
             Input Label
             <calcite-input type="text" placeholder="Placeholder" scale="l" prefix-text="Prefix" suffix-text="Suffix">
             </calcite-input>
+          </calcite-label>
+        </div>
+      </div>
+
+      <!-- Standard Prefix/Suffix -->
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Standard Prefix</div>
+        <div class="child-flex">
+          <calcite-label scale="s">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="s" prefix-text="Prefix"> </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="m" prefix-text="Prefix"> </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label scale="l">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="l" prefix-text="Prefix"> </calcite-input>
+          </calcite-label>
+        </div>
+      </div>
+
+      <!-- Standard Prefix/Suffix -->
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Standard Suffix</div>
+        <div class="child-flex">
+          <calcite-label scale="s">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="s" suffix-text="Suffix"> </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label>
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="m" suffix-text="Suffix"> </calcite-input>
+          </calcite-label>
+        </div>
+
+        <div class="child-flex">
+          <calcite-label scale="l">
+            Input Label
+            <calcite-input type="text" placeholder="Placeholder" scale="l" suffix-text="Suffix"> </calcite-input>
           </calcite-label>
         </div>
       </div>

--- a/packages/calcite-components/src/demos/input.html
+++ b/packages/calcite-components/src/demos/input.html
@@ -56,7 +56,7 @@
         flex: 0 0 20%;
       }
 
-      calcite-input {
+      .themed {
         --calcite-input-background-color: lightyellow;
         --calcite-input-border-color: green;
         --calcite-input-corner-radius: 8px;
@@ -157,6 +157,15 @@
         <div class="child-flex font">Large</div>
       </div>
 
+      <div class="parent-flex">
+        <div class="child-flex font right-aligned-text">Enable theming</div>
+        <div class="child-flex">
+          <calcite-segmented-control id="theming-toggle">
+            <calcite-segmented-control-item value="Unthemed" checked>Unthemed</calcite-segmented-control-item>
+            <calcite-segmented-control-item value="Themed">Themed</calcite-segmented-control-item>
+          </calcite-segmented-control>
+        </div>
+      </div>
       <!-- Standard -->
       <div class="parent-flex">
         <div class="child-flex font right-aligned-text">Standard</div>
@@ -1795,6 +1804,20 @@
     </demo-dom-swapper>
   </body>
   <script>
+    const themingToggle = document.getElementById("theming-toggle");
+    const allInputs = document.querySelectorAll("calcite-input");
+
     document.addEventListener("calciteInputInput", ({ target }) => console.log(`input: ${target.value}`));
+
+    themingToggle.addEventListener("calciteSegmentedControlChange", ({ target }) => {
+      const val = target.value;
+      allInputs.forEach((input) => {
+        if (val === "Themed") {
+          input.classList.add("themed");
+        } else {
+          input.classList.remove("themed");
+        }
+      });
+    });
   </script>
 </html>


### PR DESCRIPTION
**Related Issue:** #7180 

This will also serve as a pattern for related component like Input Text, Input Number, etc.

## Summary

`--calcite-input-background-color`: Specifies the background color of the component.
`--calcite-input-border-color`: Specifies the border color of the component.
`--calcite-input-corner-radius`: Specifies the corner radius of the component.
`--calcite-input-shadow`: Specifies the shadow of the component.

`--calcite-input-icon-color`:  Specifies the icon color of the component.
`--calcite-input-text-color`: Specifies the text color of the component.
`--calcite-input-placeholder-text-color`: Specifies the color of placeholder text in the component.

`--calcite-input-actions-background-color`: Specifies the background color of Input's `clearable` and `number-button-type` elements.
`--calcite-input-actions-background-color-hover`: Specifies the background color of Input's `clearable` and `number-button-type` elements when hovered.
`--calcite-input-actions-background-color-press`: Specifies the background color of Input's `clearable` and `number-button-type` elements when pressed.
`--calcite-input-actions-icon-color`: Specifies the icon color of Input's `clearable` and `number-button-type` elements.
`--calcite-input-actions-icon-color-hover`: Specifies the icon color of Input's `clearable` and `number-button-type` elements when hovered.
`--calcite-input-actions-icon-color-press`: Specifies the icon color of Input's `clearable` and `number-button-type` elements when pressed.
 
`--calcite-input-loading-background-color`: Specifies the background color of the `loading` element, when present.
`--calcite-input-loading-fill-color`: Specifies the fill color of the `loading` element, when present.
 
`--calcite-input-prefix-background-color`:  Specifies the background color of the component's prefix, when present.
`--calcite-input-prefix-text-color`:  Specifies the text color of the prefix of the component's prefix, when present.

`--calcite-input-suffix-background-color`:  Specifies the background color of the component's suffix, when present.
`--calcite-input-suffix-text-color`:  Specifies the text color of the component's suffix, when present.

`--calcite-input-prefix-size`: Specifies the component's prefix width, when present. _[existing]_
`--calcite-input-suffix-size`: Specifies the component's suffix width, when present. _[existing]_