### PR TITLE
fix(list, sort-handle): disable sort-handle when no move to items are present and item count is one

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -1231,8 +1231,26 @@ describe("calcite-list", () => {
                   slot="actions-end"
                 ></calcite-action
               ></calcite-list-item>
+              <calcite-list-item id="three" value="three" label="Three" description="hello world">
+                <calcite-action
+                  appearance="transparent"
+                  icon="ellipsis"
+                  text="menu"
+                  label="menu"
+                  slot="actions-end"
+                ></calcite-action
+              ></calcite-list-item>
             </calcite-list>
           </calcite-list-item>
+          <calcite-list-item id="four" value="four" label="Four" description="hello world">
+            <calcite-action
+              appearance="transparent"
+              icon="ellipsis"
+              text="menu"
+              label="menu"
+              slot="actions-end"
+            ></calcite-action
+          ></calcite-list-item>
         </calcite-list>
       `);
       await page.waitForChanges();

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -5083,3 +5083,8 @@ export const interactiveMode = (): string => html`
     <calcite-list-item label="List Item 3" description="Descriptive description about something"></calcite-list-item>
   </calcite-list>
 `;
+
+export const sortableListWithSingleItem = (): string =>
+  html`<calcite-list drag-enabled label="test">
+    <calcite-list-item label="small" value="small" description="small hello world"></calcite-list-item>
+  </calcite-list>`;

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
@@ -96,6 +96,52 @@ describe("calcite-sort-handle", () => {
     expect(calciteSortHandleMoveSpy).toHaveReceivedEventTimes(1);
   });
 
+  it("is disabled when no moveToItems, no setPosition or setSize < 2", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-sort-handle label="test"></calcite-sort-handle>`);
+    await skipAnimations(page);
+
+    const dropdown = await page.find("calcite-sort-handle >>> calcite-dropdown");
+    expect(await dropdown.getProperty("disabled")).toBe(true);
+
+    const sortHandle = await page.find("calcite-sort-handle");
+
+    const moveToItems = [
+      { label: "List 2", id: "list2" },
+      { label: "List 3", id: "list3" },
+    ];
+
+    sortHandle.setProperty("setSize", 2);
+    sortHandle.setProperty("setPosition", 1);
+    sortHandle.setProperty("moveToItems", moveToItems);
+    await page.waitForChanges();
+
+    expect(await dropdown.getProperty("disabled")).toBe(false);
+
+    sortHandle.setProperty("setPosition", undefined);
+    await page.waitForChanges();
+
+    expect(await dropdown.getProperty("disabled")).toBe(true);
+
+    sortHandle.setProperty("setSize", undefined);
+    sortHandle.setProperty("setPosition", 1);
+    await page.waitForChanges();
+
+    expect(await dropdown.getProperty("disabled")).toBe(true);
+
+    sortHandle.setProperty("setSize", 1);
+    sortHandle.setProperty("moveToItems", []);
+    await page.waitForChanges();
+
+    expect(await dropdown.getProperty("disabled")).toBe(true);
+
+    sortHandle.setProperty("moveToItems", moveToItems);
+    sortHandle.setProperty("setSize", 2);
+    await page.waitForChanges();
+
+    expect(await dropdown.getProperty("disabled")).toBe(false);
+  });
+
   describe("translation support", () => {
     t9n("calcite-sort-handle");
   });

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -73,7 +73,7 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
   @property() messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /** Defines the "Move to" items. */
-  @property() moveToItems: MoveTo[];
+  @property() moveToItems: MoveTo[] = [];
 
   /** When `true`, displays and positions the component. */
   @property({ reflect: true }) open = false;
@@ -254,10 +254,12 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
       setPosition,
       setSize,
       widthScale,
+      moveToItems,
     } = this;
     const text = this.getLabel();
 
-    const isDisabled = disabled || !setPosition || !setSize;
+    const isDisabled =
+      disabled || !setPosition || !setSize || (setSize < 2 && moveToItems?.length < 1);
 
     return (
       <InteractiveContainer disabled={disabled}>

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -259,7 +259,7 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
     const text = this.getLabel();
 
     const isDisabled =
-      disabled || !setPosition || !setSize || (setSize < 2 && moveToItems?.length < 1);
+      disabled || !setPosition || !setSize || (setSize < 2 && moveToItems.length < 1);
 
     return (
       <InteractiveContainer disabled={disabled}>
@@ -321,7 +321,7 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
   private renderMoveToGroup(): JsxNode {
     const { messages, moveToItems, scale } = this;
 
-    return moveToItems?.length ? (
+    return moveToItems.length ? (
       <calcite-dropdown-group
         groupTitle={messages.moveTo}
         key="move-to-items"


### PR DESCRIPTION
**Related Issue:** #10731

## Summary

- disable drag handle when a single item is in the list and the list has nowhere else to move to
- add e2e
- add story


BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE