### PR TITLE
deprecate(notice): deprecate --calcite-notice-width token

### DIFF
--- a/packages/calcite-components/src/components/notice/notice.scss
+++ b/packages/calcite-components/src/components/notice/notice.scss
@@ -9,7 +9,7 @@
  * @prop --calcite-notice-close-text-color-hover: Specifies the background color of the component's close button when hovered.
  * @prop --calcite-notice-close-text-color: Specifies the text color of the component's close button.
  * @prop --calcite-notice-content-text-color: Specifies the component's content text color.
- * @prop --calcite-notice-width: Specifies the component's width.
+ * @prop --calcite-notice-width: [Deprecated] Specifies the component's width.
  */
 
 // scale variables


### PR DESCRIPTION
**Related Issue:** N/A

## Summary
Deprecate `--calcite-notice-width token` token.