### PR TITLE
docs: update copyright to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components-react/LICENSE.md
+++ b/packages/calcite-components-react/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components/LICENSE.md
+++ b/packages/calcite-components/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-components/readme.md
+++ b/packages/calcite-components/readme.md
@@ -154,7 +154,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-design-tokens/LICENSE.md
+++ b/packages/calcite-design-tokens/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/calcite-ui-icons/LICENSE.md
+++ b/packages/calcite-ui-icons/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/eslint-plugin-calcite-components/LICENSE.md
+++ b/packages/eslint-plugin-calcite-components/LICENSE.md
@@ -1,6 +1,6 @@
 # Licensing
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/packages/eslint-plugin-calcite-components/README.md
+++ b/packages/eslint-plugin-calcite-components/README.md
@@ -59,7 +59,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 ## License
 
-COPYRIGHT © 2024 Esri
+COPYRIGHT © 2025 Esri
 
 All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Updates Calcite's copyright year to 2️⃣0️⃣2️⃣5️⃣ 🎉 