### PR TITLE
chore: restore stylelint known custom functions

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -1,7 +1,13 @@
 // @ts-check
 
 // ⚠️ AUTO-GENERATED CODE - DO NOT EDIT
-const customFunctions = [];
+const customFunctions = [
+  "get-trailing-text-input-padding",
+  "medium-modular-scale",
+  "modular-scale",
+  "scale-duration",
+  "small-modular-scale"
+];
 // ⚠️ END OF AUTO-GENERATED CODE
 
 const scssPatternRules = [


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restores [`customFunctions`](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/.stylelintrc.cjs#L4) to prevent [`function-no-unknown`](https://github.com/stylelint-scss/stylelint-scss/tree/master/src/rules/function-no-unknown) errors.