### PR TITLE
docs(block, notice): update component token descriptions

### DIFF
--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -3,13 +3,13 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-block-border-color: Specifies the border color of the component.
- * @prop --calcite-block-header-background-color: Specifies the background color of the component's header.
- * @prop --calcite-block-header-background-color-hover: Specifies the background color of the component's header when hovered.
- * @prop --calcite-block-header-text-color: Specifies the text color of the component's header.
+ * @prop --calcite-block-border-color: Specifies the component's border color.
+ * @prop --calcite-block-header-background-color: Specifies the component's `heading` background color.
+ * @prop --calcite-block-header-background-color-hover: Specifies the component's `heading` background color when hovered.
+ * @prop --calcite-block-header-text-color: Specifies the component's `heading` text color.
  * @prop --calcite-block-padding: [Deprecated] Specifies the padding of the component's `default` slot.
- * @prop --calcite-block-text-color: Specifies the text color of the component.
- * @prop --calcite-block-text-color-hover: Specifies the text color component when hovered
+ * @prop --calcite-block-text-color: Specifies the component's text color.
+ * @prop --calcite-block-text-color-hover: Specifies the component's text color when hovered.
  */
 
 :host {

--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -3,13 +3,13 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-notice-background-color: Specifies the background color of the component.
- * @prop --calcite-notice-close-background-color-focus: Specifies the background color of the component when focused.
- * @prop --calcite-notice-close-background-color-press: Specifies the background color of the component when active.
- * @prop --calcite-notice-close-text-color-hover: Specifies the background color of component's close button when hovered.
- * @prop --calcite-notice-close-text-color: Specifies the text color of component's close button.
- * @prop --calcite-notice-content-text-color: Specifies the content text color of the component.
- * @prop --calcite-notice-width: Specifies the width of the component.
+ * @prop --calcite-notice-background-color: Specifies the component's background color.
+ * @prop --calcite-notice-close-background-color-focus: Specifies the component's background color when focused.
+ * @prop --calcite-notice-close-background-color-press: Specifies the component's background color when active.
+ * @prop --calcite-notice-close-text-color-hover: Specifies the background color of the component's close button when hovered.
+ * @prop --calcite-notice-close-text-color: Specifies the text color of the component's close button.
+ * @prop --calcite-notice-content-text-color: Specifies the component's content text color.
+ * @prop --calcite-notice-width: Specifies the component's width.
  */
 
 // scale variables


### PR DESCRIPTION
**Related Issue:** #7180 

## Summary
Updates component token descriptions for `block` and `notice` in alignment with our [documentation standard](https://github.com/Esri/calcite-design-system/wiki/tokens-documentation#component-tokens).