### PR TITLE
fix(combobox, list)!: stop filtering on value by default

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -190,6 +190,107 @@ describe("calcite-combobox", () => {
   });
 
   describe("filtering", () => {
+    it("filters by visible, rendered props", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-combobox>
+          <calcite-combobox-item
+            text-label="text-label-1"
+            description="description-1"
+            value="value-1"
+            short-heading="short-heading-1"
+          ></calcite-combobox-item>
+          <calcite-combobox-item
+            text-label="text-label-2"
+            description="description-2"
+            value="value-2"
+            short-heading="short-heading-2"
+          ></calcite-combobox-item>
+          <calcite-combobox-item
+            text-label="text-label-3"
+            description="description-3"
+            value="value-3"
+            short-heading="short-heading-3"
+          ></calcite-combobox-item>
+          <calcite-combobox-item
+            text-label="text-label-4"
+            description="description-4"
+            value="value-4"
+            short-heading="short-heading-4"
+          ></calcite-combobox-item>
+        </calcite-combobox>
+      `);
+
+      const combobox = await page.find("calcite-combobox");
+      const filterEventSpy = await combobox.spyOnEvent("calciteComboboxFilterChange");
+
+      await clearAndType(combobox, "text-label-1");
+
+      let items = await page.findAll("calcite-combobox-item");
+      expect(await items[0].isVisible()).toBe(true);
+      expect(await items[1].isVisible()).toBe(false);
+      expect(await items[2].isVisible()).toBe(false);
+      expect(await items[3].isVisible()).toBe(false);
+      expect(await combobox.getProperty("filterText")).toBe("text-label-1");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(1);
+      expect(filterEventSpy).toHaveReceivedEventTimes(1);
+
+      await clearAndType(combobox, "description-2");
+
+      items = await page.findAll("calcite-combobox-item");
+      expect(await items[0].isVisible()).toBe(false);
+      expect(await items[1].isVisible()).toBe(true);
+      expect(await items[2].isVisible()).toBe(false);
+      expect(await items[3].isVisible()).toBe(false);
+      expect(await combobox.getProperty("filterText")).toBe("description-2");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(1);
+      expect(filterEventSpy).toHaveReceivedEventTimes(2);
+
+      await clearAndType(combobox, "short-heading-3");
+
+      items = await page.findAll("calcite-combobox-item");
+      expect(await items[0].isVisible()).toBe(false);
+      expect(await items[1].isVisible()).toBe(false);
+      expect(await items[2].isVisible()).toBe(true);
+      expect(await items[3].isVisible()).toBe(false);
+      expect(await combobox.getProperty("filterText")).toBe("short-heading-3");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(1);
+      expect(filterEventSpy).toHaveReceivedEventTimes(3);
+
+      await clearAndType(combobox, "value-4");
+
+      items = await page.findAll("calcite-combobox-item");
+      expect(await items[0].isVisible()).toBe(false);
+      expect(await items[1].isVisible()).toBe(false);
+      expect(await items[2].isVisible()).toBe(false);
+      expect(await items[3].isVisible()).toBe(false);
+      expect(await combobox.getProperty("filterText")).toBe("value-4");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(0);
+      expect(filterEventSpy).toHaveReceivedEventTimes(4);
+
+      await clearAndType(combobox, "-"); // common in all values
+
+      items = await page.findAll("calcite-combobox-item");
+      expect(await items[0].isVisible()).toBe(true);
+      expect(await items[1].isVisible()).toBe(true);
+      expect(await items[2].isVisible()).toBe(true);
+      expect(await items[3].isVisible()).toBe(true);
+      expect(await combobox.getProperty("filterText")).toBe("-");
+      expect((await combobox.getProperty("filteredItems")).length).toBe(4);
+      expect(filterEventSpy).toHaveReceivedEventTimes(5);
+
+      async function clearAndType(combobox: E2EElement, text: string): Promise<void> {
+        await combobox.callMethod("setFocus");
+        await combobox.press("Escape"); // closes list
+        await combobox.press("Escape"); // clears input
+
+        const filterEvent = combobox.waitForEvent("calciteComboboxFilterChange");
+        await combobox.type(text);
+        await filterEvent;
+        await page.waitForChanges();
+      }
+    });
+
     it("should toggle the combobox when typing within the input", async () => {
       const page = await newE2EPage();
 
@@ -275,67 +376,6 @@ describe("calcite-combobox", () => {
       expect(await items[1].isVisible()).toBe(false);
       expect(await items[2].isVisible()).toBe(false);
       expect(await items[3].isVisible()).toBe(false);
-    });
-
-    it("should filter the items in listbox when typing into the input", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-combobox>
-          <calcite-combobox-item value="Raising Arizona" text-label="Raising Arizona"></calcite-combobox-item>
-          <calcite-combobox-item value="Miller's Crossing" text-label="Miller's Crossing"></calcite-combobox-item>
-          <calcite-combobox-item value="The Hudsucker Proxy" text-label="The Hudsucker Proxy"></calcite-combobox-item>
-          <calcite-combobox-item value="Inside Llewyn Davis" text-label="Inside Llewyn Davis"></calcite-combobox-item>
-        </calcite-combobox>
-      `);
-
-      const combobox = await page.find("calcite-combobox");
-      const items = await page.findAll("calcite-combobox-item");
-
-      const openEvent = await combobox.spyOnEvent("calciteComboboxOpen");
-      const filterEventSpy = await combobox.spyOnEvent("calciteComboboxFilterChange");
-
-      await combobox.click();
-      await page.waitForChanges();
-      expect(openEvent).toHaveReceivedEventTimes(1);
-
-      await combobox.press("s");
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
-      expect(filterEventSpy).toHaveReceivedEventTimes(1);
-
-      expect(await items[0].isVisible()).toBe(true);
-      expect(await items[1].isVisible()).toBe(true);
-      expect(await items[2].isVisible()).toBe(true);
-      expect(await items[3].isVisible()).toBe(true);
-
-      expect(await combobox.getProperty("filterText")).toBe("s");
-      expect((await combobox.getProperty("filteredItems")).length).toBe(4);
-
-      await combobox.press("i");
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
-      expect(filterEventSpy).toHaveReceivedEventTimes(2);
-
-      expect(await items[0].isVisible()).toBe(true);
-      expect(await items[1].isVisible()).toBe(true);
-      expect(await items[2].isVisible()).toBe(false);
-      expect(await items[3].isVisible()).toBe(true);
-
-      expect(await combobox.getProperty("filterText")).toBe("si");
-      expect((await combobox.getProperty("filteredItems")).length).toBe(3);
-
-      await combobox.press("n");
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
-      expect(filterEventSpy).toHaveReceivedEventTimes(3);
-
-      expect(await items[0].isVisible()).toBe(true);
-      expect(await items[1].isVisible()).toBe(true);
-      expect(await items[2].isVisible()).toBe(false);
-      expect(await items[3].isVisible()).toBe(false);
-
-      expect(await combobox.getProperty("filterText")).toBe("sin");
-      expect((await combobox.getProperty("filteredItems")).length).toBe(2);
     });
 
     it("does not clear filter if pointer down/up on an item has a delay in between events", async () => {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -81,9 +81,6 @@ declare global {
   }
 }
 
-const isGroup = (el: ComboboxChildElement): el is HTMLCalciteComboboxItemGroupElement["el"] =>
-  el.tagName === ComboboxItemGroup;
-
 const itemUidPrefix = "combobox-item-";
 const chipUidPrefix = "combobox-chip-";
 const labelUidPrefix = "combobox-label-";
@@ -125,13 +122,15 @@ export class Combobox
 
   private filterItems = (() => {
     const find = (item: ComboboxChildElement, filteredData: ItemData[]) =>
-      item &&
-      filteredData.some(({ label, value }) =>
-        isGroup(item) ? label === item.label : value === item.value && label === item.textLabel,
-      );
+      item && filteredData.some(({ el }) => item === el);
 
     return debounce((text: string, setOpenToEmptyState = false, emit = true): void => {
-      const filteredData = filter([...this.data, ...this.groupData], text);
+      const filteredData = filter([...this.data, ...this.groupData], text, [
+        "description",
+        "label",
+        "metadata",
+        "shortHeading",
+      ]);
       const itemsAndGroups = this.getItemsAndGroups();
 
       const matchAll = text === "";
@@ -1264,16 +1263,17 @@ export class Combobox
     return this.items.map((item) => ({
       description: item.description,
       filterDisabled: item.filterDisabled,
-      label: item.textLabel,
+      label: item.heading || item.textLabel,
       metadata: item.metadata,
       shortHeading: item.shortHeading,
-      value: item.value,
+      el: item, // used for matching items to data
     }));
   }
 
   private getGroupData(): GroupData[] {
-    return this.groupItems.map((groupItem: HTMLCalciteComboboxItemGroupElement["el"]) => ({
+    return this.groupItems.map((groupItem) => ({
       label: groupItem.label,
+      el: groupItem,
     }));
   }
 

--- a/packages/calcite-components/src/components/combobox/interfaces.ts
+++ b/packages/calcite-components/src/components/combobox/interfaces.ts
@@ -4,14 +4,15 @@ import type { ComboboxItem } from "../combobox-item/combobox-item";
 export type ComboboxChildElement = ComboboxItem["el"] | ComboboxItemGroup["el"];
 export type SelectionDisplay = "all" | "fit" | "single";
 
-export interface ItemData {
+export interface ItemData extends BaseData {
   description: string;
-  label: string;
   metadata: Record<string, unknown>;
   shortHeading: string;
-  value: string;
+  el: ComboboxItem["el"] | ComboboxItemGroup["el"];
 }
 
-export interface GroupData {
+export interface GroupData extends BaseData {}
+
+interface BaseData {
   label: string;
 }

--- a/packages/calcite-components/src/components/list-item/interfaces.d.ts
+++ b/packages/calcite-components/src/components/list-item/interfaces.d.ts
@@ -1,6 +1,8 @@
+import { ListItem } from "./list-item";
+
 export type ItemData = {
   label: string;
   description: string;
   metadata: Record<string, unknown>;
-  value: string;
+  el: ListItem["el"];
 }[];

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -513,7 +513,7 @@ describe("calcite-list", () => {
           value="value-1"
         ></calcite-list-item>
         <calcite-list-item
-          id="value-match"
+          id="value-not-matched-by-default"
           label="label-3"
           description="description-3"
           value="match"
@@ -531,12 +531,12 @@ describe("calcite-list", () => {
     const list = await page.find("calcite-list");
     await page.waitForTimeout(DEBOUNCE.filter);
 
-    expect(await list.getProperty("filteredItems")).toHaveLength(3);
-    expect(await list.getProperty("filteredData")).toHaveLength(3);
+    expect(await list.getProperty("filteredItems")).toHaveLength(2);
+    expect(await list.getProperty("filteredData")).toHaveLength(2);
 
     const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
 
-    expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match", "value-match"]);
+    expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match"]);
   });
 
   it("filters initially with filterProps", async () => {
@@ -556,7 +556,7 @@ describe("calcite-list", () => {
           value="value-1"
         ></calcite-list-item>
         <calcite-list-item
-          id="value-match"
+          id="value-not-matched-by-default"
           label="label-3"
           description="description-3"
           value="match"

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -689,15 +689,11 @@ export class List
   private updateFilteredItems(): void {
     const { visibleItems, filteredData, filterText } = this;
 
-    const values = filteredData.map((item) => item.value);
-
     const lastDescendantItems = visibleItems?.filter((listItem) =>
       visibleItems.every((li) => li === listItem || !listItem.contains(li)),
     );
 
-    const filteredItems =
-      visibleItems.filter((item) => !filterText || values.includes(item.value)) || [];
-
+    const filteredItems = !filterText ? visibleItems || [] : filteredData.map((item) => item.el);
     const visibleParents = new WeakSet<HTMLElement>();
 
     lastDescendantItems.forEach((listItem) =>
@@ -731,15 +727,23 @@ export class List
     this.updateFilteredData();
   }
 
+  private get effectiveFilterProps(): string[] {
+    if (!this.filterProps) {
+      return ["description", "label", "metadata"];
+    }
+
+    return this.filterProps.filter((prop) => prop !== "el");
+  }
+
   private performFilter(): void {
-    const { filterEl, filterText, filterProps } = this;
+    const { filterEl, filterText, effectiveFilterProps } = this;
 
     if (!filterEl) {
       return;
     }
 
     filterEl.value = filterText;
-    filterEl.filterProps = filterProps;
+    filterEl.filterProps = effectiveFilterProps;
     this.filterAndUpdateData();
   }
 
@@ -761,7 +765,7 @@ export class List
       label: item.label,
       description: item.description,
       metadata: item.metadata,
-      value: item.value,
+      el: item,
     }));
   }
 
@@ -964,7 +968,7 @@ export class List
       hasFilterActionsStart,
       hasFilterActionsEnd,
       hasFilterNoResults,
-      filterProps,
+      effectiveFilterProps,
     } = this;
     return (
       <InteractiveContainer disabled={this.disabled}>
@@ -996,7 +1000,7 @@ export class List
                       <calcite-filter
                         ariaLabel={filterPlaceholder}
                         disabled={disabled}
-                        filterProps={filterProps}
+                        filterProps={effectiveFilterProps}
                         items={dataForFilter}
                         oncalciteFilterChange={this.handleFilterChange}
                         placeholder={filterPlaceholder}


### PR DESCRIPTION
**Related Issue:** #9615 

## Summary

Updates components to only filter known-visibly-rendered properties. 

BREAKING CHANGE: Filtering will no longer include item values by default. If value-filtering is desired, developers will need to configure items' `metadata` property.