### PR TITLE
fix(t9n): make TypeScript inline .json type imports

### DIFF
--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -23,9 +23,9 @@ import {
 } from "../../utils/loadable";
 import { NumberingSystem } from "../../utils/locale";
 import { OPACITY_LIMITS } from "../color-picker/resources";
-import T9nStrings from "../color-picker/assets/t9n/color-picker.t9n.en.json";
 import type { InputNumber } from "../input-number/input-number";
 import type { InputText } from "../input-text/input-text";
+import type { ColorPicker } from "../color-picker/color-picker";
 import { CSS } from "./resources";
 import { styles } from "./color-picker-hex-input.scss";
 
@@ -85,7 +85,7 @@ export class ColorPickerHexInput extends LitElement implements LoadableComponent
    *
    * @private
    */
-  @property() messages: typeof T9nStrings;
+  @property() messages: ColorPicker["messages"]["_overrides"];
 
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property() numberingSystem?: NumberingSystem;

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -20,7 +20,6 @@ import {
 import { closestElementCrossShadowBoundary, getTextWidth } from "../../utils/dom";
 import { isActivationKey } from "../../utils/key";
 import { numberStringFormatter } from "../../utils/locale";
-import T9nStrings from "../date-picker/assets/t9n/date-picker.t9n.en.json";
 import { DateLocaleData } from "../date-picker/utils";
 import { HeadingLevel } from "../functional/Heading";
 import { Position, Scale } from "../interfaces";
@@ -89,7 +88,7 @@ export class DatePickerMonthHeader extends LitElement {
    * @private
    * @readonly
    */
-  @property() messages: typeof T9nStrings;
+  @property() messages: DatePicker["messages"]["_overrides"];
 
   /** Specifies the earliest allowed date (`"yyyy-mm-dd"`). */
   @property() min: Date;

--- a/packages/calcite-components/src/components/date-picker-month/date-picker-month.tsx
+++ b/packages/calcite-components/src/components/date-picker-month/date-picker-month.tsx
@@ -11,10 +11,10 @@ import {
 } from "../../utils/date";
 import { DateLocaleData } from "../date-picker/utils";
 import { Scale } from "../interfaces";
-import T9nStrings from "../date-picker/assets/t9n/date-picker.t9n.en.json";
 import { HeadingLevel } from "../functional/Heading";
 import type { DatePickerMonthHeader } from "../date-picker-month-header/date-picker-month-header";
 import type { DatePickerDay } from "../date-picker-day/date-picker-day";
+import type { DatePicker } from "../date-picker/date-picker";
 import { CSS } from "./resources";
 import { styles } from "./date-picker-month.scss";
 
@@ -99,7 +99,7 @@ export class DatePickerMonth extends LitElement {
    *
    * @private
    */
-  @property() messages: typeof T9nStrings;
+  @property() messages: DatePicker["messages"]["_overrides"];
 
   /** Specifies the earliest allowed date (`"yyyy-mm-dd"`). */
   @property() min: Date;

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -61,7 +61,6 @@ import {
   numberStringFormatter,
 } from "../../utils/locale";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
-import DatePickerMessages from "../date-picker/assets/t9n/date-picker.t9n.en.json";
 import { DateLocaleData, getLocaleData, getValueAsDateRange } from "../date-picker/utils";
 import { HeadingLevel } from "../functional/Heading";
 import {
@@ -84,7 +83,7 @@ import type { Label } from "../label/label";
 import type { Input } from "../input/input";
 import { styles } from "./input-date-picker.scss";
 import { CSS, IDS } from "./resources";
-import T9nStrings from "./assets/t9n/input-date-picker.t9n.en.json";
+import type T9nStrings from "./assets/t9n/input-date-picker.t9n.en.json";
 import { isTwoDigitYear, normalizeToCurrentCentury } from "./utils";
 
 declare global {
@@ -209,8 +208,7 @@ export class InputDatePicker
   @property() maxAsDate: Date;
 
   /** Use this property to override individual strings used by the component. */
-  @property() messageOverrides?: typeof this.messages._overrides &
-    Partial<typeof DatePickerMessages>;
+  @property() messageOverrides?: typeof this.messages._overrides & DatePicker["messageOverrides"];
 
   /**
    * Made into a prop for testing purposes only

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -83,7 +83,7 @@ import type { Label } from "../label/label";
 import type { Input } from "../input/input";
 import { styles } from "./input-date-picker.scss";
 import { CSS, IDS } from "./resources";
-import type T9nStrings from "./assets/t9n/input-date-picker.t9n.en.json";
+import T9nStrings from "./assets/t9n/input-date-picker.t9n.en.json";
 import { isTwoDigitYear, normalizeToCurrentCentury } from "./utils";
 
 declare global {

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -52,7 +52,6 @@ import {
   toISOTimeString,
 } from "../../utils/time";
 import { Scale, Status } from "../interfaces";
-import TimePickerMessages from "../time-picker/assets/t9n/time-picker.t9n.en.json";
 import { decimalPlaces } from "../../utils/math";
 import { getIconScale } from "../../utils/component";
 import { Validation } from "../functional/Validation";
@@ -203,8 +202,7 @@ export class InputTimePicker
   @property({ reflect: true }) max: string;
 
   /** Use this property to override individual strings used by the component. */
-  @property() messageOverrides?: typeof this.messages._overrides &
-    Partial<typeof TimePickerMessages>;
+  @property() messageOverrides?: typeof this.messages._overrides & TimePicker["messageOverrides"];
 
   /**
    * Made into a prop for testing purposes only

--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -1,6 +1,6 @@
 import { getDateTimeFormat, SupportedLocale } from "../../utils/locale";
+import type { InputTimeZone } from "./input-time-zone";
 import { OffsetStyle, TimeZone, TimeZoneItem, TimeZoneItemGroup, TimeZoneMode } from "./interfaces";
-import T9nStrings from "./assets/t9n/input-time-zone.t9n.en.json";
 
 const hourToMinutes = 60;
 
@@ -51,7 +51,7 @@ export async function getNormalizer(mode: TimeZoneMode): Promise<(timeZone: Time
 
 export async function createTimeZoneItems(
   locale: SupportedLocale,
-  messages: typeof T9nStrings,
+  messages: InputTimeZone["messages"],
   mode: TimeZoneMode,
   referenceDate: Date,
   standardTime: OffsetStyle,
@@ -203,16 +203,20 @@ export async function createTimeZoneItems(
     .sort((groupA, groupB) => groupA.value - groupB.value);
 }
 
-function getTimeZoneLabel(timeZone: string, messages: typeof T9nStrings): string {
+function getTimeZoneLabel(timeZone: string, messages: InputTimeZone["messages"]): string {
   return messages[timeZone] || getCity(timeZone);
 }
 
-export function getSelectedRegionTimeZoneLabel(city: string, country: string, messages: typeof T9nStrings): string {
+export function getSelectedRegionTimeZoneLabel(
+  city: string,
+  country: string,
+  messages: InputTimeZone["messages"],
+): string {
   const template = messages.timeZoneRegionLabel;
   return template.replace("{city}", city).replace("{country}", getMessageOrKeyFallback(messages, country));
 }
 
-export function getMessageOrKeyFallback(messages: typeof T9nStrings, key: string): string {
+export function getMessageOrKeyFallback(messages: InputTimeZone["messages"], key: string): string {
   return messages[key] || key;
 }
 
@@ -234,7 +238,11 @@ export function toUserFriendlyName(timeZoneName: string): string {
   return timeZoneName.replace(/_/g, " ");
 }
 
-function createTimeZoneOffsetLabel(messages: typeof T9nStrings, offsetLabel: string, groupLabel: string): string {
+function createTimeZoneOffsetLabel(
+  messages: InputTimeZone["messages"],
+  offsetLabel: string,
+  groupLabel: string,
+): string {
   return messages.timeZoneLabel.replace("{offset}", offsetLabel).replace("{cities}", groupLabel);
 }
 


### PR DESCRIPTION
**Related Issue:** #10803

## Summary

Subtly change the JSON type imports to encourage TypeScript to inline these in the final .d.ts files, rather than preserve them as `.json` imports.

Opened an issue 2047 in AWC to add a build-time error if any .json import appears in the public .d.ts file. We can extend that as needed