### PR TITLE
refactor(popover): remove unnecessary CSS

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -47,14 +47,6 @@
   }
 }
 
-:host {
-  @apply pointer-events-none;
-}
-
-:host([open]) {
-  pointer-events: initial;
-}
-
 .position-container .calcite-floating-ui-anim {
   @apply border
     border-solid;


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

- No longer necessary since the internal element is hidden when closed now