### PR TITLE
chore(linting): update ESLint setup

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
   "*.{json,html,yml}": ["prettier --write"],
   "*.scss": ["stylelint --fix", "prettier --write"],
-  "packages/**/*.{ts,tsx}": ["eslint --ext .ts,.tsx --fix", "prettier --write"],
-  ".github/scripts/*.js": ["eslint --ext .js", "prettier --write"],
+  "packages/**/*.{ts,tsx}": ["cross-env ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx --fix", "prettier --write"],
+  ".github/scripts/*.js": ["cross-env ESLINT_USE_FLAT_CONFIG=false eslint --ext .js", "prettier --write"],
   "*.md": ["prettier --write", "markdownlint --fix"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "conventional-changelog-conventionalcommits": "7.0.2",
         "cpy": "11.1.0",
         "cpy-cli": "5.0.0",
+        "cross-env": "7.0.3",
         "dedent": "1.5.3",
         "eslint": "9.15.0",
         "eslint-config-prettier": "9.1.0",
@@ -13977,6 +13978,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "conventional-changelog-conventionalcommits": "7.0.2",
     "cpy": "11.1.0",
     "cpy-cli": "5.0.0",
+    "cross-env": "7.0.3",
     "dedent": "1.5.3",
     "eslint": "9.15.0",
     "eslint-config-prettier": "9.1.0",

--- a/packages/calcite-components/.eslintrc.cjs
+++ b/packages/calcite-components/.eslintrc.cjs
@@ -20,16 +20,6 @@ module.exports = {
     ecmaVersion: 2021,
     sourceType: "module",
   },
-  plugins: [
-    "@esri/calcite-components",
-    "@typescript-eslint",
-    "eslint-plugin-react",
-    "import",
-    "jest",
-    "jsdoc",
-    "prettier",
-    "unicorn",
-  ],
   rules: {
     "@esri/calcite-components/ban-events": [
       "warn",
@@ -44,7 +34,6 @@ module.exports = {
     ],
     "@esri/calcite-components/enforce-ref-last-prop": "off",
     "@esri/calcite-components/strict-boolean-attributes": "off",
-    "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/explicit-module-boundary-types": [
       "error",
       {
@@ -62,11 +51,13 @@ module.exports = {
         ],
       },
     ],
-    "@typescript-eslint/lines-between-class-members": ["error", "always"],
     "@typescript-eslint/method-signature-style": ["error", "property"],
+    "@typescript-eslint/no-empty-object-type": "warn",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
-    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-unused-expressions": "warn",
+    "@typescript-eslint/no-unused-vars": "warn",
+    "no-constant-binary-expression": "warn",
     curly: "error",
     "import/no-dynamic-require": ["error", { esmodule: true }],
     "import/order": ["error", { "newlines-between": "never" }],
@@ -90,7 +81,6 @@ module.exports = {
     "jsdoc/require-property-type": "off",
     "jsdoc/require-returns-type": "off",
     "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
-    "lines-between-class-members": "off",
     "no-eval": "error",
     "no-implied-eval": "error",
     "no-multiple-empty-lines": [
@@ -168,6 +158,16 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    "@esri/calcite-components",
+    "@typescript-eslint",
+    "eslint-plugin-react",
+    "import",
+    "jest",
+    "jsdoc",
+    "prettier",
+    "unicorn",
+  ],
   settings: {
     react: {
       pragma: "h",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -46,7 +46,7 @@
     "lint:json": "prettier --write \"**/*.json\" >/dev/null",
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path .gitignore",
     "lint:scss": "stylelint --fix \"src/**/*.scss\" && prettier --write \"**/*.scss\" >/dev/null",
-    "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
+    "lint:ts": "cross-env ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
     "prepublish": "./support/cleanupDistFiles.sh",
     "screenshot-tests": "npm run build-storybook",
     "screenshot-tests:preview": "npm run util:prep-build-reqs && NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_SCREENSHOT_LOCAL_BUILD=true storybook dev",

--- a/packages/calcite-design-tokens/package.json
+++ b/packages/calcite-design-tokens/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf dist",
     "lint:json": "prettier --write \"**/*.json\" >/dev/null",
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path ../../.gitignore",
-    "lint:ts": "eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
+    "lint:ts": "cross-env ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx --fix . && prettier --write \"**/*.ts?(x)\" >/dev/null",
     "lint": "concurrently npm:lint:*",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

After https://github.com/Esri/calcite-design-system/pull/10884, we need a few more tweaks for linting to run properly. 

### Additional notes

* The following rules have been set to warn or removed until they can be fixed separately:
  * `ban-types` (removed) – [split into separate rules](https://typescript-eslint.io/rules/ban-types/).
  * `@typescript-eslint/no-empty-object-type` (warns)
  * `@typescript-eslint/no-unused-expressions` (warns)
  * `@typescript-eslint/no-unused-vars` (warns)
  *  `no-constant-binary-expression` (warns)
  * `lines-between-class-members` [(removed))](https://typescript-eslint.io/rules/lines-between-class-members/) – moved to `@stylistic`
* Installs `cross-env` per [ESLint](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated) [documentation](https://github.com/lint-staged/lint-staged#use-environment-variables-with-linting-commands). We can remove after migrating our configs to the [recommended flat structure](https://eslint.org/docs/latest/use/configure/configuration-files).
