### PR TITLE
ci(renovate): enable followTag for @arcgis prereleases

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -26,7 +26,8 @@
   "packageRules": [
     {
       "groupName": "ArcGIS",
-      "matchPackageNames": ["@arcgis/**"]
+      "matchPackageNames": ["@arcgis/**"],
+      "followTag": "next"
     },
     {
       "groupName": "ESLint",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

[`followTag`](https://docs.renovatebot.com/configuration-options/#followtag) should help bump prerelease versions in `package.json` instead of only updating the lock file, which could cause different versions to be installed (see https://github.com/Esri/calcite-design-system/pull/11174).

**Note**: we should remove this option once `@arcgis` packages are stable. cc @benelan 