### PR TITLE
fix(dialog): update content background color to match modal

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -118,7 +118,7 @@ calcite-panel {
   --calcite-panel-content-space: var(--calcite-dialog-content-space, var(--calcite-internal-dialog-content-padding));
   --calcite-panel-footer-space: var(--calcite-dialog-footer-space);
   --calcite-panel-border-color: var(--calcite-dialog-border-color);
-  --calcite-panel-background-color: var(--calcite-dialog-background-color);
+  --calcite-panel-background-color: var(--calcite-dialog-background-color, var(--calcite-color-foreground-1));
 }
 
 .dialog {


### PR DESCRIPTION
**Related Issue:** #10809 

## Summary

Updates `dialog`’s content background color to be consistent with `modal`, easing the team’s migration efforts.