### PR TITLE
fix(tree): ensures `lines` length is accurate

### DIFF
--- a/packages/calcite-components/src/components/tree-item/tree-item.scss
+++ b/packages/calcite-components/src/components/tree-item/tree-item.scss
@@ -58,7 +58,7 @@
         transition-colors
         z-default;
     // ensure lines don't overlap focus outline
-    block-size: 96%;
+    block-size: 100%;
     left: var(--calcite-internal-tree-item-line-left-position);
     content: "";
     background-color: var(--calcite-color-border-2);


### PR DESCRIPTION
**Related Issue:** #11035 

## Summary

Fixed `lines` length of parent `tree-item` with slotted children.