### PR TITLE
fix: use explicit module imports for dayjs

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -1,9 +1,9 @@
-import dayjs from "dayjs/esm";
-import customParseFormat from "dayjs/esm/plugin/customParseFormat";
-import localeData from "dayjs/esm/plugin/localeData";
-import localizedFormat from "dayjs/esm/plugin/localizedFormat";
-import preParsePostFormat from "dayjs/esm/plugin/preParsePostFormat";
-import updateLocale from "dayjs/esm/plugin/updateLocale";
+import dayjs from "dayjs/esm/index.js";
+import customParseFormat from "dayjs/esm/plugin/customParseFormat/index.js";
+import localeData from "dayjs/esm/plugin/localeData/index.js";
+import localizedFormat from "dayjs/esm/plugin/localizedFormat/index.js";
+import preParsePostFormat from "dayjs/esm/plugin/preParsePostFormat/index.js";
+import updateLocale from "dayjs/esm/plugin/updateLocale/index.js";
 import { PropertyValues } from "lit";
 import {
   LitElement,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This should help bundlers (e.g., Webpack) resolve dependencies due to ambiguous paths.

For context, Lumina doesn't bundle dependencies like Stencil did. `dayjs` imports were causing trouble because of this.