### PR TITLE
docs(list): use lumina ref for required label property

### DIFF
--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -228,8 +228,10 @@ export class List
    * Specifies an accessible name for the component.
    *
    * When `dragEnabled` is `true` and multiple list sorting is enabled with `group`, specifies the component's name for dragging between lists.
+   *
+   * @required
    */
-  @property() label!: string;
+  @property() label: string;
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;


### PR DESCRIPTION
**Related PR:** https://github.com/Esri/calcite-design-system/pull/10702

## Summary

It looks like the new Lumina language wasn't included in the [original PR](https://github.com/Esri/calcite-design-system/pull/10702). This PR updates so the documentation picks up `list`'s required `label` property.