### PR TITLE
fix(combobox-item-group): cascade scale from combobox

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1241,6 +1241,8 @@ export class Combobox
       item.scale = this.scale;
     });
 
+    this.groupItems.forEach((groupItem) => (groupItem.scale = this.scale));
+
     if (!this.allowCustomValues) {
       this.setMaxScrollerHeight();
     }


### PR DESCRIPTION
**Related Issue:** #10897 

## Summary

cascade `scale` from `combobox` onto `combobox-item-group`