### PR TITLE
fix(action): component in transparent active mode should use -hover

### DIFF
--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -156,7 +156,7 @@ button {
 
 :host([appearance="transparent"]) {
   &:host([active]) .button {
-    background-color: var(--calcite-color-transparent-press);
+    background-color: var(--calcite-color-transparent-hover);
   }
 
   .button {


### PR DESCRIPTION
**Related Issue:** #10982

## Summary

Update the background color of the component when active=true and appearance=transparent to use the transparent-hover instead of transparent-press.