### PR TITLE
fix(slider): avoid breaking thumb label on edges

### DIFF
--- a/packages/calcite-components/src/components/slider/slider.scss
+++ b/packages/calcite-components/src/components/slider/slider.scss
@@ -125,6 +125,8 @@
   transform: translate(var(--calcite-slider-thumb-x-offset), var(--calcite-slider-thumb-y-offset));
 
   .handle__label {
+    white-space: nowrap;
+
     &.static,
     &.transformed {
       @apply absolute

--- a/packages/calcite-components/src/components/slider/slider.stories.ts
+++ b/packages/calcite-components/src/components/slider/slider.stories.ts
@@ -643,6 +643,21 @@ export const customLabelsAndTicks = (): string => html`
     min-label="Temperature"
   ></calcite-slider>
 
+  <br />
+  <br />
+
+  <label>Label formatter (single value + long label)</label>
+  <calcite-slider id="singleFormattedLongLabelSlider" label-handles label-ticks></calcite-slider>
+
+  <label>Label formatter (min/max value + long label)</label>
+  <calcite-slider
+    id="minMaxFormattedLongLabelSlider"
+    label-handles
+    label-ticks
+    min-value="0"
+    max-value="100"
+  ></calcite-slider>
+
   <script>
     const singleValueSlider = document.getElementById("singleFormattedLabelSlider");
 
@@ -667,6 +682,18 @@ export const customLabelsAndTicks = (): string => html`
       if (type === "tick") {
         return value === minMaxValueSlider.max ? value + "ºF" : value + "º";
       }
+    };
+
+    const singleValueLongLabelSlider = document.getElementById("singleFormattedLongLabelSlider");
+
+    singleValueLongLabelSlider.labelFormatter = function (value) {
+      return "long " + value + " label";
+    };
+
+    const minMaxValueLongLabelSlider = document.getElementById("minMaxFormattedLongLabelSlider");
+
+    minMaxValueLongLabelSlider.labelFormatter = function (value) {
+      return "long " + value + " label";
     };
   </script>
 `;

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -995,15 +995,14 @@ export class Slider
    * @private
    */
   private getHostOffset(leftBounds: number, rightBounds: number): number {
-    const hostBounds = this.el.getBoundingClientRect();
-    const buffer = 7;
+    const { left, right } = this.el.getBoundingClientRect();
 
-    if (leftBounds + buffer < hostBounds.left) {
-      return hostBounds.left - leftBounds - buffer;
+    if (leftBounds < left) {
+      return left - leftBounds;
     }
 
-    if (rightBounds - buffer > hostBounds.right) {
-      return -(rightBounds - hostBounds.right) + buffer;
+    if (rightBounds > right) {
+      return -(rightBounds - right);
     }
 
     return 0;


### PR DESCRIPTION
**Related Issue:** #9239

## Summary

This improves label handling for long thumb labels.
