### PR TITLE
chore(a11y): remove default priority label from a11y issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -1,6 +1,6 @@
 name: Accessibility
 description: Report an accessibility issue in a component
-labels: ["a11y", "bug", "0 - new", "p - high", "needs triage"]
+labels: ["a11y", "bug", "0 - new", "needs triage"]
 body:
   - type: checkboxes
     id: existing-issues


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Remove the default priority, `p - high`, from the accessibility issue template, where the team can assess the a11y issue's priority during regular bug triage meetings.