### PR TITLE
feat(accordion-item): update token naming schema

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -6,13 +6,15 @@
  * @prop --calcite-accordion-border-color: [Deprecated] Use `--calcite-accordion-item-border-color`. Specifies the component's border color.
  * @prop --calcite-accordion-item-background-color: Specifies the component's background color.
  * @prop --calcite-accordion-item-border-color: Specifies the component's border color.
+ * @prop --calcite-accordion-item-icon-color-end: Specifies the component's `iconEnd` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
+ * @prop --calcite-accordion-item-icon-color-start: Specifies the component's `iconStart` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
  * @prop --calcite-accordion-item-content-space: Specifies the component's padding.
- * @prop --calcite-accordion-item-end-icon-color: Specifies the component's `iconEnd` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
+ * @prop --calcite-accordion-item-end-icon-color: [Deprecated] Use --calcite-accordion-item-icon-color-end. Specifies the component's `iconEnd` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
  * @prop --calcite-accordion-item-expand-icon-color: Specifies the component's expand icon color.
  * @prop --calcite-accordion-item-header-background-color: Specifies the component's `heading` background color.
  * @prop --calcite-accordion-item-heading-text-color: Specifies the component's `heading` text color.
  * @prop --calcite-accordion-item-icon-color: Specifies the component's default icon color.
- * @prop --calcite-accordion-item-start-icon-color: Specifies the component's `iconStart` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
+ * @prop --calcite-accordion-item-start-icon-color: [Deprecated] Use --calcite-accordion-item-icon-color-start. Specifies the component's `iconStart` color. Fallback to `--calcite-accordion-item-icon-color` or current color.
  * @prop --calcite-accordion-item-text-color: Specifies the component's text color.
  * @prop --calcite-accordion-text-color-hover: [Deprecated] Use `--calcite-accordion-item-text-color-hover`. Specifies the component's main text color on hover.
  * @prop --calcite-accordion-text-color-pressed: [Deprecated] Use `--calcite-accordion-item-text-color-press`. Specifies the component's main text color when pressed.
@@ -169,12 +171,18 @@
 }
 
 .icon--start {
-  color: var(--calcite-accordion-item-start-icon-color, var(--calcite-accordion-item-icon-color, currentColor));
+  color: var(
+    --calcite-accordion-item-icon-color-start,
+    var(--calcite-accordion-item-start-icon-color, var(--calcite-accordion-item-icon-color, currentColor))
+  );
   margin-inline-end: var(--calcite-internal-accordion-icon-margin);
 }
 
 .icon--end {
-  color: var(--calcite-accordion-item-end-icon-color, var(--calcite-accordion-item-icon-color, currentColor));
+  color: var(
+    --calcite-accordion-item-icon-color-end,
+    var(--calcite-accordion-item-end-icon-color, var(--calcite-accordion-item-icon-color, currentColor))
+  );
   margin-inline-end: var(--calcite-internal-accordion-icon-margin);
   margin-inline-start: var(--calcite-internal-accordion-icon-margin);
 }

--- a/packages/calcite-components/src/custom-theme/accordion-item.ts
+++ b/packages/calcite-components/src/custom-theme/accordion-item.ts
@@ -4,17 +4,20 @@ import { html } from "../../support/formatting";
 export const accordionItemTokens = {
   calciteAccordionItemBackgroundColor: "",
   calciteAccordionItemBorderColor: "",
+  calciteAccordionItemIconColorEnd: "",
+  calciteAccordionItemIconColorStart: "",
   calciteAccordionItemContentSpace: "",
-  calciteAccordionItemEndIconColor: "",
   calciteAccordionItemExpandIconColor: "",
   calciteAccordionItemHeaderBackgroundColor: "",
   calciteAccordionItemHeadingTextColor: "",
   calciteAccordionItemIconColor: "",
-  calciteAccordionItemStartIconColor: "",
   calciteAccordionItemTextColor: "",
 };
 
 export const accordionItem = (idx: number): string =>
-  html`<calcite-accordion-item heading="${idx === 0 ? "Accordion Item" : `Accordion Item ${idx + 1}`}"
-    ><img src="${placeholderImage({ width: 300, height: 200 })}" />
+  html`<calcite-accordion-item
+    icon-end="car"
+    icon-start="layers"
+    heading="${idx === 0 ? "Accordion Item" : `Accordion Item ${idx + 1}`}"
+    ><img src="${placeholderImage({ width: 100, height: 50 })}" />
   </calcite-accordion-item>`;

--- a/packages/calcite-components/src/custom-theme/accordion.ts
+++ b/packages/calcite-components/src/custom-theme/accordion.ts
@@ -16,5 +16,5 @@ export const accordion = html`<style>
     }</style
   ><calcite-accordion>
     ${[0, 1, 2, 3, 4].map((idx) => accordionItem(idx)).join("\n")}
-    <calcite-accordion-item heading="Accordion Item 5" expanded>${tree}</calcite-accordion-item>
+    <calcite-accordion-item heading="Accordion Item 6" expanded>${tree}</calcite-accordion-item>
   </calcite-accordion>`;


### PR DESCRIPTION
**Related Issue:** #10894 

## Summary

This PR adds two new tokens which align with the Calcite naming schema.

--calcite-accordion-item-icon-color-start
--calcite-accordion-item-icon-color-end

BEGIN_COMMIT_OVERRIDE
deprecate(accordion-item): deprecate `--calcite-accordion-item-start-icon-color` and `--calcite-accordion-item-end-icon-color` tokens
END_COMMIT_OVERRIDE

