### PR TITLE
fix(input): Avoid styling on non-reflected attributes

### DIFF
--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -177,20 +177,18 @@ input {
   border-end-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
 }
 
-:host([prefix-text]) input {
+.has-prefix input {
   border-start-start-radius: 0;
   border-end-start-radius: 0;
 }
 
-:host([suffix-text]) input,
+.has-suffix input,
 .element-wrapper:has(.clear-button) input,
 :host([number-button-type="vertical"][type="number"]) input,
-:host([suffix-text][number-button-type="horizontal"]) .suffix,
-:host([suffix-text][number-button-type="vertical"][type="number"]) .suffix,
-:host([number-button-type="vertical"][type="number"])
-  .clear-button
-  :host([number-button-type="horizontal"][type="number"])
-  .clear-button {
+:host([number-button-type="horizontal"]) .has-suffix .suffix,
+:host([number-button-type="vertical"][type="number"]) .has-suffix .suffix,
+:host([number-button-type="vertical"][type="number"]) .clear-button,
+:host([number-button-type="horizontal"][type="number"]) .clear-button {
   border-start-end-radius: 0;
   border-end-end-radius: 0;
 }
@@ -202,18 +200,23 @@ input {
   border-end-end-radius: 0;
 }
 
-:host([prefix-text]) .prefix:first-child,
+.has-prefix .prefix:first-child,
 :host([number-button-type="horizontal"]) .number-button-item[data-adjustment="down"] {
   border-start-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
   border-end-start-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
 }
 
-:host([suffix-text]) .suffix,
-:host([suffix-text][number-button-type="vertical"][type="number"][read-only]) .suffix,
-:host([clearable]:not([suffix-text])) .clear-button,
+.has-suffix .suffix,
+:host([number-button-type="vertical"][type="number"][read-only]) .has-suffix .suffix,
+:host([clearable]) .clear-button,
 :host([number-button-type="horizontal"]) .number-button-item[data-adjustment="up"] {
   border-end-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
   border-start-end-radius: var(--calcite-input-corner-radius, var(--calcite-corner-radius-sharp));
+}
+
+:host([clearable]) .has-suffix .clear-button {
+  border-end-end-radius: 0;
+  border-start-end-radius: 0;
 }
 
 :host([number-button-type="vertical"]) .number-button-item[data-adjustment="down"] {

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -1140,7 +1140,12 @@ export class Input
     return (
       <InteractiveContainer disabled={this.disabled}>
         <div
-          class={{ [CSS.inputWrapper]: true, [CSS_UTILITY.rtl]: dir === "rtl" }}
+          class={{
+            [CSS.inputWrapper]: true,
+            [CSS_UTILITY.rtl]: dir === "rtl",
+            [CSS.hasSuffix]: this.suffixText,
+            [CSS.hasPrefix]: this.prefixText,
+          }}
           ref={this.inputWrapperEl}
         >
           {this.type === "number" && this.numberButtonType === "horizontal" && !this.readOnly

--- a/packages/calcite-components/src/components/input/resources.ts
+++ b/packages/calcite-components/src/components/input/resources.ts
@@ -12,6 +12,8 @@ export const CSS = {
   inputWrapper: "wrapper",
   actionWrapper: "action-wrapper",
   numberButtonItem: "number-button-item",
+  hasSuffix: "has-suffix",
+  hasPrefix: "has-prefix",
 };
 
 export const IDS = {


### PR DESCRIPTION
**Related Issue:** #10959 #10958

## Summary
Adds classes to use for specific styling cases in Input. This only adjusts `suffix-text` and `prefix-text`. There are other styles set on attributes in the component, but those are reflected attributes. We could still improve that in the future if needed - and / or, in the newer `input-x` components.