### PR TITLE
fix(chip): provide label context to assistive technologies

### DIFF
--- a/packages/calcite-components/src/components/chip/chip.e2e.ts
+++ b/packages/calcite-components/src/components/chip/chip.e2e.ts
@@ -13,8 +13,8 @@ describe("calcite-chip", () => {
     hidden("calcite-chip");
   });
 
-  describe("accessible without calcite-label", () => {
-    accessible(`<calcite-chip>doritos</calcite-chip>`);
+  describe("accessible with icon only", () => {
+    accessible(`<calcite-chip label="Gray basemap" icon="basemap"></calcite-chip>`);
   });
 
   describe("slots", () => {

--- a/packages/calcite-components/src/components/chip/chip.stories.ts
+++ b/packages/calcite-components/src/components/chip/chip.stories.ts
@@ -7,7 +7,7 @@ import { Chip } from "./chip";
 
 const { scale, appearance, kind } = ATTRIBUTES;
 
-type ChipStoryArgs = Pick<Chip, "scale" | "appearance" | "kind" | "closable" | "selected">;
+type ChipStoryArgs = Pick<Chip, "scale" | "appearance" | "kind" | "closable" | "selected" | "label">;
 
 export default {
   title: "Components/Chip",
@@ -17,6 +17,7 @@ export default {
     kind: kind.values[4],
     closable: false,
     selected: false,
+    label: "My great chip",
   },
   argTypes: {
     scale: {
@@ -33,6 +34,9 @@ export default {
       ),
       control: { type: "select" },
     },
+    label: {
+      control: { type: "text" },
+    },
   },
 };
 
@@ -42,7 +46,7 @@ export const simple = (args: ChipStoryArgs): string => html`
       scale="${args.scale}"
       appearance="${args.appearance}"
       kind="${args.kind}"
-      label="My great chip"
+      label="${args.label}"
       ${boolean("closable", args.closable)}
       ${boolean("selected", args.selected)}
       >My great chip</calcite-chip
@@ -50,17 +54,17 @@ export const simple = (args: ChipStoryArgs): string => html`
   </div>
 `;
 
-export const withIcon = (): string => html`
+export const withIcon = (args: ChipStoryArgs): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="My great chip">
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="${args.label}">
       My great chip</calcite-chip
     >
   </div>
 `;
 
-export const withImage = (): string => html`
+export const withImage = (args: ChipStoryArgs): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip scale="m" appearance="solid" kind="neutral" label="My great chip">
+    <calcite-chip scale="m" appearance="solid" kind="neutral" label="${args.label}">
       <img slot="image" src="${placeholderImage({ width: 50, height: 50 })}" />
       My great chip</calcite-chip
     >
@@ -99,9 +103,9 @@ export const withAvatarAndIcon = (): string => {
   `;
 };
 
-export const withClosable = (): string => html`
+export const withClosable = (args: ChipStoryArgs): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="My great chip" closable>
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="${args.label}" closable>
       My great chip</calcite-chip
     >
   </div>
@@ -125,9 +129,9 @@ export const withAvatarAndIconAndClosable = (): string => {
 export const overriddenIconColor = (): string =>
   html`<calcite-chip icon="banana" style="--calcite-icon-color: #ac9f42" label="Banana" closable>Banana</calcite-chip>`;
 
-export const darkModeRTL_TestOnly = (): string => html`
+export const darkModeRTL_TestOnly = (args: ChipStoryArgs): string => html`
   <div style="background-color:#2b2b2b;padding:100px" dir="rtl">
-    <calcite-chip class="calcite-mode-dark" label="My great chip">My great chip</calcite-chip>
+    <calcite-chip class="calcite-mode-dark" label="${args.label}">My great chip</calcite-chip>
   </div>
 `;
 

--- a/packages/calcite-components/src/components/chip/chip.stories.ts
+++ b/packages/calcite-components/src/components/chip/chip.stories.ts
@@ -42,6 +42,7 @@ export const simple = (args: ChipStoryArgs): string => html`
       scale="${args.scale}"
       appearance="${args.appearance}"
       kind="${args.kind}"
+      label="My great chip"
       ${boolean("closable", args.closable)}
       ${boolean("selected", args.selected)}
       >My great chip</calcite-chip
@@ -51,13 +52,15 @@ export const simple = (args: ChipStoryArgs): string => html`
 
 export const withIcon = (): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral"> My great chip</calcite-chip>
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="My great chip">
+      My great chip</calcite-chip
+    >
   </div>
 `;
 
 export const withImage = (): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip scale="m" appearance="solid" kind="neutral">
+    <calcite-chip scale="m" appearance="solid" kind="neutral" label="My great chip">
       <img slot="image" src="${placeholderImage({ width: 50, height: 50 })}" />
       My great chip</calcite-chip
     >
@@ -67,7 +70,7 @@ export const withImage = (): string => html`
 export const withAvatar = (): string => {
   return html`
     <div style="background-color:white;padding:100px">
-      <calcite-chip scale="m" appearance="solid" kind="neutral">
+      <calcite-chip scale="m" appearance="solid" kind="neutral" label="Username">
         <calcite-avatar
           slot="image"
           scale="m"
@@ -83,7 +86,7 @@ export const withAvatar = (): string => {
 export const withAvatarAndIcon = (): string => {
   return html`
     <div style="background-color:white;padding:100px">
-      <calcite-chip scale="m" appearance="solid" kind="neutral" icon="layer">
+      <calcite-chip scale="m" appearance="solid" kind="neutral" icon="layer" label="Username">
         <calcite-avatar
           slot="image"
           scale="m"
@@ -98,7 +101,7 @@ export const withAvatarAndIcon = (): string => {
 
 export const withClosable = (): string => html`
   <div style="background-color:white;padding:100px">
-    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" closable>
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="My great chip" closable>
       My great chip</calcite-chip
     >
   </div>
@@ -107,7 +110,7 @@ export const withClosable = (): string => html`
 export const withAvatarAndIconAndClosable = (): string => {
   return html`
     <div style="background-color:white;padding:100px">
-      <calcite-chip scale="m" appearance="solid" kind="neutral" closable icon="layer">
+      <calcite-chip scale="m" appearance="solid" kind="neutral" label="Username" closable icon="layer">
         <calcite-avatar
           slot="image"
           scale="m"
@@ -120,11 +123,11 @@ export const withAvatarAndIconAndClosable = (): string => {
   `;
 };
 export const overriddenIconColor = (): string =>
-  html`<calcite-chip icon="banana" style="--calcite-icon-color: #ac9f42" closable>Banana</calcite-chip>`;
+  html`<calcite-chip icon="banana" style="--calcite-icon-color: #ac9f42" label="Banana" closable>Banana</calcite-chip>`;
 
 export const darkModeRTL_TestOnly = (): string => html`
   <div style="background-color:#2b2b2b;padding:100px" dir="rtl">
-    <calcite-chip class="calcite-mode-dark">My great chip</calcite-chip>
+    <calcite-chip class="calcite-mode-dark" label="My great chip">My great chip</calcite-chip>
   </div>
 `;
 

--- a/packages/calcite-components/src/components/chip/chip.tsx
+++ b/packages/calcite-components/src/components/chip/chip.tsx
@@ -354,10 +354,10 @@ export class Chip extends LitElement implements InteractiveComponent, LoadableCo
           ? "radio"
           : this.interactive
             ? "button"
-            : undefined;
+            : "img";
     return (
       <InteractiveContainer disabled={disabled}>
-        <span
+        <div
           ariaChecked={
             this.selectionMode !== "none" && this.interactive ? this.selected : undefined
           }
@@ -392,7 +392,7 @@ export class Chip extends LitElement implements InteractiveComponent, LoadableCo
             <slot onSlotChange={this.handleDefaultSlotChange} />
           </span>
           {this.closable && this.renderCloseButton()}
-        </span>
+        </div>
       </InteractiveContainer>
     );
   }

--- a/packages/calcite-components/src/components/chip/chip.tsx
+++ b/packages/calcite-components/src/components/chip/chip.tsx
@@ -357,7 +357,7 @@ export class Chip extends LitElement implements InteractiveComponent, LoadableCo
             : undefined;
     return (
       <InteractiveContainer disabled={disabled}>
-        <div
+        <span
           ariaChecked={
             this.selectionMode !== "none" && this.interactive ? this.selected : undefined
           }
@@ -392,7 +392,7 @@ export class Chip extends LitElement implements InteractiveComponent, LoadableCo
             <slot onSlotChange={this.handleDefaultSlotChange} />
           </span>
           {this.closable && this.renderCloseButton()}
-        </div>
+        </span>
       </InteractiveContainer>
     );
   }

--- a/packages/calcite-components/src/demos/chip.html
+++ b/packages/calcite-components/src/demos/chip.html
@@ -133,34 +133,34 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s" label="My great chip">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse" label="My great chip">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand" label="My great chip">My great chip</calcite-chip>
+            <calcite-chip value="light-grey" scale="s" label="Gray basemap">Basemap</calcite-chip>
+            <calcite-chip value="light-grey" scale="m" kind="inverse" label="Gray basemap">Basemap</calcite-chip>
+            <calcite-chip value="light-grey" scale="l" kind="brand" label="Gray basemap">Basemap</calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s" appearance="outline" label="My great chip">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" scale="s" appearance="outline" label="Gray basemap">Basemap</calcite-chip>
+            <calcite-chip value="light-grey" scale="m" appearance="outline" kind="inverse" label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" scale="l" appearance="outline" kind="brand" label="Gray basemap"
+              >Basemap</calcite-chip
             >
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s" appearance="outline-fill" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" scale="s" appearance="outline-fill" label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" scale="m" appearance="outline-fill" kind="inverse" label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" scale="l" appearance="outline-fill" kind="brand" label="Gray basemap"
+              >Basemap</calcite-chip
             >
           </div>
         </div>
@@ -172,40 +172,50 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s" label="My great chip">My great chip</calcite-chip>
-            <calcite-chip value="chip" closable scale="m" kind="inverse" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" closable scale="s" label="Gray basemap">Basemap</calcite-chip>
+            <calcite-chip value="light-grey" closable scale="m" kind="inverse" label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" closable scale="l" kind="brand" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" closable scale="l" kind="brand" label="Gray basemap">Basemap</calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="light-grey" closable scale="s" appearance="outline" label="Gray basemap"
+              >Basemap</calcite-chip
+            >
+            <calcite-chip value="light-grey" closable scale="m" appearance="outline" kind="inverse" label="Gray basemap"
+              >Basemap</calcite-chip
+            >
+            <calcite-chip value="light-grey" closable scale="l" appearance="outline" kind="brand" label="Gray basemap"
+              >Basemap</calcite-chip
             >
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s" appearance="outline" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip value="light-grey" closable scale="s" appearance="outline-fill" label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" closable scale="m" appearance="outline" kind="inverse" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip
+              value="light-grey"
+              closable
+              scale="m"
+              appearance="outline-fill"
+              kind="inverse"
+              label="Gray basemap"
+              >Basemap</calcite-chip
             >
-            <calcite-chip value="chip" closable scale="l" appearance="outline" kind="brand" label="My great chip"
-              >My great chip</calcite-chip
-            >
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s" appearance="outline-fill" label="My great chip"
-              >My great chip</calcite-chip
-            >
-            <calcite-chip value="chip" closable scale="m" appearance="outline-fill" kind="inverse" label="My great chip"
-              >My great chip</calcite-chip
-            >
-            <calcite-chip value="chip" closable scale="l" appearance="outline-fill" kind="brand" label="My great chip"
-              >My great chip</calcite-chip
+            <calcite-chip
+              value="light-grey"
+              closable
+              scale="l"
+              appearance="outline-fill"
+              kind="brand"
+              label="Gray basemap"
+              >Basemap</calcite-chip
             >
           </div>
         </div>

--- a/packages/calcite-components/src/demos/chip.html
+++ b/packages/calcite-components/src/demos/chip.html
@@ -133,25 +133,35 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="s" label="My great chip">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="m" kind="inverse" label="My great chip">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="l" kind="brand" label="My great chip">My great chip</calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s" appearance="outline">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="s" appearance="outline" label="My great chip">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand" label="My great chip"
+              >My great chip</calcite-chip
+            >
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s" appearance="outline-fill">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse">My great chip</calcite-chip>
-            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand">My great chip</calcite-chip>
+            <calcite-chip value="chip" scale="s" appearance="outline-fill" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand" label="My great chip"
+              >My great chip</calcite-chip
+            >
           </div>
         </div>
       </div>
@@ -162,29 +172,39 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s">My great chip</calcite-chip>
-            <calcite-chip value="chip" closable scale="m" kind="inverse">My great chip</calcite-chip>
-            <calcite-chip value="chip" closable scale="l" kind="brand">My great chip</calcite-chip>
+            <calcite-chip value="chip" closable scale="s" label="My great chip">My great chip</calcite-chip>
+            <calcite-chip value="chip" closable scale="m" kind="inverse" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" closable scale="l" kind="brand" label="My great chip"
+              >My great chip</calcite-chip
+            >
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s" appearance="outline">My great chip</calcite-chip>
-            <calcite-chip value="chip" closable scale="m" appearance="outline" kind="inverse"
+            <calcite-chip value="chip" closable scale="s" appearance="outline" label="My great chip"
               >My great chip</calcite-chip
             >
-            <calcite-chip value="chip" closable scale="l" appearance="outline" kind="brand">My great chip</calcite-chip>
+            <calcite-chip value="chip" closable scale="m" appearance="outline" kind="inverse" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" closable scale="l" appearance="outline" kind="brand" label="My great chip"
+              >My great chip</calcite-chip
+            >
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable scale="s" appearance="outline-fill">My great chip</calcite-chip>
-            <calcite-chip value="chip" closable scale="m" appearance="outline-fill" kind="inverse"
+            <calcite-chip value="chip" closable scale="s" appearance="outline-fill" label="My great chip"
               >My great chip</calcite-chip
             >
-            <calcite-chip value="chip" closable scale="l" appearance="outline-fill" kind="brand"
+            <calcite-chip value="chip" closable scale="m" appearance="outline-fill" kind="inverse" label="My great chip"
+              >My great chip</calcite-chip
+            >
+            <calcite-chip value="chip" closable scale="l" appearance="outline-fill" kind="brand" label="My great chip"
               >My great chip</calcite-chip
             >
           </div>
@@ -197,32 +217,15 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s">
+            <calcite-chip value="chip" scale="s" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse">
+            <calcite-chip value="chip" scale="m" kind="inverse" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-              Siamese Cat
-            </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-              Siamese Cat
-            </calcite-chip>
-            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-              Siamese Cat
-            </calcite-chip>
-            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand">
+            <calcite-chip value="chip" scale="l" kind="brand" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
@@ -231,15 +234,32 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline-fill" scale="s">
+            <calcite-chip value="chip" appearance="outline" scale="s" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
-            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse">
+            <calcite-chip value="chip" scale="m" appearance="outline" kind="inverse" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
-            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand">
+            <calcite-chip value="chip" scale="l" appearance="outline" kind="brand" label="Siamese Cat">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+              Siamese Cat
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" appearance="outline-fill" scale="s" label="Siamese Cat">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="m" appearance="outline-fill" kind="inverse" label="Siamese Cat">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+              Siamese Cat
+            </calcite-chip>
+            <calcite-chip value="chip" scale="l" appearance="outline-fill" kind="brand" label="Siamese Cat">
               <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
               Siamese Cat
             </calcite-chip>
@@ -253,7 +273,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s">
+            <calcite-chip value="chip" scale="s" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -262,11 +282,11 @@
               ></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse">
+            <calcite-chip value="chip" scale="m" kind="inverse" label="User Name">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand">
+            <calcite-chip value="chip" scale="l" kind="brand" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -280,7 +300,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline" scale="s">
+            <calcite-chip value="chip" appearance="outline" scale="s" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -289,11 +309,11 @@
               ></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse" label="User Name">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -307,7 +327,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline-fill" scale="s">
+            <calcite-chip value="chip" appearance="outline-fill" scale="s" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -316,11 +336,11 @@
               ></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip value="chip" appearance="outline-fill" scale="m" kind="inverse" label="User Name">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip value="chip" appearance="outline-fill" scale="l" kind="brand" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -339,7 +359,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip icon="premium-content-user-credit" value="chip" scale="s">
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="s" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -348,11 +368,11 @@
               ></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip icon="premium-content-user-credit" value="chip" scale="m" kind="inverse">
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="m" kind="inverse" label="User Name">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip icon="premium-content-user-credit" value="chip" scale="l" kind="brand">
+            <calcite-chip icon="premium-content-user-credit" value="chip" scale="l" kind="brand" label="User Name">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -366,7 +386,13 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="s">
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline"
+              scale="s"
+              label="User Name"
+            >
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -375,11 +401,25 @@
               ></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline"
+              scale="m"
+              kind="inverse"
+              label="User Name"
+            >
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
             </calcite-chip>
-            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline" scale="l" kind="brand">
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline"
+              scale="l"
+              kind="brand"
+              label="User Name"
+            >
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -393,7 +433,13 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip icon="premium-content-user-credit" value="chip" appearance="outline-fill" scale="s">
+            <calcite-chip
+              icon="premium-content-user-credit"
+              value="chip"
+              appearance="outline-fill"
+              scale="s"
+              label="User Name"
+            >
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -408,6 +454,7 @@
               appearance="outline-fill"
               scale="m"
               kind="inverse"
+              label="User Name"
             >
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
               User Name
@@ -418,6 +465,7 @@
               appearance="outline-fill"
               scale="l"
               kind="brand"
+              label="User Name"
             >
               <calcite-avatar
                 slot="image"
@@ -437,19 +485,21 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" icon="embark" scale="s"> Maritime </calcite-chip>
-            <calcite-chip value="chip" icon="embark" scale="m" kind="inverse"> Maritime </calcite-chip>
-            <calcite-chip value="chip" icon="embark" scale="l" kind="brand"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" scale="s" label="Maritime"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" scale="m" kind="inverse" label="Maritime"> Maritime </calcite-chip>
+            <calcite-chip value="chip" icon="embark" scale="l" kind="brand" label="Maritime"> Maritime </calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" icon="embark" appearance="outline" scale="s"> Maritime </calcite-chip>
-            <calcite-chip value="chip" icon="embark" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="s" label="Maritime">
               Maritime
             </calcite-chip>
-            <calcite-chip value="chip" icon="embark" appearance="outline" scale="l" kind="brand">
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="m" kind="inverse" label="Maritime">
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline" scale="l" kind="brand" label="Maritime">
               Maritime
             </calcite-chip>
           </div>
@@ -457,11 +507,20 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="s"> Maritime </calcite-chip>
-            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="s" label="Maritime">
               Maritime
             </calcite-chip>
-            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip
+              value="chip"
+              icon="embark"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+              label="Maritime"
+            >
+              Maritime
+            </calcite-chip>
+            <calcite-chip value="chip" icon="embark" appearance="outline-fill" scale="l" kind="brand" label="Maritime">
               Maritime
             </calcite-chip>
           </div>
@@ -474,19 +533,11 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable icon="embark" scale="s"> Maritime </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" scale="m" kind="inverse"> Maritime </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" scale="l" kind="brand"> Maritime </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="s"> Maritime </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip value="chip" closable icon="embark" scale="s" label="Maritime"> Maritime </calcite-chip>
+            <calcite-chip value="chip" closable icon="embark" scale="m" kind="inverse" label="Maritime">
               Maritime
             </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="l" kind="brand">
+            <calcite-chip value="chip" closable icon="embark" scale="l" kind="brand" label="Maritime">
               Maritime
             </calcite-chip>
           </div>
@@ -494,13 +545,59 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="s">
+            <calcite-chip value="chip" closable icon="embark" appearance="outline" scale="s" label="Maritime">
               Maritime
             </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip
+              value="chip"
+              closable
+              icon="embark"
+              appearance="outline"
+              scale="m"
+              kind="inverse"
+              label="Maritime"
+            >
               Maritime
             </calcite-chip>
-            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip
+              value="chip"
+              closable
+              icon="embark"
+              appearance="outline"
+              scale="l"
+              kind="brand"
+              label="Maritime"
+            >
+              Maritime
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value="chip" closable icon="embark" appearance="outline-fill" scale="s" label="Maritime">
+              Maritime
+            </calcite-chip>
+            <calcite-chip
+              value="chip"
+              closable
+              icon="embark"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+              label="Maritime"
+            >
+              Maritime
+            </calcite-chip>
+            <calcite-chip
+              value="chip"
+              closable
+              icon="embark"
+              appearance="outline-fill"
+              scale="l"
+              kind="brand"
+              label="Maritime"
+            >
               Maritime
             </calcite-chip>
           </div>
@@ -513,28 +610,72 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" icon="drone-flying-wing" scale="s"> </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" scale="m" kind="inverse"> </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" scale="l" kind="brand"> </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="s"> </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="s" label="Drone small"> </calcite-chip>
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="m" kind="inverse" label="Drone medium">
             </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline" scale="l" kind="brand">
+            <calcite-chip value="chip" icon="drone-flying-wing" scale="l" kind="brand" label="Drone large">
             </calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="s"> </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline"
+              scale="s"
+              label="Drone small outline"
+            >
             </calcite-chip>
-            <calcite-chip value="chip" icon="drone-flying-wing" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline"
+              scale="m"
+              kind="inverse"
+              label="Drone medium outline"
+            >
+            </calcite-chip>
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline"
+              scale="l"
+              kind="brand"
+              label="Drone large outline"
+            >
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="s"
+              label="Drone small outline fill"
+            >
+            </calcite-chip>
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+              label="Drone medium outline fill"
+            >
+            </calcite-chip>
+            <calcite-chip
+              value="chip"
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="l"
+              kind="brand"
+              label="Drone large outline fill"
+            >
             </calcite-chip>
           </div>
         </div>
@@ -546,17 +687,42 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="s"> </calcite-chip>
-            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="m" kind="inverse">
+            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="s" label="Drone small">
             </calcite-chip>
-            <calcite-chip closable value="chip" closable icon="drone-flying-wing" scale="l" kind="brand">
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              scale="m"
+              kind="inverse"
+              label="Drone medium"
+            >
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              scale="l"
+              kind="brand"
+              label="Drone large"
+            >
             </calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" closable icon="drone-flying-wing" appearance="outline" scale="s">
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline"
+              scale="s"
+              label="Drone small outline"
+            >
             </calcite-chip>
             <calcite-chip
               closable
@@ -566,6 +732,7 @@
               appearance="outline"
               scale="m"
               kind="inverse"
+              label="Drone medium outline"
             >
             </calcite-chip>
             <calcite-chip
@@ -576,6 +743,7 @@
               appearance="outline"
               scale="l"
               kind="brand"
+              label="Drone large outline"
             >
             </calcite-chip>
           </div>
@@ -583,7 +751,15 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" closable icon="drone-flying-wing" appearance="outline-fill" scale="s">
+            <calcite-chip
+              closable
+              value="chip"
+              closable
+              icon="drone-flying-wing"
+              appearance="outline-fill"
+              scale="s"
+              label="Drone small outline fill"
+            >
             </calcite-chip>
             <calcite-chip
               closable
@@ -593,6 +769,7 @@
               appearance="outline-fill"
               scale="m"
               kind="inverse"
+              label="Drone medium outline fill"
             >
             </calcite-chip>
             <calcite-chip
@@ -603,6 +780,7 @@
               appearance="outline-fill"
               scale="l"
               kind="brand"
+              label="Drone large outline fill"
             >
             </calcite-chip>
           </div>
@@ -615,7 +793,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s">
+            <calcite-chip value="chip" scale="s" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -623,10 +801,10 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse">
+            <calcite-chip value="chip" scale="m" kind="inverse" label="Username">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand">
+            <calcite-chip value="chip" scale="l" kind="brand" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -639,7 +817,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline" scale="s">
+            <calcite-chip value="chip" appearance="outline" scale="s" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -647,10 +825,10 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse" label="Username">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -663,7 +841,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value=" chip" appearance="outline-fill" scale="s">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="s" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -671,10 +849,10 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse" label="Username">
               <calcite-avatar slot="image" user-id="52e44e112b1f429182515dba79b71eb8" username="au"></calcite-avatar>
             </calcite-chip>
-            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="l"
@@ -692,7 +870,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" scale="s">
+            <calcite-chip closable value="chip" scale="s" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -700,7 +878,7 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip closable value="chip" scale="m" kind="inverse">
+            <calcite-chip closable value="chip" scale="m" kind="inverse" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -708,36 +886,7 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip closable value="chip" scale="l" kind="brand">
-              <calcite-avatar
-                slot="image"
-                scale="s"
-                user-id="52e44e112b1f429182515dba79b71eb8"
-                username="au"
-              ></calcite-avatar>
-            </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip closable value="chip" appearance="outline" scale="s">
-              <calcite-avatar
-                slot="image"
-                scale="s"
-                user-id="52e44e112b1f429182515dba79b71eb8"
-                username="au"
-              ></calcite-avatar>
-            </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse">
-              <calcite-avatar
-                slot="image"
-                scale="s"
-                user-id="52e44e112b1f429182515dba79b71eb8"
-                username="au"
-              ></calcite-avatar>
-            </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand">
+            <calcite-chip closable value="chip" scale="l" kind="brand" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -750,7 +899,7 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="s">
+            <calcite-chip closable value="chip" appearance="outline" scale="s" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -758,7 +907,7 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="m" kind="inverse">
+            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -766,7 +915,36 @@
                 username="au"
               ></calcite-avatar>
             </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="l" kind="brand">
+            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand" label="Username">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="s" label="Username">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="m" kind="inverse" label="Username">
+              <calcite-avatar
+                slot="image"
+                scale="s"
+                user-id="52e44e112b1f429182515dba79b71eb8"
+                username="au"
+              ></calcite-avatar>
+            </calcite-chip>
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="l" kind="brand" label="Username">
               <calcite-avatar
                 slot="image"
                 scale="s"
@@ -784,42 +962,42 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value="chip" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip value="chip" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" scale="m" kind="inverse" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip value="chip" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip value="chip" appearance="outline" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" scale="l" kind="brand" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip value=" chip" appearance="outline-fill" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" appearance="outline" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" appearance="outline" scale="m" kind="inverse" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip value="chip" appearance="outline" scale="l" kind="brand" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip value=" chip" appearance="outline-fill" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="m" kind="inverse" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+            <calcite-chip value=" chip" appearance="outline-fill" scale="l" kind="brand" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
           </div>
         </div>
@@ -831,42 +1009,56 @@
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip closable value="chip" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" scale="m" kind="inverse" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip closable value="chip" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-          </div>
-        </div>
-
-        <div class="child">
-          <div class="chip-group">
-            <calcite-chip closable value="chip" appearance="outline" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
-            </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" scale="l" kind="brand" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
           </div>
         </div>
 
         <div class="child">
           <div class="chip-group">
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="s">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" appearance="outline" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="m" kind="inverse">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" appearance="outline" scale="m" kind="inverse" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
-            <calcite-chip closable value="chip" appearance="outline-fill" scale="l" kind="brand">
-              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" />
+            <calcite-chip closable value="chip" appearance="outline" scale="l" kind="brand" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+          </div>
+        </div>
+
+        <div class="child">
+          <div class="chip-group">
+            <calcite-chip closable value="chip" appearance="outline-fill" scale="s" label="Placeholder image">
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              appearance="outline-fill"
+              scale="m"
+              kind="inverse"
+              label="Placeholder image"
+            >
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
+            </calcite-chip>
+            <calcite-chip
+              closable
+              value="chip"
+              appearance="outline-fill"
+              scale="l"
+              kind="brand"
+              label="Placeholder image"
+            >
+              <img slot="image" width="80" height="80" src="./_assets/images/placeholder.svg" alt="" />
             </calcite-chip>
           </div>
         </div>
@@ -878,36 +1070,40 @@
 
         <div class="child themed-children">
           <div class="chip-group">
-            <calcite-chip kind="brand" value="calcite chip">AWS</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Azure</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Maintained</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Host</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Test</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Priority - High</calcite-chip>
-            <calcite-chip kind="brand" value="calcite chip">Archived</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Amazon Web Services">AWS</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Azure">Azure</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Maintained">Maintained</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Host">Host</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Test">Test</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Priority - High">Priority - High</calcite-chip>
+            <calcite-chip kind="brand" value="calcite chip" label="Archived">Archived</calcite-chip>
           </div>
         </div>
 
         <div class="child themed-children">
           <div class="chip-group">
-            <calcite-chip value="calcite chip" appearance="outline">AWS</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Azure</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Maintained</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Host</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Test</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Priority - High</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline">Archived</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Amazon Web Services">AWS</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Azure">Azure</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Maintained">Maintained</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Host">Host</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Test">Test</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline" label="Priority - High"
+              >Priority - High</calcite-chip
+            >
+            <calcite-chip value="calcite chip" appearance="outline" label="Archived">Archived</calcite-chip>
           </div>
         </div>
         <div class="child themed-children">
           <div class="chip-group">
-            <calcite-chip value="calcite chip" appearance="outline-fill">AWS</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Azure</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Maintained</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Host</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Test</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Priority - High</calcite-chip>
-            <calcite-chip value="calcite chip" appearance="outline-fill">Archived</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Amazon Web Services">AWS</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Azure">Azure</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Maintained">Maintained</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Host">Host</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Test">Test</calcite-chip>
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Priority - High"
+              >Priority - High</calcite-chip
+            >
+            <calcite-chip value="calcite chip" appearance="outline-fill" label="Archived">Archived</calcite-chip>
           </div>
         </div>
       </div>
@@ -956,13 +1152,23 @@
               />
               <h3 slot="title">My great Workforce project that might wrap two lines</h3>
               <span slot="subtitle">Johnathan Smith</span>
-              <calcite-chip-group class="themed-children-card" scale="s" slot="footer-start" style="flex-flow: row">
-                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s"> </calcite-chip>
-                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s"> </calcite-chip>
-                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s"> </calcite-chip>
+              <calcite-chip-group
+                class="themed-children-card"
+                scale="s"
+                slot="footer-start"
+                style="flex-flow: row"
+                label="Access constraints"
+              >
+                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s" label="Authoritative">
+                </calcite-chip>
+                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s" label="Shared universally">
+                </calcite-chip>
+                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s" label="Secured">
+                </calcite-chip>
               </calcite-chip-group>
               <div slot="footer-end" style="display: flex; align-items: center">
-                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-end"> </calcite-chip>
+                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-end" label="User">
+                </calcite-chip>
                 <calcite-action scale="s" icon="ellipsis" style="margin-inline-start: 4px"></calcite-action>
               </div>
             </calcite-card>
@@ -992,16 +1198,26 @@
               />
               <h3 slot="title">My great Workforce project that might wrap two lines</h3>
               <span slot="subtitle">Johnathan Smith</span>
-              <calcite-chip-group class="themed-children-card" scale="s" slot="footer-start" style="flex-flow: row">
-                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s">
+              <calcite-chip-group
+                class="themed-children-card"
+                scale="s"
+                slot="footer-start"
+                style="flex-flow: row"
+                label="Access constaints"
+              >
+                <calcite-chip id="badge-1" value="calcite chip" icon="check-circle" scale="s" label="Authoritative">
                   authoritative</calcite-chip
                 >
-                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s">authoritative </calcite-chip>
-                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s"> authoritative</calcite-chip>
+                <calcite-chip id="badge-2" value="calcite chip" icon="globe" scale="s" label="Shared universally"
+                  >shared
+                </calcite-chip>
+                <calcite-chip id="badge-3" value="calcite chip" icon="security" scale="s" label="Secured">
+                  secured</calcite-chip
+                >
               </calcite-chip-group>
               <div slot="footer-end" style="display: flex; align-items: center">
-                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-end"
-                  >authoritative
+                <calcite-chip id="badge-4" value="calcite chip" icon="user" scale="s" slot="footer-end" label="Username"
+                  >username
                 </calcite-chip>
                 <calcite-action scale="s" icon="ellipsis" style="margin-inline-start: 4px"></calcite-action>
               </div>
@@ -1030,7 +1246,7 @@
     </demo-dom-swapper>
   </body>
   <script>
-    const chipHTML = `<calcite-chip appearance="outline" kind="neutral" icon="layers" value="layers">Layers</calcite-chip>`;
+    const chipHTML = `<calcite-chip appearance="outline" kind="neutral" icon="layers" value="layers" label="Layers">Layers</calcite-chip>`;
 
     const shadowEl = document.getElementById("shadowEl");
     const shadow = shadowEl.attachShadow({ mode: "open" });


### PR DESCRIPTION
**Related Issue:** #8696 

## Summary
Provides context to the component's `label` property for JAWS and NVDA users using the [`"img"` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role), conveying content is delivered in a visual manner and should be accompanied with the required `label` property.