### PR TITLE
fix(tooltip): fix closeOnClick property in Safari

### DIFF
--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -167,6 +167,12 @@ export default class TooltipManager {
       return;
     }
 
+    if (tooltip === this.clickedTooltip) {
+      return;
+    }
+
+    this.clickedTooltip = null;
+
     this.closeTooltipIfNotActive(tooltip);
 
     if (!tooltip) {


### PR DESCRIPTION
**Related Issue:** #10715

## Summary

- fixes closeOnClick for the Safari browser