### PR TITLE
feat(block)!: add required label property and mark heading as optional

### DIFF
--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -405,6 +405,20 @@ describe("calcite-block", () => {
     expect(contentPadding).toEqual(overrideStyle);
   });
 
+  it("should set aria-label", async () => {
+    const label = "Spatial";
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-block label=${label} open>
+        <calcite-notice open>
+          <div slot="message">Use layer effects sparingly, for emphasis</div>
+        </calcite-notice>
+      </calcite-block>`,
+    );
+    const article = await page.find(`calcite-block >>> article`);
+    expect(article.getAttribute("aria-label")).toEqual(label);
+  });
+
   describe("translation support", () => {
     t9n("calcite-block");
   });

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -90,7 +90,6 @@ export class Block
   /**
    * The component header text.
    *
-   * @required
    */
   @property() heading: string;
 
@@ -108,6 +107,13 @@ export class Block
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
+
+  /**
+   * Specifies an accessible name for the component.
+   *
+   * @required
+   */
+  @property() label: string;
 
   /** Specifies the component's fallback menu `placement` when it's initial or specified `placement` has insufficient space available. */
   @property() menuFlipPlacements: FlipPlacement[];
@@ -353,6 +359,7 @@ export class Block
       collapsible,
       loading,
       open,
+      label,
       heading,
       messages,
       description,
@@ -378,7 +385,7 @@ export class Block
 
     const headerNode = (
       <div class={CSS.headerContainer}>
-        {this.dragHandle ? <calcite-handle label={heading} /> : null}
+        {this.dragHandle ? <calcite-handle label={heading || label} /> : null}
         {collapsible ? (
           <button
             aria-controls={IDS.content}
@@ -422,6 +429,7 @@ export class Block
     return (
       <InteractiveContainer disabled={this.disabled}>
         <article
+          aria-label={label}
           ariaBusy={loading}
           class={{
             [CSS.container]: true,


### PR DESCRIPTION
**Related Issue:** #8697 

## Summary

- Adds `label` property as required to provide context for AT users.
- `heading` is no longer a required property.


BREAKING CHANGE: The component's `label` property is a required property and `heading` is an optional property.