### PR TITLE
fix(tile): wrap overflowing text content

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -68,7 +68,7 @@ calcite-link {
 
 .content-container {
   flex-direction: column;
-  word-break: break-word;
+@include word-break();
 }
 
 .text-content-container {

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -68,7 +68,7 @@ calcite-link {
 
 .content-container {
   flex-direction: column;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .text-content-container {

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -68,6 +68,7 @@ calcite-link {
 
 .content-container {
   flex-direction: column;
+  word-break: break-all;
 }
 
 .text-content-container {


### PR DESCRIPTION
**Related Issue:** #11170 

## Summary

This PR fixes an issue where overflowing content doesn't stay within the outer bounds of the Tile.