### PR TITLE
fix(block): label property should not be required

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -110,8 +110,6 @@ export class Block
 
   /**
    * Specifies an accessible name for the component.
-   *
-   * @required
    */
   @property() label: string;
 


### PR DESCRIPTION
**Related Issue:** #8697

## Summary

- No longer make label a required property