### PR TITLE
ci(milestone-estimates): add run when milestone is closed

### DIFF
--- a/.github/workflows/track-milestone-estimates.yml
+++ b/.github/workflows/track-milestone-estimates.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   issues:
     types: [closed]
+  milestone:
+    types: [closed]
 jobs:
   estimates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Adds a new run to the track-milestone-estimates when a milestone has been closed. The `trackMilestoneEstimates.js` script does not contain specific context to the issue, so the accompanying script shouldn't need any tweaks with the new run condition. 

The run will now execute when either:
- an issue is closed
- a milestone is closed, or
- manually via `workflow_dispatch`