### PR TITLE
test(popover): ensure popover doesn't reopen when trigger is clicked and autoClose is true

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -687,7 +687,7 @@ describe("calcite-popover", () => {
     const page = await newE2EPage();
 
     await page.setContent(html`
-      <calcite-popover reference-element="ref">Content</calcite-popover>
+      <calcite-popover auto-close reference-element="ref">Content</calcite-popover>
       <button id="ref">Button</button>
     `);
 

--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -683,6 +683,31 @@ describe("calcite-popover", () => {
     expect(await popover.getProperty("open")).toBe(false);
   });
 
+  it("should not reopen when trigger is clicked and autoClose=true", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(html`
+      <calcite-popover reference-element="ref">Content</calcite-popover>
+      <button id="ref">Button</button>
+    `);
+
+    await page.waitForChanges();
+    const popover = await page.find("calcite-popover");
+
+    expect(await popover.getProperty("open")).toBe(false);
+
+    const referenceElement = await page.find("#ref");
+    await referenceElement.click();
+    await page.waitForChanges();
+
+    expect(await popover.getProperty("open")).toBe(true);
+
+    await referenceElement.click();
+    await page.waitForChanges();
+
+    expect(await popover.getProperty("open")).toBe(false);
+  });
+
   describe("setFocus", () => {
     const createPopoverHTML = (contentHTML?: string, attrs?: string) =>
       `<calcite-popover open ${attrs} reference-element="ref">${contentHTML}</calcite-popover><button id="ref">Button</button>`;


### PR DESCRIPTION
**Related Issue:** #10867

## Summary
Ensure `popover` doesn't reopen when the trigger is clicked and `autoClose` is true.