### PR TITLE
refactor(action-group)!: remove deprecated layout property

### DIFF
--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -57,7 +57,7 @@ export class ActionGroup extends LitElement implements LoadableComponent {
   /**
    * Indicates the layout of the component.
    *
-   * @deprecated Use the `layout` property on the component's parent instead.
+   * `@internal`
    */
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
     "vertical";

--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -57,7 +57,7 @@ export class ActionGroup extends LitElement implements LoadableComponent {
   /**
    * Indicates the layout of the component.
    *
-   * `@internal`
+   * @internal
    */
   @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
     "vertical";


### PR DESCRIPTION
**Related Issue:** #9173

## Summary

BREAKING CHANGE: Removes the deprecated `layout` property by converting it to an internal property.

Developers will need to replace `calcite-action-group`'s `layout` property with it's parent's `layout` property (i.e., parent `action-pad` or `action-bar`).