### PR TITLE
fix: prevent transpilation issues by using `this` to reference static props

### DIFF
--- a/packages/calcite-components/src/utils/number.ts
+++ b/packages/calcite-components/src/utils/number.ts
@@ -16,7 +16,7 @@ export class BigDecimal {
 
   static ROUNDED = true; // numbers are truncated (false) or rounded (true)
 
-  static SHIFT = BigInt("1" + "0".repeat(BigDecimal.DECIMALS)); // derived constant
+  static SHIFT = BigInt("1" + "0".repeat(this.DECIMALS)); // derived constant
 
   constructor(input: string | BigDecimal) {
     if (input instanceof BigDecimal) {


### PR DESCRIPTION
**Related Issue:** #10731

## Summary

Referencing the class would cause incorrect JS output in certain vite builds:

**source ✅**
```ts
class i {
  static {
    this.DECIMALS = 100;
  }
  static {
    this.SHIFT = BigInt("1" + "0".repeat(i.DECIMALS));
  }
}
```

**transpiled ❌**

```ts
var b = class {
  static{this.DECIMALS = 100;}
  static{this.SHIFT = BigInt("1" + "0".repeat(b.DECIMALS));} // TypeError: Cannot read properties of undefined (reading 'DECIMALS')
}
```