### PR TITLE
refactor(checkbox)!: remove deprecated guid property

### DIFF
--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -84,7 +84,7 @@ export class Checkbox
   /**
    * The `id` attribute of the component. When omitted, a globally unique identifier is used.
    *
-   * @deprecated No longer necessary.
+   * @internal
    */
   @property({ reflect: true }) guid: string;
 

--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -8,7 +8,6 @@ import {
   HiddenFormInputSlot,
   MutableValidityState,
 } from "../../utils/form";
-import { guid } from "../../utils/guid";
 import {
   InteractiveComponent,
   InteractiveContainer,
@@ -80,13 +79,6 @@ export class Checkbox
    * When not set, the component will be associated with its ancestor form element, if any.
    */
   @property({ reflect: true }) form: string;
-
-  /**
-   * The `id` attribute of the component. When omitted, a globally unique identifier is used.
-   *
-   * @internal
-   */
-  @property({ reflect: true }) guid: string;
 
   /**
    * The hovered state of the checkbox.
@@ -190,7 +182,6 @@ export class Checkbox
   }
 
   override connectedCallback(): void {
-    this.guid = this.el.id || `calcite-checkbox-${guid()}`;
     connectLabel(this);
     connectForm(this);
   }


### PR DESCRIPTION
**Related Issue:** #9713

## Summary

This property is no longer needed since the `connectForm` utility takes the place of the previous implementation that required rendering a native `input` element that needed a unique id set with the `guid` utility to enable native form submission.

BREAKING CHANGE: Removes the deprecated `guid` property from `calcite-checkbox`.

Migration plan: Developers may need to replace `calcite-checkbox`'s "guid" property with a unique "id" property.