### PR TITLE
refactor(t9n): drop deprecated and obsolete `useNoForNorwegian` arg

### DIFF
--- a/packages/calcite-components/src/controllers/useT9n.ts
+++ b/packages/calcite-components/src/controllers/useT9n.ts
@@ -1,4 +1,4 @@
 import { makeT9nController } from "@arcgis/components-controllers";
 import { getAssetPath } from "../runtime";
 
-export const useT9n = makeT9nController(getAssetPath, true);
+export const useT9n = makeT9nController(getAssetPath);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

`@arcgis/lumina@4.32.0-next.52` uses `no` for Norwegian by default, so we can drop this argument.