### PR TITLE
refactor(combobox, dropdown, input-date-picker, input-time-picker, split-button)!: avoid modifying `open` based on `disabled` prop

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -642,7 +642,6 @@ export class Combobox
     onToggleOpenCloseComponent(this);
 
     if (this.disabled) {
-      this.open = false;
       return;
     }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -297,7 +297,6 @@ export class Dropdown
     onToggleOpenCloseComponent(this);
 
     if (this.disabled) {
-      this.open = false;
       return;
     }
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -591,7 +591,6 @@ export class InputDatePicker
     onToggleOpenCloseComponent(this);
 
     if (this.disabled || this.readOnly) {
-      this.open = false;
       return;
     }
 

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -432,7 +432,6 @@ export class InputTimePicker
 
   private openHandler(): void {
     if (this.disabled || this.readOnly) {
-      this.open = false;
       return;
     }
 

--- a/packages/calcite-components/src/components/split-button/split-button.tsx
+++ b/packages/calcite-components/src/components/split-button/split-button.tsx
@@ -1,4 +1,3 @@
-import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { FlipPlacement, MenuPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import {
@@ -147,24 +146,6 @@ export class SplitButton extends LitElement implements InteractiveComponent, Loa
 
   load(): void {
     setUpLoadableComponent(this);
-  }
-
-  override willUpdate(changes: PropertyValues<this>): void {
-    /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
-    To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
-    Please refactor your code to reduce the need for this check.
-    Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
-    if (changes.has("disabled") && (this.hasUpdated || this.disabled !== false)) {
-      if (!this.disabled) {
-        this.active = false;
-      }
-    }
-
-    if (changes.has("active") && (this.hasUpdated || this.active !== false)) {
-      if (this.disabled) {
-        this.active = false;
-      }
-    }
   }
 
   override updated(): void {


### PR DESCRIPTION
**Related Issue:** #7547 

## Summary

Updates components to no longer close a component when disabled.

BREAKING CHANGE: Components will no longer close automatically when disabled. Developers relying on this behavior will also need to update the `open` property as well.
