### PR TITLE
fix(dialog, modal, popover, sheet): restore deactivating focus traps on outside click

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -78,19 +78,7 @@ export class Dialog
 
   private dragPosition: DialogDragPosition = { ...initialDragPosition };
 
-  private escapeDeactivates = (event: KeyboardEvent): boolean => {
-    if (event.defaultPrevented || this.escapeDisabled) {
-      return false;
-    }
-    event.preventDefault();
-    return true;
-  };
-
   focusTrap: FocusTrap;
-
-  private focusTrapDeactivates = (): void => {
-    this.open = false;
-  };
 
   private ignoreOpenChange = false;
 
@@ -306,10 +294,16 @@ export class Dialog
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     connectFocusTrap(this, {
       focusTrapOptions: {
-        // Scrim has it's own close handler, allow it to take over.
-        clickOutsideDeactivates: false,
-        escapeDeactivates: this.escapeDeactivates,
-        onDeactivate: this.focusTrapDeactivates,
+        // scrim closes on click, so we let it take over
+        clickOutsideDeactivates: () => !this.modal,
+        escapeDeactivates: (event) => {
+          if (!event.defaultPrevented && !this.escapeDisabled) {
+            this.open = false;
+            event.preventDefault();
+          }
+
+          return false;
+        },
       },
     });
     this.setupInteractions();

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -80,19 +80,7 @@ export class Modal
     this.updateSizeCssVars();
   });
 
-  private escapeDeactivates = (event: KeyboardEvent) => {
-    if (event.defaultPrevented || this.escapeDisabled) {
-      return false;
-    }
-    event.preventDefault();
-    return true;
-  };
-
   focusTrap: FocusTrap;
-
-  private focusTrapDeactivates = () => {
-    this.open = false;
-  };
 
   private ignoreOpenChange = false;
 
@@ -276,10 +264,16 @@ export class Modal
     this.updateSizeCssVars();
     connectFocusTrap(this, {
       focusTrapOptions: {
-        // Scrim has it's own close handler, allow it to take over.
+        // scrim closes on click, so we let it take over
         clickOutsideDeactivates: false,
-        escapeDeactivates: this.escapeDeactivates,
-        onDeactivate: this.focusTrapDeactivates,
+        escapeDeactivates: (event) => {
+          if (!event.defaultPrevented && !this.escapeDisabled) {
+            this.open = false;
+            event.preventDefault();
+          }
+
+          return false;
+        },
       },
     });
   }

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -78,20 +78,6 @@ export class Popover
 
   private arrowEl: SVGSVGElement;
 
-  private clickOutsideDeactivates = (event: MouseEvent): boolean => {
-    const path = event.composedPath();
-    const isReferenceElementInPath =
-      this.referenceEl instanceof EventTarget && path.includes(this.referenceEl);
-
-    const outsideClick = !path.includes(this.el);
-    const shouldCloseOnOutsideClick = this.autoClose && outsideClick;
-
-    return (
-      shouldCloseOnOutsideClick &&
-      (this.triggerDisabled || (isReferenceElementInPath && !this.autoClose))
-    );
-  };
-
   private closeButtonEl = createRef<Action["el"]>();
 
   private filteredFlipPlacements: FlipPlacement[];
@@ -99,10 +85,6 @@ export class Popover
   floatingEl: HTMLDivElement;
 
   focusTrap: FocusTrap;
-
-  private focusTrapDeactivates = (): void => {
-    this.open = false;
-  };
 
   private guid = `calcite-popover-${guid()}`;
 
@@ -298,9 +280,15 @@ export class Popover
       focusTrapEl: this.el,
       focusTrapOptions: {
         allowOutsideClick: true,
-        clickOutsideDeactivates: this.clickOutsideDeactivates,
+        escapeDeactivates: (event) => {
+          if (!event.defaultPrevented) {
+            this.open = false;
+            event.preventDefault();
+          }
+
+          return false;
+        },
         initialFocus: this.initialFocusTrapFocus,
-        onDeactivate: this.focusTrapDeactivates,
       },
     });
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -60,19 +60,7 @@ export class Sheet
 
   private contentId: string;
 
-  private escapeDeactivates = (event: KeyboardEvent) => {
-    if (event.defaultPrevented || this.escapeDisabled) {
-      return false;
-    }
-    event.preventDefault();
-    return true;
-  };
-
   focusTrap: FocusTrap;
-
-  private focusTrapDeactivates = (): void => {
-    this.open = false;
-  };
 
   private ignoreOpenChange = false;
 
@@ -254,10 +242,16 @@ export class Sheet
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     connectFocusTrap(this, {
       focusTrapOptions: {
-        // Scrim has it's own close handler, allow it to take over.
+        // scrim closes on click, so we let it take over
         clickOutsideDeactivates: false,
-        escapeDeactivates: this.escapeDeactivates,
-        onDeactivate: this.focusTrapDeactivates,
+        escapeDeactivates: (event) => {
+          if (!event.defaultPrevented && !this.escapeDisabled) {
+            this.open = false;
+            event.preventDefault();
+          }
+
+          return false;
+        },
       },
     });
     this.setupInteractions();

--- a/packages/calcite-components/src/utils/focusTrapComponent.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.ts
@@ -46,6 +46,7 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
   }
 
   const focusTrapOptions: FocusTrapOptions = {
+    clickOutsideDeactivates: true,
     fallbackFocus: focusTrapNode,
     setReturnFocus: (el) => {
       focusElement(el as FocusableElement);


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

This addresses an issue where focus-trapping components were unintentionally modified by https://github.com/Esri/calcite-design-system/pull/9231/ to block interaction/focusing via outside clicks.