### PR TITLE
build: externalize non-esm deps in ssr build

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -53,8 +53,6 @@
     "screenshot-tests:publish": "npm run screenshot-tests && storybook-to-ghpages --existing-output-dir=docs",
     "start": "npm run util:clean-js-files && concurrently --kill-others --raw \"tsc --project ./tsconfig-demos.json --watch\" \"npm run build:watch-dev\"",
     "test": "vitest run",
-    "posttest": "npm run test:prerender",
-    "test:prerender": "vite build --ssr",
     "test:watch": "vitest",
     "util:clean-js-files": "rimraf --glob -- *.js {src,.storybook,support}/**.js",
     "util:clean-readmes": "git restore src/components/*/readme.md",

--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -12,6 +12,10 @@ import tailwindConfig from "./tailwind.config";
 const nonEsmDependencies = ["color", "interactjs"];
 
 export default defineConfig({
+  ssr: {
+    noExternal: nonEsmDependencies,
+  },
+
   plugins: [
     useLumina({
       build: {

--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -12,10 +12,6 @@ import tailwindConfig from "./tailwind.config";
 const nonEsmDependencies = ["color", "interactjs"];
 
 export default defineConfig({
-  ssr: {
-    noExternal: nonEsmDependencies,
-  },
-
   plugins: [
     useLumina({
       build: {


### PR DESCRIPTION
## Summary

We need to set Vite's `ssr.noExternal` option to the same non-ESM dependencies we add to Lumina's `bundleIn` option.

This also removes calcite-component's `test:prerender` NPM script, which does a Vite SSR build and is no longer necessary after migrating to Lumina.

ref: <https://vite.dev/guide/ssr#ssr-externals>
