### PR TITLE
fix(input-time-zone): ensure name-mode displays IANA time zone identifiers

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -280,7 +280,7 @@ describe("calcite-input-time-zone", () => {
 
             const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-            expect(await timeZoneItem.getProperty("textLabel")).toMatch(toUserFriendlyName(name));
+            expect(await timeZoneItem.getProperty("textLabel")).toMatch(name);
           });
         });
       });
@@ -298,7 +298,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(toUserFriendlyName(testTimeZoneItems[1].name));
+        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[1].name);
       });
 
       it("ignores invalid values", async () => {
@@ -314,7 +314,7 @@ describe("calcite-input-time-zone", () => {
 
         const timeZoneItem = await page.find("calcite-input-time-zone >>> calcite-combobox-item[selected]");
 
-        expect(await timeZoneItem.getProperty("textLabel")).toMatch(toUserFriendlyName(testTimeZoneItems[0].name));
+        expect(await timeZoneItem.getProperty("textLabel")).toMatch(testTimeZoneItems[0].name);
       });
     });
 

--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -62,7 +62,7 @@ export async function createTimeZoneItems(
 
     return groups
       .map<TimeZoneItem<string>>(({ label: timeZone }) => {
-        const label = toUserFriendlyName(timeZone);
+        const label = timeZone;
         const value = timeZone;
 
         return {


### PR DESCRIPTION
**Related Issue:** #8698, #8005

## Summary

Updates time zone labels (name-mode) to display IANA identifiers per https://github.com/Esri/calcite-design-system/issues/8005#issuecomment-2379908947.