### PR TITLE
fix(list): fix issue where last call to debounced update filter logic would override args from previous calls

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -14,7 +14,13 @@ import {
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { CSS as ListItemCSS, activeCellTestAttribute } from "../list-item/resources";
-import { GlobalTestProps, dragAndDrop, isElementFocused, getFocusedElementProp } from "../../tests/utils";
+import {
+  GlobalTestProps,
+  dragAndDrop,
+  isElementFocused,
+  getFocusedElementProp,
+  newProgrammaticE2EPage,
+} from "../../tests/utils";
 import { DEBOUNCE } from "../../utils/resources";
 import { Reorder } from "../sort-handle/interfaces";
 import type { ListItem } from "../list-item/list-item";
@@ -474,253 +480,334 @@ describe("calcite-list", () => {
     expect(await firstChildItem.getProperty("bordered")).toBe(true);
   });
 
-  it("navigating items after filtering", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-list filter-enabled>
-        <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
-        <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
-      </calcite-list>
-    `);
-    await page.waitForChanges();
-    const list = await page.find("calcite-list");
-    const eventSpy = await list.spyOnEvent("calciteListChange");
-    const filter = await page.find(`calcite-list >>> calcite-filter`);
-    await page.waitForTimeout(DEBOUNCE.filter);
-    expect(await list.getProperty("filteredItems")).toHaveLength(2);
-    expect(await list.getProperty("filteredData")).toHaveLength(2);
-    expect(await list.getProperty("filterText")).toBeUndefined();
+  describe("filtering", () => {
+    it("navigating items after filtering", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled>
+          <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
+          <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
+        </calcite-list>
+      `);
+      await page.waitForChanges();
+      const list = await page.find("calcite-list");
+      const eventSpy = await list.spyOnEvent("calciteListChange");
+      const filter = await page.find(`calcite-list >>> calcite-filter`);
+      await page.waitForTimeout(DEBOUNCE.filter);
+      expect(await list.getProperty("filteredItems")).toHaveLength(2);
+      expect(await list.getProperty("filteredData")).toHaveLength(2);
+      expect(await list.getProperty("filterText")).toBeUndefined();
 
-    await filter.callMethod("setFocus");
-    await page.waitForChanges();
+      await filter.callMethod("setFocus");
+      await page.waitForChanges();
 
-    const calciteListFilterEvent = list.waitForEvent("calciteListFilter");
-    await page.keyboard.type("one");
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-    await calciteListFilterEvent;
-    expect(eventSpy).toHaveReceivedEventTimes(0);
-    expect(await list.getProperty("filteredItems")).toHaveLength(1);
-    expect(await list.getProperty("filteredData")).toHaveLength(1);
-    expect(await list.getProperty("filterText")).toBe("one");
+      const calciteListFilterEvent = list.waitForEvent("calciteListFilter");
+      await page.keyboard.type("one");
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+      await calciteListFilterEvent;
+      expect(eventSpy).toHaveReceivedEventTimes(0);
+      expect(await list.getProperty("filteredItems")).toHaveLength(1);
+      expect(await list.getProperty("filteredData")).toHaveLength(1);
+      expect(await list.getProperty("filterText")).toBe("one");
 
-    await page.keyboard.press("Backspace");
-    await page.keyboard.press("Backspace");
-    await page.keyboard.press("Backspace");
-    await page.waitForChanges();
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Backspace");
+      await page.keyboard.press("Backspace");
+      await page.waitForChanges();
 
-    const calciteListFilterEvent2 = list.waitForEvent("calciteListFilter");
-    await page.keyboard.type("two");
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-    await calciteListFilterEvent2;
-    expect(eventSpy).toHaveReceivedEventTimes(0);
-    expect(await list.getProperty("filteredItems")).toHaveLength(1);
-    expect(await list.getProperty("filteredData")).toHaveLength(1);
-    expect(await list.getProperty("filterText")).toBe("two");
+      const calciteListFilterEvent2 = list.waitForEvent("calciteListFilter");
+      await page.keyboard.type("two");
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+      await calciteListFilterEvent2;
+      expect(eventSpy).toHaveReceivedEventTimes(0);
+      expect(await list.getProperty("filteredItems")).toHaveLength(1);
+      expect(await list.getProperty("filteredData")).toHaveLength(1);
+      expect(await list.getProperty("filterText")).toBe("two");
 
-    const calciteListFilterEvent3 = list.waitForEvent("calciteListFilter");
-    await page.keyboard.type(" blah");
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-    await calciteListFilterEvent3;
-    expect(eventSpy).toHaveReceivedEventTimes(0);
-    expect(await list.getProperty("filteredItems")).toHaveLength(0);
-    expect(await list.getProperty("filteredData")).toHaveLength(0);
-    expect(await list.getProperty("filterText")).toBe("two blah");
-  });
+      const calciteListFilterEvent3 = list.waitForEvent("calciteListFilter");
+      await page.keyboard.type(" blah");
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+      await calciteListFilterEvent3;
+      expect(eventSpy).toHaveReceivedEventTimes(0);
+      expect(await list.getProperty("filteredItems")).toHaveLength(0);
+      expect(await list.getProperty("filteredData")).toHaveLength(0);
+      expect(await list.getProperty("filterText")).toBe("two blah");
+    });
 
