### PR TITLE
fix(filter): remove unnecessary inline margin from internal label element

### DIFF
--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -27,7 +27,6 @@
 
 label {
   @apply relative
-    mx-1
     my-0
     flex w-full
     items-center


### PR DESCRIPTION
**Related Issue:** #10941

## Summary

This update removes an inline margin applied to `calcite-filter`'s internal `label` element.  This spacing is now handled by `list`'s supported scales.