### PR TITLE
refactor(table)!: remove deprecated zebra property

### DIFF
--- a/packages/calcite-components/src/components/table/table.stories.ts
+++ b/packages/calcite-components/src/components/table/table.stories.ts
@@ -193,34 +193,6 @@ export const borderedStriped_TestOnly = (): string =>
     </calcite-table-row>
   </calcite-table>`;
 
-export const deprecatedZebraStriped_TestOnly = (): string =>
-  html`<calcite-table bordered zebra caption="Bordered striped table">
-    <calcite-table-row slot="table-header">
-      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-      <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-    </calcite-table-row>
-    <calcite-table-row>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-    </calcite-table-row>
-    <calcite-table-row>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-    </calcite-table-row>
-    <calcite-table-row>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-      <calcite-table-cell>cell</calcite-table-cell>
-    </calcite-table-row>
-  </calcite-table>`;
-
 export const alignments_TestOnly = (): string =>
   html`<calcite-table numbered>
     <calcite-table-row slot="table-header" caption="Various alignments table">

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -151,13 +151,6 @@ export class Table extends LitElement implements LoadableComponent {
   /** When `true`, displays striped styling in the component. */
   @property({ reflect: true }) striped = false;
 
-  /**
-   * When `true`, displays striped styling in the component.
-   *
-   * @deprecated Use the `striped` property instead.
-   */
-  @property({ reflect: true }) zebra = false;
-
   // #endregion
 
   // #region Events
@@ -487,7 +480,7 @@ export class Table extends LitElement implements LoadableComponent {
         <div
           class={{
             [CSS.bordered]: this.bordered,
-            [CSS.striped]: this.striped || this.zebra,
+            [CSS.striped]: this.striped,
             [CSS.tableContainer]: true,
           }}
         >


### PR DESCRIPTION
**Related Issue:** #9713

## Summary

BREAKING CHANGE: Removes the deprecated property `zebra` from `calcite-table`.

Developers will need to replace `calcite-table`'s "zebra" property with "striped".