### PR TITLE
fix(inline-editable): fix cancel workflow

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -225,6 +225,7 @@ describe("calcite-inline-editable", () => {
       await cancelEvent;
       expect(await input.getProperty("value")).toBe("John Doe");
       expect(calciteInlineEditableEditCancel).toHaveReceivedEventTimes(1);
+      expect(await element.getProperty("editingEnabled")).toBe(false);
     });
 
     it("restores input value after escape key is pressed", async () => {

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -234,7 +234,7 @@ export class InlineEditable
       this.inputElement.value = this.valuePriorToEditing;
     }
     this.disableEditing();
-    this.enableEditingButton.value.setFocus();
+    this.enableEditingButton.value?.setFocus();
     if (!this.editingEnabled && !!this.shouldEmitCancel) {
       this.calciteInlineEditableEditCancel.emit();
     }
@@ -270,8 +270,7 @@ export class InlineEditable
   private async enableEditingHandler(event: MouseEvent) {
     if (
       this.disabled ||
-      event.target === this.cancelEditingButton.value ||
-      event.target === this.confirmEditingButton.value
+      (event.target !== this.enableEditingButton.value && event.target !== this.inputElement)
     ) {
       return;
     }


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Fixes issue that prevented canceling an edit session and restoring the input.
