### PR TITLE
feat(list)!: add displayMode property to choose between flat and nested lists

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -352,7 +352,7 @@ describe("calcite-list-item", () => {
 
   it("should fire calciteListItemToggle event when opened and closed", async () => {
     const page = await newE2EPage({
-      html: html`<calcite-list-item
+      html: html`<calcite-list-item mode="nested"
         ><calcite-list><calcite-list-item></calcite-list-item></calcite-list
       ></calcite-list-item>`,
     });

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -58,7 +58,7 @@ describe("calcite-list-item", () => {
         defaultValue: false,
       },
       {
-        propertyName: "mode",
+        propertyName: "displayMode",
         defaultValue: undefined,
       },
     ]);
@@ -352,7 +352,7 @@ describe("calcite-list-item", () => {
 
   it("should fire calciteListItemToggle event when opened and closed", async () => {
     const page = await newE2EPage({
-      html: html`<calcite-list-item mode="nested"
+      html: html`<calcite-list-item display-mode="nested"
         ><calcite-list><calcite-list-item></calcite-list-item></calcite-list
       ></calcite-list-item>`,
     });
@@ -375,7 +375,7 @@ describe("calcite-list-item", () => {
 
   it("should not fire calciteListItemToggle event without nested items", async () => {
     const page = await newE2EPage({
-      html: html`<calcite-list-item mode="nested"></calcite-list-item>`,
+      html: html`<calcite-list-item display-mode="nested"></calcite-list-item>`,
     });
 
     const listItem = await page.find("calcite-list-item");
@@ -398,7 +398,7 @@ describe("calcite-list-item", () => {
 
   it("flat list should not render open container", async () => {
     const page = await newE2EPage({
-      html: html`<calcite-list-item mode="flat"
+      html: html`<calcite-list-item display-mode="flat"
         ><calcite-list><calcite-list-item></calcite-list-item></calcite-list
       ></calcite-list-item>`,
     });

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -57,6 +57,10 @@ describe("calcite-list-item", () => {
         propertyName: "unavailable",
         defaultValue: false,
       },
+      {
+        propertyName: "mode",
+        defaultValue: undefined,
+      },
     ]);
   });
 

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -373,6 +373,41 @@ describe("calcite-list-item", () => {
     expect(calciteListItemToggle).toHaveReceivedEventTimes(2);
   });
 
+  it("should not fire calciteListItemToggle event without nested items", async () => {
+    const page = await newE2EPage({
+      html: html`<calcite-list-item mode="nested"></calcite-list-item>`,
+    });
+
+    const listItem = await page.find("calcite-list-item");
+    const calciteListItemToggle = await page.spyOnEvent("calciteListItemToggle", "window");
+
+    expect(await listItem.getProperty("open")).toBe(false);
+
+    const openButton = await page.find(`calcite-list-item >>> .${CSS.openContainer}`);
+
+    expect(openButton.getAttribute("title")).toBe(null);
+
+    await openButton.click();
+    expect(await listItem.getProperty("open")).toBe(false);
+    expect(calciteListItemToggle).toHaveReceivedEventTimes(0);
+
+    await openButton.click();
+    expect(await listItem.getProperty("open")).toBe(false);
+    expect(calciteListItemToggle).toHaveReceivedEventTimes(0);
+  });
+
+  it("flat list should not render open container", async () => {
+    const page = await newE2EPage({
+      html: html`<calcite-list-item mode="flat"
+        ><calcite-list><calcite-list-item></calcite-list-item></calcite-list
+      ></calcite-list-item>`,
+    });
+
+    const openButton = await page.find(`calcite-list-item >>> .${CSS.openContainer}`);
+
+    expect(openButton).toBe(null);
+  });
+
   describe("themed", () => {
     describe(`selection-appearance="icon"`, () => {
       themed(

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -20,7 +20,7 @@ import { MoveTo } from "../sort-handle/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import type { SortHandle } from "../sort-handle/sort-handle";
 import type { List } from "../list/list";
-import { ListMode } from "../list/interfaces";
+import { ListDisplayMode } from "../list/interfaces";
 import T9nStrings from "./assets/t9n/list-item.t9n.en.json";
 import { getDepth, hasListItemChildren } from "./utils";
 import { CSS, activeCellTestAttribute, ICONS, SLOTS } from "./resources";
@@ -167,7 +167,7 @@ export class ListItem
    *
    * @private
    */
-  @property() mode: ListMode;
+  @property() displayMode: ListDisplayMode;
 
   /**
    * Sets the item to display a border.
@@ -373,7 +373,7 @@ export class ListItem
       this.sortHandleOpenHandler();
     }
 
-    if (changes.has("mode") && this.hasUpdated) {
+    if (changes.has("displayMode") && this.hasUpdated) {
       this.handleOpenableChange(this.defaultSlotEl.value);
     }
   }
@@ -531,7 +531,7 @@ export class ListItem
       return;
     }
 
-    this.openable = this.mode === "nested" && hasListItemChildren(slotEl);
+    this.openable = this.displayMode === "nested" && hasListItemChildren(slotEl);
   }
 
   private handleDefaultSlotChange(event: Event): void {
@@ -751,9 +751,9 @@ export class ListItem
   }
 
   private renderOpen(): JsxNode {
-    const { el, open, openable, messages, mode } = this;
+    const { el, open, openable, messages, displayMode } = this;
 
-    if (mode !== "nested") {
+    if (displayMode !== "nested") {
       return null;
     }
 

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -20,6 +20,7 @@ import { MoveTo } from "../sort-handle/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import type { SortHandle } from "../sort-handle/sort-handle";
 import type { List } from "../list/list";
+import { ListMode } from "../list/interfaces";
 import T9nStrings from "./assets/t9n/list-item.t9n.en.json";
 import { getDepth, hasListItemChildren } from "./utils";
 import { CSS, activeCellTestAttribute, ICONS, SLOTS } from "./resources";
@@ -160,6 +161,13 @@ export class ListItem
 
   /** Provides additional metadata to the component. Primary use is for a filter on the parent `calcite-list`. */
   @property() metadata: Record<string, unknown>;
+
+  /**
+   * Specifies the nesting behavior.
+   *
+   * @private
+   */
+  @property() mode: ListMode;
 
   /**
    * Sets the item to display a border.
@@ -364,6 +372,10 @@ export class ListItem
     if (changes.has("sortHandleOpen") && (this.hasUpdated || this.sortHandleOpen !== false)) {
       this.sortHandleOpenHandler();
     }
+
+    if (changes.has("mode") && this.hasUpdated) {
+      this.handleOpenableChange(this.defaultSlotEl.value);
+    }
   }
 
   override updated(): void {
@@ -519,7 +531,7 @@ export class ListItem
       return;
     }
 
-    this.openable = hasListItemChildren(slotEl);
+    this.openable = this.mode === "nested" && hasListItemChildren(slotEl);
   }
 
   private handleDefaultSlotChange(event: Event): void {
@@ -739,21 +751,36 @@ export class ListItem
   }
 
   private renderOpen(): JsxNode {
-    const { el, open, openable, messages } = this;
-    const dir = getElementDir(el);
-    const icon = open ? ICONS.open : dir === "rtl" ? ICONS.closedRTL : ICONS.closedLTR;
-    const tooltip = open ? messages.collapse : messages.expand;
+    const { el, open, openable, messages, mode } = this;
 
-    return openable ? (
+    if (mode !== "nested") {
+      return null;
+    }
+
+    const dir = getElementDir(el);
+
+    const icon = openable
+      ? open
+        ? ICONS.open
+        : dir === "rtl"
+          ? ICONS.closedRTL
+          : ICONS.closedLTR
+      : ICONS.blank;
+
+    const tooltip = openable ? (open ? messages.collapse : messages.expand) : undefined;
+
+    const openClickHandler = openable ? this.handleToggleClick : undefined;
+
+    return (
       <div
         class={CSS.openContainer}
         key="open-container"
-        onClick={this.handleToggleClick}
+        onClick={openClickHandler}
         title={tooltip}
       >
         <calcite-icon icon={icon} key={icon} scale="s" />
       </div>
-    ) : null;
+    );
   }
 
   private renderActionsStart(): JsxNode {

--- a/packages/calcite-components/src/components/list/interfaces.ts
+++ b/packages/calcite-components/src/components/list/interfaces.ts
@@ -2,7 +2,7 @@ import { DragDetail, MoveDetail } from "../../utils/sortableComponent";
 import type { ListItem } from "../list-item/list-item";
 import type { List } from "./list";
 
-export type ListMode = "flat" | "nested";
+export type ListDisplayMode = "flat" | "nested";
 
 export interface ListDragDetail extends DragDetail {
   toEl: List["el"];

--- a/packages/calcite-components/src/components/list/interfaces.ts
+++ b/packages/calcite-components/src/components/list/interfaces.ts
@@ -2,6 +2,8 @@ import { DragDetail, MoveDetail } from "../../utils/sortableComponent";
 import type { ListItem } from "../list-item/list-item";
 import type { List } from "./list";
 
+export type ListMode = "flat" | "nested";
+
 export interface ListDragDetail extends DragDetail {
   toEl: List["el"];
   fromEl: List["el"];

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -975,7 +975,7 @@ describe("calcite-list", () => {
     it("should navigate via ArrowRight and ArrowLeft", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list>
+        <calcite-list mode="nested">
           <calcite-list-item id="one" value="one" label="One" description="hello world">
             <calcite-action
               appearance="transparent"
@@ -1039,7 +1039,7 @@ describe("calcite-list", () => {
     it("should navigate a draggable list via ArrowRight and ArrowLeft", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list drag-enabled>
+        <calcite-list mode="nested" drag-enabled>
           <calcite-list-item id="one" value="one" label="One" description="hello world">
             <calcite-action
               appearance="transparent"

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -159,153 +159,259 @@ describe("calcite-list", () => {
       </calcite-list>`,
       { focusTarget: "child" },
     );
+  });
 
-    it("should set the dragHandle property on items", async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        html`<calcite-list id="root" drag-enabled group="my-list">
-          <calcite-list-item open label="Depth 1" description="Item 1">
-            <calcite-list group="my-list">
-              <calcite-list-item open label="Depth 2" description="Item 2">
-                <calcite-list drag-enabled group="my-list">
-                  <calcite-list-item label="Depth 3" description="Item 3">
-                    <calcite-list drag-enabled group="my-list"></calcite-list>
-                  </calcite-list-item>
-                  <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
-                </calcite-list>
-              </calcite-list-item>
-              <calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item>
-            </calcite-list>
-          </calcite-list-item>
-          <calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item>
-          <calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item>
-        </calcite-list>`,
-      );
-
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
-
-      let dragHandleValues = [true, false, true, true, false, true, true];
-
-      const items = await page.findAll("calcite-list-item");
-
-      expect(items.length).toBe(dragHandleValues.length);
-
-      for (let i = 0; i < items.length; i++) {
-        expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
-      }
-
-      const rootList = await page.find("#root");
-
-      rootList.setProperty("dragEnabled", false);
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
-
-      dragHandleValues = [false, false, true, true, false, false, false];
-
-      expect(items.length).toBe(dragHandleValues.length);
-
-      for (let i = 0; i < items.length; i++) {
-        expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
-      }
-    });
-
-    it("should set the dragHandle property on items which are not direct children", async () => {
-      const page = await newE2EPage();
-      await page.setContent(
-        html`<calcite-list id="root" drag-enabled group="my-list">
-          <div>
-            <calcite-list-item open label="Depth 1" description="Item 1">
-              <calcite-list group="my-list">
-                <div>
-                  <calcite-list-item open label="Depth 2" description="Item 2">
-                    <calcite-list drag-enabled group="my-list">
-                      <div>
-                        <calcite-list-item label="Depth 3" description="Item 3">
-                          <calcite-list drag-enabled group="my-list"></calcite-list>
-                        </calcite-list-item>
-                      </div>
-                      <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>
-                    </calcite-list>
-                  </calcite-list-item>
-                </div>
-                <div><calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item></div>
+  it("should set the mode property on items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list id="root" mode="nested" group="my-list">
+        <calcite-list-item open label="Depth 1" description="Item 1">
+          <calcite-list group="my-list">
+            <calcite-list-item open label="Depth 2" description="Item 2">
+              <calcite-list mode="nested" group="my-list">
+                <calcite-list-item label="Depth 3" description="Item 3">
+                  <calcite-list mode="nested" group="my-list"></calcite-list>
+                </calcite-list-item>
+                <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
               </calcite-list>
             </calcite-list-item>
-          </div>
-          <div><calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item></div>
-          <div><calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item></div>
-        </calcite-list>`,
-      );
+            <calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item>
+          </calcite-list>
+        </calcite-list-item>
+        <calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item>
+        <calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item>
+      </calcite-list>`,
+    );
 
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
 
-      let dragHandleValues = [true, false, true, true, false, true, true];
+    let modeValues = ["nested", "flat", "nested", "nested", "flat", "nested", "nested"];
 
-      const items = await page.findAll("calcite-list-item");
+    const items = await page.findAll("calcite-list-item");
 
-      expect(items.length).toBe(dragHandleValues.length);
+    expect(items.length).toBe(modeValues.length);
 
-      for (let i = 0; i < items.length; i++) {
-        expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
-      }
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+    }
 
-      const rootList = await page.find("#root");
+    const rootList = await page.find("#root");
 
-      rootList.setProperty("dragEnabled", false);
-      await page.waitForChanges();
-      await page.waitForTimeout(DEBOUNCE.filter);
+    rootList.setProperty("mode", "flat");
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
 
-      dragHandleValues = [false, false, true, true, false, false, false];
+    modeValues = ["flat", "flat", "nested", "nested", "flat", "flat", "flat"];
 
-      expect(items.length).toBe(dragHandleValues.length);
+    expect(items.length).toBe(modeValues.length);
 
-      for (let i = 0; i < items.length; i++) {
-        expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
-      }
-    });
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+    }
+  });
 
-    it("disabling and enabling an item restores actions from being tabbable", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-list selection-mode="multiple">
-          <calcite-list-item label="first">
-            <calcite-action id="action-1" icon="information" slot="actions-end"></calcite-action>
+  it("should set the mode property on items which are not direct children", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list id="root" mode="nested" group="my-list">
+        <div>
+          <calcite-list-item open label="Depth 1" description="Item 1">
+            <calcite-list group="my-list">
+              <div>
+                <calcite-list-item open label="Depth 2" description="Item 2">
+                  <calcite-list mode="nested" group="my-list">
+                    <div>
+                      <calcite-list-item label="Depth 3" description="Item 3">
+                        <calcite-list mode="nested" group="my-list"></calcite-list>
+                      </calcite-list-item>
+                    </div>
+                    <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>
+                  </calcite-list>
+                </calcite-list-item>
+              </div>
+              <div><calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item></div>
+            </calcite-list>
           </calcite-list-item>
-          <calcite-list-item label="second">
-            <calcite-action id="action-2" icon="information" slot="actions-end"></calcite-action>
+        </div>
+        <div><calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item></div>
+        <div><calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item></div>
+      </calcite-list>`,
+    );
+
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
+
+    let modeValues = ["nested", "flat", "nested", "nested", "flat", "nested", "nested"];
+
+    const items = await page.findAll("calcite-list-item");
+
+    expect(items.length).toBe(modeValues.length);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+    }
+
+    const rootList = await page.find("#root");
+
+    rootList.setProperty("mode", "flat");
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
+
+    modeValues = ["flat", "flat", "nested", "nested", "flat", "flat", "flat"];
+
+    expect(items.length).toBe(modeValues.length);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+    }
+  });
+
+  it("should set the dragHandle property on items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list id="root" drag-enabled group="my-list">
+        <calcite-list-item open label="Depth 1" description="Item 1">
+          <calcite-list group="my-list">
+            <calcite-list-item open label="Depth 2" description="Item 2">
+              <calcite-list drag-enabled group="my-list">
+                <calcite-list-item label="Depth 3" description="Item 3">
+                  <calcite-list drag-enabled group="my-list"></calcite-list>
+                </calcite-list-item>
+                <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
+              </calcite-list>
+            </calcite-list-item>
+            <calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item>
+          </calcite-list>
+        </calcite-list-item>
+        <calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item>
+        <calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item>
+      </calcite-list>`,
+    );
+
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
+
+    let dragHandleValues = [true, false, true, true, false, true, true];
+
+    const items = await page.findAll("calcite-list-item");
+
+    expect(items.length).toBe(dragHandleValues.length);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
+    }
+
+    const rootList = await page.find("#root");
+
+    rootList.setProperty("dragEnabled", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
+
+    dragHandleValues = [false, false, true, true, false, false, false];
+
+    expect(items.length).toBe(dragHandleValues.length);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
+    }
+  });
+
+  it("should set the dragHandle property on items which are not direct children", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list id="root" drag-enabled group="my-list">
+        <div>
+          <calcite-list-item open label="Depth 1" description="Item 1">
+            <calcite-list group="my-list">
+              <div>
+                <calcite-list-item open label="Depth 2" description="Item 2">
+                  <calcite-list drag-enabled group="my-list">
+                    <div>
+                      <calcite-list-item label="Depth 3" description="Item 3">
+                        <calcite-list drag-enabled group="my-list"></calcite-list>
+                      </calcite-list-item>
+                    </div>
+                    <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>
+                  </calcite-list>
+                </calcite-list-item>
+              </div>
+              <div><calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item></div>
+            </calcite-list>
           </calcite-list-item>
-          <calcite-list-item label="third">
-            <calcite-action id="action-3" icon="information" slot="actions-end"></calcite-action>
-          </calcite-list-item>
-        </calcite-list>
-      `);
+        </div>
+        <div><calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item></div>
+        <div><calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item></div>
+      </calcite-list>`,
+    );
 
-      const [firstItem, secondItem] = await page.findAll("calcite-list-item");
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
 
-      await firstItem.callMethod("setFocus");
-      await page.waitForChanges();
+    let dragHandleValues = [true, false, true, true, false, true, true];
 
-      await page.keyboard.press("Tab");
-      await page.keyboard.press("Tab");
-      await page.keyboard.press("Tab");
+    const items = await page.findAll("calcite-list-item");
 
-      expect(await getFocusedElementProp(page, "id")).toBe("action-3");
+    expect(items.length).toBe(dragHandleValues.length);
 
-      secondItem.setProperty("disabled", true);
-      await page.waitForChanges();
-      secondItem.setProperty("disabled", false);
-      await page.waitForChanges();
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
+    }
 
-      await firstItem.callMethod("setFocus");
-      await page.waitForChanges();
+    const rootList = await page.find("#root");
 
-      await page.keyboard.press("Tab");
-      await page.keyboard.press("Tab");
+    rootList.setProperty("dragEnabled", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
 
-      expect(await getFocusedElementProp(page, "id")).toBe("action-3");
-    });
+    dragHandleValues = [false, false, true, true, false, false, false];
+
+    expect(items.length).toBe(dragHandleValues.length);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
+    }
+  });
+
+  it("disabling and enabling an item restores actions from being tabbable", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`
+      <calcite-list selection-mode="multiple">
+        <calcite-list-item label="first">
+          <calcite-action id="action-1" icon="information" slot="actions-end"></calcite-action>
+        </calcite-list-item>
+        <calcite-list-item label="second">
+          <calcite-action id="action-2" icon="information" slot="actions-end"></calcite-action>
+        </calcite-list-item>
+        <calcite-list-item label="third">
+          <calcite-action id="action-3" icon="information" slot="actions-end"></calcite-action>
+        </calcite-list-item>
+      </calcite-list>
+    `);
+
+    const [firstItem, secondItem] = await page.findAll("calcite-list-item");
+
+    await firstItem.callMethod("setFocus");
+    await page.waitForChanges();
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+
+    expect(await getFocusedElementProp(page, "id")).toBe("action-3");
+
+    secondItem.setProperty("disabled", true);
+    await page.waitForChanges();
+    secondItem.setProperty("disabled", false);
+    await page.waitForChanges();
+
+    await firstItem.callMethod("setFocus");
+    await page.waitForChanges();
+
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+
+    expect(await getFocusedElementProp(page, "id")).toBe("action-3");
   });
 
   it("should border nested list items", async () => {

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -1,6 +1,16 @@
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, focusable, disabled, defaults, t9n, themed } from "../../tests/commonTests";
+import {
+  accessible,
+  hidden,
+  renders,
+  focusable,
+  disabled,
+  defaults,
+  t9n,
+  themed,
+  reflects,
+} from "../../tests/commonTests";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { CSS as ListItemCSS, activeCellTestAttribute } from "../list-item/resources";
@@ -75,6 +85,19 @@ describe("calcite-list", () => {
       {
         propertyName: "filterProps",
         defaultValue: undefined,
+      },
+      {
+        propertyName: "mode",
+        defaultValue: "flat",
+      },
+    ]);
+  });
+
+  describe("reflects", () => {
+    reflects("calcite-list", [
+      {
+        propertyName: "mode",
+        value: "nested",
       },
     ]);
   });

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -87,7 +87,7 @@ describe("calcite-list", () => {
         defaultValue: undefined,
       },
       {
-        propertyName: "mode",
+        propertyName: "displayMode",
         defaultValue: "flat",
       },
     ]);
@@ -96,7 +96,7 @@ describe("calcite-list", () => {
   describe("reflects", () => {
     reflects("calcite-list", [
       {
-        propertyName: "mode",
+        propertyName: "displayMode",
         value: "nested",
       },
     ]);
@@ -161,16 +161,16 @@ describe("calcite-list", () => {
     );
   });
 
-  it("should set the mode property on items", async () => {
+  it("should set the displayMode property on items", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      html`<calcite-list id="root" mode="nested" group="my-list">
+      html`<calcite-list id="root" display-mode="nested" group="my-list">
         <calcite-list-item open label="Depth 1" description="Item 1">
           <calcite-list group="my-list">
             <calcite-list-item open label="Depth 2" description="Item 2">
-              <calcite-list mode="nested" group="my-list">
+              <calcite-list display-mode="nested" group="my-list">
                 <calcite-list-item label="Depth 3" description="Item 3">
-                  <calcite-list mode="nested" group="my-list"></calcite-list>
+                  <calcite-list display-mode="nested" group="my-list"></calcite-list>
                 </calcite-list-item>
                 <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
               </calcite-list>
@@ -193,12 +193,12 @@ describe("calcite-list", () => {
     expect(items.length).toBe(modeValues.length);
 
     for (let i = 0; i < items.length; i++) {
-      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+      expect(await items[i].getProperty("displayMode")).toBe(modeValues[i]);
     }
 
     const rootList = await page.find("#root");
 
-    rootList.setProperty("mode", "flat");
+    rootList.setProperty("displayMode", "flat");
     await page.waitForChanges();
     await page.waitForTimeout(DEBOUNCE.filter);
 
@@ -207,63 +207,7 @@ describe("calcite-list", () => {
     expect(items.length).toBe(modeValues.length);
 
     for (let i = 0; i < items.length; i++) {
-      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
-    }
-  });
-
-  it("should set the mode property on items which are not direct children", async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      html`<calcite-list id="root" mode="nested" group="my-list">
-        <div>
-          <calcite-list-item open label="Depth 1" description="Item 1">
-            <calcite-list group="my-list">
-              <div>
-                <calcite-list-item open label="Depth 2" description="Item 2">
-                  <calcite-list mode="nested" group="my-list">
-                    <div>
-                      <calcite-list-item label="Depth 3" description="Item 3">
-                        <calcite-list mode="nested" group="my-list"></calcite-list>
-                      </calcite-list-item>
-                    </div>
-                    <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>
-                  </calcite-list>
-                </calcite-list-item>
-              </div>
-              <div><calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item></div>
-            </calcite-list>
-          </calcite-list-item>
-        </div>
-        <div><calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item></div>
-        <div><calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item></div>
-      </calcite-list>`,
-    );
-
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-
-    let modeValues = ["nested", "flat", "nested", "nested", "flat", "nested", "nested"];
-
-    const items = await page.findAll("calcite-list-item");
-
-    expect(items.length).toBe(modeValues.length);
-
-    for (let i = 0; i < items.length; i++) {
-      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
-    }
-
-    const rootList = await page.find("#root");
-
-    rootList.setProperty("mode", "flat");
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-
-    modeValues = ["flat", "flat", "nested", "nested", "flat", "flat", "flat"];
-
-    expect(items.length).toBe(modeValues.length);
-
-    for (let i = 0; i < items.length; i++) {
-      expect(await items[i].getProperty("mode")).toBe(modeValues[i]);
+      expect(await items[i].getProperty("displayMode")).toBe(modeValues[i]);
     }
   });
 
@@ -1081,7 +1025,7 @@ describe("calcite-list", () => {
     it("should navigate via ArrowRight and ArrowLeft", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list mode="nested">
+        <calcite-list display-mode="nested">
           <calcite-list-item id="one" value="one" label="One" description="hello world">
             <calcite-action
               appearance="transparent"
@@ -1145,7 +1089,7 @@ describe("calcite-list", () => {
     it("should navigate a draggable list via ArrowRight and ArrowLeft", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list mode="nested" drag-enabled>
+        <calcite-list display-mode="nested" drag-enabled>
           <calcite-list-item id="one" value="one" label="One" description="hello world">
             <calcite-action
               appearance="transparent"

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -168,57 +168,49 @@ export const nestedItems = (): string => html`
       label="Level 1 item 2"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     >
-      <calcite-list mode="nested">
+      <calcite-list-item
+        open
+        label="Level 2 item 1"
+        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      >
         <calcite-list-item
           open
-          label="Level 2 item 1"
+          label="Level 3 item 1"
+          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        ></calcite-list-item>
+        <calcite-list-item
+          open
+          label="Level 3 item 2"
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         >
-          <calcite-list mode="nested">
+          <calcite-list-item
+            open
+            label="Level 4 item 1"
+            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          >
             <calcite-list-item
               open
-              label="Level 3 item 1"
+              label="Level 5 item 1"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             ></calcite-list-item>
-            <calcite-list-item
-              open
-              label="Level 3 item 2"
-              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            >
-              <calcite-list mode="nested">
-                <calcite-list-item
-                  open
-                  label="Level 4 item 1"
-                  description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-                >
-                  <calcite-list mode="nested">
-                    <calcite-list-item
-                      open
-                      label="Level 5 item 1"
-                      description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-                    ></calcite-list-item>
-                  </calcite-list>
-                </calcite-list-item>
-              </calcite-list>
-              <calcite-list-item
-                open
-                label="Level 4 item 2"
-                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-              ></calcite-list-item>
-              <calcite-list-item
-                open
-                label="Level 4 item 3"
-                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-              ></calcite-list-item>
-            </calcite-list-item>
-            <calcite-list-item
-              open
-              label="Level 3 item 3"
-              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            ></calcite-list-item>
-          </calcite-list>
+          </calcite-list-item>
+          <calcite-list-item
+            open
+            label="Level 4 item 2"
+            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          ></calcite-list-item>
+          <calcite-list-item
+            open
+            label="Level 4 item 3"
+            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          ></calcite-list-item>
         </calcite-list-item>
-      </calcite-list>
+        <calcite-list-item
+          open
+          label="Level 3 item 3"
+          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        ></calcite-list-item>
+      </calcite-list-item>
       <calcite-list-item
         open
         label="Level 2 item 2"
@@ -659,22 +651,20 @@ export const filteredChildListItems_TestOnly = (): string =>
           </calcite-dropdown>
         </calcite-list-item>
         <calcite-list-item label="Rivers" value="rivers" open>
-          <calcite-list mode="nested">
-            <calcite-list-item label="Estuaries" value="estuaries">
-              <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
-                <calcite-action
-                  slot="trigger"
-                  appearance="transparent"
-                  icon="ellipsis"
-                  scale="s"
-                  text="Trails layer"
-                ></calcite-action>
-                <calcite-dropdown-group scale="s" selection-mode="none">
-                  <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
-                </calcite-dropdown-group>
-              </calcite-dropdown>
-            </calcite-list-item>
-          </calcite-list>
+          <calcite-list-item label="Estuaries" value="estuaries">
+            <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
+              <calcite-action
+                slot="trigger"
+                appearance="transparent"
+                icon="ellipsis"
+                scale="s"
+                text="Trails layer"
+              ></calcite-action>
+              <calcite-dropdown-group scale="s" selection-mode="none">
+                <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
+              </calcite-dropdown-group>
+            </calcite-dropdown>
+          </calcite-list-item>
         </calcite-list-item>
       </calcite-list-item-group>
       <calcite-list-item-group heading="Tables">
@@ -714,7 +704,6 @@ export const filteredChildListItems_TestOnly = (): string =>
         </calcite-list-item>
       </calcite-list-item-group> </calcite-list
     ><calcite-list
-      mode="nested"
       filter-enabled
       filter-text="water"
       filter-placeholder="Find content"
@@ -752,22 +741,20 @@ export const filteredChildListItems_TestOnly = (): string =>
           </calcite-dropdown>
         </calcite-list-item>
         <calcite-list-item label="Rivers" value="rivers" open>
-          <calcite-list mode="nested">
-            <calcite-list-item label="Estuaries" value="estuaries">
-              <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
-                <calcite-action
-                  slot="trigger"
-                  appearance="transparent"
-                  icon="ellipsis"
-                  scale="s"
-                  text="Trails layer"
-                ></calcite-action>
-                <calcite-dropdown-group scale="s" selection-mode="none">
-                  <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
-                </calcite-dropdown-group>
-              </calcite-dropdown>
-            </calcite-list-item>
-          </calcite-list>
+          <calcite-list-item label="Estuaries" value="estuaries">
+            <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
+              <calcite-action
+                slot="trigger"
+                appearance="transparent"
+                icon="ellipsis"
+                scale="s"
+                text="Trails layer"
+              ></calcite-action>
+              <calcite-dropdown-group scale="s" selection-mode="none">
+                <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
+              </calcite-dropdown-group>
+            </calcite-dropdown>
+          </calcite-list-item>
         </calcite-list-item>
       </calcite-list-item-group>
       <calcite-list-item-group heading="Tables">
@@ -1081,7 +1068,7 @@ export const filteredListItemsNoResults_TestOnly = (): string =>
   </calcite-list>`;
 
 export const nestingLists_TestOnly = (): string => html`<h4>Nesting List Items</h4>
-  <calcite-list>
+  <calcite-list mode="nested">
     <calcite-list-item label="List Item" open>
       <calcite-list-item label="List Item"></calcite-list-item>
       <calcite-list-item label="List Item"></calcite-list-item>

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -16,6 +16,7 @@ interface ListStoryArgs
     | "filterEnabled"
     | "dragEnabled"
     | "disabled"
+    | "mode"
     | "label"
   > {
   closable: boolean;
@@ -34,6 +35,7 @@ export default {
     filterEnabled: false,
     dragEnabled: false,
     disabled: false,
+    mode: "flat",
     label: "My List",
   },
   argTypes: {
@@ -45,6 +47,10 @@ export default {
     },
     interactionMode: {
       options: interactionMode.values,
+      control: { type: "select" },
+    },
+    mode: {
+      options: ["flat", "nested"],
       control: { type: "select" },
     },
     selectionAppearance: {
@@ -68,6 +74,7 @@ export const simple = (args: ListStoryArgs): string => html`
     selection-mode="${args.selectionMode}"
     interaction-mode="${args.interactionMode}"
     selection-appearance="${args.selectionAppearance}"
+    mode="${args.mode}"
     ${boolean("loading", args.loading)}
     ${boolean("closable", args.closable)}
     ${boolean("closed", args.closed)}
@@ -150,7 +157,7 @@ export const stretchSlottedContent = (): string => html`
 `;
 
 export const nestedItems = (): string => html`
-  <calcite-list ${listHTML()}>
+  <calcite-list mode="nested" ${listHTML()}>
     <calcite-list-item
       open
       label="Level 1 item 1"
@@ -161,49 +168,57 @@ export const nestedItems = (): string => html`
       label="Level 1 item 2"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     >
-      <calcite-list-item
-        open
-        label="Level 2 item 1"
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      >
+      <calcite-list mode="nested">
         <calcite-list-item
           open
-          label="Level 3 item 1"
-          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        ></calcite-list-item>
-        <calcite-list-item
-          open
-          label="Level 3 item 2"
+          label="Level 2 item 1"
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         >
-          <calcite-list-item
-            open
-            label="Level 4 item 1"
-            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-          >
+          <calcite-list mode="nested">
             <calcite-list-item
               open
-              label="Level 5 item 1"
+              label="Level 3 item 1"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             ></calcite-list-item>
-          </calcite-list-item>
-          <calcite-list-item
-            open
-            label="Level 4 item 2"
-            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-          ></calcite-list-item>
-          <calcite-list-item
-            open
-            label="Level 4 item 3"
-            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-          ></calcite-list-item>
+            <calcite-list-item
+              open
+              label="Level 3 item 2"
+              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            >
+              <calcite-list mode="nested">
+                <calcite-list-item
+                  open
+                  label="Level 4 item 1"
+                  description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                >
+                  <calcite-list mode="nested">
+                    <calcite-list-item
+                      open
+                      label="Level 5 item 1"
+                      description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+                    ></calcite-list-item>
+                  </calcite-list>
+                </calcite-list-item>
+              </calcite-list>
+              <calcite-list-item
+                open
+                label="Level 4 item 2"
+                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+              ></calcite-list-item>
+              <calcite-list-item
+                open
+                label="Level 4 item 3"
+                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+              ></calcite-list-item>
+            </calcite-list-item>
+            <calcite-list-item
+              open
+              label="Level 3 item 3"
+              description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            ></calcite-list-item>
+          </calcite-list>
         </calcite-list-item>
-        <calcite-list-item
-          open
-          label="Level 3 item 3"
-          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-        ></calcite-list-item>
-      </calcite-list-item>
+      </calcite-list>
       <calcite-list-item
         open
         label="Level 2 item 2"
@@ -228,7 +243,7 @@ nestedItems.parameters = {
 };
 
 export const groupedItems = (): string => html`
-  <calcite-list ${listHTML()}>
+  <calcite-list mode="nested" ${listHTML()}>
     <calcite-list-item-group heading="Nested">
       <calcite-list-item
         open
@@ -236,18 +251,23 @@ export const groupedItems = (): string => html`
         label="Cras iaculis ultricies nulla."
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       >
-        <calcite-list-item
-          open
-          expanded
-          label="Ut aliquam sollicitudin leo."
-          description="Aliquam tincidunt mauris eu risus."
-        >
+        <calcite-list mode="nested">
           <calcite-list-item
             open
-            label="Vestibulum commodo felis quis tortor."
-            description="Vestibulum auctor dapibus neque."
-          ></calcite-list-item></calcite-list-item
-      ></calcite-list-item>
+            expanded
+            label="Ut aliquam sollicitudin leo."
+            description="Aliquam tincidunt mauris eu risus."
+          >
+            <calcite-list mode="nested">
+              <calcite-list-item
+                open
+                label="Vestibulum commodo felis quis tortor."
+                description="Vestibulum auctor dapibus neque."
+              ></calcite-list-item>
+            </calcite-list>
+          </calcite-list-item>
+        </calcite-list>
+      </calcite-list-item>
     </calcite-list-item-group>
     <calcite-list-item-group heading="Digits">
       <calcite-list-item
@@ -332,13 +352,13 @@ export const contentBottomSlots = (): string =>
   </calcite-list> `;
 
 export const contentBottomSlotsNested = (): string =>
-  html`<calcite-list ${listHTML()}>
+  html`<calcite-list mode="nested" ${listHTML()}>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom" open>
       <span slot="content-bottom">Some value or something and a <b>thing</b>.</span>
-      <calcite-list
+      <calcite-list mode="nested"
         ><calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom" open>
           <span slot="content-bottom">Some value or something and a <b>thing</b>.</span
-          ><calcite-list
+          ><calcite-list mode="nested"
             ><calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
               <span slot="content-bottom">Some value or something and a <b>thing</b>.</span>
             </calcite-list-item></calcite-list
@@ -600,6 +620,7 @@ export const closableListItems_TestOnly = (): string =>
 
 export const filteredChildListItems_TestOnly = (): string =>
   html`<calcite-list
+      mode="nested"
       filter-enabled
       filter-text="est"
       filter-placeholder="Find content"
@@ -638,20 +659,22 @@ export const filteredChildListItems_TestOnly = (): string =>
           </calcite-dropdown>
         </calcite-list-item>
         <calcite-list-item label="Rivers" value="rivers" open>
-          <calcite-list-item label="Estuaries" value="estuaries">
-            <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
-              <calcite-action
-                slot="trigger"
-                appearance="transparent"
-                icon="ellipsis"
-                scale="s"
-                text="Trails layer"
-              ></calcite-action>
-              <calcite-dropdown-group scale="s" selection-mode="none">
-                <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
-              </calcite-dropdown-group>
-            </calcite-dropdown>
-          </calcite-list-item>
+          <calcite-list mode="nested">
+            <calcite-list-item label="Estuaries" value="estuaries">
+              <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
+                <calcite-action
+                  slot="trigger"
+                  appearance="transparent"
+                  icon="ellipsis"
+                  scale="s"
+                  text="Trails layer"
+                ></calcite-action>
+                <calcite-dropdown-group scale="s" selection-mode="none">
+                  <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
+                </calcite-dropdown-group>
+              </calcite-dropdown>
+            </calcite-list-item>
+          </calcite-list>
         </calcite-list-item>
       </calcite-list-item-group>
       <calcite-list-item-group heading="Tables">
@@ -691,6 +714,7 @@ export const filteredChildListItems_TestOnly = (): string =>
         </calcite-list-item>
       </calcite-list-item-group> </calcite-list
     ><calcite-list
+      mode="nested"
       filter-enabled
       filter-text="water"
       filter-placeholder="Find content"
@@ -728,20 +752,22 @@ export const filteredChildListItems_TestOnly = (): string =>
           </calcite-dropdown>
         </calcite-list-item>
         <calcite-list-item label="Rivers" value="rivers" open>
-          <calcite-list-item label="Estuaries" value="estuaries">
-            <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
-              <calcite-action
-                slot="trigger"
-                appearance="transparent"
-                icon="ellipsis"
-                scale="s"
-                text="Trails layer"
-              ></calcite-action>
-              <calcite-dropdown-group scale="s" selection-mode="none">
-                <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
-              </calcite-dropdown-group>
-            </calcite-dropdown>
-          </calcite-list-item>
+          <calcite-list mode="nested">
+            <calcite-list-item label="Estuaries" value="estuaries">
+              <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
+                <calcite-action
+                  slot="trigger"
+                  appearance="transparent"
+                  icon="ellipsis"
+                  scale="s"
+                  text="Trails layer"
+                ></calcite-action>
+                <calcite-dropdown-group scale="s" selection-mode="none">
+                  <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
+                </calcite-dropdown-group>
+              </calcite-dropdown>
+            </calcite-list-item>
+          </calcite-list>
         </calcite-list-item>
       </calcite-list-item-group>
       <calcite-list-item-group heading="Tables">
@@ -914,13 +940,19 @@ export const sortableList_TestOnly = (): string =>
   </calcite-list>`;
 
 export const sortableNestedList_TestOnly = (): string =>
-  html`<calcite-list drag-enabled group="nested" label="List 1" selection-mode="multiple">
+  html`<calcite-list mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
     <calcite-list-item open label="Hi! 1" description="hello world">
-      <calcite-list drag-enabled label="List 2" group="nested" selection-mode="multiple">
+      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
         <calcite-list-item open label="Hi! 2" description="hello world">
-          <calcite-list drag-enabled label="List 3" group="nested" selection-mode="multiple">
+          <calcite-list mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
             <calcite-list-item open label="Hi! 3" description="hello world">
-              <calcite-list drag-enabled label="List 4" group="nested" selection-mode="multiple"></calcite-list>
+              <calcite-list
+                mode="nested"
+                drag-enabled
+                label="List 4"
+                group="nested"
+                selection-mode="multiple"
+              ></calcite-list>
             </calcite-list-item>
             <calcite-list-item open label="Hi! 4" description="hello world"></calcite-list-item>
           </calcite-list>
@@ -933,11 +965,11 @@ export const sortableNestedList_TestOnly = (): string =>
   </calcite-list>`;
 
 export const emptyOpenLists_TestOnly = (): string =>
-  html`<calcite-list drag-enabled group="nested" label="List 1" selection-mode="multiple">
+  html`<calcite-list mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
     <calcite-list-item open label="Hi! 1" description="hello world">
-      <calcite-list drag-enabled label="List 2" group="nested" selection-mode="multiple">
+      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
         <calcite-list-item open label="Hi! 2" description="hello world">
-          <calcite-list drag-enabled label="List 3" group="nested" selection-mode="multiple">
+          <calcite-list mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
             <calcite-list-item open label="Hi! 3" description="hello world">
               <calcite-action-menu overlay-positioning="fixed" slot="actions-end">
                 <calcite-action text-enabled text="Edit" icon="pencil"></calcite-action>
@@ -946,23 +978,42 @@ export const emptyOpenLists_TestOnly = (): string =>
                 <calcite-action text-enabled text="Delete" icon="trash"></calcite-action>
                 <calcite-action text-enabled text="Delete" icon="trash"></calcite-action>
               </calcite-action-menu>
-              <calcite-list drag-enabled label="List 4" group="nested" selection-mode="multiple"></calcite-list>
+              <calcite-list
+                mode="nested"
+                drag-enabled
+                label="List 4"
+                group="nested"
+                selection-mode="multiple"
+              ></calcite-list>
             </calcite-list-item>
             <calcite-list-item open label="Hi! 4" description="hello world">
-              <calcite-list drag-enabled label="List 5" group="nested" selection-mode="multiple"></calcite-list>
+              <calcite-list
+                mode="nested"
+                drag-enabled
+                label="List 5"
+                group="nested"
+                selection-mode="multiple"
+              ></calcite-list>
             </calcite-list-item>
           </calcite-list>
         </calcite-list-item>
         <calcite-list-item open label="Hi! 5" description="hello world">
-          <calcite-list drag-enabled label="List 6" group="nested" selection-mode="multiple"></calcite-list>
+          <calcite-list
+            mode="nested"
+            drag-enabled
+            label="List 6"
+            group="nested"
+            selection-mode="multiple"
+          ></calcite-list>
         </calcite-list-item>
       </calcite-list>
     </calcite-list-item>
     <calcite-list-item open label="Hi! 6" description="hello world">
-      <calcite-list drag-enabled label="List 7" group="nested" selection-mode="multiple"></calcite-list>
+      <calcite-list mode="nested" drag-enabled label="List 7" group="nested" selection-mode="multiple"></calcite-list>
     </calcite-list-item>
     <calcite-list-item open label="Hi! 7" description="hello world">
       <calcite-list
+        mode="nested"
         drag-enabled
         label="List 8"
         group="nested"
@@ -971,9 +1022,9 @@ export const emptyOpenLists_TestOnly = (): string =>
   ></calcite-list>`;
 
 export const listWithEmptyChildList_TestOnly = (): string =>
-  html`<calcite-list drag-enabled label="List 1" group="nested" selection-mode="single">
+  html`<calcite-list mode="nested" drag-enabled label="List 1" group="nested" selection-mode="single">
     <calcite-list-item open label="Hi! 4" description="hello world">
-      <calcite-list drag-enabled label="List 2" group="nested" selection-mode="single"></calcite-list>
+      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="single"></calcite-list>
     </calcite-list-item>
   </calcite-list>`;
 
@@ -1039,9 +1090,9 @@ export const nestingLists_TestOnly = (): string => html`<h4>Nesting List Items</
   </calcite-list>
   </br>
   <h4>Nesting Lists</h4>
-  <calcite-list>
+  <calcite-list mode="nested">
     <calcite-list-item label="List Item" open>
-      <calcite-list>
+      <calcite-list mode="nested">
         <calcite-list-item label="List Item"></calcite-list-item>
         <calcite-list-item label="List Item"></calcite-list-item>
         <calcite-list-item label="List Item"></calcite-list-item>
@@ -1114,13 +1165,13 @@ export const closedItems_TestOnly = (): string =>
   </calcite-list>`;
 
 export const dragEnabledNestedLists = (): string =>
-  html`<calcite-list id="root" drag-enabled label="List 1" group="my-list">
+  html`<calcite-list mode="nested" id="root" drag-enabled label="List 1" group="my-list">
     <calcite-list-item open label="Depth 1" description="Item 1">
-      <calcite-list group="my-list">
+      <calcite-list mode="nested" group="my-list">
         <calcite-list-item open label="Depth 2" description="Item 2">
-          <calcite-list drag-enabled label="List 2" group="my-list">
+          <calcite-list mode="nested" drag-enabled label="List 2" group="my-list">
             <calcite-list-item label="Depth 3" description="Item 3">
-              <calcite-list drag-enabled label="List 3" group="my-list"></calcite-list>
+              <calcite-list mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
             </calcite-list-item>
             <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
           </calcite-list>
@@ -1133,16 +1184,16 @@ export const dragEnabledNestedLists = (): string =>
   </calcite-list>`;
 
 export const dragEnabledNestedListsIndirectChildren = (): string =>
-  html`<calcite-list id="root" drag-enabled label="List 1" group="my-list">
+  html`<calcite-list mode="nested" id="root" drag-enabled label="List 1" group="my-list">
     <div>
       <calcite-list-item open label="Depth 1" description="Item 1">
-        <calcite-list group="my-list">
+        <calcite-list mode="nested" group="my-list">
           <div>
             <calcite-list-item open label="Depth 2" description="Item 2">
-              <calcite-list drag-enabled label="List 2" group="my-list">
+              <calcite-list mode="nested" drag-enabled label="List 2" group="my-list">
                 <div>
                   <calcite-list-item label="Depth 3" description="Item 3">
-                    <calcite-list drag-enabled label="List 3" group="my-list"></calcite-list>
+                    <calcite-list mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
                   </calcite-list-item>
                 </div>
                 <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -243,23 +243,18 @@ export const groupedItems = (): string => html`
         label="Cras iaculis ultricies nulla."
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       >
-        <calcite-list mode="nested">
+        <calcite-list-item
+          open
+          expanded
+          label="Ut aliquam sollicitudin leo."
+          description="Aliquam tincidunt mauris eu risus."
+        >
           <calcite-list-item
             open
-            expanded
-            label="Ut aliquam sollicitudin leo."
-            description="Aliquam tincidunt mauris eu risus."
-          >
-            <calcite-list mode="nested">
-              <calcite-list-item
-                open
-                label="Vestibulum commodo felis quis tortor."
-                description="Vestibulum auctor dapibus neque."
-              ></calcite-list-item>
-            </calcite-list>
-          </calcite-list-item>
-        </calcite-list>
-      </calcite-list-item>
+            label="Vestibulum commodo felis quis tortor."
+            description="Vestibulum auctor dapibus neque."
+          ></calcite-list-item></calcite-list-item
+      ></calcite-list-item>
     </calcite-list-item-group>
     <calcite-list-item-group heading="Digits">
       <calcite-list-item

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -9,15 +9,15 @@ const { selectionMode, interactionMode, selectionAppearance } = ATTRIBUTES;
 interface ListStoryArgs
   extends Pick<
     List,
-    | "selectionMode"
-    | "interactionMode"
-    | "selectionAppearance"
-    | "loading"
-    | "filterEnabled"
-    | "dragEnabled"
     | "disabled"
-    | "mode"
+    | "displayMode"
+    | "dragEnabled"
+    | "filterEnabled"
+    | "interactionMode"
     | "label"
+    | "loading"
+    | "selectionAppearance"
+    | "selectionMode"
   > {
   closable: boolean;
   closed: boolean;
@@ -26,17 +26,17 @@ interface ListStoryArgs
 export default {
   title: "Components/List",
   args: {
-    selectionMode: selectionMode.values[1],
-    interactionMode: interactionMode.values[0],
-    selectionAppearance: selectionAppearance.defaultValue,
-    loading: false,
     closable: false,
     closed: false,
-    filterEnabled: false,
-    dragEnabled: false,
     disabled: false,
-    mode: "flat",
+    displayMode: "flat",
+    dragEnabled: false,
+    filterEnabled: false,
+    interactionMode: interactionMode.values[0],
     label: "My List",
+    loading: false,
+    selectionAppearance: selectionAppearance.defaultValue,
+    selectionMode: selectionMode.values[1],
   },
   argTypes: {
     selectionMode: {
@@ -49,7 +49,7 @@ export default {
       options: interactionMode.values,
       control: { type: "select" },
     },
-    mode: {
+    displayMode: {
       options: ["flat", "nested"],
       control: { type: "select" },
     },
@@ -71,17 +71,17 @@ const listHTML = (): string => html` selection-mode="none" selection-appearance=
 
 export const simple = (args: ListStoryArgs): string => html`
   <calcite-list
-    selection-mode="${args.selectionMode}"
-    interaction-mode="${args.interactionMode}"
-    selection-appearance="${args.selectionAppearance}"
-    mode="${args.mode}"
-    ${boolean("loading", args.loading)}
     ${boolean("closable", args.closable)}
     ${boolean("closed", args.closed)}
-    ${boolean("filter-enabled", args.filterEnabled)}
-    ${boolean("drag-enabled", args.dragEnabled)}
     ${boolean("disabled", args.disabled)}
+    ${boolean("drag-enabled", args.dragEnabled)}
+    ${boolean("filter-enabled", args.filterEnabled)}
+    ${boolean("loading", args.loading)}
+    display-mode="${args.displayMode}"
+    interaction-mode="${args.interactionMode}"
     label="${args.label}"
+    selection-appearance="${args.selectionAppearance}"
+    selection-mode="${args.selectionMode}"
   >
     <calcite-list-item
       label="Cras iaculis ultricies nulla."
@@ -157,7 +157,7 @@ export const stretchSlottedContent = (): string => html`
 `;
 
 export const nestedItems = (): string => html`
-  <calcite-list mode="nested" ${listHTML()}>
+  <calcite-list display-mode="nested" ${listHTML()}>
     <calcite-list-item
       open
       label="Level 1 item 1"
@@ -235,7 +235,7 @@ nestedItems.parameters = {
 };
 
 export const groupedItems = (): string => html`
-  <calcite-list mode="nested" ${listHTML()}>
+  <calcite-list display-mode="nested" ${listHTML()}>
     <calcite-list-item-group heading="Nested">
       <calcite-list-item
         open
@@ -339,13 +339,13 @@ export const contentBottomSlots = (): string =>
   </calcite-list> `;
 
 export const contentBottomSlotsNested = (): string =>
-  html`<calcite-list mode="nested" ${listHTML()}>
+  html`<calcite-list display-mode="nested" ${listHTML()}>
     <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom" open>
       <span slot="content-bottom">Some value or something and a <b>thing</b>.</span>
-      <calcite-list mode="nested"
+      <calcite-list display-mode="nested"
         ><calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom" open>
           <span slot="content-bottom">Some value or something and a <b>thing</b>.</span
-          ><calcite-list mode="nested"
+          ><calcite-list display-mode="nested"
             ><calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
               <span slot="content-bottom">Some value or something and a <b>thing</b>.</span>
             </calcite-list-item></calcite-list
@@ -607,7 +607,7 @@ export const closableListItems_TestOnly = (): string =>
 
 export const filteredChildListItems_TestOnly = (): string =>
   html`<calcite-list
-      mode="nested"
+      display-mode="nested"
       filter-enabled
       filter-text="est"
       filter-placeholder="Find content"
@@ -922,14 +922,14 @@ export const sortableList_TestOnly = (): string =>
   </calcite-list>`;
 
 export const sortableNestedList_TestOnly = (): string =>
-  html`<calcite-list mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
+  html`<calcite-list display-mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
     <calcite-list-item open label="Hi! 1" description="hello world">
-      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
+      <calcite-list display-mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
         <calcite-list-item open label="Hi! 2" description="hello world">
-          <calcite-list mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
+          <calcite-list display-mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
             <calcite-list-item open label="Hi! 3" description="hello world">
               <calcite-list
-                mode="nested"
+                display-mode="nested"
                 drag-enabled
                 label="List 4"
                 group="nested"
@@ -947,11 +947,11 @@ export const sortableNestedList_TestOnly = (): string =>
   </calcite-list>`;
 
 export const emptyOpenLists_TestOnly = (): string =>
-  html`<calcite-list mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
+  html`<calcite-list display-mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
     <calcite-list-item open label="Hi! 1" description="hello world">
-      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
+      <calcite-list display-mode="nested" drag-enabled label="List 2" group="nested" selection-mode="multiple">
         <calcite-list-item open label="Hi! 2" description="hello world">
-          <calcite-list mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
+          <calcite-list display-mode="nested" drag-enabled label="List 3" group="nested" selection-mode="multiple">
             <calcite-list-item open label="Hi! 3" description="hello world">
               <calcite-action-menu overlay-positioning="fixed" slot="actions-end">
                 <calcite-action text-enabled text="Edit" icon="pencil"></calcite-action>
@@ -961,7 +961,7 @@ export const emptyOpenLists_TestOnly = (): string =>
                 <calcite-action text-enabled text="Delete" icon="trash"></calcite-action>
               </calcite-action-menu>
               <calcite-list
-                mode="nested"
+                display-mode="nested"
                 drag-enabled
                 label="List 4"
                 group="nested"
@@ -970,7 +970,7 @@ export const emptyOpenLists_TestOnly = (): string =>
             </calcite-list-item>
             <calcite-list-item open label="Hi! 4" description="hello world">
               <calcite-list
-                mode="nested"
+                display-mode="nested"
                 drag-enabled
                 label="List 5"
                 group="nested"
@@ -981,7 +981,7 @@ export const emptyOpenLists_TestOnly = (): string =>
         </calcite-list-item>
         <calcite-list-item open label="Hi! 5" description="hello world">
           <calcite-list
-            mode="nested"
+            display-mode="nested"
             drag-enabled
             label="List 6"
             group="nested"
@@ -991,11 +991,17 @@ export const emptyOpenLists_TestOnly = (): string =>
       </calcite-list>
     </calcite-list-item>
     <calcite-list-item open label="Hi! 6" description="hello world">
-      <calcite-list mode="nested" drag-enabled label="List 7" group="nested" selection-mode="multiple"></calcite-list>
+      <calcite-list
+        display-mode="nested"
+        drag-enabled
+        label="List 7"
+        group="nested"
+        selection-mode="multiple"
+      ></calcite-list>
     </calcite-list-item>
     <calcite-list-item open label="Hi! 7" description="hello world">
       <calcite-list
-        mode="nested"
+        display-mode="nested"
         drag-enabled
         label="List 8"
         group="nested"
@@ -1004,9 +1010,15 @@ export const emptyOpenLists_TestOnly = (): string =>
   ></calcite-list>`;
 
 export const listWithEmptyChildList_TestOnly = (): string =>
-  html`<calcite-list mode="nested" drag-enabled label="List 1" group="nested" selection-mode="single">
+  html`<calcite-list display-mode="nested" drag-enabled label="List 1" group="nested" selection-mode="single">
     <calcite-list-item open label="Hi! 4" description="hello world">
-      <calcite-list mode="nested" drag-enabled label="List 2" group="nested" selection-mode="single"></calcite-list>
+      <calcite-list
+        display-mode="nested"
+        drag-enabled
+        label="List 2"
+        group="nested"
+        selection-mode="single"
+      ></calcite-list>
     </calcite-list-item>
   </calcite-list>`;
 
@@ -1063,7 +1075,7 @@ export const filteredListItemsNoResults_TestOnly = (): string =>
   </calcite-list>`;
 
 export const nestingLists_TestOnly = (): string => html`<h4>Nesting List Items</h4>
-  <calcite-list mode="nested">
+  <calcite-list display-mode="nested">
     <calcite-list-item label="List Item" open>
       <calcite-list-item label="List Item"></calcite-list-item>
       <calcite-list-item label="List Item"></calcite-list-item>
@@ -1072,9 +1084,9 @@ export const nestingLists_TestOnly = (): string => html`<h4>Nesting List Items</
   </calcite-list>
   </br>
   <h4>Nesting Lists</h4>
-  <calcite-list mode="nested">
+  <calcite-list display-mode="nested">
     <calcite-list-item label="List Item" open>
-      <calcite-list mode="nested">
+      <calcite-list display-mode="nested">
         <calcite-list-item label="List Item"></calcite-list-item>
         <calcite-list-item label="List Item"></calcite-list-item>
         <calcite-list-item label="List Item"></calcite-list-item>
@@ -1147,13 +1159,13 @@ export const closedItems_TestOnly = (): string =>
   </calcite-list>`;
 
 export const dragEnabledNestedLists = (): string =>
-  html`<calcite-list mode="nested" id="root" drag-enabled label="List 1" group="my-list">
+  html`<calcite-list display-mode="nested" id="root" drag-enabled label="List 1" group="my-list">
     <calcite-list-item open label="Depth 1" description="Item 1">
-      <calcite-list mode="nested" group="my-list">
+      <calcite-list display-mode="nested" group="my-list">
         <calcite-list-item open label="Depth 2" description="Item 2">
-          <calcite-list mode="nested" drag-enabled label="List 2" group="my-list">
+          <calcite-list display-mode="nested" drag-enabled label="List 2" group="my-list">
             <calcite-list-item label="Depth 3" description="Item 3">
-              <calcite-list mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
+              <calcite-list display-mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
             </calcite-list-item>
             <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
           </calcite-list>
@@ -1166,16 +1178,16 @@ export const dragEnabledNestedLists = (): string =>
   </calcite-list>`;
 
 export const dragEnabledNestedListsIndirectChildren = (): string =>
-  html`<calcite-list mode="nested" id="root" drag-enabled label="List 1" group="my-list">
+  html`<calcite-list display-mode="nested" id="root" drag-enabled label="List 1" group="my-list">
     <div>
       <calcite-list-item open label="Depth 1" description="Item 1">
-        <calcite-list mode="nested" group="my-list">
+        <calcite-list display-mode="nested" group="my-list">
           <div>
             <calcite-list-item open label="Depth 2" description="Item 2">
-              <calcite-list mode="nested" drag-enabled label="List 2" group="my-list">
+              <calcite-list display-mode="nested" drag-enabled label="List 2" group="my-list">
                 <div>
                   <calcite-list-item label="Depth 3" description="Item 3">
-                    <calcite-list mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
+                    <calcite-list display-mode="nested" drag-enabled label="List 3" group="my-list"></calcite-list>
                   </calcite-list-item>
                 </div>
                 <div><calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item></div>

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -33,7 +33,7 @@ import type { Filter } from "../filter/filter";
 import type { ListItemGroup } from "../list-item-group/list-item-group";
 import { CSS, debounceTimeout, SelectionAppearance, SLOTS } from "./resources";
 import T9nStrings from "./assets/t9n/list.t9n.en.json";
-import { ListDragDetail, ListMoveDetail } from "./interfaces";
+import { ListDragDetail, ListMode, ListMoveDetail } from "./interfaces";
 import { styles } from "./list.scss";
 
 declare global {
@@ -99,6 +99,7 @@ export class List
       filterEl,
       filterEnabled,
       moveToItems,
+      mode,
     } = this;
 
     const items = Array.from(this.el.querySelectorAll(listItemSelector));
@@ -112,6 +113,7 @@ export class List
           (moveToItem) => moveToItem.element !== el && !item.contains(moveToItem.element),
         );
         item.dragHandle = dragEnabled;
+        item.mode = mode;
       }
     });
 
@@ -238,6 +240,9 @@ export class List
    * @private
    */
   messages = useT9n<typeof T9nStrings>({ blocking: true });
+
+  /** Specifies the nesting behavior. */
+  @property({ reflect: true }) mode: ListMode = "flat";
 
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property() numberingSystem: NumberingSystem;
@@ -385,7 +390,8 @@ export class List
       (changes.has("dragEnabled") && (this.hasUpdated || this.dragEnabled !== false)) ||
       (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) ||
       (changes.has("selectionAppearance") &&
-        (this.hasUpdated || this.selectionAppearance !== "icon"))
+        (this.hasUpdated || this.selectionAppearance !== "icon")) ||
+      (changes.has("mode") && this.hasUpdated)
     ) {
       this.handleListItemChange();
     }

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -48,7 +48,7 @@ const parentSelector = "calcite-list-item-group, calcite-list-item";
 /**
  * A general purpose list that enables users to construct list items that conform to Calcite styling.
  *
- * @slot - A slot for adding `calcite-list-item` elements.
+ * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot filter-actions-start - A slot for adding actionable `calcite-action` elements before the filter component.
  * @slot filter-actions-end - A slot for adding actionable `calcite-action` elements after the filter component.
  * @slot filter-no-results - When `filterEnabled` is `true`, a slot for adding content to display when no results are found.

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -33,7 +33,7 @@ import type { Filter } from "../filter/filter";
 import type { ListItemGroup } from "../list-item-group/list-item-group";
 import { CSS, debounceTimeout, SelectionAppearance, SLOTS } from "./resources";
 import T9nStrings from "./assets/t9n/list.t9n.en.json";
-import { ListDragDetail, ListMode, ListMoveDetail } from "./interfaces";
+import { ListDragDetail, ListDisplayMode, ListMoveDetail } from "./interfaces";
 import { styles } from "./list.scss";
 
 declare global {
@@ -99,7 +99,7 @@ export class List
       filterEl,
       filterEnabled,
       moveToItems,
-      mode,
+      displayMode,
     } = this;
 
     const items = Array.from(this.el.querySelectorAll(listItemSelector));
@@ -113,7 +113,7 @@ export class List
           (moveToItem) => moveToItem.element !== el && !item.contains(moveToItem.element),
         );
         item.dragHandle = dragEnabled;
-        item.mode = mode;
+        item.displayMode = displayMode;
       }
     });
 
@@ -242,7 +242,7 @@ export class List
   messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /** Specifies the nesting behavior. */
-  @property({ reflect: true }) mode: ListMode = "flat";
+  @property({ reflect: true }) displayMode: ListDisplayMode = "flat";
 
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property() numberingSystem: NumberingSystem;
@@ -391,7 +391,7 @@ export class List
       (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) ||
       (changes.has("selectionAppearance") &&
         (this.hasUpdated || this.selectionAppearance !== "icon")) ||
-      (changes.has("mode") && this.hasUpdated)
+      (changes.has("displayMode") && this.hasUpdated)
     ) {
       this.handleListItemChange();
     }

--- a/packages/calcite-components/src/demos/list.html
+++ b/packages/calcite-components/src/demos/list.html
@@ -489,11 +489,15 @@
         <div class="child right-aligned-text">nested</div>
 
         <div class="child">
-          <calcite-list label="test" selection-mode="multiple">
+          <calcite-list mode="nested" label="test" selection-mode="multiple">
             <calcite-list-item label="Hi!" description="hello world">
-              <calcite-list-item label="Hi!" description="hello world">
-                <calcite-list-item label="Hi!" description="hello world"></calcite-list-item>
-              </calcite-list-item>
+              <calcite-list mode="nested">
+                <calcite-list-item label="Hi!" description="hello world">
+                  <calcite-list mode="nested">
+                    <calcite-list-item label="Hi!" description="hello world"></calcite-list-item>
+                  </calcite-list>
+                </calcite-list-item>
+              </calcite-list>
             </calcite-list-item>
           </calcite-list>
         </div>
@@ -521,24 +525,32 @@
         <div class="child right-aligned-text">grouped and nested</div>
 
         <div class="child">
-          <calcite-list selection-mode="single">
+          <calcite-list mode="nested" selection-mode="single">
             <calcite-list-item heading="test" description="hello world">
               <calcite-icon
                 icon="embark"
                 slot="content-start"
                 style="color: var(--calcite-color-status-success)"
               ></calcite-icon>
-              <calcite-list-item heading="test" description="hello world">
-                <calcite-icon
-                  icon="embark"
-                  slot="content-start"
-                  style="color: var(--calcite-color-status-success)"
-                ></calcite-icon>
+              <calcite-list mode="nested">
                 <calcite-list-item heading="test" description="hello world">
-                  <calcite-icon icon="embark" slot="content-start" style="color: var(--calcite-color-status-success)">
-                  </calcite-icon>
+                  <calcite-icon
+                    icon="embark"
+                    slot="content-start"
+                    style="color: var(--calcite-color-status-success)"
+                  ></calcite-icon>
+                  <calcite-list mode="nested">
+                    <calcite-list-item heading="test" description="hello world">
+                      <calcite-icon
+                        icon="embark"
+                        slot="content-start"
+                        style="color: var(--calcite-color-status-success)"
+                      >
+                      </calcite-icon>
+                    </calcite-list-item>
+                  </calcite-list>
                 </calcite-list-item>
-              </calcite-list-item>
+              </calcite-list>
             </calcite-list-item>
             <calcite-list-item-group heading="My Group">
               <calcite-list-item heading="test" description="hello world">
@@ -645,6 +657,7 @@
 
         <div class="child">
           <calcite-list
+            mode="nested"
             filter-enabled
             filter-placeholder="Find content"
             selection-appearance="border"
@@ -681,20 +694,22 @@
                 </calcite-dropdown>
               </calcite-list-item>
               <calcite-list-item label="Rivers" value="rivers" open>
-                <calcite-list-item label="Estuaries" value="estuaries">
-                  <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
-                    <calcite-action
-                      slot="trigger"
-                      appearance="transparent"
-                      icon="ellipsis"
-                      scale="s"
-                      text="Trails layer"
-                    ></calcite-action>
-                    <calcite-dropdown-group scale="s" selection-mode="none">
-                      <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
-                    </calcite-dropdown-group>
-                  </calcite-dropdown>
-                </calcite-list-item>
+                <calcite-list mode="nested">
+                  <calcite-list-item label="Estuaries" value="estuaries">
+                    <calcite-dropdown slot="actions-end" overlay-positioning="fixed" placement="bottom-end" scale="s">
+                      <calcite-action
+                        slot="trigger"
+                        appearance="transparent"
+                        icon="ellipsis"
+                        scale="s"
+                        text="Trails layer"
+                      ></calcite-action>
+                      <calcite-dropdown-group scale="s" selection-mode="none">
+                        <calcite-dropdown-item icon-start="trash">Remove</calcite-dropdown-item>
+                      </calcite-dropdown-group>
+                    </calcite-dropdown>
+                  </calcite-list-item>
+                </calcite-list>
               </calcite-list-item>
             </calcite-list-item-group>
             <calcite-list-item-group heading="Tables">
@@ -813,11 +828,11 @@
         <div class="child right-aligned-text">nested & draggable</div>
 
         <div class="child">
-          <calcite-list drag-enabled group="nested" label="List 1" selection-mode="multiple">
+          <calcite-list mode="nested" drag-enabled group="nested" label="List 1" selection-mode="multiple">
             <calcite-list-item open label="Hi! 1" description="hello world">
-              <calcite-list label="List 2" drag-enabled group="nested" selection-mode="multiple">
+              <calcite-list mode="nested" label="List 2" drag-enabled group="nested" selection-mode="multiple">
                 <calcite-list-item open label="Hi! 2" description="hello world">
-                  <calcite-list label="List 3" drag-enabled group="nested" selection-mode="multiple">
+                  <calcite-list mode="nested" label="List 3" drag-enabled group="nested" selection-mode="multiple">
                     <calcite-list-item label="Hi! 3" description="hello world">
                       <calcite-list label="List 4" drag-enabled group="nested" selection-mode="multiple"></calcite-list>
                     </calcite-list-item>
@@ -852,7 +867,7 @@
         <div class="child right-aligned-text">Themed: icon</div>
 
         <div class="child">
-          <calcite-list selection-mode="multiple" selection-appearance="icon" class="themed-list">
+          <calcite-list mode="nested" selection-mode="multiple" selection-appearance="icon" class="themed-list">
             <calcite-list-item-group heading="Outdoor recreation">
               <calcite-list-item
                 selected
@@ -916,18 +931,20 @@
                   icon="layer"
                   text="Lodges layer"
                 ></calcite-action>
-                <calcite-list-item
-                  label="Guest lodges"
-                  description="Small houses available for visitors to book for stays."
-                  value="lodges"
-                >
-                  <calcite-action
-                    appearance="transparent"
-                    slot="actions-end"
-                    icon="layer"
-                    text="Lodges layer"
-                  ></calcite-action>
-                </calcite-list-item>
+                <calcite-list mode="nested">
+                  <calcite-list-item
+                    label="Guest lodges"
+                    description="Small houses available for visitors to book for stays."
+                    value="lodges"
+                  >
+                    <calcite-action
+                      appearance="transparent"
+                      slot="actions-end"
+                      icon="layer"
+                      text="Lodges layer"
+                    ></calcite-action>
+                  </calcite-list-item>
+                </calcite-list>
               </calcite-list-item>
               <calcite-list-item
                 label="Yurts"
@@ -950,7 +967,7 @@
         <div class="child right-aligned-text">Themed: border</div>
 
         <div class="child">
-          <calcite-list selection-mode="multiple" selection-appearance="border" class="themed-list">
+          <calcite-list mode="nested" selection-mode="multiple" selection-appearance="border" class="themed-list">
             <calcite-list-item-group heading="Outdoor recreation">
               <calcite-list-item
                 selected
@@ -1014,18 +1031,20 @@
                   icon="layer"
                   text="Lodges layer"
                 ></calcite-action>
-                <calcite-list-item
-                  label="Guest lodges"
-                  description="Small houses available for visitors to book for stays."
-                  value="lodges"
-                >
-                  <calcite-action
-                    appearance="transparent"
-                    slot="actions-end"
-                    icon="layer"
-                    text="Lodges layer"
-                  ></calcite-action>
-                </calcite-list-item>
+                <calcite-list mode="nested">
+                  <calcite-list-item
+                    label="Guest lodges"
+                    description="Small houses available for visitors to book for stays."
+                    value="lodges"
+                  >
+                    <calcite-action
+                      appearance="transparent"
+                      slot="actions-end"
+                      icon="layer"
+                      text="Lodges layer"
+                    ></calcite-action>
+                  </calcite-list-item>
+                </calcite-list>
               </calcite-list-item>
               <calcite-list-item
                 label="Yurts"

--- a/packages/calcite-components/src/demos/list.html
+++ b/packages/calcite-components/src/demos/list.html
@@ -401,9 +401,9 @@
             <calcite-list-item label="Princess Bubblegum" description="Ruler of The Candy Kingdom">
               <calcite-action
                 appearance="transparent"
-                icon="drag"
-                text="drag"
-                label="drag"
+                icon="information"
+                text="information"
+                label="information"
                 scale="s"
                 slot="actions-start"
               >
@@ -429,9 +429,9 @@
             <calcite-list-item label="Finn Mertens" description="Part owner of the Tree House">
               <calcite-action
                 appearance="transparent"
-                icon="drag"
-                text="drag"
-                label="drag"
+                icon="information"
+                text="information"
+                label="information"
                 scale="s"
                 slot="actions-start"
               >
@@ -457,9 +457,9 @@
             <calcite-list-item label="Jake T. Dog" description="Part owner of the Tree House">
               <calcite-action
                 appearance="transparent"
-                icon="drag"
-                text="drag"
-                label="drag"
+                icon="information"
+                text="information"
+                label="information"
                 scale="s"
                 slot="actions-start"
               >
@@ -610,6 +610,7 @@
       </div>
 
       <!-- custom content -->
+
       <div class="parent">
         <style>
           .list-chip {


### PR DESCRIPTION
**Related Issue:** #9173

## Summary

- add `displayMode` property to choose between flat and nested lists
- update demos
- update stories
- add tests

BREAKING CHANGE: Choose a `displayMode` of "nested" or "flat" according to space and nesting requirements.
