### PR TITLE
fix(Popover): Popover reopens when trigger is clicked and autoClose = true

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -86,7 +86,10 @@ export class Popover
     const outsideClick = !path.includes(this.el);
     const shouldCloseOnOutsideClick = this.autoClose && outsideClick;
 
-    return shouldCloseOnOutsideClick && (this.triggerDisabled || isReferenceElementInPath);
+    return (
+      shouldCloseOnOutsideClick &&
+      (this.triggerDisabled || (isReferenceElementInPath && !this.autoClose))
+    );
   };
 
   private closeButtonEl = createRef<Action["el"]>();


### PR DESCRIPTION
**Related Issue:** #10841

## Summary
