### PR TITLE
fix(button, dialog, dropdown, notice, select, sheet, shell-panel, split-button): fix width types

### DIFF
--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -185,7 +185,7 @@ export class Button
   @property({ reflect: true }) type = "button";
 
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
-  @property({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
+  @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   // #endregion
 

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -239,7 +239,7 @@ export class Dialog
   @property({ reflect: true }) widthScale: Scale = "m";
 
   /** Specifies the width of the component. */
-  @property({ reflect: true }) width: Extract<"s" | "m" | "l", Width>;
+  @property({ reflect: true }) width: Extract<Width, Scale>;
 
   // #endregion
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -162,7 +162,7 @@ export class Dropdown
   @property({ reflect: true }) widthScale: Scale;
 
   /** Specifies the width of the component. */
-  @property({ reflect: true }) width: Extract<"s" | "m" | "l", Width>;
+  @property({ reflect: true }) width: Extract<Width, Scale>;
 
   // #endregion
 

--- a/packages/calcite-components/src/components/notice/notice.tsx
+++ b/packages/calcite-components/src/components/notice/notice.tsx
@@ -105,7 +105,7 @@ export class Notice extends LitElement implements LoadableComponent, OpenCloseCo
   @property({ reflect: true }) scale: Scale = "m";
 
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
-  @property({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
+  @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   // #endregion
 

--- a/packages/calcite-components/src/components/select/select.tsx
+++ b/packages/calcite-components/src/components/select/select.tsx
@@ -158,7 +158,7 @@ export class Select
   @property() value: string = null;
 
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
-  @property({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
+  @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   // #endregion
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -171,7 +171,7 @@ export class Sheet
   @property({ reflect: true }) widthScale: Scale = "m";
 
   /** Specifies the width of the component. */
-  @property({ reflect: true }) width: Extract<"s" | "m" | "l", Width>;
+  @property({ reflect: true }) width: Extract<Width, Scale>;
 
   // #endregion
 

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -215,7 +215,7 @@ export class ShellPanel extends LitElement {
   @property({ reflect: true }) widthScale: Scale = "m";
 
   /** Specifies the width of the component. */
-  @property({ reflect: true }) width: Extract<"s" | "m" | "l", Width>;
+  @property({ reflect: true }) width: Extract<Width, Scale>;
 
   // #endregion
 

--- a/packages/calcite-components/src/components/split-button/split-button.tsx
+++ b/packages/calcite-components/src/components/split-button/split-button.tsx
@@ -117,7 +117,7 @@ export class SplitButton extends LitElement implements InteractiveComponent, Loa
   @property({ reflect: true }) scale: Scale = "m";
 
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
-  @property({ reflect: true }) width: Extract<"auto" | "full", Width> = "auto";
+  @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
   // #endregion
 


### PR DESCRIPTION
**Related Issue:** #10934

## Summary
Include `half` in the updated types. Fix `width` types. 