### PR TITLE
chore: set up `typescript-strict-plugin` to help enable strict mode globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "tsx": "4.19.2",
         "turbo": "2.3.3",
         "typescript": "5.6.3",
+        "typescript-strict-plugin": "2.4.4",
         "vite": "5.4.11"
       },
       "optionalDependencies": {
@@ -31685,6 +31686,274 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-strict-plugin": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.4.4.tgz",
+      "integrity": "sha512-OXcWHQk+pW9gqEL/Mb1eTgj/Yiqk1oHBERr9v4VInPOYN++p+cXejmQK/h/VlUPGD++FXQ8pgiqVMyEtxU4T6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "tsc-strict": "dist/cli/tsc-strict/index.js",
+        "update-strict-comments": "dist/cli/update-strict-comments/index.js"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript-strict-plugin/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/typescript-strict-plugin/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.39",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
@@ -33876,9 +34145,9 @@
       "version": "3.0.0-next.82",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/components-controllers": "4.32.0-next.62",
-        "@arcgis/components-utils": "4.32.0-next.62",
-        "@arcgis/lumina": "4.32.0-next.62",
+        "@arcgis/components-controllers": "^4.32.0-next.55",
+        "@arcgis/components-utils": "^4.32.0-next.55",
+        "@arcgis/lumina": "^4.32.0-next.55",
         "@esri/calcite-ui-icons": "^4.0.0-next.3",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/rule-tester": "8.18.2",
     "@typescript-eslint/utils": "8.18.2",
     "@vitest/coverage-v8": "2.1.8",
+    "@vitest/eslint-plugin": "1.0.1",
     "@whitespace/storybook-addon-html": "6.1.1",
     "autoprefixer": "10.4.20",
     "axe-core": "4.10.2",
@@ -96,7 +97,6 @@
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-react": "7.37.3",
     "eslint-plugin-unicorn": "56.0.1",
-    "@vitest/eslint-plugin": "1.0.1",
     "globals": "15.14.0",
     "globby": "14.0.2",
     "happy-dom": "15.11.7",
@@ -127,6 +127,7 @@
     "tsx": "4.19.2",
     "turbo": "2.3.3",
     "typescript": "5.6.3",
+    "typescript-strict-plugin": "2.4.4",
     "vite": "5.4.11"
   },
   "license": "SEE LICENSE.md",

--- a/packages/calcite-components-react/tsconfig.json
+++ b/packages/calcite-components-react/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "allowUnreachableCode": false,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
     "declaration": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "jsx": "react",
     "lib": ["dom", "es2015"],
     "module": "esnext",
     "moduleResolution": "node",
@@ -15,9 +16,9 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "removeComments": false,
-    "jsx": "react",
-    "target": "es2015",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2015"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/calcite-components/calcite-preset.ts
+++ b/packages/calcite-components/calcite-preset.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import plugin from "tailwindcss/plugin";
 

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {
   closestElementCrossShadowBoundary,

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { debounce } from "lodash-es";
 import { PropertyValues } from "lit";
 import {

--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, h, method, state, JsxNode, ToEvents } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { focusFirstTabbable, slotChangeGetAssignedElements } from "../../utils/dom";

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, h, method, JsxNode } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";

--- a/packages/calcite-components/src/components/alert/AlertManager.ts
+++ b/packages/calcite-components/src/components/alert/AlertManager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Alert } from "./alert";
 
 export const alertQueueTimeoutMs = 300;

--- a/packages/calcite-components/src/components/alert/alert.e2e.ts
+++ b/packages/calcite-components/src/components/alert/alert.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode } from "@arcgis/lumina";
 import { Scale } from "../interfaces";
 import { CSS } from "./resources";

--- a/packages/calcite-components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/calcite-components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import { FlipContext, Scale } from "../interfaces";
 import {

--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/avatar/avatar.e2e.ts
+++ b/packages/calcite-components/src/components/avatar/avatar.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, renders, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/avatar/avatar.tsx
+++ b/packages/calcite-components/src/components/avatar/avatar.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, state, JsxNode } from "@arcgis/lumina";
 import { getModeName } from "../../utils/dom";
 import { isValidHex } from "../color-picker/utils";

--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, focusable, hidden, reflects, renders, themed, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, Fragment, h, method, JsxNode } from "@arcgis/lumina";
 import { focusFirstTabbable } from "../../utils/dom";
 import { isActivationKey } from "../../utils/key";

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { focusFirstTabbable, slotChangeHasAssignedElement } from "../../utils/dom";

--- a/packages/calcite-components/src/components/button/button.e2e.ts
+++ b/packages/calcite-components/src/components/button/button.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, disabled, hidden, HYDRATED_ATTR, labelable, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import { literal } from "lit-html/static.js";
 import {

--- a/packages/calcite-components/src/components/card-group/card-group.e2e.ts
+++ b/packages/calcite-components/src/components/card-group/card-group.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/card-group/card-group.tsx
+++ b/packages/calcite-components/src/components/card-group/card-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/card/card.tsx
+++ b/packages/calcite-components/src/components/card/card.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/carousel-item/carousel-item.tsx
+++ b/packages/calcite-components/src/components/carousel-item/carousel-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode, setAttribute } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";
 import { CSS } from "./resources";

