### PR TITLE
fix(input, input-text, input-number): restore handling of autofocus global attribute

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -89,7 +89,7 @@ export class InputNumber
   private actionWrapperEl = createRef<HTMLDivElement>();
 
   attributeWatch = useWatchAttributes(
-    ["enterkeyhint", "inputmode"],
+    ["autofocus", "enterkeyhint", "inputmode"],
     this.handleGlobalAttributesChanged,
   );
 

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -75,7 +75,7 @@ export class InputText
   private actionWrapperEl = createRef<HTMLDivElement>();
 
   attributeWatch = useWatchAttributes(
-    ["enterkeyhint", "inputmode", "spellcheck"],
+    ["autofocus", "enterkeyhint", "inputmode", "spellcheck"],
     this.handleGlobalAttributesChanged,
   );
 

--- a/packages/calcite-components/src/components/input/common/tests.ts
+++ b/packages/calcite-components/src/components/input/common/tests.ts
@@ -128,11 +128,26 @@ export function testWorkaroundForGlobalPropRemoval(
         <${inputTag} autofocus inputmode="${testInputMode}" enterkeyhint="${testEnterKeyHint}"></${inputTag}>
     `);
 
-    const input = await page.find(`${inputTag} >>> input`);
+    const internalInput = await page.find(`${inputTag} >>> input`);
 
-    expect(input.getAttribute("autofocus")).toBe("");
-    expect(input.getAttribute("inputmode")).toBe(testInputMode);
-    expect(input.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
+    expect(internalInput.getAttribute("autofocus")).toBe("");
+    expect(internalInput.getAttribute("inputmode")).toBe(testInputMode);
+    expect(internalInput.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
+
+    const input = await page.find(inputTag);
+
+    // we intentionally teast each one to avoid renders caused by unrelated props affecting result
+    await input.removeAttribute("autofocus");
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("autofocus")).toBe(null);
+
+    await input.removeAttribute("inputmode");
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("inputmode")).toBe("");
+
+    await input.removeAttribute("enterkeyhint");
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("enterkeyhint")).toBe("");
   });
 
   it("supports global props", async () => {
@@ -150,5 +165,18 @@ export function testWorkaroundForGlobalPropRemoval(
     expect(internalInput.getAttribute("autofocus")).toBe("");
     expect(internalInput.getAttribute("inputmode")).toBe(testInputMode);
     expect(internalInput.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
+
+    // we intentionally teast each one to avoid renders caused by unrelated props affecting result
+    input.setProperty("autofocus", false);
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("autofocus")).toBe(null);
+
+    input.setProperty("inputMode", null);
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("inputmode")).toBe("");
+
+    input.setProperty("enterKeyHint", null);
+    await page.waitForChanges();
+    expect(internalInput.getAttribute("enterkeyhint")).toBe("");
   });
 }

--- a/packages/calcite-components/src/components/input/common/tests.ts
+++ b/packages/calcite-components/src/components/input/common/tests.ts
@@ -136,18 +136,9 @@ export function testWorkaroundForGlobalPropRemoval(
 
     const input = await page.find(inputTag);
 
-    // we intentionally teast each one to avoid renders caused by unrelated props affecting result
     await input.removeAttribute("autofocus");
     await page.waitForChanges();
     expect(internalInput.getAttribute("autofocus")).toBe(null);
-
-    await input.removeAttribute("inputmode");
-    await page.waitForChanges();
-    expect(internalInput.getAttribute("inputmode")).toBe("");
-
-    await input.removeAttribute("enterkeyhint");
-    await page.waitForChanges();
-    expect(internalInput.getAttribute("enterkeyhint")).toBe("");
   });
 
   it("supports global props", async () => {
@@ -166,17 +157,8 @@ export function testWorkaroundForGlobalPropRemoval(
     expect(internalInput.getAttribute("inputmode")).toBe(testInputMode);
     expect(internalInput.getAttribute("enterkeyhint")).toBe(testEnterKeyHint);
 
-    // we intentionally teast each one to avoid renders caused by unrelated props affecting result
     input.setProperty("autofocus", false);
     await page.waitForChanges();
     expect(internalInput.getAttribute("autofocus")).toBe(null);
-
-    input.setProperty("inputMode", null);
-    await page.waitForChanges();
-    expect(internalInput.getAttribute("inputmode")).toBe("");
-
-    input.setProperty("enterKeyHint", null);
-    await page.waitForChanges();
-    expect(internalInput.getAttribute("enterkeyhint")).toBe("");
   });
 }

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -91,7 +91,7 @@ export class Input
   private actionWrapperEl = createRef<HTMLDivElement>();
 
   attributeWatch = useWatchAttributes(
-    ["enterkeyhint", "inputmode", "spellcheck"],
+    ["autofocus", "enterkeyhint", "inputmode", "spellcheck"],
     this.handleGlobalAttributesChanged,
   );
 


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Fixes an issue caused by #10310, where `autofocus` was no longer used within rendering.
