### PR TITLE
fix(list-item): ensure consistent focus border color by referencing updated tokens

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -411,7 +411,7 @@
     content: "";
     inline-size: theme("spacing[0.5]");
     z-index: theme("zIndex.header");
-    background-color: theme("colors.brand");
+    background-color: var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
     inset-block: 0;
   }
   &::before {


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Updates `list-item` to use the default focus color token introduced in https://github.com/Esri/calcite-design-system/pull/10512.