--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, hidden, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/calcite-components/src/components/checkbox/checkbox.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { getElementDir } from "../../utils/dom";

--- a/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
+++ b/packages/calcite-components/src/components/chip-group/chip-group.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/chip-group/chip-group.tsx
+++ b/packages/calcite-components/src/components/chip-group/chip-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/chip/chip.e2e.ts
+++ b/packages/calcite-components/src/components/chip/chip.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, disabled, focusable, hidden, renders, slots, t9n, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/chip/chip.tsx
+++ b/packages/calcite-components/src/components/chip/chip.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, defaults, focusable, hidden, reflects, renders } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
+++ b/packages/calcite-components/src/components/color-picker-hex-input/color-picker-hex-input.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Color from "color";
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Color from "color";
 import { PropertyValues } from "lit";
 import { LitElement, property, Fragment, h, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, afterAll, afterEach, beforeAll, beforeEach, vi, MockInstance } from "vitest";
 import { accessible, defaults, hidden, reflects, renders, focusable, disabled, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Color from "color";
 import { throttle } from "lodash-es";
 import { PropertyValues } from "lit";

--- a/packages/calcite-components/src/components/color-picker/utils.ts
+++ b/packages/calcite-components/src/components/color-picker/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Color from "color";
 import { Scale } from "../interfaces";
 import { ColorValue, HSLA, HSVA, RGB, RGBA } from "./interfaces";

--- a/packages/calcite-components/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/packages/calcite-components/src/components/combobox-item-group/combobox-item-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";
 import { ComboboxChildElement } from "../combobox/interfaces";

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, state, JsxNode } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";

--- a/packages/calcite-components/src/components/combobox/combobox.e2e.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import {

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { debounce, escapeRegExp } from "lodash-es";
 import { calciteSize48 } from "@esri/calcite-design-tokens/dist/es6/core.js";
 import { PropertyValues } from "lit";

--- a/packages/calcite-components/src/components/combobox/utils.ts
+++ b/packages/calcite-components/src/components/combobox/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { nodeListToArray } from "../../utils/dom";
 import { isBrowser } from "../../utils/browser";
 import { ComboboxItem } from "../combobox-item/combobox-item";

--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.tsx
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
   LitElement,
   property,

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
   calciteSpacingBase,
   calciteSpacingXxs,

--- a/packages/calcite-components/src/components/date-picker-month/date-picker-month.tsx
+++ b/packages/calcite-components/src/components/date-picker-month/date-picker-month.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, state, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/date-picker/utils.ts
+++ b/packages/calcite-components/src/components/date-picker/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { dateFromISO } from "../../utils/date";
 import { getSupportedLocale } from "../../utils/locale";
 import { getAssetPath } from "../../runtime";

--- a/packages/calcite-components/src/components/dialog/dialog.e2e.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import interact from "interactjs";
 import type { DragEvent, Interactable, ResizeEvent } from "@interactjs/types";
 import { PropertyValues } from "lit";

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { defaults, hidden, reflects, renders } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import { Scale, SelectionMode } from "../interfaces";

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import dedent from "dedent";
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { focusElement, focusElementInGroup, focusFirstTabbable } from "../../utils/dom";

--- a/packages/calcite-components/src/components/fab/fab.tsx
+++ b/packages/calcite-components/src/components/fab/fab.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, h, method, JsxNode } from "@arcgis/lumina";
 import { focusElement } from "../../utils/dom";

--- a/packages/calcite-components/src/components/filter/filter.e2e.ts
+++ b/packages/calcite-components/src/components/filter/filter.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, defaults, disabled, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/filter/filter.tsx
+++ b/packages/calcite-components/src/components/filter/filter.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { debounce } from "lodash-es";
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { getElementDir } from "../../utils/dom";

--- a/packages/calcite-components/src/components/flow/flow.e2e.ts
+++ b/packages/calcite-components/src/components/flow/flow.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, h, method, state, JsxNode } from "@arcgis/lumina";
 import { createObserver } from "../../utils/observers";

--- a/packages/calcite-components/src/components/functional/ExpandToggle.tsx
+++ b/packages/calcite-components/src/components/functional/ExpandToggle.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TemplateResult } from "lit-html";
 import { h } from "@arcgis/lumina";
 import { getElementDir } from "../../utils/dom";

--- a/packages/calcite-components/src/components/graph/graph.tsx
+++ b/packages/calcite-components/src/components/graph/graph.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";
 import { createObserver } from "../../utils/observers";