-  it("selecting items after filtering", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-list filter-enabled>
-        <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
-        <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
-        <calcite-list-item value="three" label="Three" description="hello world"></calcite-list-item>
-      </calcite-list>
-    `);
-    await page.waitForChanges();
+    it("selecting items after filtering", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled>
+          <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
+          <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
+          <calcite-list-item value="three" label="Three" description="hello world"></calcite-list-item>
+        </calcite-list>
+      `);
+      await page.waitForChanges();
 
-    async function getSelectedItemValues(): Promise<string[]> {
-      return await page.$eval("calcite-list", (list: List["el"]) => list.selectedItems.map((item) => item.value));
-    }
+      async function getSelectedItemValues(): Promise<string[]> {
+        return await page.$eval("calcite-list", (list: List["el"]) => list.selectedItems.map((item) => item.value));
+      }
 
-    const list = await page.find("calcite-list");
-    const listItems = await page.findAll("calcite-list-item");
-    await page.waitForTimeout(DEBOUNCE.filter);
-    expect(await list.getProperty("filteredItems")).toHaveLength(3);
-    expect(await list.getProperty("filteredData")).toHaveLength(3);
-    expect(await list.getProperty("filterText")).toBeUndefined();
+      const list = await page.find("calcite-list");
+      const listItems = await page.findAll("calcite-list-item");
+      await page.waitForTimeout(DEBOUNCE.filter);
+      expect(await list.getProperty("filteredItems")).toHaveLength(3);
+      expect(await list.getProperty("filteredData")).toHaveLength(3);
+      expect(await list.getProperty("filterText")).toBeUndefined();
 
-    listItems[0].setProperty("selected", true);
-    list.setProperty("filterText", "two");
-    await page.waitForTimeout(DEBOUNCE.filter);
-    await page.waitForChanges();
-    let selectedItemValues = await getSelectedItemValues();
-    expect(selectedItemValues).toHaveLength(1);
-    expect(selectedItemValues[0]).toBe("one");
+      listItems[0].setProperty("selected", true);
+      list.setProperty("filterText", "two");
+      await page.waitForTimeout(DEBOUNCE.filter);
+      await page.waitForChanges();
+      let selectedItemValues = await getSelectedItemValues();
+      expect(selectedItemValues).toHaveLength(1);
+      expect(selectedItemValues[0]).toBe("one");
 
