### PR TITLE
fix(list, list-item): ensure change and select events are emitted after state is updated

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -578,7 +578,7 @@ export class ListItem
     this.toggleSelected(event.shiftKey);
   }
 
-  private toggleSelected(shiftKey: boolean): void {
+  private async toggleSelected(shiftKey: boolean): Promise<void> {
     const { selectionMode, selected } = this;
 
     if (this.disabled) {
@@ -594,6 +594,8 @@ export class ListItem
     this.calciteInternalListItemSelectMultiple.emit({
       selectMultiple: shiftKey && selectionMode === "multiple",
     });
+
+    await this.updateComplete;
     this.calciteListItemSelect.emit();
   }
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -654,7 +654,9 @@ export class List
     }
   }
 
-  private updateSelectedItems(emit = false): void {
+  private async updateSelectedItems(emit = false): Promise<void> {
+    await this.updateComplete;
+
     this.selectedItems = this.visibleItems.filter((item) => item.selected);
     if (emit) {
       this.calciteListChange.emit();


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Changes `calcite-list` and `calcite-list-item` to wait for their update to be complete before emitting the change and selection events.