--- a/packages/calcite-components/src/components/graph/util.ts
+++ b/packages/calcite-components/src/components/graph/util.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DataSeries, Extent, Graph, Point, TranslateOptions, Translator } from "./interfaces";
 
 /**

--- a/packages/calcite-components/src/components/handle/handle.e2e.ts
+++ b/packages/calcite-components/src/components/handle/handle.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, disabled, hidden, renders, themed, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/icon/icon.e2e.ts
+++ b/packages/calcite-components/src/components/icon/icon.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, reflects, renders, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/icon/icon.tsx
+++ b/packages/calcite-components/src/components/icon/icon.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { CalciteIconPath, CalciteMultiPathEntry } from "@esri/calcite-ui-icons";
 import { PropertyValues } from "lit";
 import { LitElement, property, h, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, disabled, labelable, renders, hidden, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { FocusTrap } from "focus-trap";
 import { PropertyValues } from "lit";
 import {

--- a/packages/calcite-components/src/components/input-message/input-message.e2e.ts
+++ b/packages/calcite-components/src/components/input-message/input-message.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, hidden, renders } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/input-message/input-message.tsx
+++ b/packages/calcite-components/src/components/input-message/input-message.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { KeyInput } from "puppeteer";
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/input-text/input-text.e2e.ts
+++ b/packages/calcite-components/src/components/input-text/input-text.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { localizeTimeString } from "../../utils/time";

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import dayjs from "dayjs/esm/index.js";
 import customParseFormat from "dayjs/esm/plugin/customParseFormat/index.js";
 import localeData from "dayjs/esm/plugin/localeData/index.js";

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   createEvent,

--- a/packages/calcite-components/src/components/input-time-zone/utils.ts
+++ b/packages/calcite-components/src/components/input-time-zone/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getDateTimeFormat, SupportedLocale } from "../../utils/locale";
 import type { InputTimeZone } from "./input-time-zone";
 import { OffsetStyle, TimeZone, TimeZoneItem, TimeZoneItemGroup, TimeZoneMode } from "./interfaces";

--- a/packages/calcite-components/src/components/input/common/input.ts
+++ b/packages/calcite-components/src/components/input/common/input.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export type InputComponent = NumericInputComponent | TextualInputComponent | DateTimeInputComponent;
 
 export interface DateTimeInputComponent {

--- a/packages/calcite-components/src/components/input/input.e2e.ts
+++ b/packages/calcite-components/src/components/input/input.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { KeyInput } from "puppeteer";
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { literal } from "lit-html/static.js";

--- a/packages/calcite-components/src/components/label/label.e2e.ts
+++ b/packages/calcite-components/src/components/label/label.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { renders, hidden, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/label/label.tsx
+++ b/packages/calcite-components/src/components/label/label.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/link/link.e2e.ts
+++ b/packages/calcite-components/src/components/link/link.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, defaults, disabled, hidden, renders, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/link/link.tsx
+++ b/packages/calcite-components/src/components/link/link.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { literal } from "lit-html/static.js";
 import { LitElement, property, h, method, JsxNode, stringOrBoolean } from "@arcgis/lumina";
 import { focusElement, getElementDir } from "../../utils/dom";

--- a/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
+++ b/packages/calcite-components/src/components/list-item-group/list-item-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import {
   InteractiveComponent,

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Sortable from "sortablejs";
 import { debounce } from "lodash-es";
 import { PropertyValues } from "lit";

--- a/packages/calcite-components/src/components/loader/loader.e2e.ts
+++ b/packages/calcite-components/src/components/loader/loader.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { hidden, renders, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/loader/loader.tsx
+++ b/packages/calcite-components/src/components/loader/loader.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { Fragment, h, JsxNode, LitElement, property, setAttribute } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";

--- a/packages/calcite-components/src/components/menu-item/menu-item.tsx
+++ b/packages/calcite-components/src/components/menu-item/menu-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/menu/menu.e2e.ts
+++ b/packages/calcite-components/src/components/menu/menu.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, h, method, JsxNode, LuminaJsx } from "@arcgis/lumina";
 import { useWatchAttributes } from "@arcgis/components-controllers";

--- a/packages/calcite-components/src/components/meter/meter.tsx
+++ b/packages/calcite-components/src/components/meter/meter.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, h, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { defaults, focusable, hidden, openClose, renders, slots, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, method, JsxNode } from "@arcgis/lumina";
 import {
   LoadableComponent,

--- a/packages/calcite-components/src/components/navigation-user/navigation-user.tsx
+++ b/packages/calcite-components/src/components/navigation-user/navigation-user.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, method, JsxNode } from "@arcgis/lumina";
 import {
   LoadableComponent,

--- a/packages/calcite-components/src/components/navigation/navigation.tsx
+++ b/packages/calcite-components/src/components/navigation/navigation.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/notice/notice.tsx
+++ b/packages/calcite-components/src/components/notice/notice.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/option-group/option-group.e2e.ts
+++ b/packages/calcite-components/src/components/option-group/option-group.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/option-group/option-group.tsx
+++ b/packages/calcite-components/src/components/option-group/option-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, Fragment, h, JsxNode } from "@arcgis/lumina";
 import { styles } from "./option-group.scss";

--- a/packages/calcite-components/src/components/option/option.e2e.ts
+++ b/packages/calcite-components/src/components/option/option.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, reflects, renders, hidden } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/option/option.tsx
+++ b/packages/calcite-components/src/components/option/option.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import { createObserver } from "../../utils/observers";

--- a/packages/calcite-components/src/components/pagination/pagination.e2e.ts
+++ b/packages/calcite-components/src/components/pagination/pagination.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/pagination/pagination.tsx
+++ b/packages/calcite-components/src/components/pagination/pagination.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/popover/PopoverManager.ts
+++ b/packages/calcite-components/src/components/popover/PopoverManager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { ReferenceElement } from "../../utils/floating-ui";
 import { isActivationKey } from "../../utils/key";
 import { isKeyboardTriggeredClick } from "../../utils/dom";

--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/progress/progress.tsx
+++ b/packages/calcite-components/src/components/progress/progress.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode } from "@arcgis/lumina";
 import { getElementDir } from "../../utils/dom";
 import { CSS_UTILITY } from "../../utils/resources";

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
+++ b/packages/calcite-components/src/components/radio-button/radio-button.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/radio-button/radio-button.tsx
+++ b/packages/calcite-components/src/components/radio-button/radio-button.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { getRoundRobinIndex } from "../../utils/array";

--- a/packages/calcite-components/src/components/rating/rating.tsx
+++ b/packages/calcite-components/src/components/rating/rating.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
   LitElement,
   property,

--- a/packages/calcite-components/src/components/scrim/scrim.e2e.ts
+++ b/packages/calcite-components/src/components/scrim/scrim.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/scrim/scrim.tsx
+++ b/packages/calcite-components/src/components/scrim/scrim.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, state, JsxNode } from "@arcgis/lumina";
 import { createObserver } from "../../utils/observers";
 import { Scale } from "../interfaces";

--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.tsx
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, state, JsxNode } from "@arcgis/lumina";
 import { slotChangeHasContent, toAriaBoolean } from "../../utils/dom";

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/select/select.e2e.ts
+++ b/packages/calcite-components/src/components/select/select.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/calcite-components/src/components/select/select.tsx
+++ b/packages/calcite-components/src/components/select/select.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import interact from "interactjs";
 import type { Interactable, ResizeEvent } from "@interactjs/types";
 import { PropertyValues } from "lit";

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.e2e.ts
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, renders, slots } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
+++ b/packages/calcite-components/src/components/shell-center-row/shell-center-row.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, Fragment, h, state, JsxNode } from "@arcgis/lumina";
 import { Position, Scale } from "../interfaces";
 import { slotChangeGetAssignedElements } from "../../utils/dom";

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.e2e.ts
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, reflects, renders, slots, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, state, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/shell/shell.tsx
+++ b/packages/calcite-components/src/components/shell/shell.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, Fragment, h, state, JsxNode } from "@arcgis/lumina";
 import { slotChangeGetAssignedElements, slotChangeHasAssignedElement } from "../../utils/dom";

--- a/packages/calcite-components/src/components/slider/slider.e2e.ts
+++ b/packages/calcite-components/src/components/slider/slider.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, disabled, hidden, renders, t9n, openClose } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Sortable from "sortablejs";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/split-button/split-button.e2e.ts
+++ b/packages/calcite-components/src/components/split-button/split-button.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/split-button/split-button.tsx
+++ b/packages/calcite-components/src/components/split-button/split-button.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { FlipPlacement, MenuPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import {

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeAll } from "vitest";
 import { defaults, hidden, reflects, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { focusElementInGroup, slotChangeGetAssignedElements } from "../../utils/dom";

--- a/packages/calcite-components/src/components/switch/switch.tsx
+++ b/packages/calcite-components/src/components/switch/switch.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import { focusElement } from "../../utils/dom";
 import {

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.e2e.ts
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
   calciteSize24,
   calciteSize32,

--- a/packages/calcite-components/src/components/tab-title/tab-title.tsx
+++ b/packages/calcite-components/src/components/tab-title/tab-title.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/tab/tab.tsx
+++ b/packages/calcite-components/src/components/tab/tab.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, method, state, JsxNode, setAttribute } from "@arcgis/lumina";
 import { nodeListToArray } from "../../utils/dom";
 import { guid } from "../../utils/guid";

--- a/packages/calcite-components/src/components/table-cell/table-cell.tsx
+++ b/packages/calcite-components/src/components/table-cell/table-cell.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, h, method, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/table-header/table-header.tsx
+++ b/packages/calcite-components/src/components/table-header/table-header.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, h, method, state, JsxNode } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import { createRef } from "lit-html/directives/ref.js";

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { render } from "lit-html";
 import { createRef } from "lit-html/directives/ref.js";

--- a/packages/calcite-components/src/components/tabs/tabs.e2e.ts
+++ b/packages/calcite-components/src/components/tabs/tabs.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/tabs/tabs.tsx
+++ b/packages/calcite-components/src/components/tabs/tabs.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, Fragment, h, state, JsxNode } from "@arcgis/lumina";
 import { Scale } from "../interfaces";

--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { throttle } from "lodash-es";
 import { createRef } from "lit-html/directives/ref.js";
 import {

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/tile-select/tile-select.e2e.ts
+++ b/packages/calcite-components/src/components/tile-select/tile-select.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, disabled, focusable, hidden, reflects, renders } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/tile-select/tile-select.tsx
+++ b/packages/calcite-components/src/components/tile-select/tile-select.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { guid } from "../../utils/guid";

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {
   InteractiveComponent,

--- a/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/time-picker/time-picker.tsx
+++ b/packages/calcite-components/src/components/time-picker/time-picker.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { numberKeys } from "../../utils/key";

--- a/packages/calcite-components/src/components/tip-group/tip-group.tsx
+++ b/packages/calcite-components/src/components/tip-group/tip-group.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, h, JsxNode } from "@arcgis/lumina";
 import { logger } from "../../utils/logger";
 import { styles } from "./tip-group.scss";

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.e2e.ts
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { accessible, defaults, hidden, renders, t9n } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
+++ b/packages/calcite-components/src/components/tip-manager/tip-manager.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import { getElementDir } from "../../utils/dom";

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement, property, createEvent, Fragment, h, state, JsxNode } from "@arcgis/lumina";
 import { constrainHeadingLevel, Heading, HeadingLevel } from "../functional/Heading";
 import { logger } from "../../utils/logger";

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getShadowRootNode } from "../../utils/dom";
 import { ReferenceElement } from "../../utils/floating-ui";
 import { TOOLTIP_OPEN_DELAY_MS, TOOLTIP_CLOSE_DELAY_MS } from "./resources";

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 import { accessible, defaults, floatingUIOwner, hidden, openClose, renders, themed } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import {
   LitElement,

--- a/packages/calcite-components/src/components/tooltip/utils.ts
+++ b/packages/calcite-components/src/components/tooltip/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { ReferenceElement } from "../../utils/floating-ui";
 import { queryElementRoots } from "../../utils/dom";
 import type { Tooltip } from "./tooltip";

--- a/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
+++ b/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { accessible, defaults, disabled, hidden, renders, slots } from "../../tests/commonTests";

--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createRef } from "lit-html/directives/ref.js";
 import { LitElement, property, createEvent, h, state, JsxNode, setAttribute } from "@arcgis/lumina";

--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, afterAll, beforeAll, vi, MockInstance } from "vitest";
 import { html } from "../../../support/formatting";

--- a/packages/calcite-components/src/components/tree/tree.tsx
+++ b/packages/calcite-components/src/components/tree/tree.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, JsxNode, setAttribute } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/components/tree/utils.ts
+++ b/packages/calcite-components/src/components/tree/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { TreeItem } from "../tree-item/tree-item";
 import type { Tree } from "./tree";
 

--- a/packages/calcite-components/src/tests/commonTests/disabled.ts
+++ b/packages/calcite-components/src/tests/commonTests/disabled.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { SetFieldType } from "type-fest";
 import { E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";

--- a/packages/calcite-components/src/tests/commonTests/floatingUI.ts
+++ b/packages/calcite-components/src/tests/commonTests/floatingUI.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { getTag, simplePageSetup } from "./utils";

--- a/packages/calcite-components/src/tests/commonTests/focusable.ts
+++ b/packages/calcite-components/src/tests/commonTests/focusable.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import {} from "../utils";
 import { expect, it } from "vitest";

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { KeyInput } from "puppeteer";
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";

--- a/packages/calcite-components/src/tests/commonTests/labelable.ts
+++ b/packages/calcite-components/src/tests/commonTests/labelable.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";

--- a/packages/calcite-components/src/tests/commonTests/openClose.ts
+++ b/packages/calcite-components/src/tests/commonTests/openClose.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it } from "vitest";

--- a/packages/calcite-components/src/tests/commonTests/slots.ts
+++ b/packages/calcite-components/src/tests/commonTests/slots.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { getTag, simplePageSetup } from "./utils";

--- a/packages/calcite-components/src/tests/commonTests/t9n.ts
+++ b/packages/calcite-components/src/tests/commonTests/t9n.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import { LitElement, PublicLitElement } from "@arcgis/lumina";
 import { E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { toHaveNoViolations } from "jest-axe";
 import type { RequireExactlyOne } from "type-fest";
 import { E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";

--- a/packages/calcite-components/src/tests/spec-helpers/animationEvents.ts
+++ b/packages/calcite-components/src/tests/spec-helpers/animationEvents.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export interface AnimationEventDispatcher {
   (element: HTMLElement, type: "animationstart" | "animationend", animationName: string): void;
 }

--- a/packages/calcite-components/src/tests/spec-helpers/computedStyle.ts
+++ b/packages/calcite-components/src/tests/spec-helpers/computedStyle.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { vi } from "vitest";
 
 /**

--- a/packages/calcite-components/src/tests/spec-helpers/transitionEvents.ts
+++ b/packages/calcite-components/src/tests/spec-helpers/transitionEvents.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 export interface TransitionEventDispatcher {
   (element: HTMLElement, type: "transitionstart" | "transitionend", propertyName: string): void;
 }

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { BoundingBox, ElementHandle } from "puppeteer";
 import { LuminaJsx } from "@arcgis/lumina";
 import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";

--- a/packages/calcite-components/src/utils/config.spec.ts
+++ b/packages/calcite-components/src/utils/config.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 
 describe("config", () => {

--- a/packages/calcite-components/src/utils/config.ts
+++ b/packages/calcite-components/src/utils/config.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { isServer } from "lit-html/is-server.js";
 import { FocusTrap } from "./focusTrapComponent";
 import { LogLevel } from "./logger";

--- a/packages/calcite-components/src/utils/date.spec.ts
+++ b/packages/calcite-components/src/utils/date.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it } from "vitest";
 import { DateLocaleData } from "../components/date-picker/utils";
 import arabic from "../components/date-picker/assets/nls/ar.json";

--- a/packages/calcite-components/src/utils/date.ts
+++ b/packages/calcite-components/src/utils/date.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { DateLocaleData } from "../components/date-picker/utils";
 import { numberStringFormatter } from "./locale";
 

--- a/packages/calcite-components/src/utils/dom.e2e.ts
+++ b/packages/calcite-components/src/utils/dom.e2e.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
 import { getHost, getRootNode, queryElementRoots } from "./dom";

--- a/packages/calcite-components/src/utils/dom.spec.ts
+++ b/packages/calcite-components/src/utils/dom.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { beforeAll, beforeEach, describe, expect, it, Mock, vi } from "vitest";
 import { ModeName } from "../components/interfaces";
 import { html } from "../../support/formatting";

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { tabbable } from "tabbable";
 import { IconNameOrString } from "../components/icon/interfaces";
 import { guid } from "./guid";

--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import {
   arrow,
   autoPlacement,

--- a/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 import { GlobalTestProps } from "../tests/utils";
 import {

--- a/packages/calcite-components/src/utils/form.spec.ts
+++ b/packages/calcite-components/src/utils/form.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, vi } from "vitest";
 import { findAssociatedForm, FormOwner, resetForm, submitForm } from "./form";
 

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Writable } from "type-fest";
 import { TemplateResult } from "lit-html";
 import { h } from "@arcgis/lumina";

--- a/packages/calcite-components/src/utils/interactive.spec.ts
+++ b/packages/calcite-components/src/utils/interactive.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it } from "vitest";
 import { InteractiveHTMLElement, updateHostInteraction } from "./interactive";
 

--- a/packages/calcite-components/src/utils/interactive.tsx
+++ b/packages/calcite-components/src/utils/interactive.tsx
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TemplateResult } from "lit-html";
 import { h, JsxNode, LuminaJsx } from "@arcgis/lumina";
 

--- a/packages/calcite-components/src/utils/label.spec.ts
+++ b/packages/calcite-components/src/utils/label.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, vi } from "vitest";
 import { connectLabel, disconnectLabel, getLabelText, LabelableComponent, labelClickEvent } from "./label";
 

--- a/packages/calcite-components/src/utils/label.ts
+++ b/packages/calcite-components/src/utils/label.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import type { Label } from "../components/label/label";
 import { closestElementCrossShadowBoundary, isBefore, queryElementRoots } from "./dom";
 

--- a/packages/calcite-components/src/utils/loadable.ts
+++ b/packages/calcite-components/src/utils/loadable.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LitElement } from "@arcgis/lumina";
 import { isBrowser } from "./browser";
 

--- a/packages/calcite-components/src/utils/locale.spec.ts
+++ b/packages/calcite-components/src/utils/locale.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, beforeEach } from "vitest";
 import {
   dateTimeFormatCache,

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { BigDecimal, isValidNumber, sanitizeExponentialNumberString } from "./number";
 
 export const defaultLocale = "en";

--- a/packages/calcite-components/src/utils/logger.spec.ts
+++ b/packages/calcite-components/src/utils/logger.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it, afterEach, beforeEach, vi, MockInstance } from "vitest";
 import { GlobalTestProps } from "../tests/utils";
 import { LogLevel } from "./logger";

--- a/packages/calcite-components/src/utils/logger.ts
+++ b/packages/calcite-components/src/utils/logger.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { LuminaJsx } from "@arcgis/lumina";
 import { logLevel } from "./config";
 

--- a/packages/calcite-components/src/utils/number.spec.ts
+++ b/packages/calcite-components/src/utils/number.spec.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { describe, expect, it } from "vitest";
 import { locales, numberStringFormatter } from "./locale";
 import {

--- a/packages/calcite-components/src/utils/number.ts
+++ b/packages/calcite-components/src/utils/number.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { numberKeys } from "./key";
 import { NumberStringFormat } from "./locale";
 

--- a/packages/calcite-components/src/utils/openCloseComponent.ts
+++ b/packages/calcite-components/src/utils/openCloseComponent.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { whenTransitionDone } from "./dom";
 
 /**

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import Sortable from "sortablejs";
 
 const sortableComponentSet = new Set<SortableComponent>();

--- a/packages/calcite-components/src/utils/time.ts
+++ b/packages/calcite-components/src/utils/time.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { getDateTimeFormat, getSupportedNumberingSystem, NumberingSystem, numberStringFormatter } from "./locale";
 import { decimalPlaces } from "./math";
 import { isValidNumber } from "./number";

--- a/packages/calcite-components/tsconfig-base.json
+++ b/packages/calcite-components/tsconfig-base.json
@@ -4,17 +4,18 @@
     "allowUnreachableCode": false,
     "declaration": false,
     "experimentalDecorators": true,
+    "jsx": "preserve",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
     "lib": ["dom", "dom.iterable", "es2022"],
-    "moduleResolution": "Bundler",
-    "skipLibCheck": true,
     "module": "esnext",
-    "target": "es2022",
-    "resolveJsonModule": true,
+    "moduleResolution": "Bundler",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "useDefineForClassFields": false,
-    "jsx": "preserve",
-    "jsxFragmentFactory": "Fragment",
-    "jsxFactory": "h"
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "target": "es2022",
+    "useDefineForClassFields": false
   }
 }

--- a/packages/calcite-components/tsconfig.json
+++ b/packages/calcite-components/tsconfig.json
@@ -2,6 +2,13 @@
 // TODO: [MIGRATION] Compare your config to that in starter package to see if anything needs to be updated: https://devtopia.esri.com/WebGIS/arcgis-web-components/blob/main/packages/starter-packages/lumina-components/tsconfig.json
 // TODO: [MIGRATION] If you used "files" tsconfig option to reference .d.ts files before, that may no longer be necessary. Read https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-jsx--docs#using-custom-elements-from-another-library-in-your-component
 {
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "typescript-strict-plugin"
+      }
+    ]
+  },
   "extends": "./tsconfig-base",
   "include": ["src", "*.ts"],
   "exclude": ["src/demos/**/*", "src/tests/**/*", "src/**/*.stories.ts"]

