### PR TITLE
feat(dropdown-item): update selection state according to spec

### DIFF
--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -34,11 +34,7 @@
 
 // item icon
 .dropdown-item-icon {
-  @apply relative
-    opacity-0
-    duration-150
-    ease-in-out;
-  transform: scale(0.9);
+  @apply relative;
 }
 
 :host([scale="s"]) {
@@ -120,12 +116,10 @@
 
 :host(:hover:not([disabled])) .dropdown-item-icon {
   color: theme("borderColor.color.1");
-  @apply opacity-100;
 }
 
 :host([selected]) .dropdown-item-icon {
   color: theme("backgroundColor.brand");
-  @apply opacity-100;
 }
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #7688 #10775

## Summary

This updates `dropdown-item` to:

* use `bullet-point-large` when single selection + large scale
* always show icon when multiple selection
  * `square` when unselected
  * `check-square` when hovered
  * `check-square-f` when selected