### PR TITLE
chore(linting): restore consistent linting on JS/TS files

### DIFF
--- a/.github/scripts/.lintstagedrc.js
+++ b/.github/scripts/.lintstagedrc.js
@@ -1,6 +1,0 @@
-const baseConfig = require("../../.lintstagedrc.js");
-
-module.exports = {
-  ...baseConfig,
-  "*.{m,c,}js": ["eslint --fix", "prettier --write"],
-};

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  "*.{json,html,yml}": ["prettier --write"],
-  "*.scss": ["stylelint --fix", "prettier --write"],
+  "*.{cjs,mjs,ts,tsx}": ["eslint --fix", "prettier --write"],
+  "*.{html,json,yml}": ["prettier --write"],
   "*.md": ["prettier --write", "markdownlint --fix"],
+  "*.scss": ["stylelint --fix", "prettier --write"],
 };

--- a/packages/calcite-design-tokens/.lintstagedrc.js
+++ b/packages/calcite-design-tokens/.lintstagedrc.js
@@ -1,6 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-  "*.{ts,tsx,mjs,cjs}": ["eslint --fix", "prettier --write"],
-};


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes an issue where JS/TS files were no longer being linted on commit after https://github.com/Esri/calcite-design-system/pull/10938 was merged.