### PR TITLE
refactor: drop obsolete `componentOnReady` util

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -683,7 +683,7 @@ export class Combobox
       return;
     }
 
-    await this.el.componentOnReady();
+    await this.componentOnReady();
 
     if (!this.allowCustomValues && this.filterText) {
       this.clearInputValue();

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -3,13 +3,13 @@ import { calciteSize48 } from "@esri/calcite-design-tokens/dist/es6/core.js";
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {
-  LitElement,
-  property,
   createEvent,
   h,
-  method,
-  state,
   JsxNode,
+  LitElement,
+  method,
+  property,
+  state,
   stringOrBoolean,
 } from "@arcgis/lumina";
 import { filter } from "../../utils/filter";
@@ -55,7 +55,7 @@ import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/open
 import { DEBOUNCE } from "../../utils/resources";
 import { Scale, SelectionMode, Status } from "../interfaces";
 import { CSS as XButtonCSS, XButton } from "../functional/XButton";
-import { componentOnReady, getIconScale } from "../../utils/component";
+import { getIconScale } from "../../utils/component";
 import { Validation } from "../functional/Validation";
 import { IconNameOrString } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
@@ -683,7 +683,7 @@ export class Combobox
       return;
     }
 
-    await componentOnReady(this.el);
+    await this.el.componentOnReady();
 
     if (!this.allowCustomValues && this.filterText) {
       this.clearInputValue();

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -2,7 +2,7 @@ import interact from "interactjs";
 import type { DragEvent, Interactable, ResizeEvent } from "@interactjs/types";
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
-import { createEvent, JsxNode, LitElement, method, property, state } from "@arcgis/lumina";
+import { createEvent, h, JsxNode, LitElement, method, property, state } from "@arcgis/lumina";
 import { focusFirstTabbable } from "../../utils/dom";
 import {
   activateFocusTrap,

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -1,8 +1,8 @@
 import interact from "interactjs";
-import type { Interactable, ResizeEvent, DragEvent } from "@interactjs/types";
+import type { DragEvent, Interactable, ResizeEvent } from "@interactjs/types";
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
-import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
+import { createEvent, JsxNode, LitElement, method, property, state } from "@arcgis/lumina";
 import { focusFirstTabbable } from "../../utils/dom";
 import {
   activateFocusTrap,
@@ -21,7 +21,6 @@ import {
 import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { Kind, Scale } from "../interfaces";
-import { componentOnReady } from "../../utils/component";
 import { SLOTS as PANEL_SLOTS } from "../panel/resources";
 import { HeadingLevel } from "../functional/Heading";
 import type { OverlayPositioning } from "../../utils/floating-ui";
@@ -706,7 +705,7 @@ export class Dialog
   }
 
   private async openDialog(): Promise<void> {
-    await componentOnReady(this.el);
+    await this.el.componentOnReady();
     this.el.addEventListener(
       "calciteDialogOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -705,7 +705,7 @@ export class Dialog
   }
 
   private async openDialog(): Promise<void> {
-    await this.el.componentOnReady();
+    await this.componentOnReady();
     this.el.addEventListener(
       "calciteDialogOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -2,6 +2,7 @@ import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {
   createEvent,
+  h,
   JsxNode,
   LitElement,
   method,

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -405,7 +405,7 @@ export class Modal
   }
 
   private async openModal(): Promise<void> {
-    await this.el.componentOnReady();
+    await this.componentOnReady();
     this.el.addEventListener(
       "calciteModalOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -1,14 +1,13 @@
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {
-  LitElement,
-  property,
   createEvent,
-  h,
-  method,
-  state,
   JsxNode,
+  LitElement,
+  method,
+  property,
   setAttribute,
+  state,
 } from "@arcgis/lumina";
 import { getNearestOverflowAncestor } from "@floating-ui/utils/dom";
 import {
@@ -34,7 +33,7 @@ import {
 import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { Kind, Scale } from "../interfaces";
-import { componentOnReady, getIconScale } from "../../utils/component";
+import { getIconScale } from "../../utils/component";
 import { logger } from "../../utils/logger";
 import { useT9n } from "../../controllers/useT9n";
 import T9nStrings from "./assets/t9n/modal.t9n.en.json";
@@ -406,7 +405,7 @@ export class Modal
   }
 
   private async openModal(): Promise<void> {
-    await componentOnReady(this.el);
+    await this.el.componentOnReady();
     this.el.addEventListener(
       "calciteModalOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -283,7 +283,7 @@ export class Sheet
   }
 
   private async openSheet(): Promise<void> {
-    await this.el.componentOnReady();
+    await this.componentOnReady();
     this.el.addEventListener(
       "calciteSheetOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -1,13 +1,5 @@
 import { PropertyValues } from "lit";
-import {
-  LitElement,
-  property,
-  createEvent,
-  h,
-  method,
-  JsxNode,
-  setAttribute,
-} from "@arcgis/lumina";
+import { createEvent, JsxNode, LitElement, method, property, setAttribute } from "@arcgis/lumina";
 import { ensureId, focusFirstTabbable, getElementDir } from "../../utils/dom";
 import {
   activateFocusTrap,
@@ -27,7 +19,6 @@ import { createObserver } from "../../utils/observers";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { LogicalFlowPosition, Scale } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
-import { componentOnReady } from "../../utils/component";
 import { CSS } from "./resources";
 import { DisplayMode } from "./interfaces";
 import { styles } from "./sheet.scss";
@@ -292,7 +283,7 @@ export class Sheet
   }
 
   private async openSheet(): Promise<void> {
-    await componentOnReady(this.el);
+    await this.el.componentOnReady();
     this.el.addEventListener(
       "calciteSheetOpen",
       this.openEnd,

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -1,5 +1,13 @@
 import { PropertyValues } from "lit";
-import { createEvent, JsxNode, LitElement, method, property, setAttribute } from "@arcgis/lumina";
+import {
+  createEvent,
+  h,
+  JsxNode,
+  LitElement,
+  method,
+  property,
+  setAttribute,
+} from "@arcgis/lumina";
 import { ensureId, focusFirstTabbable, getElementDir } from "../../utils/dom";
 import {
   activateFocusTrap,

--- a/packages/calcite-components/src/utils/component.spec.ts
+++ b/packages/calcite-components/src/utils/component.spec.ts
@@ -1,7 +1,5 @@
-import { PublicLitElement } from "@arcgis/lumina";
-import { describe, expect, it, afterEach, beforeEach, vi, MockInstance } from "vitest";
-import { html } from "../../support/formatting";
-import { componentOnReady, getIconScale } from "./component";
+import { describe, expect, it } from "vitest";
+import { getIconScale } from "./component";
 
 describe("getIconScale", () => {
   it('should return "m" when input is "l"', () => {
@@ -11,42 +9,5 @@ describe("getIconScale", () => {
   it('should return "s" when input is not "l"', () => {
     expect(getIconScale("m")).toBe("s");
     expect(getIconScale("s")).toBe("s");
-  });
-});
-
-describe("componentOnReady", () => {
-  let requestAnimationFrameSpy: MockInstance;
-  let fakeComponent: HTMLElement;
-
-  beforeEach(() => {
-    document.body.innerHTML = html` <fake-component></fake-component> `;
-    fakeComponent = document.querySelector<HTMLElement>("fake-component");
-
-    const originalRaf = globalThis.requestAnimationFrame;
-    requestAnimationFrameSpy = vi
-      .spyOn(globalThis, "requestAnimationFrame")
-      .mockImplementation((callback) => originalRaf(callback));
-  });
-
-  afterEach(() => requestAnimationFrameSpy.mockRestore());
-
-  it("should call componentOnReady if it exists on the element (lazy-loaded)", async () => {
-    const componentOnReadyStub = ((fakeComponent as PublicLitElement).componentOnReady = vi.fn());
-
-    const promise = componentOnReady(fakeComponent);
-    expect(promise).toBeInstanceOf(Promise);
-
-    await promise;
-    expect(componentOnReadyStub).toHaveBeenCalled();
-  });
-
-  it("waits for an animation frame if componentOnReady does not exist on the element", async () => {
-    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
-
-    const promise = componentOnReady(fakeComponent);
-    expect(promise).toBeInstanceOf(Promise);
-
-    await promise;
-    expect(requestAnimationFrameSpy).toHaveBeenCalled();
   });
 });

--- a/packages/calcite-components/src/utils/component.ts
+++ b/packages/calcite-components/src/utils/component.ts
@@ -1,23 +1,5 @@
-import { PublicLitElement } from "@arcgis/lumina";
 import { Scale } from "../components/interfaces";
 
 export function getIconScale(componentScale: Scale): Extract<Scale, "s" | "m"> {
   return componentScale === "l" ? "m" : "s";
-}
-
-/**
- * This util helps us wait for a component to be ready for both lazy-loading (`dist` output) and non-lazy-loading (`components` output) components.
- *
- * Based on https://github.com/ionic-team/ionic-framework/blob/1a8bd6d/core/src/utils/helpers.ts#L60C1-L79C3
- *
- * @param el - the host element to wait for
- */
-export async function componentOnReady(el: HTMLElement): Promise<void> {
-  await (isStencilEl(el)
-    ? el.componentOnReady()
-    : new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
-}
-
-function isStencilEl(el: HTMLElement): el is PublicLitElement {
-  return typeof (el as PublicLitElement).componentOnReady === "function";
 }

--- a/packages/calcite-components/src/utils/label.ts
+++ b/packages/calcite-components/src/utils/label.ts
@@ -1,6 +1,5 @@
 import type { Label } from "../components/label/label";
 import { closestElementCrossShadowBoundary, isBefore, queryElementRoots } from "./dom";
-import { componentOnReady } from "./component";
 
 export interface LabelableComponent {
   /** When true, disabled prevents interaction. */
@@ -208,7 +207,7 @@ function onLabelDisconnected(this: LabelableComponent): void {
  * @param label - the label element
  */
 export async function associateExplicitLabelToUnlabeledComponent(label: Label["el"]): Promise<void> {
-  await componentOnReady(label);
+  await label.componentOnReady();
 
   const alreadyLabeled = labelToLabelables.has(label);
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Lumina provides `componentOnReady` for both lazy and non-lazy outputs, so this util is no longer necessary.