### PR TITLE
fix: bundle-in non-ESM dependencies

### DIFF
--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -9,12 +9,18 @@ import replace from "@rollup/plugin-replace";
 import { version } from "./package.json";
 import tailwindConfig from "./tailwind.config";
 
+const nonEsmDependencies = ["color", "interactjs"];
+
 export default defineConfig({
   plugins: [
     useLumina({
       build: {
         cdn: {
           namespace: "calcite",
+        },
+        dependencies: {
+          // Workaround for https://github.com/Esri/calcite-design-system/issues/10761
+          externalize: nonEsmDependencies,
         },
         ssr: {
           stencilCompatibility: {

--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
         },
         dependencies: {
           // Workaround for https://github.com/Esri/calcite-design-system/issues/10761
-          externalize: nonEsmDependencies,
+          bundleIn: nonEsmDependencies,
         },
         ssr: {
           stencilCompatibility: {


### PR DESCRIPTION
**Related Issue:** #10761

## Summary

Fixes build issues caused by non-ESM dependencies being externalized by default.

cc @dasa @maxpatiiuk 
