### PR TITLE
deprecate(letter-spacing, paragraph-spacing, text-decoration, text-case): align with UIKit

### DIFF
--- a/packages/calcite-design-tokens/src/core/font.json
+++ b/packages/calcite-design-tokens/src/core/font.json
@@ -556,6 +556,7 @@
         "none": {
           "value": "none",
           "type": "textDecoration",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -580,6 +581,7 @@
         "underline": {
           "value": "underline",
           "type": "textDecoration",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -606,6 +608,7 @@
         "none": {
           "value": "none",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -630,6 +633,7 @@
         "uppercase": {
           "value": "uppercase",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -654,6 +658,7 @@
         "lowercase": {
           "value": "lowercase",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -678,6 +683,7 @@
         "capitalize": {
           "value": "capitalize",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",

--- a/packages/calcite-design-tokens/src/semantic/font.json
+++ b/packages/calcite-design-tokens/src/semantic/font.json
@@ -668,6 +668,7 @@
         "tight": {
           "value": "{core.size.default.none} - .4 ",
           "type": "letterSpacing",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -692,6 +693,7 @@
         "normal": {
           "value": "{core.size.default.none}",
           "type": "letterSpacing",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -716,6 +718,7 @@
         "wide": {
           "value": "{core.size.default.none} + .4 ",
           "type": "letterSpacing",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -742,6 +745,7 @@
         "normal": {
           "value": "{core.size.default.4}",
           "type": "paragraphSpacing",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -768,6 +772,7 @@
         "none": {
           "value": "{core.font.text-decoration.none}",
           "type": "textDecoration",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -792,6 +797,7 @@
         "underline": {
           "value": "{core.font.text-decoration.underline}",
           "type": "textDecoration",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -818,6 +824,7 @@
         "none": {
           "value": "{core.font.text-case.none}",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -842,6 +849,7 @@
         "uppercase": {
           "value": "{core.font.text-case.uppercase}",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -866,6 +874,7 @@
         "lowercase": {
           "value": "{core.font.text-case.lowercase}",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",
@@ -890,6 +899,7 @@
         "capitalize": {
           "value": "{core.font.text-case.capitalize}",
           "type": "textCase",
+          "description": "Deprecated",
           "attributes": {
             "calcite-schema": {
               "system": "calcite",


### PR DESCRIPTION
**Related Issue:** #9524

## Summary

letter-spacing, paragraph-spacing, text-decoration, and text-case tokens are deprecated to align tokens with the Calcite UIKit
