### PR TITLE
fix(action): active styles present with transparent appearance

### DIFF
--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -441,5 +441,26 @@ describe("calcite-action", () => {
         ],
       });
     });
+    describe("transparent", () => {
+      themed(html`<calcite-action appearance="transparent"></calcite-action>`, {
+        "--calcite-action-background-color": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          expectedValue: "rgba(0, 0, 0, 0)",
+        },
+        "--calcite-action-background-color-hover": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          expectedValue: "rgba(0, 0, 0, 0.04)",
+          state: "hover",
+        },
+        "--calcite-action-background-color-pressed": {
+          shadowSelector: `.${CSS.button}`,
+          targetProp: "backgroundColor",
+          expectedValue: "rgba(0, 0, 0, 0.08)",
+          state: { press: { attribute: "class", value: ` ${CSS.button} ` } },
+        },
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -150,6 +150,10 @@ button {
 }
 
 :host([appearance="transparent"]) {
+  &:host([active]) .button {
+    background-color: var(--calcite-color-transparent-press);
+  }
+
   .button {
     @apply bg-transparent
       transition-shadow

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -148,7 +148,7 @@ export function themed(componentTestSetup: ComponentTestSetup, tokens: Component
           targetProp,
           contextSelector,
           state: stateName,
-          expectedValue: setTokens[token],
+          expectedValue: tokens[token].expectedValue || setTokens[token],
           token: token as CalciteCSSCustomProp,
         });
       }
@@ -218,6 +218,9 @@ type TestSelectToken = {
 
   /** The CSSStyleDeclaration property to assert on. */
   targetProp: CSSProp | MappedCalciteCSSCustomProp;
+
+  /** Override the default expect value set based on the token schema. Good for testing edge-cases where a token should not set the targetProp. */
+  expectedValue?: string;
 
   /** The state to apply to the target element. */
   state?: State | RequireExactlyOne<Record<State, ContextSelectByAttr>, "focus" | "hover" | "press">;


### PR DESCRIPTION
**Related Issue:** #10982

## Summary

Resolves issue where transparent styles are not correctly applied when the action[active] state is set.
Adds optional "expectedValue" prop to themed test utility
Adds e2e test coverage
