### PR TITLE
chore(linting): clean up warnings

### DIFF
--- a/packages/calcite-components/eslint.config.mjs
+++ b/packages/calcite-components/eslint.config.mjs
@@ -110,9 +110,13 @@ export default [
         },
       ],
 
+      "jsdoc/check-param-names": "off",
       "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-param-description": "off",
       "jsdoc/require-param-type": "off",
       "jsdoc/require-property-type": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
       "jsdoc/require-returns-type": "off",
       "jsdoc/check-tag-names": "off",
       "jsdoc/tag-lines": [

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -992,6 +992,7 @@ export class InputNumber
         onFocus={this.inputNumberFocusHandler}
         onInput={this.inputNumberInputHandler}
         onKeyDown={this.inputNumberKeyDownHandler}
+        // eslint-disable-next-line react/forbid-dom-props -- intentional onKeyUp usage
         onKeyUp={this.inputNumberKeyUpHandler}
         placeholder={this.placeholder || ""}
         readOnly={this.readOnly}

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -1081,6 +1081,7 @@ export class Input
           onFocus={this.inputFocusHandler}
           onInput={this.inputNumberInputHandler}
           onKeyDown={this.inputNumberKeyDownHandler}
+          // eslint-disable-next-line react/forbid-dom-props -- intentional onKeyUp usage
           onKeyUp={this.inputKeyUpHandler}
           pattern={this.pattern}
           placeholder={this.placeholder || ""}
@@ -1123,6 +1124,7 @@ export class Input
           onFocus={this.inputFocusHandler}
           onInput={this.inputInputHandler}
           onKeyDown={this.inputKeyDownHandler}
+          // eslint-disable-next-line react/forbid-component-props -- intentional onKeyUp usage
           onKeyUp={this.inputKeyUpHandler}
           pattern={this.pattern}
           placeholder={this.placeholder || ""}


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This PR disables:

* false-positives from [`react/forbid-dom-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md) and [`react/forbid-component-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md) 
* `eslint-plugin-jsdoc` rules that create churn without added value (most already covered by TypeScript):
  * [`jsdoc/check-param-names`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/check-param-names.md)
  * [`jsdoc/require-param-description`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/require-param-description.md)
  * [`jsdoc/require-returns`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/require-returns.md)
  * [`jsdoc/require-returns-description`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/.README/rules/require-returns-description.md)