### PR TITLE
docs(input-time-zone): add setFocus method description

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -233,6 +233,7 @@ export class InputTimeZone
 
   // #region Public Methods
 
+  /** Sets focus on the component. */
   @method()
   async setFocus(): Promise<void> {
     await componentFocusable(this);


### PR DESCRIPTION
**Related Issue:** #11138

## Summary
Add a description to `input-time-zone`'s `setFocus` method.