### PR TITLE
fix(input-date-picker, modal, tile-select): avoid using refs that have been nulled

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -696,7 +696,7 @@ export class InputDatePicker
     activateFocusTrap(this, {
       onActivate: () => {
         if (this.focusOnOpen) {
-          this.datePickerEl.setFocus();
+          this.datePickerEl?.setFocus();
           this.focusOnOpen = false;
         }
       },
@@ -713,7 +713,7 @@ export class InputDatePicker
     hideFloatingUI(this);
     deactivateFocusTrap(this);
     this.focusOnOpen = false;
-    this.datePickerEl.reset();
+    this.datePickerEl?.reset();
   }
 
   syncHiddenFormInput(input: HTMLInputElement): void {

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -380,23 +380,23 @@ export class Modal
   }
 
   onBeforeOpen(): void {
-    this.transitionEl.classList.add(CSS.openingActive);
+    this.transitionEl?.classList.add(CSS.openingActive);
     this.calciteModalBeforeOpen.emit();
   }
 
   onOpen(): void {
-    this.transitionEl.classList.remove(CSS.openingIdle, CSS.openingActive);
+    this.transitionEl?.classList.remove(CSS.openingIdle, CSS.openingActive);
     this.calciteModalOpen.emit();
     activateFocusTrap(this);
   }
 
   onBeforeClose(): void {
-    this.transitionEl.classList.add(CSS.closingActive);
+    this.transitionEl?.classList.add(CSS.closingActive);
     this.calciteModalBeforeClose.emit();
   }
 
   onClose(): void {
-    this.transitionEl.classList.remove(CSS.closingIdle, CSS.closingActive);
+    this.transitionEl?.classList.remove(CSS.closingIdle, CSS.closingActive);
     this.calciteModalClose.emit();
     deactivateFocusTrap(this);
   }

--- a/packages/calcite-components/src/components/tile-select/tile-select.tsx
+++ b/packages/calcite-components/src/components/tile-select/tile-select.tsx
@@ -177,7 +177,7 @@ export class TileSelect extends LitElement implements InteractiveComponent, Load
   }
 
   override disconnectedCallback(): void {
-    this.input.parentNode.removeChild(this.input);
+    this.input?.remove();
   }
 
   // #endregion


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Adds guards for refs that may be nulled. Unlike Stencil, Lumina calls `ref` when the component is disconnected, so this addresses some issues caused by logic running after an element is no longer connected.

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE