### PR TITLE
fix(checkbox): ensure that border shows in high contrast mode

### DIFF
--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -109,6 +109,13 @@
   }
 }
 
+@media (forced-colors: active) {
+  .check-svg {
+    /* use real border since box-shadow is removed in high contrast mode */
+    border: 1px solid currentColor;
+  }
+}
+
 @include disabled();
 @include hidden-form-input();
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #10537 

## Summary

Applies a border for high contrast mode in Firefox. 