### PR TITLE
fix: allow custom Calcite CSS properties in style object type

### DIFF
--- a/packages/calcite-components/src/index.ts
+++ b/packages/calcite-components/src/index.ts
@@ -9,7 +9,7 @@ import { setAssetPath as runtimeSetAssetPath } from "./runtime";
 
 declare module "csstype" {
   interface Properties {
-    [index: `--${string}`]: any;
+    [index: `--calcite-${string}`]: any;
   }
 }
 

--- a/packages/calcite-components/src/index.ts
+++ b/packages/calcite-components/src/index.ts
@@ -7,6 +7,12 @@
 import { Runtime } from "@arcgis/lumina";
 import { setAssetPath as runtimeSetAssetPath } from "./runtime";
 
+declare module "csstype" {
+  interface Properties {
+    [index: `--${string}`]: any;
+  }
+}
+
 /** @internal */
 export let assetPathChanged = false;
 


### PR DESCRIPTION
**Related Issue:** #11013

## Summary

Augments `csstype`'s module to allow all custom Calcite CSS properties (step 3 from https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors).