### PR TITLE
chore: add context to no-changelog commit override

### DIFF
--- a/.github/scripts/omitPrFromChangelog.js
+++ b/.github/scripts/omitPrFromChangelog.js
@@ -13,7 +13,7 @@ module.exports = async ({ github, context }) => {
   } = payload;
 
   const pullRequestBody = payload.pull_request.body;
-  const omitComment = `\n\nBEGIN_COMMIT_OVERRIDE\nEND_COMMIT_OVERRIDE`;
+  const omitComment = `\n\nBEGIN_COMMIT_OVERRIDE\nomitted from changelog\nEND_COMMIT_OVERRIDE`;
   const omitCommentRegex = /BEGIN_COMMIT_OVERRIDE/gm;
 
   if (!pullRequestBody) {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This adds context (ignored by changelog generation) to the commit override to clarify its intent.