### PR TITLE
feat(menu-item): enhance component's interactive states

### DIFF
--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -46,6 +46,8 @@
   }
   &:focus {
     @apply text-color-2 focus-inset border-b-4;
+    padding-block-start: theme("spacing.1");
+    border-block-end-width: theme("spacing.1");
   }
   &:active {
     @apply bg-foreground-3 text-color-1;

--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -42,10 +42,10 @@
   border-block-end: theme("spacing[0.5]") solid transparent;
   padding-block-start: theme("spacing[0.5]");
   &:hover {
-    @apply bg-foreground-2 text-color-2;
+    @apply text-color-2 border-b-color-2;
   }
   &:focus {
-    @apply bg-foreground-2 text-color-2 focus-inset;
+    @apply text-color-2 focus-inset border-b-4;
   }
   &:active {
     @apply bg-foreground-3 text-color-1;


### PR DESCRIPTION
**Related Issue:** [#10001](https://github.com/Esri/calcite-design-system/issues/10001)

## Summary

This:
- Removes the background color on `:hover` and `:focus`.
- Adds `border.2` `2px` bottom border on `:hover`.
- Increases `:active` state `bottom border` to `4px` on `:focus`.
