### PR TITLE
fix(dialog): no longer modify slotted panels background color

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -121,7 +121,7 @@ calcite-panel {
   --calcite-panel-background-color: var(--calcite-dialog-background-color, var(--calcite-color-foreground-1));
 }
 
-::slotted(calcite-panel) {
+::slotted(*) {
   --calcite-panel-background-color: initial;
 }
 

--- a/packages/calcite-components/src/components/dialog/dialog.stories.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.stories.ts
@@ -238,6 +238,12 @@ export const withCustomContentPanel = (): string => html`
   </calcite-dialog>
 `;
 
+export const withCustomContentDivPanel = (): string => html`
+  <calcite-dialog open modal heading="heading" description="description" scale="m" width-scale="s">
+    <div slot="${SLOTS.content}"><calcite-panel heading="Custom Panel">Custom Panel Content!</calcite-panel></div>
+  </calcite-dialog>
+`;
+
 export const loading = (): string => html`
   <calcite-dialog loading open modal heading="heading" description="description" scale="m" width-scale="s">
     <p>Slotted content!</p>


### PR DESCRIPTION
**Related Issue:** #11052

## Summary

- set slotted panel bg color to initial color
- add story test