--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { execSync } from "child_process";
 import tailwindcss, { Config as TailwindConfig } from "tailwindcss";
 import autoprefixer from "autoprefixer";

--- a/packages/calcite-design-tokens/support/run.ts
+++ b/packages/calcite-design-tokens/support/run.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { run as styleDictionaryRunner } from "./token-transformer/sd-run.js";
 import { config } from "../src/$config.js";
 import { CalciteTokenTransformConfig } from "./types/config.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/css.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/css.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import sd, { Core as StyleDictionary } from "style-dictionary";
 import prettierSync from "@prettier/sync";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/docs.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/docs.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import prettierSync from "@prettier/sync";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/javascript.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/javascript.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import styleDictionary, { Core as StyleDictionary } from "style-dictionary";
 import prettierSync from "@prettier/sync";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/scss.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/scss.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import sd, { Core as StyleDictionary } from "style-dictionary";
 
 import { formatTokens } from "./utils/formatTokens.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/typography/utils.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/typography/utils.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { EOL } from "os";
 import { Platform } from "../../../../types/platform.js";
 import { MappedFormatterArguments } from "../../../../types/styleDictionary/formatterArguments.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/createTokenReference.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/createTokenReference.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TransformedToken } from "style-dictionary/types/TransformedToken.js";
 import { PlatformOptions } from "../../../../types/styleDictionary/platform.js";
 import { FormattingRules } from "../utils.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/formatExtraOutput.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/formatExtraOutput.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { writeFileSync } from "fs";
 import { resolve } from "path";
 import prettierSync from "@prettier/sync";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/formatTokens.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/formatTokens.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from "../../../../types/styleDictionary/dictionary.js";
 import { handleColor } from "./handleColor.js";
 import { handleStringValueTokens } from "./handleStringValue.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/getReferenceFromValue.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/getReferenceFromValue.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from "style-dictionary/types/Dictionary.js";
 import { PlatformOptions } from "../../../../types/styleDictionary/platform.js";
 import { createTokenReference } from "./createTokenReference.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleBreakpoint.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleBreakpoint.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { checkAndEvaluateMath } from "@tokens-studio/sd-transforms";
 
 import { Dictionary } from "../../../../types/styleDictionary/dictionary.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleColor.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleColor.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from "../../../../types/styleDictionary/dictionary.js";
 import { MappedFormatterArguments } from "../../../../types/styleDictionary/formatterArguments.js";
 import { TransformedToken } from "../../../../types/styleDictionary/transformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleStringValue.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleStringValue.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { TransformedToken } from "style-dictionary/types/TransformedToken.js";
 import { Dictionary } from "style-dictionary/types/Dictionary.js";
 import { getReferencesFromValue } from "./getReferenceFromValue.js";
