### PR TITLE
fix(input-time-zone): keep selection in sync when item-related props are set along with value

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.e2e.ts
@@ -650,4 +650,23 @@ describe("calcite-input-time-zone", () => {
       await assertItemLabelMatches(page, "UTC");
     });
   });
+
+  it("keeps internal combobox in sync after selection when setting value along with time zone item-related props", async () => {
+    const page = await newE2EPage();
+    await page.emulateTimezone(testTimeZoneItems[0].name);
+    await page.setContent(html`<calcite-input-time-zone></calcite-input-time-zone>`);
+    const inputTimeZone = await page.find("calcite-input-time-zone");
+    const combobox = await page.find("calcite-input-time-zone >>> calcite-combobox");
+
+    inputTimeZone.setProperty("referenceDate", new Date());
+    inputTimeZone.setProperty("value", testTimeZoneItems[1].offset);
+    await page.waitForChanges();
+
+    await inputTimeZone.callMethod("setFocus");
+    await inputTimeZone.press("ArrowDown");
+    await inputTimeZone.press("Escape");
+    await page.waitForChanges();
+
+    expect(await combobox.getProperty("value")).not.toBe("");
+  });
 });

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -276,8 +276,7 @@ export class InputTimeZone
     const initialValue = this.value;
     const normalized = this.normalizeValue(initialValue);
     this.value = normalized || (initialValue === "" ? normalized : undefined);
-
-    await this.updateTimeZoneSelection();
+    this.updateTimeZoneSelection();
 
     const selectedValue = this.selectedTimeZoneItem ? `${this.selectedTimeZoneItem.value}` : "";
     afterConnectDefaultValueSet(this, selectedValue);
@@ -289,6 +288,10 @@ export class InputTimeZone
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
+    if (changes.has("value") && this.hasUpdated) {
+      this.handleValueChange(this.value, changes.get("value"));
+    }
+
     if (
       changes.has("messages") ||
       (changes.has("mode") && (this.hasUpdated || this.mode !== "offset")) ||
@@ -299,10 +302,6 @@ export class InputTimeZone
 
     if (changes.has("open") && (this.hasUpdated || this.open !== false)) {
       this.openChanged();
-    }
-
-    if (changes.has("value") && this.hasUpdated) {
-      this.handleValueChange(this.value, changes.get("value"));
     }
   }
 
@@ -325,12 +324,12 @@ export class InputTimeZone
 
   // #region Private Methods
 
-  private handleTimeZoneItemPropsChange(): void {
+  private async handleTimeZoneItemPropsChange(): Promise<void> {
     if (!this.timeZoneItems || !this.hasUpdated) {
       return;
     }
 
-    this.updateTimeZoneItems();
+    await this.updateTimeZoneItems();
     this.updateTimeZoneSelection();
   }
 
@@ -459,7 +458,7 @@ export class InputTimeZone
     this.timeZoneItems = await this.createTimeZoneItems();
   }
 
-  private async updateTimeZoneSelection(): Promise<void> {
+  private updateTimeZoneSelection(): void {
     if (this.value === "" && this.clearable) {
       this.selectedTimeZoneItem = null;
       return;


### PR DESCRIPTION
**Related Issue:** #11128 

## Summary

Fixes an issue caused by having selection-related logic run before items are updated.

### Noteworthy changes

* removes `async` from synchronous method
* moves internal value-setting logic earlier to ensure proper state