### PR TITLE
revert: fix(input): fix broken selector

### DIFF
--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -565,11 +565,6 @@ input[type="number"] {
   box-shadow: var(--calcite-input-shadow, var(--calcite-shadow-none));
 }
 
-// hide the default date picker
-input::-webkit-calendar-picker-indicator {
-  @apply hidden;
-}
-
 input[type="date"]::-webkit-input-placeholder {
   visibility: hidden !important;
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The Chrome-specific selector fixed in [this PR](https://github.com/Esri/calcite-design-system/pull/10973) introduces cross-browser inconsistencies and prevents users from toggling the calendar via mouse. This change removes the selector to address these issues.