@@ -17,7 +18,7 @@ export function handleStringValueTokens(
     options: args.options,
   });
   // the key comes from Token Studio, which is why we have to keep the misspelling
-  // eslint-disable-next-line @cspell/spellchecker
+
   const themeAble = ["sass", "scss"].includes(args.options.platform) && !!token["themeable"] ? "!default" : false;
   const comment = !token.comment
     ? undefined

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleTypography.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/handleTypography.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { kebabCase } from "change-case";
 
 import { TransformedToken } from "../../../../types/styleDictionary/transformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/sortByReference.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/formatter/utils/sortByReference.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Dictionary } from "../../../../types/styleDictionary/dictionary.js";
 
 export function sortByReference(dictionary: Dictionary): (a, b) => 1 | -1 {

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/add-font-styles.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/add-font-styles.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 // This is a copy/extension of sd-transforms/src/parsers/add-font-styles.ts with better types
 
 import { TransformOptions } from "../../../../types/styleDictionary/transformOptions.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/excludeParentKeys.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/excludeParentKeys.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * This is a copy of @tokens-studio/sd-transforms/dist/parsers/exclude-parent-key.js because it is not provided in the exports and we need to update the types.
  */

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/expandComposites.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/expandComposites.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * This is a copy/extension of @tokens-studio/sd-transforms/dist/parsers/expand-composites.js but now with better types!
  */

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/resolveRelevance.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/resolveRelevance.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * This is a copy/extension of sd-transforms/src/parsers/resolveReference.ts but now with better types!
  */

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/transformFontWeights.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/parser/utils/transformFontWeights.ts
@@ -1,5 +1,6 @@
+// @ts-strict-ignore
 // This is a copy/extension of sd-transforms/src/transformFontWeights.ts
-// eslint-disable-next-line @cspell/spellchecker
+
 // "demi" was added to align with our design terminology. This was added to utils because these named exports are not available from the node module dependency.
 
 import { FontWeight } from "../../../../types/tokenStudio/fontWeight.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/attributes/attributePlatformName.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/attributes/attributePlatformName.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 
 import { Platform, PlatformUnion } from "../../../../types/platform.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameCamelCase.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameCamelCase.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { camelCase } from "change-case";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameJoinPath.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameJoinPath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameKebabCase.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameKebabCase.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { kebabCase } from "change-case";
 

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameSet.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameSet.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameSpacePath.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/name/nameSpacePath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";
 import { parseTokenPath } from "../utils/parseTokenPath.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/utils/parseTokenPath.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/utils/parseTokenPath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 /**
  * Replaces the word "color" with "ui" when it is the first value in the path and removes the word "default" from the final token names.
  * This puts generated tokens in alignment with the theme variable names in Calcite-Colors

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/utils/setTokenNameByPlatform.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/utils/setTokenNameByPlatform.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Platform } from "../../../../types/platform.js";
 import { PlatformOptions } from "../../../../types/styleDictionary/platform.js";
 import { TransformedToken } from "../../../../types/styleDictionary/transformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueAlignFontWeightAndStyle.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueAlignFontWeightAndStyle.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { Matcher } from "style-dictionary/types/Matcher.js";
 import { TransformedToken } from "style-dictionary/types/TransformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueAssetToken.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueAssetToken.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { Matcher } from "style-dictionary/types/Matcher.js";
 import { TransformedToken } from "style-dictionary/types/TransformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueCheckEvaluateMath.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueCheckEvaluateMath.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { checkAndEvaluateMath } from "@tokens-studio/sd-transforms";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueColorCss.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueColorCss.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { Matcher } from "style-dictionary/types/Matcher";
 import Color from "tinycolor2";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueFontFamilyFallbacks.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueFontFamilyFallbacks.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { Matcher } from "style-dictionary/types/Matcher.js";
 import { TransformedToken } from "style-dictionary/types/TransformedToken.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueStringWrapper.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueStringWrapper.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { Matcher } from "style-dictionary/types/Matcher.js";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueToREM.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueToREM.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";
 import { Matcher } from "style-dictionary/types/Matcher.js";

