### PR TITLE
refactor(shell-panel)!: remove deprecated properties

### DIFF
--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -166,13 +166,6 @@ export class ShellPanel extends LitElement {
   @property({ reflect: true }) detached = false;
 
   /**
-   * When `displayMode` is `float-content` or `float`, specifies the maximum height of the component.
-   *
-   * @deprecated Use `heightScale` instead.
-   */
-  @property({ reflect: true }) detachedHeightScale: Scale;
-
-  /**
    * Specifies the display mode of the component, where:
    *
    * `"dock"` displays at full height adjacent to center content,
@@ -237,14 +230,6 @@ export class ShellPanel extends LitElement {
 
     if (changes.has("displayMode") && (this.hasUpdated || this.displayMode !== "dock")) {
       this.detached = this.displayMode === "float-content" || this.displayMode === "float";
-    }
-
-    if (changes.has("detachedHeightScale")) {
-      this.heightScale = this.detachedHeightScale;
-    }
-
-    if (changes.has("heightScale")) {
-      this.detachedHeightScale = this.heightScale;
     }
 
     if (changes.has("layout") && (this.hasUpdated || this.layout !== "vertical")) {


### PR DESCRIPTION
**Related Issue:** #9173

## Summary

BREAKING CHANGE: Removes the following deprecated properties from `calcite-shell-panel`: `detachedHeightScale`, `detached` and the `--calcite-shell-panel-detached-max-height` CSS property.