### PR TITLE
fix(font): calcite-font-bold to be semi-bold

### DIFF
--- a/packages/calcite-design-tokens/src/semantic/font.json
+++ b/packages/calcite-design-tokens/src/semantic/font.json
@@ -191,7 +191,7 @@
           }
         },
         "bold": {
-          "value": "{core.font.weight.bold}",
+          "value": "{core.font.weight.demi}",
           "type": "fontWeights",
           "attributes": {
             "calcite-schema": {


### PR DESCRIPTION
**Related Issue:** #9524

## Summary

Reassign font > font-weight > bold in semantic tokens to {core.font.weight.demi} to align with Calcite UIKit