### PR TITLE
build(deps): drop `@esri/calcite-colors`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@arcgis/lumina-compiler": "4.32.0-next.29",
         "@cspell/eslint-plugin": "8.16.0",
         "@esri/calcite-base": "1.2.0",
-        "@esri/calcite-colors": "6.1.0",
         "@octokit/webhooks-types": "7.6.1",
         "@prettier/sync": "0.5.2",
         "@rollup/plugin-node-resolve": "15.3.0",
@@ -3401,13 +3400,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@esri/calcite-base/-/calcite-base-1.2.0.tgz",
       "integrity": "sha512-xcEfk/lsj8SqHXDA8ekgZVCVZsRtfGiZDd6eGI/+U1QCqPhy8lmHh50fQhDiQvSOQ4NFWPXems5xaTQoQdiA8A==",
-      "dev": true,
-      "license": "SEE LICENSE IN README.md"
-    },
-    "node_modules/@esri/calcite-colors": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.1.0.tgz",
-      "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q==",
       "dev": true,
       "license": "SEE LICENSE IN README.md"
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@arcgis/lumina-compiler": "4.32.0-next.29",
     "@cspell/eslint-plugin": "8.16.0",
     "@esri/calcite-base": "1.2.0",
-    "@esri/calcite-colors": "6.1.0",
     "@octokit/webhooks-types": "7.6.1",
     "@prettier/sync": "0.5.2",
     "@rollup/plugin-node-resolve": "15.3.0",

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -1,4 +1,3 @@
-@import "@esri/calcite-colors/dist/colors";
 @import "@esri/calcite-base/dist/index";
 @import "@esri/calcite-design-tokens/dist/scss/index";
 @import "@esri/calcite-design-tokens/dist/scss/core";
@@ -164,7 +163,7 @@
       focus-base
       items-center
       m-0
-      rounded-half 
+      rounded-half
       transition-default;
 
     background-color: var(--calcite-close-background-color, var(--calcite-color-transparent));

--- a/packages/calcite-components/src/components/sheet/sheet.scss
+++ b/packages/calcite-components/src/components/sheet/sheet.scss
@@ -17,7 +17,7 @@
   @apply flex absolute z-overlay inset-0;
   visibility: hidden !important;
   // the sheet should always use a dark scrim, regardless of light / dark mode - matches value in global.scss
-  --calcite-sheet-scrim-background-internal: #{rgba($blk-240, 0.85)};
+  --calcite-sheet-scrim-background-internal: #{rgba($calcite-color-neutral-blk-240, 0.85)};
   --calcite-scrim-shadow-block-start-internal: 0 4px 8px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
   --calcite-scrim-shadow-block-end-internal: 0 -4px 8px -1px rgba(0, 0, 0, 0.08), 0 -2px 4px -1px rgba(0, 0, 0, 0.04);
   --calcite-scrim-shadow-inline-start-internal: 4px 0 8px -1px rgba(0, 0, 0, 0.08), 2px 0 4px -1px rgba(0, 0, 0, 0.04);

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -138,7 +138,7 @@
 
 :host([complete]) .container {
   // todo dark mode
-  border-color: rgba($h-bb-060, 0.5);
+  border-color: rgba($calcite-color-high-saturation-blue-h-bb-060, 0.5);
   & .stepper-item-icon {
     color: theme("backgroundColor.brand");
   }
@@ -225,7 +225,7 @@
 }
 
 :host([layout="vertical"][complete]) .container {
-  border-color: rgba($h-bb-060, 0.5);
+  border-color: rgba($calcite-color-high-saturation-blue-h-bb-060, 0.5);
 }
 :host([layout="vertical"][complete]:hover:not([disabled]):not([selected])) .container,
 :host([layout="vertical"][complete]:focus:not([disabled]):not([selected])) .container {
@@ -243,7 +243,7 @@
 }
 :host([layout="vertical"]:hover:not([disabled]):not([selected])) .container,
 :host([layout="vertical"]:focus:not([disabled]):not([selected])) .container {
-  border-color: rgba($h-bb-060, 0.5);
+  border-color: rgba($calcite-color-high-saturation-blue-h-bb-060, 0.5);
 }
 :host([layout="vertical"][error]:hover:not([disabled]):not([selected])) .container,
 :host([layout="vertical"][error]:focus:not([disabled]):not([selected])) .container {
@@ -302,7 +302,7 @@
 :host([layout="horizontal"][complete]),
 :host([layout="horizontal-single"][complete]) {
   .stepper-item-header {
-    border-color: rgba($h-bb-060, 0.5);
+    border-color: rgba($calcite-color-high-saturation-blue-h-bb-060, 0.5);
   }
 }
 :host([layout="horizontal"][complete]:hover:not([disabled]):not([selected])),
@@ -330,7 +330,7 @@
 :host([layout="horizontal-single"]:hover:not([disabled]):not([selected])),
 :host([layout="horizontal-single"]:focus:not([disabled]):not([selected])) {
   .stepper-item-header {
-    border-color: rgba($h-bb-060, 0.5);
+    border-color: rgba($calcite-color-high-saturation-blue-h-bb-060, 0.5);
   }
 }
 :host([layout="horizontal"][error]:hover:not([disabled]):not([selected])),


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Updates Sass vars to use design tokens, removing a legacy dep.