### PR TITLE
fix(combobox-item): fix icon color css override

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -105,7 +105,6 @@ ul:focus {
 
 .icon--custom {
   margin-block-start: -1px;
-  @apply text-color-3;
 }
 
 .icon--active {

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -18,6 +18,7 @@ import { calciteSwitch } from "./custom-theme/switch";
 import { card, cardThumbnail, cardTokens } from "./custom-theme/card";
 import { checkbox, checkboxTokens } from "./custom-theme/checkbox";
 import { chips, chipTokens } from "./custom-theme/chips";
+import { comboboxItem } from "./custom-theme/combobox-item";
 import { datePicker } from "./custom-theme/date-picker";
 import { dropdown } from "./custom-theme/dropdown";
 import { handle, handleTokens } from "./custom-theme/handle";
@@ -126,13 +127,10 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       </div>
       <div class="demo-column">
         ${datePicker} ${tabs} ${label} ${link} ${list} ${loader} ${calciteSwitch} ${avatarIcon} ${avatarInitials}
-        ${avatarThumbnail} ${progress} ${handle} ${textArea} ${popover} ${tile} ${tooltip}
+        ${avatarThumbnail} ${progress} ${handle} ${textArea} ${popover} ${tile} ${tooltip} ${comboboxItem}
       </div>
-      <div class="demo-column">
-      ${navigation} ${navigationLogos} ${navigationUsers}
-       </div>
-      ${alert} 
-
+      <div class="demo-column">${navigation} ${navigationLogos} ${navigationUsers}</div>
+      ${alert}
     </div>
   </div>`;
 

--- a/packages/calcite-components/src/custom-theme/combobox-item.ts
+++ b/packages/calcite-components/src/custom-theme/combobox-item.ts
@@ -1,0 +1,7 @@
+import { html } from "../../support/formatting";
+
+export const comboboxItem = html`<calcite-combobox-item
+  icon="altitude"
+  value="altitude"
+  text-label="Altitude"
+></calcite-combobox-item>`;


### PR DESCRIPTION
**Related Issue:** [#7854](https://github.com/Esri/calcite-design-system/issues/7854)

## Summary
Update to allow `--calcite-ui-icon-color` to override the component's icon color.