### PR TITLE
fix(list): Don't require `filterEnabled` for `filterPredicate` usage

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -652,7 +652,7 @@ describe("calcite-list", () => {
 
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list filter-enabled filter-text="">
+        <calcite-list filter-text="">
           <calcite-list-item value="item1" label="${matchingFont}" description="list1"></calcite-list-item>
           <calcite-list-item value="item2" label="${matchingFont} 2" description="list1"></calcite-list-item>
           <calcite-list-item value="item3" label="Other Font" description="list1"></calcite-list-item>

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -652,7 +652,7 @@ describe("calcite-list", () => {
 
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list filter-text="">
+        <calcite-list filter-enabled filter-text="">
           <calcite-list-item value="item1" label="${matchingFont}" description="list1"></calcite-list-item>
           <calcite-list-item value="item2" label="${matchingFont} 2" description="list1"></calcite-list-item>
           <calcite-list-item value="item3" label="Other Font" description="list1"></calcite-list-item>
@@ -694,6 +694,34 @@ describe("calcite-list", () => {
       for (const item of visibleItems) {
         expect(await item.getProperty("description")).toBe("list1");
       }
+    });
+
+    it("filterPredicate will work without filterEnabled", async () => {
+      const matchingFont = "Courier";
+
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-list>
+          <calcite-list-item value="item1" label="${matchingFont}" description="list1"></calcite-list-item>
+          <calcite-list-item value="item2" label="${matchingFont} 2" description="list1"></calcite-list-item>
+          <calcite-list-item value="item3" label="Other Font" description="list1"></calcite-list-item>
+        </calcite-list>
+      `);
+      await page.waitForChanges();
+
+      await page.$eval("calcite-list", (list: List["el"]) => {
+        list.filterPredicate = (item) => {
+          return item.value === "item2";
+        };
+      });
+
+      await page.waitForChanges();
+      await page.waitForTimeout(DEBOUNCE.filter);
+
+      const visibleItems = await page.findAll("calcite-list-item:not([filter-hidden])");
+
+      expect(visibleItems).toHaveLength(1);
+      expect(await visibleItems[0].getProperty("value")).toBe("item2");
     });
 
     it("filters initially", async () => {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -128,7 +128,7 @@ export class List
     }
 
     this.listItems = items;
-    if ((this.filterEnabled || !!this.filterPredicate) && this.willPerformFilter) {
+    if (this.filterEnabled && this.willPerformFilter) {
       this.willPerformFilter = false;
       this.dataForFilter = this.getItemData();
 
@@ -437,7 +437,8 @@ export class List
       (changes.has("selectionAppearance") &&
         (this.hasUpdated || this.selectionAppearance !== "icon")) ||
       (changes.has("displayMode") && this.hasUpdated) ||
-      (changes.has("scale") && this.hasUpdated)
+      (changes.has("scale") && this.hasUpdated) ||
+      (changes.has("filterPredicate") && this.hasUpdated)
     ) {
       this.handleListItemChange();
     }
@@ -813,14 +814,12 @@ export class List
   }
 
   private getItemData(): ItemData {
-    return this.filterPredicate
-      ? []
-      : this.listItems.map((item) => ({
-          label: item.label,
-          description: item.description,
-          metadata: item.metadata,
-          el: item,
-        }));
+    return this.listItems.map((item) => ({
+      label: item.label,
+      description: item.description,
+      metadata: item.metadata,
+      el: item,
+    }));
   }
 
   private updateGroupItems(): void {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -101,7 +101,6 @@ export class List
       dragEnabled,
       el,
       filterEl,
-      filterEnabled,
       moveToItems,
       displayMode,
       scale,
@@ -129,7 +128,7 @@ export class List
     }
 
     this.listItems = items;
-    if (filterEnabled && this.willPerformFilter) {
+    if ((this.filterEnabled || !!this.filterPredicate) && this.willPerformFilter) {
       this.willPerformFilter = false;
       this.dataForFilter = this.getItemData();
 


### PR DESCRIPTION
**Related Issue:** #6544

## Summary

- fix to not require filterEnabled to use filterPredicate
- It was basically the `(changes.has("filterPredicate") && this.hasUpdated)` that was the culprit.
- add test

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE