### PR TITLE
feat(list-item): update single-select icons

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -177,10 +177,6 @@
   padding-inline: var(--calcite-spacing-md) var(--calcite-spacing-xxs);
 }
 
-.selection-container--single {
-  color: transparent;
-}
-
 :host(:not([disabled]):not([selected])) .container:hover .selection-container--single {
   color: var(--calcite-list-icon-color, var(--calcite-color-border-input));
 }

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -182,7 +182,7 @@
 }
 
 :host(:not([disabled]):not([selected])) .container:hover .selection-container--single {
-  color: var(--calcite-list-icon-color, var(--calcite-color-border-1));
+  color: var(--calcite-list-icon-color, var(--calcite-color-border-input));
 }
 
 :host([selected]:hover) .selection-container,

--- a/packages/calcite-components/src/components/list-item/resources.ts
+++ b/packages/calcite-components/src/components/list-item/resources.ts
@@ -44,9 +44,9 @@ export const MAX_COLUMNS = 0;
 
 export const ICONS = {
   selectedMultiple: "check-square-f",
-  selectedSingle: "bullet-point-large",
+  selectedSingle: "circle-inset-large",
   unselectedMultiple: "square",
-  unselectedSingle: "bullet-point-large",
+  unselectedSingle: "circle",
   closedLTR: "chevron-right",
   closedRTL: "chevron-left",
   open: "chevron-down",


### PR DESCRIPTION
**Related Issue:** #9174

## Summary

Updates single-select icons according to the updated spec:

* `circle` for unselected (using `color.border.input`)
* `circle-inset-large` for selected