-    listItems[1].setProperty("selected", true);
-    await page.waitForChanges();
-    selectedItemValues = await getSelectedItemValues();
-    expect(selectedItemValues).toHaveLength(2);
-    expect(selectedItemValues[0]).toBe("one");
-    expect(selectedItemValues[1]).toBe("two");
+      listItems[1].setProperty("selected", true);
+      await page.waitForChanges();
+      selectedItemValues = await getSelectedItemValues();
+      expect(selectedItemValues).toHaveLength(2);
+      expect(selectedItemValues[0]).toBe("one");
+      expect(selectedItemValues[1]).toBe("two");
 
-    list.setProperty("filterText", "three");
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
-    listItems[2].setProperty("selected", true);
-    await page.waitForChanges();
-    selectedItemValues = await getSelectedItemValues();
-    expect(selectedItemValues).toHaveLength(3);
-    expect(selectedItemValues[0]).toBe("one");
-    expect(selectedItemValues[1]).toBe("two");
-    expect(selectedItemValues[2]).toBe("three");
+      list.setProperty("filterText", "three");
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+      listItems[2].setProperty("selected", true);
+      await page.waitForChanges();
+      selectedItemValues = await getSelectedItemValues();
+      expect(selectedItemValues).toHaveLength(3);
+      expect(selectedItemValues[0]).toBe("one");
+      expect(selectedItemValues[1]).toBe("two");
+      expect(selectedItemValues[2]).toBe("three");
 
-    listItems[0].setProperty("selected", false);
-    await page.waitForChanges();
-    selectedItemValues = await getSelectedItemValues();
-    expect(selectedItemValues).toHaveLength(2);
-    expect(selectedItemValues[0]).toBe("two");
-    expect(selectedItemValues[1]).toBe("three");
-  });
+      listItems[0].setProperty("selected", false);
+      await page.waitForChanges();
+      selectedItemValues = await getSelectedItemValues();
+      expect(selectedItemValues).toHaveLength(2);
+      expect(selectedItemValues[0]).toBe("two");
+      expect(selectedItemValues[1]).toBe("three");
+    });
 
-  it("updating items after filtering", async () => {
-    const matchingFont = "Courier";
+    it("updating items after filtering", async () => {
+      const matchingFont = "Courier";
 
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-list filter-enabled filter-text="">
-        <calcite-list-item value="item1" label="${matchingFont}" description="list1"></calcite-list-item>
-        <calcite-list-item value="item2" label="${matchingFont} 2" description="list1"></calcite-list-item>
-        <calcite-list-item value="item3" label="Other Font" description="list1"></calcite-list-item>
-      </calcite-list>
-    `);
-    await page.waitForChanges();
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled filter-text="">
+          <calcite-list-item value="item1" label="${matchingFont}" description="list1"></calcite-list-item>
+          <calcite-list-item value="item2" label="${matchingFont} 2" description="list1"></calcite-list-item>
+          <calcite-list-item value="item3" label="Other Font" description="list1"></calcite-list-item>
+        </calcite-list>
+      `);
+      await page.waitForChanges();
 
-    const list = await page.find("calcite-list");
-    let visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+      const list = await page.find("calcite-list");
+      let visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
 
-    expect(visibleItems).toHaveLength(3);
-    for (const item of visibleItems) {
-      expect(await item.getProperty("description")).toBe("list1");
-    }
+      expect(visibleItems).toHaveLength(3);
+      for (const item of visibleItems) {
+        expect(await item.getProperty("description")).toBe("list1");
+      }
 
-    list.setProperty("filterText", matchingFont);
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
+      list.setProperty("filterText", matchingFont);
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
 
-    visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
-    expect(visibleItems).toHaveLength(2);
-    for (const item of visibleItems) {
-      expect(await item.getProperty("description")).toBe("list1");
-    }
+      visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+      expect(visibleItems).toHaveLength(2);
+      for (const item of visibleItems) {
+        expect(await item.getProperty("description")).toBe("list1");
+      }
 
-    list.innerHTML = html`
-      <calcite-list-item value="item4" label="${matchingFont}" description="list2"></calcite-list-item>
-      <calcite-list-item value="item5" label="${matchingFont} 2" description="list2"></calcite-list-item>
-      <calcite-list-item value="item6" label="Other Font" description="list2"></calcite-list-item>
-    `;
+      list.innerHTML = html`
+        <calcite-list-item value="item4" label="${matchingFont}" description="list2"></calcite-list-item>
+        <calcite-list-item value="item5" label="${matchingFont} 2" description="list2"></calcite-list-item>
+        <calcite-list-item value="item6" label="Other Font" description="list2"></calcite-list-item>
+      `;
 
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
 
-    expect(await list.getProperty("filterText")).toBe(matchingFont);
-    visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+      expect(await list.getProperty("filterText")).toBe(matchingFont);
+      visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
 
-    expect(visibleItems).toHaveLength(2);
-    for (const item of visibleItems) {
-      expect(await item.getProperty("description")).toBe("list2");
-    }
-  });
+      expect(visibleItems).toHaveLength(2);
+      for (const item of visibleItems) {
+        expect(await item.getProperty("description")).toBe("list2");
+      }
+    });
 
