### PR TITLE
ci(renovate): group dep bump PRs for arcgis and eslint

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -31,7 +31,15 @@
   "ignorePaths": ["packages/calcite-ui-icons/**", "examples/**"],
   "packageRules": [
     {
-      "matchPackagePatterns": ["*"],
+      "groupName": "ArcGIS",
+      "matchPackageNames": ["@arcgis/**"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackageNames": ["/eslint/"]
+    },
+    {
+      "matchPackageNames": ["*"],
       "semanticCommitType": "build",
       "semanticCommitScope": "deps",
       "addLabels": ["chore"]


### PR DESCRIPTION
## Summary

- Group dependency updates in the `@arcgis` scope into a single pull request.
- Group dependency updates that have `eslint` anywhere in the name into a single pull request.
