### PR TITLE
fix(dialog): restore outside click closing for non-modal dialogs

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -306,8 +306,8 @@ export class Dialog
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     connectFocusTrap(this, {
       focusTrapOptions: {
-        // Scrim has it's own close handler, allow it to take over.
-        clickOutsideDeactivates: false,
+        // when modal, scrim has its own close handler, so we let it handle closing on click
+        clickOutsideDeactivates: () => !this.modal,
         escapeDeactivates: this.escapeDeactivates,
         onDeactivate: this.focusTrapDeactivates,
       },


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Closes non-modal dialogs on outside click.