-  it("filters initially", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-list filter-enabled filter-text="match">
-        <calcite-list-item
-          id="label-match"
-          label="match"
-          description="description-1"
-          value="value-1"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="description-match"
-          label="label-2"
-          description="match"
-          value="value-1"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="value-not-matched-by-default"
-          label="label-3"
-          description="description-3"
-          value="match"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="no-match"
-          label="label-4"
-          description="description-4"
-          value="value-4"
-        ></calcite-list-item>
-      </calcite-list>
-    `);
+    it("filters initially", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled filter-text="match">
+          <calcite-list-item
+            id="label-match"
+            label="match"
+            description="description-1"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="description-match"
+            label="label-2"
+            description="match"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="value-not-matched-by-default"
+            label="label-3"
+            description="description-3"
+            value="match"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="no-match"
+            label="label-4"
+            description="description-4"
+            value="value-4"
+          ></calcite-list-item>
+        </calcite-list>
+      `);
 
-    await page.waitForChanges();
-    const list = await page.find("calcite-list");
-    await page.waitForTimeout(DEBOUNCE.filter);
+      await page.waitForChanges();
+      const list = await page.find("calcite-list");
+      await page.waitForTimeout(DEBOUNCE.filter);
 
-    expect(await list.getProperty("filteredItems")).toHaveLength(2);
-    expect(await list.getProperty("filteredData")).toHaveLength(2);
+      expect(await list.getProperty("filteredItems")).toHaveLength(2);
+      expect(await list.getProperty("filteredData")).toHaveLength(2);
 
-    const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+      const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
 
-    expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match"]);
-  });
+      expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match"]);
+    });
 
-  it("filters initially with filterProps", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-list filter-enabled filter-text="match">
-        <calcite-list-item
-          id="label-match"
-          label="match"
-          description="description-1"
-          value="value-1"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="description-match"
-          label="label-2"
-          description="match"
-          value="value-1"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="value-not-matched-by-default"
-          label="label-3"
-          description="description-3"
-          value="match"
-        ></calcite-list-item>
-        <calcite-list-item
-          id="no-match"
-          label="label-4"
-          description="description-4"
-          value="value-4"
-        ></calcite-list-item>
-      </calcite-list>
-    `);
+    it("filters initially with filterProps", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list filter-enabled filter-text="match">
+          <calcite-list-item
+            id="label-match"
+            label="match"
+            description="description-1"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="description-match"
+            label="label-2"
+            description="match"
+            value="value-1"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="value-not-matched-by-default"
+            label="label-3"
+            description="description-3"
+            value="match"
+          ></calcite-list-item>
+          <calcite-list-item
+            id="no-match"
+            label="label-4"
+            description="description-4"
+            value="value-4"
+          ></calcite-list-item>
+        </calcite-list>
+      `);
 
