### PR TITLE
fix(sort-handle): pass scale to handle action

### DIFF
--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -281,7 +281,7 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
             class={CSS.handle}
             icon={disabled ? ICONS.blank : ICONS.drag}
             label={text}
-            scale="s"
+            scale={scale}
             slot="trigger"
             text={text}
             title={text}


### PR DESCRIPTION
**Related Issue:** #10723

## Summary

This update passes `sort-handle`'s `scale` property down to the handle `action` component.  This corrects the appearance for large scale sort handles used in components like `list-item`.