### PR TITLE
chore: add script to generate supported browser info for docs

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "npm run util:prep-build-reqs && vite build",
-    "postbuild": "npm run util:generate-t9n-docs-json && npm run util:clean-readmes && npm run util:copy-legacy-vscode-data",
+    "postbuild": "npm run util:generate-t9n-docs-json && npm run util:generate-supported-browsers-json && npm run util:clean-readmes && npm run util:copy-legacy-vscode-data",
     "build-storybook": "npm run util:prep-build-reqs && NODE_OPTIONS=--openssl-legacy-provider storybook build --output-dir ./docs --quiet",
     "build:dev": "vite build --mode development",
     "build:watch": "npm run util:prep-build-reqs && vite --mode production",
@@ -61,6 +61,7 @@
     "util:copy-assets": "npm run util:copy-icons",
     "util:copy-icons": "cpy \"../../node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/\" --flat",
     "util:generate-t9n-docs-json": "tsx support/generateT9nDocsJSON.ts",
+    "util:generate-supported-browsers-json": "tsx support/generateSupportedBrowsersJSON.ts",
     "util:hydration-styles": "tsx support/hydrationStyles.ts",
     "util:is-working-tree-clean": "[ -z \"$(git status --porcelain=v1)\" ]",
     "util:prep-build-reqs": "npm run util:copy-assets",

--- a/packages/calcite-components/support/generateSupportedBrowsersJSON.ts
+++ b/packages/calcite-components/support/generateSupportedBrowsersJSON.ts
@@ -1,0 +1,19 @@
+(async () => {
+  const { dirname, resolve } = await import("path");
+  const { fileURLToPath } = await import("url");
+  const {
+    promises: { writeFile },
+  } = await import("fs");
+  const { default: browserslist } = await import("browserslist");
+
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const outFile = resolve(__dirname, "..", "dist", "docs", "supported-browsers.json");
+    const supportedBrowsers = browserslist();
+    await writeFile(outFile, JSON.stringify(supportedBrowsers), "utf-8");
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();
+


### PR DESCRIPTION
**Related Issue:** #10217

## Summary

Adds a script that generates supported browsers JSON file for our internal docs output on each build.

### Preview

**`docs/supported-browsers.json`** (split into lines for readability)
```json
[
  "chrome 131",
  "chrome 130",
  "edge 131",
  "edge 130",
  "firefox 133",
  "firefox 132",
  "firefox 128",
  "ios_saf 18.2",
  "ios_saf 18.1",
  "ios_saf 18.0",
  "ios_saf 17.6-17.7",
  "ios_saf 17.5",
  "ios_saf 17.4",
  "ios_saf 17.3",
  "ios_saf 17.2",
  "ios_saf 17.1",
  "ios_saf 17.0",
  "safari 18.2",
  "safari 18.1",
  "safari 18.0",
  "safari 17.6",
  "safari 17.5",
  "safari 17.4",
  "safari 17.3",
  "safari 17.2",
  "safari 17.1",
  "safari 17.0"
]
```