### PR TITLE
deprecate(action): deprecate tokens

### DIFF
--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -220,7 +220,7 @@ describe("calcite-action", () => {
           targetProp: "backgroundColor",
           state: "hover",
         },
-        "--calcite-action-background-color-pressed": {
+        "--calcite-action-background-color-press": {
           shadowSelector: `.${CSS.button}`,
           targetProp: "backgroundColor",
           state: { press: { attribute: "class", value: ` ${CSS.button} ` } },
@@ -241,7 +241,7 @@ describe("calcite-action", () => {
             shadowSelector: `.${CSS.button}`,
             targetProp: "color",
           },
-          "--calcite-action-text-color-pressed": {
+          "--calcite-action-text-color-press": {
             shadowSelector: `.${CSS.button}`,
             targetProp: "color",
             state: "hover",
@@ -260,7 +260,7 @@ describe("calcite-action", () => {
           icon="configure-popup"
         ></calcite-action>`,
         {
-          "--calcite-action-text-color-pressed": {
+          "--calcite-action-text-color-press": {
             shadowSelector: `.${CSS.button}`,
             targetProp: "color",
           },
@@ -443,6 +443,16 @@ describe("calcite-action", () => {
             targetProp: "borderStartStartRadius",
           },
         ],
+        "--calcite-action-text-color-pressed": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "color",
+          state: "hover",
+        },
+        "--calcite-action-background-color-pressed": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          state: { press: { attribute: "class", value: ` ${CSS.button} ` } },
+        },
       });
     });
   });

--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -319,6 +319,10 @@ describe("calcite-action", () => {
             targetProp: "borderStartStartRadius",
           },
         ],
+      });
+    });
+    describe("deprecated", () => {
+      themed(html`calcite-action`, {
         "--calcite-action-corner-radius-end-end": [
           {
             shadowSelector: `.${CSS.button}`,

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -6,12 +6,17 @@
  * @prop --calcite-action-indicator-color: Specifies the component's indicator color.
  * @prop --calcite-action-background-color: Specifies the component's background color.
  * @prop --calcite-action-background-color-hover: Specifies the component's background color when hovered or focused.
- * @prop --calcite-action-background-color-pressed: Specifies the component's background color when active.
+ * @prop --calcite-action-background-color-press: Specifies the component's background color when active.
+ * @prop --calcite-action-background-color-pressed: [Deprecated] Use --calcite-action-background-color-press. Specifies the component's background color when active.
+ * @prop --calcite-action-background-color: Specifies the component's background color.
+ * @prop --calcite-action-corner-radius-end-end: [Deprecated] Use --calcite-action-corner-radius. Specifies the component's corner radius end end.
+ * @prop --calcite-action-corner-radius-end-start: [Deprecated] Use --calcite-action-corner-radius. Specifies the component's corner radius end start.
+ * @prop --calcite-action-corner-radius-start-end: [Deprecated] Use --calcite-action-corner-radius. Specifies the component's corner radius start end.
+ * @prop --calcite-action-corner-radius-start-start: [Deprecated] Use --calcite-action-corner-radius. Specifies the component's corner radius start start.
  * @prop --calcite-action-corner-radius: Specifies the component's corner radius.
- * @prop --calcite-action-corner-radius-end-end: Specifies the component's corner radius end end.
- * @prop --calcite-action-corner-radius-end-start: Specifies the component's corner radius end start.
- * @prop --calcite-action-corner-radius-start-end: Specifies the component's corner radius start end.
- * @prop --calcite-action-corner-radius-start-start: Specifies the component's corner radius start start.
+ * @prop --calcite-action-indicator-color: Specifies the component's indicator color.
+ * @prop --calcite-action-text-color-press: Specifies the component's text color when hovered.
+ * @prop --calcite-action-text-color-pressed: [Deprecated] Use --calcite-action-text-color-press. Specifies the component's text color when hovered.
  * @prop --calcite-action-text-color: Specifies the component's text color.
  * @prop --calcite-action-text-color-pressed: Specifies the component's text color when hovered.
  */
@@ -39,6 +44,7 @@ button {
     --calcite-action-corner-radius-start-start,
     var(--calcite-action-corner-radius, var(--calcite-corner-radius))
   );
+  border-radius: var(--calcite-action-corner-radius);
 }
 
 @mixin action-indicator() {

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -70,7 +70,10 @@ button {
   &:hover,
   &:focus {
     background-color: var(--calcite-action-background-color-hover, var(--calcite-color-foreground-2));
-    color: var(--calcite-action-text-color-pressed, var(--calcite-color-text-1));
+    color: var(
+      --calcite-action-text-color-press,
+      var(--calcite-action-text-color-pressed, var(--calcite-color-text-1))
+    );
   }
 
   &:focus {
@@ -78,7 +81,10 @@ button {
   }
 
   &:active {
-    background-color: var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3));
+    background-color: var(
+      --calcite-action-background-color-press,
+      var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3))
+    );
   }
 }
 
@@ -115,8 +121,14 @@ button {
     &,
     &:hover,
     &:focus {
-      color: var(--calcite-action-text-color-pressed, var(--calcite-color-text-1));
-      background-color: var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3));
+      color: var(
+        --calcite-action-text-color-press,
+        var(--calcite-action-text-color-pressed, var(--calcite-color-text-1))
+      );
+      background-color: var(
+        --calcite-action-background-color-press,
+        var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3))
+      );
     }
 
     &:active {
@@ -263,7 +275,10 @@ button {
       @apply opacity-disabled;
       background-color: var(
         --calcite-action-background-color-press,
-        var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3))
+        var(
+          --calcite-action-background-color-press,
+          var(--calcite-action-background-color-pressed, var(--calcite-color-foreground-3))
+        )
       );
     }
   }

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -3,8 +3,6 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-action-indicator-color: Specifies the component's indicator color.
- * @prop --calcite-action-background-color: Specifies the component's background color.
  * @prop --calcite-action-background-color-hover: Specifies the component's background color when hovered or focused.
  * @prop --calcite-action-background-color-press: Specifies the component's background color when active.
  * @prop --calcite-action-background-color-pressed: [Deprecated] Use --calcite-action-background-color-press. Specifies the component's background color when active.
@@ -18,7 +16,6 @@
  * @prop --calcite-action-text-color-press: Specifies the component's text color when hovered.
  * @prop --calcite-action-text-color-pressed: [Deprecated] Use --calcite-action-text-color-press. Specifies the component's text color when hovered.
  * @prop --calcite-action-text-color: Specifies the component's text color.
- * @prop --calcite-action-text-color-pressed: Specifies the component's text color when hovered.
  */
 
 :host {
@@ -28,23 +25,13 @@
 
 :host,
 button {
-  border-end-end-radius: var(
-    --calcite-action-corner-radius-end-end,
-    var(--calcite-action-corner-radius, var(--calcite-corner-radius))
+  border-radius: var(
+    --calcite-action-corner-radius,
+    var(--calcite-action-corner-radius-start-start, var(--calcite-corner-radius))
+      var(--calcite-action-corner-radius-start-end, var(--calcite-corner-radius))
+      var(--calcite-action-corner-radius-end-end, var(--calcite-corner-radius))
+      var(--calcite-action-corner-radius-end-start, var(--calcite-corner-radius))
   );
-  border-end-start-radius: var(
-    --calcite-action-corner-radius-end-start,
-    var(--calcite-action-corner-radius, var(--calcite-corner-radius))
-  );
-  border-start-end-radius: var(
-    --calcite-action-corner-radius-start-end,
-    var(--calcite-action-corner-radius, var(--calcite-corner-radius))
-  );
-  border-start-start-radius: var(
-    --calcite-action-corner-radius-start-start,
-    var(--calcite-action-corner-radius, var(--calcite-corner-radius))
-  );
-  border-radius: var(--calcite-action-corner-radius);
 }
 
 @mixin action-indicator() {


### PR DESCRIPTION
**Related Issue:** #10831

## Summary

Deprecate --calcite-action-background-color-pressed in favor of --calcite-action-background-color-press
Deprecate --calcite-action-text-color-pressed in favor of --calcite-action-text-color-press
Deprecate --calcite-action-corner-radius-start-start, --calcite-action-corner-radius-start-end, --calcite-action-corner-radius-end-start, and --calcite-action-corner-radius-end-end in favor of --calcite-action-corner-radius.