### PR TITLE
ci(renovate): use bump range strategy instead of `followTag` for @arcgis prereleases

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -27,7 +27,7 @@
     {
       "groupName": "ArcGIS",
       "matchPackageNames": ["@arcgis/**"],
-      "followTag": "next"
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "ESLint",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "util:sync-linked-package-versions": "tsx support/syncLinkedPackageVersions.ts"
   },
   "devDependencies": {
-    "@arcgis/lumina-compiler": "4.32.0-next.68",
+    "@arcgis/lumina-compiler": "^4.32.0-next.68",
     "@cspell/eslint-plugin": "8.17.1",
     "@eslint/compat": "1.2.4",
     "@eslint/eslintrc": "3.2.0",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -68,10 +68,10 @@
     "util:test-types": "! grep -rnw 'dist/types' -e '<reference types='"
   },
   "dependencies": {
-    "@arcgis/components-controllers": "4.32.0-next.68",
-    "@arcgis/components-utils": "4.32.0-next.68",
-    "@arcgis/lumina": "4.32.0-next.68",
-    "@esri/calcite-ui-icons": "4.0.0-next.5",
+    "@arcgis/components-controllers": "^4.32.0-next.68",
+    "@arcgis/components-utils": "^4.32.0-next.68",
+    "@arcgis/lumina": "^4.32.0-next.68",
+    "@esri/calcite-ui-icons": "^4.0.0-next.5",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/color": "^4.2.0",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Using `bump` [range strategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) along with minor `@arcgis` instead of [`followTag`](https://docs.renovatebot.com/configuration-options/#followtag), as the latter follows versions strictly, making minor versions no longer allowed. 
versions strictly, thus no longer allowing minor versions.

cc @maxpatiiuk 