### PR TITLE
refactor: drop unnecessary prefers-reduced-motion workaround

### DIFF
--- a/packages/calcite-components/src/assets/styles/_animation.scss
+++ b/packages/calcite-components/src/assets/styles/_animation.scss
@@ -107,9 +107,7 @@
 @mixin animation-reduced-motion() {
   @media (prefers-reduced-motion: reduce) {
     :root {
-      // [workaround] using 0.01 to ensure `openCloseComponent` utils work consistently
-      // this should be removed once https://github.com/Esri/calcite-design-system/issues/6604 is addressed
-      --calcite-internal-duration-factor: 0.01;
+      --calcite-internal-duration-factor: 0;
     }
   }
 }

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -15,12 +15,6 @@ $stroke-width: 3;
 $loader-scale: 54;
 $loader-circumference: ($loader-scale - (2 * $stroke-width)) * 3.14159;
 
-@media (prefers-reduced-motion: reduce) {
-  :root {
-    --calcite-internal-duration-factor: 0;
-  }
-}
-
 :host {
   @apply relative mx-auto hidden items-center justify-center opacity-100;
   min-block-size: var(--calcite-loader-size);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes remaining workaround no longer needed after https://github.com/Esri/calcite-design-system/issues/6604.