--- a/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueToUnitless.ts
+++ b/packages/calcite-design-tokens/support/token-transformer/styleDictionary/transformer/value/valueToUnitless.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Core as StyleDictionary } from "style-dictionary";
 import { CalledTransformerFunction, TransformerConfig } from "../utils.js";
 import { Matcher } from "style-dictionary/types/Matcher.js";

--- a/packages/calcite-design-tokens/support/types/styleDictionary/registerFunctions.ts
+++ b/packages/calcite-design-tokens/support/types/styleDictionary/registerFunctions.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { Matcher } from "style-dictionary/types/Matcher.js";
 
 import {

--- a/packages/calcite-design-tokens/tsconfig.json
+++ b/packages/calcite-design-tokens/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "typescript-strict-plugin"
+      }
+    ]
+  },
   "extends": "./tsconfig-base",
   "include": ["support", "src"]
 }

--- a/packages/eslint-plugin-calcite-components/src/rules/no-dynamic-createelement.ts
+++ b/packages/eslint-plugin-calcite-components/src/rules/no-dynamic-createelement.ts
@@ -2,16 +2,18 @@ import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator((name) => name);
 
-function isCreateElement(node) {
+function isCreateElement(node: TSESTree.CallExpression) {
   return (
-    node?.callee?.type === "MemberExpression" &&
-    node?.callee?.object?.name === "document" &&
-    node?.callee?.property?.name === "createElement" &&
+    node.callee?.type === "MemberExpression" &&
+    node.callee?.object?.type === "Identifier" &&
+    node.callee?.object?.name === "document" &&
+    node.callee?.property?.type === "Identifier" &&
+    node.callee?.property?.name === "createElement" &&
     node.arguments.length >= 1
   );
 }
 
-function isStaticValue(arg) {
+function isStaticValue(arg: TSESTree.Node) {
   return arg.type === "Literal" || (arg.type === "TemplateLiteral" && arg.expressions.length === 0);
 }
 

--- a/packages/eslint-plugin-calcite-components/tsconfig.json
+++ b/packages/eslint-plugin-calcite-components/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "strict": true
+  },
   "extends": "../calcite-components/tsconfig-base.json",
   "include": ["src/index.ts", "rollup.config.ts"]
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Wires up [`typescript-strict-plugin`](https://github.com/allegro/typescript-strict-plugin) to incrementally convert files to be strict.

### Notable changes

* Adds `@ts-strict-ignore` comments to files within scope to allow opting into strict mode incrementally
* Enables strict mode for packages with no existing strict errors
* Examples and files not covered by existing `tsconfig.json` files (e.g., support files executed via `tsx`) are not included – I'll create a follow-up PR for these