### PR TITLE
fix(input-time-zone): add workaround for `Factory` time zone error in Chrome

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -251,6 +251,12 @@ function getTimeZoneShortOffset(
   locale: SupportedLocale,
   referenceDateInMs: number = Date.now(),
 ): string {
+  // workaround for https://issues.chromium.org/issues/381620359
+  // see https://github.com/Esri/calcite-design-system/issues/10895 for more info
+  if (timeZone === "Factory") {
+    timeZone = "Etc/GMT";
+  }
+
   const dateTimeFormat = getDateTimeFormat(locale, { timeZone, timeZoneName: "shortOffset" });
   const parts = dateTimeFormat.formatToParts(referenceDateInMs);
   return parts.find(({ type }) => type === "timeZoneName").value;


### PR DESCRIPTION
**Related Issue:** #10895 

## Summary

Add workaround for https://issues.chromium.org/issues/381620359.

**Note**: `timezone-groups` was [also updated](https://github.com/Esri/calcite-design-system/pull/10961) with this workaround.