### PR TITLE
refactor: ensure component class names are consistent

### DIFF
--- a/packages/calcite-components/src/components/menu-item/interfaces.ts
+++ b/packages/calcite-components/src/components/menu-item/interfaces.ts
@@ -1,7 +1,7 @@
-import type { CalciteMenuItem } from "./menu-item";
+import type { MenuItem } from "./menu-item";
 
 export interface MenuItemCustomEvent {
   event: KeyboardEvent;
-  children?: CalciteMenuItem["el"][];
+  children?: MenuItem["el"][];
   isSubmenuOpen?: boolean;
 }

--- a/packages/calcite-components/src/components/menu-item/menu-item.tsx
+++ b/packages/calcite-components/src/components/menu-item/menu-item.tsx
@@ -28,14 +28,14 @@ import { styles } from "./menu-item.scss";
 
 declare global {
   interface DeclareElements {
-    "calcite-menu-item": CalciteMenuItem;
+    "calcite-menu-item": MenuItem;
   }
 }
 
 type Layout = "horizontal" | "vertical";
 
 /** @slot submenu-item - A slot for adding `calcite-menu-item`s in a submenu. */
-export class CalciteMenuItem extends LitElement implements LoadableComponent {
+export class MenuItem extends LitElement implements LoadableComponent {
   // #region Static Members
 
   static override styles = styles;
@@ -56,7 +56,7 @@ export class CalciteMenuItem extends LitElement implements LoadableComponent {
 
   @state() hasSubmenu = false;
 
-  @state() submenuItems: CalciteMenuItem["el"][];
+  @state() submenuItems: MenuItem["el"][];
 
   // #endregion
 
@@ -206,7 +206,7 @@ export class CalciteMenuItem extends LitElement implements LoadableComponent {
   }
 
   private focusHandler(event: FocusEvent): void {
-    const target = event.target as CalciteMenuItem["el"];
+    const target = event.target as MenuItem["el"];
     this.isFocused = true;
     if (target.open && !this.open) {
       target.open = false;
@@ -214,7 +214,7 @@ export class CalciteMenuItem extends LitElement implements LoadableComponent {
   }
 
   private handleMenuItemSlotChange(event: Event): void {
-    this.submenuItems = slotChangeGetAssignedElements<CalciteMenuItem["el"]>(event);
+    this.submenuItems = slotChangeGetAssignedElements<MenuItem["el"]>(event);
     this.submenuItems.forEach((item) => {
       if (!item.topLevelMenuLayout) {
         item.topLevelMenuLayout = this.topLevelMenuLayout;

--- a/packages/calcite-components/src/components/menu/menu.stories.ts
+++ b/packages/calcite-components/src/components/menu/menu.stories.ts
@@ -1,10 +1,10 @@
 import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import { CalciteMenu } from "./menu";
+import { Menu } from "./menu";
 
 const { layout } = ATTRIBUTES;
 
-type MenuStoryArgs = Pick<CalciteMenu, "layout">;
+type MenuStoryArgs = Pick<Menu, "layout">;
 
 export default {
   title: "Components/Menu",

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -14,19 +14,19 @@ import {
   setUpLoadableComponent,
 } from "../../utils/loadable";
 import { useT9n } from "../../controllers/useT9n";
-import type { CalciteMenuItem } from "../menu-item/menu-item";
+import type { MenuItem } from "../menu-item/menu-item";
 import T9nStrings from "./assets/t9n/menu.t9n.en.json";
 import { styles } from "./menu.scss";
 
 declare global {
   interface DeclareElements {
-    "calcite-menu": CalciteMenu;
+    "calcite-menu": Menu;
   }
 }
 
 type Layout = "horizontal" | "vertical";
 
-export class CalciteMenu extends LitElement implements LoadableComponent {
+export class Menu extends LitElement implements LoadableComponent {
   // #region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
@@ -39,7 +39,7 @@ export class CalciteMenu extends LitElement implements LoadableComponent {
 
   attributeWatch = useWatchAttributes(["role"], this.handleGlobalAttributesChanged);
 
-  private menuItems: CalciteMenuItem["el"][] = [];
+  private menuItems: MenuItem["el"][] = [];
 
   // #endregion
 
@@ -113,7 +113,7 @@ export class CalciteMenu extends LitElement implements LoadableComponent {
   }
 
   private calciteInternalNavMenuItemKeyEvent(event: CustomEvent): void {
-    const target = event.target as CalciteMenuItem["el"];
+    const target = event.target as MenuItem["el"];
     const submenuItems = event.detail.children;
     const key = event.detail.event.key;
     event.stopPropagation();
@@ -147,29 +147,29 @@ export class CalciteMenu extends LitElement implements LoadableComponent {
         focusElementInGroup(this.menuItems, target, "previous", false);
       } else {
         if (event.detail.isSubmenuOpen) {
-          this.focusParentElement(event.target as CalciteMenuItem["el"]);
+          this.focusParentElement(event.target as MenuItem["el"]);
         }
       }
     } else if (key === "Escape") {
-      this.focusParentElement(event.target as CalciteMenuItem["el"]);
+      this.focusParentElement(event.target as MenuItem["el"]);
     }
     event.preventDefault();
   }
 
   private handleMenuSlotChange(event: Event): void {
-    this.menuItems = slotChangeGetAssignedElements<CalciteMenuItem["el"]>(event);
+    this.menuItems = slotChangeGetAssignedElements<MenuItem["el"]>(event);
     this.setMenuItemLayout(this.menuItems, this.layout);
   }
 
-  private focusParentElement(el: CalciteMenuItem["el"]): void {
-    const parentEl = el.parentElement as CalciteMenuItem["el"];
+  private focusParentElement(el: MenuItem["el"]): void {
+    const parentEl = el.parentElement as MenuItem["el"];
     if (parentEl) {
       focusElement(parentEl);
       parentEl.open = false;
     }
   }
 
-  private setMenuItemLayout(items: CalciteMenuItem["el"][], layout: Layout): void {
+  private setMenuItemLayout(items: MenuItem["el"][], layout: Layout): void {
     items.forEach((item) => {
       item.layout = layout;
       if (this.getEffectiveRole() === "menubar") {

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.tsx
@@ -12,11 +12,11 @@ import { styles } from "./navigation-logo.scss";
 
 declare global {
   interface DeclareElements {
-    "calcite-navigation-logo": CalciteNavigationLogo;
+    "calcite-navigation-logo": NavigationLogo;
   }
 }
 
-export class CalciteNavigationLogo extends LitElement implements LoadableComponent {
+export class NavigationLogo extends LitElement implements LoadableComponent {
   // #region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.tsx
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.tsx
@@ -10,11 +10,11 @@ import { styles } from "./navigation-user.scss";
 
 declare global {
   interface DeclareElements {
-    "calcite-navigation-user": CalciteNavigationUser;
+    "calcite-navigation-user": NavigationUser;
   }
 }
 
-export class CalciteNavigationUser extends LitElement implements LoadableComponent {
+export class NavigationUser extends LitElement implements LoadableComponent {
   // #region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };

--- a/packages/calcite-components/src/components/navigation/navigation.tsx
+++ b/packages/calcite-components/src/components/navigation/navigation.tsx
@@ -22,7 +22,7 @@ import { styles } from "./navigation.scss";
 
 declare global {
   interface DeclareElements {
-    "calcite-navigation": CalciteNavigation;
+    "calcite-navigation": Navigation;
   }
 }
 
@@ -37,7 +37,7 @@ declare global {
  * @slot navigation-secondary - A slot for adding a `calcite-navigation` component in the secondary navigation level. Components rendered here will not display `calcite-navigation-logo` or `calcite-navigation-user` components.
  * @slot navigation-tertiary - A slot for adding a `calcite-navigation` component in the tertiary navigation level.  Components rendered here will not display `calcite-navigation-logo` or `calcite-navigation-user` components.
  */
-export class CalciteNavigation extends LitElement implements LoadableComponent {
+export class Navigation extends LitElement implements LoadableComponent {
   // #region Static Members
 
   static override styles = styles;


### PR DESCRIPTION
**Related Issue:** #10845

## Summary

Renames component classes starting with `Calcite`. 

**Note**: This is not a breaking change since directly importing class interfaces is undocumented. Developers are expected to use the corresponding HTML element type (e.g., `HTMLCalciteActionElement` instead of `Action`).