### PR TITLE
feat(block-section): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -263,16 +263,10 @@ describe("calcite-block-section", () => {
             {
               targetProp: "color",
             },
-            // {
-            //   shadowSelector: `.${CSS.toggle}`,
-            //   targetProp: "color",
-            // },
           ],
           "--calcite-block-section-text-color": [
             { shadowSelector: `.${CSS.chevronIcon}`, targetProp: "color" },
             { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
-            // TODO: bug CSS.iconEnd doesn't properly apply on the element
-            // { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
           ],
           "--calcite-block-section-text-color-hover": [
             {
@@ -290,12 +284,6 @@ describe("calcite-block-section", () => {
               targetProp: "color",
               state: "hover",
             },
-            // TODO: bug CSS.iconEnd doesn't properly apply on the element
-            // {
-            //   shadowSelector: `.${CSS.iconEnd}`,
-            //   targetProp: "color",
-            //   state: "hover",
-            // },
             {
               shadowSelector: `.${CSS.iconStart}`,
               targetProp: "color",

--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, defaults, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, reflects, renders, themed, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
@@ -234,82 +234,76 @@ describe("calcite-block-section", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
   }
 
-  // describe("theme", () => {
-  //   describe("default", () => {
-  //     themed(
-  //       html`
-  //         <calcite-block-section
-  //           text="Planes, trains, and automobiles"
-  //           open
-  //           icon-end="pen"
-  //           icon-start="pen"
-  //           toggle-display="switch"
-  //           text="a block-section"
-  //           status="valid"
-  //         >
-  //         </calcite-block-section>
-  //       `,
-  //       {
-  //         "--calcite-block-section-border-color": {
-  //           targetProp: "borderColor",
-  //         },
-  //         "--calcite-block-section-background-color": [
-  //           {
-  //             targetProp: "backgroundColor",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.toggle}`,
-  //             targetProp: "backgroundColor",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.toggleContainer}`,
-  //             targetProp: "backgroundColor",
-  //           },
-  //         ],
-  //         "--calcite-block-section-header-text-color": [
-  //           {
-  //             targetProp: "color",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.toggle}`,
-  //             targetProp: "color",
-  //           },
-  //         ],
-  //         "--calcite-block-section-text-color": [
-  //           { shadowSelector: `.${CSS.toggle}`, targetProp: "color" },
-  //           { shadowSelector: `.${CSS.chevronIcon}`, targetProp: "color" },
-  //           { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
-  //           { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
-  //         ],
-  //         "--calcite-block-text-color-hover": [
-  //           {
-  //             shadowSelector: `.${CSS.toggle}`,
-  //             targetProp: "color",
-  //             state: "hover",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.chevronIcon}`,
-  //             targetProp: "color",
-  //             state: "hover",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.sectionHeader}`,
-  //             targetProp: "color",
-  //             state: "hover",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.iconEnd}`,
-  //             targetProp: "color",
-  //             state: "hover",
-  //           },
-  //           {
-  //             shadowSelector: `.${CSS.iconStart}`,
-  //             targetProp: "color",
-  //             state: "hover",
-  //           },
-  //         ],
-  //       },
-  //     );
-  //   });
-  // });
+  describe("theme", () => {
+    describe("default", () => {
+      themed(
+        html`
+          <calcite-block-section text="Planes" open icon-end="pen" icon-start="pen" text="a block-section">
+            <p>Block section content</p>
+          </calcite-block-section>
+        `,
+        {
+          "--calcite-block-section-border-color": {
+            targetProp: "borderBlockEndColor",
+          },
+          "--calcite-block-section-background-color": [
+            {
+              targetProp: "backgroundColor",
+            },
+            {
+              shadowSelector: `.${CSS.toggle}`,
+              targetProp: "backgroundColor",
+            },
+            {
+              shadowSelector: `.${CSS.toggleContainer}`,
+              targetProp: "backgroundColor",
+            },
+          ],
+          "--calcite-block-section-header-text-color": [
+            {
+              targetProp: "color",
+            },
+            // {
+            //   shadowSelector: `.${CSS.toggle}`,
+            //   targetProp: "color",
+            // },
+          ],
+          "--calcite-block-section-text-color": [
+            { shadowSelector: `.${CSS.chevronIcon}`, targetProp: "color" },
+            { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
+            // TODO: bug CSS.iconEnd doesn't properly apply on the element
+            // { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
+          ],
+          "--calcite-block-section-text-color-hover": [
+            {
+              shadowSelector: `.${CSS.toggle}`,
+              targetProp: "color",
+              state: "hover",
+            },
+            {
+              shadowSelector: `.${CSS.chevronIcon}`,
+              targetProp: "color",
+              state: "hover",
+            },
+            {
+              shadowSelector: `.${CSS.sectionHeader}`,
+              targetProp: "color",
+              state: "hover",
+            },
+            // TODO: bug CSS.iconEnd doesn't properly apply on the element
+            // {
+            //   shadowSelector: `.${CSS.iconEnd}`,
+            //   targetProp: "color",
+            //   state: "hover",
+            // },
+            {
+              shadowSelector: `.${CSS.iconStart}`,
+              targetProp: "color",
+              state: "hover",
+            },
+          ],
+        },
+      );
+    });
+  });
 });

--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -233,4 +233,83 @@ describe("calcite-block-section", () => {
     expect(await element.getProperty("open")).toBe(false);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
   }
+
+  // describe("theme", () => {
+  //   describe("default", () => {
+  //     themed(
+  //       html`
+  //         <calcite-block-section
+  //           text="Planes, trains, and automobiles"
+  //           open
+  //           icon-end="pen"
+  //           icon-start="pen"
+  //           toggle-display="switch"
+  //           text="a block-section"
+  //           status="valid"
+  //         >
+  //         </calcite-block-section>
+  //       `,
+  //       {
+  //         "--calcite-block-section-border-color": {
+  //           targetProp: "borderColor",
+  //         },
+  //         "--calcite-block-section-background-color": [
+  //           {
+  //             targetProp: "backgroundColor",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.toggle}`,
+  //             targetProp: "backgroundColor",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.toggleContainer}`,
+  //             targetProp: "backgroundColor",
+  //           },
+  //         ],
+  //         "--calcite-block-section-header-text-color": [
+  //           {
+  //             targetProp: "color",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.toggle}`,
+  //             targetProp: "color",
+  //           },
+  //         ],
+  //         "--calcite-block-section-text-color": [
+  //           { shadowSelector: `.${CSS.toggle}`, targetProp: "color" },
+  //           { shadowSelector: `.${CSS.chevronIcon}`, targetProp: "color" },
+  //           { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
+  //           { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
+  //         ],
+  //         "--calcite-block-text-color-hover": [
+  //           {
+  //             shadowSelector: `.${CSS.toggle}`,
+  //             targetProp: "color",
+  //             state: "hover",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.chevronIcon}`,
+  //             targetProp: "color",
+  //             state: "hover",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.sectionHeader}`,
+  //             targetProp: "color",
+  //             state: "hover",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.iconEnd}`,
+  //             targetProp: "color",
+  //             state: "hover",
+  //           },
+  //           {
+  //             shadowSelector: `.${CSS.iconStart}`,
+  //             targetProp: "color",
+  //             state: "hover",
+  //           },
+  //         ],
+  //       },
+  //     );
+  //   });
+  // });
 });

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -3,16 +3,18 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-block-section-background-color: Specifies the component's background color.
  * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
  * @prop --calcite-block-section-header-text-color: Specifies the component's header text color.
- * @prop --calcite-block-section-header-text-color-hover: Specifies the component's header text color on hover.
  * @prop --calcite-block-section-text-color: Specifies the component's text color.
+ * @prop --calcite-block-section-text-color-hover: Specifies the component's text color on hover.
  */
 
 :host {
-  @apply bg-foreground-1 text-n1 box-border block;
+  @apply text-n1 box-border block;
 
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
+  background-color: var(--calcite-block-section-background-color, var(--calcite-color-foreground-1));
 }
 
 calcite-switch {
@@ -32,18 +34,18 @@ calcite-switch {
   border-block-end-color: var(--calcite-block-section-border-color, var(--calcite-color-border-3));
 
   .toggle {
-    color: var(--calcite-color-text-1);
+    color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
 
     &:hover {
-      color: var(--calcite-color-text-1);
+      color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
     }
   }
 
   .chevron-icon {
-    color: var(calcite-block-section-text-color, var(--calcite-color-text-3));
+    color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
 
     &:hover {
-      color: var(--calcite-color-text-1);
+      color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
     }
   }
 }
@@ -53,14 +55,16 @@ calcite-switch {
 }
 
 .toggle {
-  @apply font-sans w-full border-0 bg-transparent;
+  @apply font-sans w-full border-0;
 
   gap: var(--calcite-spacing-md);
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
+  background-color: var(--calcite-block-section-background-color, transparent);
+
   font-weight: var(--calcite-font-weight-normal);
 
   &:hover {
-    color: var(--calcite-color-text-1);
+    color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
   }
 }
 
@@ -81,7 +85,7 @@ calcite-switch {
     @apply focus-outset;
   }
   &:hover {
-    color: var(--calcite-block-section-header-text-color-hover, var(--calcite-color-text-1));
+    color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
   }
 }
 
@@ -94,8 +98,10 @@ calcite-switch {
 }
 
 .toggle-container {
-  @apply flex items-center relative bg-transparent;
+  @apply flex items-center relative;
+
   word-break: break-word;
+  background-color: var(--calcite-block-section-background-color, transparent);
 
   .toggle--switch__content {
     @apply flex flex-auto items-center;
@@ -106,10 +112,10 @@ calcite-switch {
   .chevron-icon {
     @apply flex items-center;
 
-    color: var(calcite-block-section-text-color, var(--calcite-color-text-3));
+    color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
 
     &:hover {
-      color: var(--calcite-block-section-header-text-color-hover, var(--calcite-color-text-1));
+      color: var(--calcite-block-section-text-color-hover, var(--calcite-color-text-1));
     }
   }
 }

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -4,7 +4,7 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-block-section-background-color: Specifies the component's background color.
- * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
+ * @prop --calcite-block-section-border-color: Specifies the component's border color. When `open`, applies to the component's bottom border.
  * @prop --calcite-block-section-header-text-color: Specifies the component's header text color.
  * @prop --calcite-block-section-text-color: Specifies the component's text color.
  * @prop --calcite-block-section-text-color-hover: Specifies the component's text color on hover.

--- a/packages/calcite-components/src/components/block-section/block-section.scss
+++ b/packages/calcite-components/src/components/block-section/block-section.scss
@@ -1,7 +1,18 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-block-section-border-color: Specifies the border color of the component. Applicable on bottom border when open.
+ * @prop --calcite-block-section-header-text-color: Specifies the component's header text color.
+ * @prop --calcite-block-section-header-text-color-hover: Specifies the component's header text color on hover.
+ * @prop --calcite-block-section-text-color: Specifies the component's text color.
+ */
+
 :host {
   @apply bg-foreground-1 text-n1 box-border block;
 
-  color: var(--calcite-color-text-2);
+  color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
 }
 
 calcite-switch {
@@ -14,10 +25,11 @@ calcite-switch {
 }
 
 :host([open]) {
-  @apply border-b-color-3
-    border-0
+  @apply border-0
     border-b
     border-solid;
+
+  border-block-end-color: var(--calcite-block-section-border-color, var(--calcite-color-border-3));
 
   .toggle {
     color: var(--calcite-color-text-1);
@@ -28,7 +40,7 @@ calcite-switch {
   }
 
   .chevron-icon {
-    color: var(--calcite-color-text-3);
+    color: var(calcite-block-section-text-color, var(--calcite-color-text-3));
 
     &:hover {
       color: var(--calcite-color-text-1);
@@ -44,7 +56,7 @@ calcite-switch {
   @apply font-sans w-full border-0 bg-transparent;
 
   gap: var(--calcite-spacing-md);
-  color: var(--calcite-color-text-2);
+  color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
   font-weight: var(--calcite-font-weight-normal);
 
   &:hover {
@@ -69,7 +81,7 @@ calcite-switch {
     @apply focus-outset;
   }
   &:hover {
-    color: var(--calcite-color-text-1);
+    color: var(--calcite-block-section-header-text-color-hover, var(--calcite-color-text-1));
   }
 }
 
@@ -94,10 +106,10 @@ calcite-switch {
   .chevron-icon {
     @apply flex items-center;
 
-    color: var(--calcite-color-text-3);
+    color: var(calcite-block-section-text-color, var(--calcite-color-text-3));
 
     &:hover {
-      color: var(--calcite-color-text-1);
+      color: var(--calcite-block-section-header-text-color-hover, var(--calcite-color-text-1));
     }
   }
 }

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -14,6 +14,7 @@ import { alertTokens, alert } from "./custom-theme/alert";
 import { accordionItemTokens } from "./custom-theme/accordion-item";
 import { accordion, accordionTokens } from "./custom-theme/accordion";
 import { buttons } from "./custom-theme/button";
+import { blockSection, blockSectionTokens } from "./custom-theme/block-section";
 import { calciteSwitch } from "./custom-theme/switch";
 import { card, cardThumbnail, cardTokens } from "./custom-theme/card";
 import { checkbox, checkboxTokens } from "./custom-theme/checkbox";
@@ -130,8 +131,8 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
         ${avatarInitials} ${avatarThumbnail} ${progress} ${handle} ${textArea} ${popover} ${tile} ${tooltip}
         ${comboboxItem}
       </div>
-      <div class="demo-column">${navigation} ${navigationLogos} ${navigationUsers}</div>
-      ${alert}
+      <div class="demo-column">${navigation} ${navigationLogos} ${navigationUsers} ${blockSection}</div>
+      <div class="demo-column">${alert}</div>
     </div>
   </div>`;
 
@@ -146,6 +147,7 @@ const componentTokens = {
   ...actionTokens,
   ...alertTokens,
   ...avatarTokens,
+  ...blockSectionTokens,
   ...cardTokens,
   ...checkboxTokens,
   ...chipTokens,

--- a/packages/calcite-components/src/custom-theme/block-section.ts
+++ b/packages/calcite-components/src/custom-theme/block-section.ts
@@ -7,7 +7,7 @@ export const blockTokens = {
   calciteBlockSectionTextColor: "",
 };
 
-export const block = html` <calcite-block-section
+export const block = html`<calcite-block-section
   text="Planes, trains, and automobiles"
   open
   icon-end="pen"

--- a/packages/calcite-components/src/custom-theme/block-section.ts
+++ b/packages/calcite-components/src/custom-theme/block-section.ts
@@ -1,19 +1,14 @@
 import { html } from "../../support/formatting";
 
-export const blockTokens = {
+export const blockSectionTokens = {
   calciteBlockSectionBorderColor: "",
   calciteBlockSectionHeaderTextColor: "",
   calciteBlockSectionHeaderTextColorHover: "",
   calciteBlockSectionTextColor: "",
 };
 
-export const block = html`<calcite-block-section
-  text="Planes, trains, and automobiles"
-  open
-  icon-end="pen"
-  icon-start="pen"
-  toggle-display="switch"
-  text="a block-section"
-  status="valid"
->
-</calcite-block-section>`;
+export const blockSection = html`
+  <calcite-block-section text="Planes" open icon-end="pen" icon-start="pen" text="a block-section">
+    <p>Block section content</p>
+  </calcite-block-section>
+`;

--- a/packages/calcite-components/src/custom-theme/block-section.ts
+++ b/packages/calcite-components/src/custom-theme/block-section.ts
@@ -1,0 +1,19 @@
+import { html } from "../../support/formatting";
+
+export const blockTokens = {
+  calciteBlockSectionBorderColor: "",
+  calciteBlockSectionHeaderTextColor: "",
+  calciteBlockSectionHeaderTextColorHover: "",
+  calciteBlockSectionTextColor: "",
+};
+
+export const block = html` <calcite-block-section
+  text="Planes, trains, and automobiles"
+  open
+  icon-end="pen"
+  icon-start="pen"
+  toggle-display="switch"
+  text="a block-section"
+  status="valid"
+>
+</calcite-block-section>`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary
Adds the following subcomponent tokens (CSS props):

- `--calcite-block-section-background-color`
- `--calcite-block-section-border-color`
- `--calcite-block-section-header-text-color`
- `--calcite-block-section-text-color`
- `--calcite-block-section-text-color-hover`
