### PR TITLE
fix(combobox-item): replace type-enforced deprecated + required `textLabel` prop with runtime warning

### DIFF
--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -73,6 +73,18 @@ module.exports = {
     "jest/expect-expect": "off",
     "jest/no-export": "warn",
     "jsdoc/check-tag-names": "off",
+    "jsdoc/no-restricted-syntax": [
+      "error",
+      {
+        contexts: [
+          {
+            context: "any",
+            comment: `JsdocBlock:has(JsdocTag[tag="required"]):has(JsdocTag[tag="deprecated"])`,
+            message: "A property cannot be required and deprecated. Use `component#warnIfMissingRequiredProp` to handle required messaging.",
+          },
+        ],
+      },
+    ],
     "jsdoc/require-jsdoc": "off",
     "jsdoc/require-param-type": "off",
     "jsdoc/require-property-type": "off",

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -9,7 +9,7 @@ import {
 import { ComboboxChildElement } from "../combobox/interfaces";
 import { getAncestors, getDepth, isSingleLike } from "../combobox/utils";
 import { Scale, SelectionMode } from "../interfaces";
-import { getIconScale } from "../../utils/component";
+import { getIconScale, warnIfMissingRequiredProp } from "../../utils/component";
 import { IconNameOrString } from "../icon/interfaces";
 import { slotChangeHasContent } from "../../utils/dom";
 import { CSS, SLOTS } from "./resources";
@@ -138,7 +138,6 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
    * The component's text.
    *
    * @deprecated Use `heading` instead.
-   * @required
    */
   @property({ reflect: true }) textLabel: string;
 
@@ -169,6 +168,10 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
 
   override connectedCallback(): void {
     this.ancestors = getAncestors(this.el);
+  }
+
+  load(): void {
+    warnIfMissingRequiredProp(this, "value", "textLabel");
   }
 
   override willUpdate(changes: PropertyValues<this>): void {

--- a/packages/calcite-components/src/utils/component.ts
+++ b/packages/calcite-components/src/utils/component.ts
@@ -1,5 +1,6 @@
-import { PublicLitElement } from "@arcgis/lumina";
+import type { LitElement, PublicLitElement } from "@arcgis/lumina";
 import { Scale } from "../components/interfaces";
+import { logger } from "./logger";
 
 export function getIconScale(componentScale: Scale): Extract<Scale, "s" | "m"> {
   return componentScale === "l" ? "m" : "s";
@@ -20,4 +21,25 @@ export async function componentOnReady(el: HTMLElement): Promise<void> {
 
 function isStencilEl(el: HTMLElement): el is PublicLitElement {
   return typeof (el as PublicLitElement).componentOnReady === "function";
+}
+
+/**
+ * This utility logs a warning message when a required property is missing.
+ *
+ * Note: this should only be used for cases where using the @required JSDoc tag is not possible, such as:
+ * - when a required property is being deprecated
+ * - when a required property can be computed from another property
+ *
+ * @param component the component that requires the property
+ * @param newProp the new property that is required
+ * @param deprecatedProp the deprecated property that is required
+ */
+export function warnIfMissingRequiredProp<C extends LitElement>(
+  component: C,
+  newProp: keyof C,
+  deprecatedProp: keyof C,
+): void {
+  if (!component[newProp] && !component[deprecatedProp]) {
+    logger.warn(`[${component.el.localName}] "${newProp.toString()}" or "${deprecatedProp.toString()}" is required.`);
+  }
 }


### PR DESCRIPTION
**Related Issue:** #10321

## Summary

Addressed usage issues caused by TypeScript-enforced required property that had been marked as deprecated.

### Noteworthy changes:

* adds `warnIfMissingRequiredProp` util for cases where TS-enforced required props are not suitable
* enable [`jsdoc/no-restricted-syntax`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-restricted-syntax.md) rule to catch props tagged as both required and deprecated
