### PR TITLE
fix(segmented-control): ensure change event emits after item update

### DIFF
--- a/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
@@ -190,7 +190,7 @@ describe("calcite-segmented-control", () => {
     await page.evaluate(() => {
       (window as TestWindow).eventTimeValues = [];
       document.body.addEventListener("calciteSegmentedControlChange", (event: CustomEvent) => {
-        window.eventTimeValues.push(event.target.value);
+        (window as TestWindow).eventTimeValues.push((event.target as SegmentedControl["el"]).value);
       });
     });
 

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -341,13 +341,13 @@ export class SegmentedControl
     }
   }
 
-  private handleDefaultSlotChange(event: Event): void {
+  private async handleDefaultSlotChange(event: Event): Promise<void> {
     const items = slotChangeGetAssignedElements(event).filter(
       (el): el is SegmentedControlItem["el"] => el.matches("calcite-segmented-control-item"),
     );
 
+    // await Promise.all(items.map((item) => item.componentOnReady()));
     this.items = items;
-
     this.handleSelectedItem();
     this.handleItemPropChange();
   }
@@ -356,7 +356,7 @@ export class SegmentedControl
     this.setFocus();
   }
 
-  private selectItem(selected: SegmentedControlItem["el"], emit = false): void {
+  private async selectItem(selected: SegmentedControlItem["el"], emit = false): Promise<void> {
     if (selected === this.selectedItem) {
       return;
     }
@@ -375,14 +375,16 @@ export class SegmentedControl
 
       if (matches) {
         match = item;
-
-        if (emit) {
-          this.calciteSegmentedControlChange.emit();
-        }
       }
     });
 
     this.selectedItem = match;
+
+    if (match && emit) {
+      await this.updateComplete;
+      this.calciteSegmentedControlChange.emit();
+    }
+
     if (isBrowser() && match) {
       match.focus();
     }

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -346,7 +346,7 @@ export class SegmentedControl
       (el): el is SegmentedControlItem["el"] => el.matches("calcite-segmented-control-item"),
     );
 
-    // await Promise.all(items.map((item) => item.componentOnReady()));
+    await Promise.all(items.map((item) => item.componentOnReady()));
     this.items = items;
     this.handleSelectedItem();
     this.handleItemPropChange();


### PR DESCRIPTION
**Related Issue:** #10810

## Summary

Updates `calcite-segmented-control` to wait for the item and parent component to be updated before emitting the change event.