### PR TITLE
fix(accordion-item): stretch slotted actions only

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -95,8 +95,11 @@
 .header {
   @apply flex items-stretch;
 
-  * {
-    @apply inline-flex
+  &-content,
+  &-container,
+  .actions-start,
+  .actions-end {
+    @apply flex
       items-center
       duration-150
       ease-in-out;
@@ -153,9 +156,8 @@
 
 .actions-start,
 .actions-end {
-  @apply flex items-stretch;
-  * {
-    @apply items-stretch;
+  ::slotted(calcite-action) {
+    @apply self-stretch;
   }
 }
 

--- a/packages/calcite-components/src/components/accordion/accordion.stories.ts
+++ b/packages/calcite-components/src/components/accordion/accordion.stories.ts
@@ -226,5 +226,12 @@ export const slottedItemsStretched = (): string => html`
       </calcite-notice>
       <calcite-action slot="actions-end" icon="smile"></calcite-action>
     </calcite-accordion-item>
+    <calcite-accordion-item description="Cars, trucks and motorcycles" heading="Vehicles" icon-start="car">
+      <calcite-switch slot="actions-start" icon="smile"> </calcite-switch>
+      <calcite-notice open>
+        <div slot="message">Recommended for highway use</div>
+      </calcite-notice>
+      <calcite-switch slot="actions-end" icon="smile"></calcite-switch>
+    </calcite-accordion-item>
   </calcite-accordion>
 `;


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

This avoids unintentionally styling other actionable components and offers more flexibility.

**Note**: this changes styles to use explicit selectors instead of universal ones to improve maintainability.