### PR TITLE
fix(accordion-item): split header content padding

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -75,7 +75,13 @@
   );
 }
 
-.header-content,
+.header-content {
+  padding: var(
+    --calcite-internal-accordion-item-padding,
+    var(--calcite-internal-accordion-item-spacing-unit, theme("spacing.2") 0.75rem)
+  );
+}
+
 .content {
   padding: var(
     --calcite-accordion-item-content-space,


### PR DESCRIPTION
**Related Issue:** #10762

## Summary

Splits header and content padding rules so the token doesn't apply to header