-    await page.waitForChanges();
-    const list = await page.find("calcite-list");
-    list.setProperty("filterProps", ["label", "description"]);
-    await page.waitForChanges();
-    await page.waitForTimeout(DEBOUNCE.filter);
+      await page.waitForChanges();
+      const list = await page.find("calcite-list");
+      list.setProperty("filterProps", ["label", "description"]);
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
 
-    expect(await list.getProperty("filteredItems")).toHaveLength(2);
-    expect(await list.getProperty("filteredData")).toHaveLength(2);
+      expect(await list.getProperty("filteredItems")).toHaveLength(2);
+      expect(await list.getProperty("filteredData")).toHaveLength(2);
 
-    const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+      const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
 
-    expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match"]);
+      expect(visibleItems.map((item) => item.id)).toEqual(["label-match", "description-match"]);
+    });
+
+    it("should show no-results content when filter does not match", async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        html`<calcite-list>
+          <calcite-list-item label="Apples" value="apples"></calcite-list-item>
+          <calcite-list-item label="Oranges" value="oranges"></calcite-list-item>
+          <calcite-list-item label="Pears" value="pears"></calcite-list-item>
+          <calcite-notice slot="filter-no-results" icon kind="warning" scale="s" open>
+            <div slot="title">No fruits found</div>
+            <div slot="message">Try a different fruit?</div>
+          </calcite-notice>
+        </calcite-list>`,
+      );
+      await page.waitForChanges();
+
+      const noResultsContainer = await page.find(`calcite-list >>> [data-test-id="no-results-container"]`);
+
+      expect(await noResultsContainer.isVisible()).toBe(false);
+
+      const list = await page.find("calcite-list");
+      list.setProperty("filterText", "Bananas");
+      await page.waitForChanges();
+      expect(await noResultsContainer.isVisible()).toBe(false);
+
+      list.setProperty("filterEnabled", true);
+      await page.waitForChanges();
+      expect(await noResultsContainer.isVisible()).toBe(true);
+    });
+
+    it("subsequently appended lists should initialize filter data consistently", async () => {
+      const page = await newProgrammaticE2EPage();
+      type TestWindow = GlobalTestProps<{
+        createTestList: () => void;
+      }>;
+
+      await page.evaluate(() => {
+        (window as TestWindow).createTestList = function createTestList(): void {
+          const item1 = document.createElement("calcite-list-item");
+          item1.label = "item A";
+          item1.value = "item A";
+
+          const item2 = document.createElement("calcite-list-item");
+          item2.label = "item B";
+          item2.value = "item B";
+
+          const item3 = document.createElement("calcite-list-item");
+          item3.label = "item C";
+          item3.value = "item C";
+
+          const list = document.createElement("calcite-list");
+          list.label = "items";
+          list.filterEnabled = true;
+
+          list.append(item1, item2, item3);
+          document.body.append(list);
+        };
+      });
+
+      await page.evaluate(() => {
+        (window as TestWindow).createTestList();
+      });
+      await page.waitForChanges();
+
+      await page.$eval("calcite-list", (list) => {
+        list.remove();
+        (window as TestWindow).createTestList();
+      });
+      await page.waitForChanges();
+
+      const filter = await page.find(`calcite-list >>> calcite-filter`);
+      await filter.callMethod("setFocus");
+      await page.keyboard.type("A");
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+
+      const list = await page.find("calcite-list");
+      expect(await list.getProperty("filteredItems")).toHaveLength(1);
+    });
   });
 
   it("should support shift click to select multiple items", async () => {
@@ -942,35 +1029,6 @@ describe("calcite-list", () => {
     await page.waitForTimeout(DEBOUNCE.filter);
     expect(await listItemOne.getProperty("selected")).toBe(false);
     expect(await list.getProperty("selectedItems")).toHaveLength(0);
-  });
-
-  it("should show no-results content when filter does not match", async () => {
-    const page = await newE2EPage();
-    await page.setContent(
-      html`<calcite-list>
-        <calcite-list-item label="Apples" value="apples"></calcite-list-item>
-        <calcite-list-item label="Oranges" value="oranges"></calcite-list-item>
-        <calcite-list-item label="Pears" value="pears"></calcite-list-item>
-        <calcite-notice slot="filter-no-results" icon kind="warning" scale="s" open>
-          <div slot="title">No fruits found</div>
-          <div slot="message">Try a different fruit?</div>
-        </calcite-notice>
-      </calcite-list>`,
-    );
-    await page.waitForChanges();
-
-    const noResultsContainer = await page.find(`calcite-list >>> [data-test-id="no-results-container"]`);
-
-    expect(await noResultsContainer.isVisible()).toBe(false);
-
-    const list = await page.find("calcite-list");
-    list.setProperty("filterText", "Bananas");
-    await page.waitForChanges();
-    expect(await noResultsContainer.isVisible()).toBe(false);
-
-    list.setProperty("filterEnabled", true);
-    await page.waitForChanges();
-    expect(await noResultsContainer.isVisible()).toBe(true);
   });
 
   describe("keyboard navigation", () => {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -82,17 +82,16 @@ export class List
 
   private listItems: ListItem["el"][] = [];
 
-  mutationObserver = createObserver("mutation", () =>
-    this.updateListItems({ performFilter: true }),
-  );
+  mutationObserver = createObserver("mutation", () => {
+    this.willPerformFilter = true;
+    this.updateListItems();
+  });
 
   private parentListEl: List["el"];
 
   sortable: Sortable;
 
-  private updateListItems = debounce((options?: { performFilter?: boolean }): void => {
-    const performFilter = options?.performFilter ?? false;
-
+  private updateListItems = debounce((): void => {
     this.updateGroupItems();
 
     const {
@@ -130,7 +129,8 @@ export class List
     }
 
     this.listItems = items;
-    if (filterEnabled && performFilter) {
+    if (filterEnabled && this.willPerformFilter) {
+      this.willPerformFilter = false;
       this.dataForFilter = this.getItemData();
 
       if (filterEl) {
@@ -151,6 +151,9 @@ export class List
 
   /** TODO: [MIGRATION] this flag was used to work around an issue with debounce using the last args passed when invoking the debounced fn, causing events to not emit */
   private willFilterEmit: boolean = false;
+
+  /** TODO: [MIGRATION] this flag was used to work around an issue with debounce using the last args passed when invoking the debounced fn, causing events to not emit */
+  private willPerformFilter: boolean = false;
 
   // #endregion
 
@@ -373,7 +376,8 @@ export class List
 
   override connectedCallback(): void {
     this.connectObserver();
-    this.updateListItems({ performFilter: true });
+    this.willPerformFilter = true;
+    this.updateListItems();
     this.setUpSorting();
     this.setParentList();
   }
@@ -441,7 +445,8 @@ export class List
   }
 
   private handleListItemChange(): void {
-    this.updateListItems({ performFilter: true });
+    this.willPerformFilter = true;
+    this.updateListItems();
   }
 
   private handleCalciteListItemToggle(event: CustomEvent): void {


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Adds internal flag to determine if filter should be performed. Similar to [`ad054fd` (#10482)](https://github.com/Esri/calcite-design-system/pull/10482/commits/ad054fd07e88b9cb304f02b7ec2006a146e10d08), this is needed because subsequent calls after `updateListItem({ performFilter: true })` would take precedence due to how [`lodash#debounce`](https://lodash.com/docs/4.17.15#debounce) works:

> The `func` is invoked with the last arguments provided to the debounced function.

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE