### PR TITLE
fix(tile-group): keep selection icon size consistent for large tiles

### DIFF
--- a/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
+++ b/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
@@ -687,7 +687,7 @@ function createVariantsHtmlStory(layout: TileGroup["layout"]): () => string {
     </div>
 
     <div class="parent">
-      <div class="child right-aligned-text">icon and heading (large visual) + single selection mode</div>
+      <div class="child right-aligned-text">icon and heading (large visual) + multiple selection mode</div>
       <div class="child">
         ${getTileGroupHtml(
           {
@@ -695,7 +695,7 @@ function createVariantsHtmlStory(layout: TileGroup["layout"]): () => string {
             icon: true,
           },
           layout,
-          "single",
+          "multiple",
           "s",
         )}
       </div>
@@ -706,7 +706,7 @@ function createVariantsHtmlStory(layout: TileGroup["layout"]): () => string {
             icon: true,
           },
           layout,
-          "single",
+          "multiple",
           "m",
         )}
       </div>
@@ -717,7 +717,7 @@ function createVariantsHtmlStory(layout: TileGroup["layout"]): () => string {
             icon: true,
           },
           layout,
-          "single",
+          "multiple",
           "l",
         )}
       </div>

--- a/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
+++ b/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
@@ -101,16 +101,18 @@ function getTileHtml(options: Partial<TileHtmlOptions> = {}): string {
     selected = false,
   } = options;
 
+  const imageWidth = 275;
+  const imageHeight = 100;
   const content = [
-    contentTop ? html`<img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />` : "",
-    contentBottom ? html`<img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />` : "",
+    contentTop ? html`<img src="${placeholderImage({ width: imageWidth, height: imageHeight })}" slot="content-top" />` : "",
+    contentBottom ? html`<img src="${placeholderImage({ width: imageWidth, height: imageHeight })}" slot="content-bottom" />` : "",
   ];
 
   return html`
     <calcite-tile
-      ${heading ? 'heading="Tile heading lorem ipsum"' : ""}
+      ${heading ? 'heading="Tile heading"' : ""}
       ${description
-        ? 'description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."'
+        ? 'description="This is sort of a medium length description."'
         : ""}
       ${link ? 'href="/"' : ""}
       ${icon ? 'icon="layers"' : ""}

--- a/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
+++ b/packages/calcite-components/src/components/tile-group/tile-group.stories.ts
@@ -2,7 +2,7 @@ import { boolean } from "../../../.storybook/utils";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 import { html } from "../../../support/formatting";
 import { ATTRIBUTES } from "../../../.storybook/resources";
-import { TileGroup } from "./tile-group";
+import type { TileGroup } from "./tile-group";
 
 const { dir, layout, scale } = ATTRIBUTES;
 
@@ -46,6 +46,81 @@ export default {
   },
 };
 
+interface TileHtmlOptions {
+  contentBottom: boolean;
+  contentTop: boolean;
+  description: boolean;
+  heading: boolean;
+  icon: boolean;
+  link: boolean;
+  selected: boolean;
+}
+
+function getTileGroupHtml(
+  options: Partial<TileHtmlOptions> = {},
+  layout: TileGroup["layout"],
+  selectionMode: TileGroup["selectionMode"] = "none",
+  scale: TileGroup["scale"],
+): string {
+  return html`
+    <calcite-tile-group layout="${layout}" selection-mode="${selectionMode}" scale="${scale}">
+      ${Array(4)
+        .fill(null)
+        .map((value, index) => {
+          let selected = false;
+
+          if (selectionMode === "single") {
+            selected = index === (scale === "s" ? 0 : scale === "m" ? 1 : 2);
+          } else if (selectionMode === "multiple") {
+            selected =
+              scale === "s"
+                ? // select even tiles
+                  index % 2 === 0
+                : // select odd tiles
+                  scale === "m"
+                  ? index % 2 !== 0
+                  : // select all except for the 3rd tile
+                    index !== 2;
+          }
+
+          return getTileHtml({ ...options, selected });
+        })
+        .join("\n")}
+    </calcite-tile-group>
+  `;
+}
+
+function getTileHtml(options: Partial<TileHtmlOptions> = {}): string {
+  const {
+    contentBottom = false,
+    contentTop = false,
+    description = false,
+    heading = false,
+    icon = false,
+    link = false,
+    selected = false,
+  } = options;
+
+  const content = [
+    contentTop ? html`<img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />` : "",
+    contentBottom ? html`<img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />` : "",
+  ];
+
+  return html`
+    <calcite-tile
+      ${heading ? 'heading="Tile heading lorem ipsum"' : ""}
+      ${description
+        ? 'description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."'
+        : ""}
+      ${link ? 'href="/"' : ""}
+      ${icon ? 'icon="layers"' : ""}
+      ${selected ? "selected" : ""}
+    >
+      ${content.length > 0 ? content.join("\n") : ""}
+    </calcite-tile>
+  `;
+}
+
 export const simple = (args: TileGroupStoryArgs): string => html`
   <calcite-tile-group
     dir="${args.dir}"
@@ -53,2297 +128,665 @@ export const simple = (args: TileGroupStoryArgs): string => html`
     layout="${args.layout}"
     scale="${args.scale}"
   >
-    <calcite-tile
-      heading="Tile heading lorem ipsum"
-      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-      icon="layers"
-    ></calcite-tile>
-    <calcite-tile
-      heading="Tile heading lorem ipsum"
-      description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-      icon="layers"
-    ></calcite-tile>
-    <calcite-tile
-      heading="Tile heading lorem ipsum"
-      description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-      icon="layers"
-    ></calcite-tile>
-    <calcite-tile
-      heading="Tile heading lorem ipsum"
-      description="Iterative approaches to corporate strategy foster collab."
-      icon="layers"
-    ></calcite-tile>
+    ${getTileHtml({ heading: true, description: true, icon: true })}
+    ${getTileHtml({ heading: true, description: true, icon: true })}
+    ${getTileHtml({ heading: true, description: true, icon: true })}
+    ${getTileHtml({ heading: true, description: true, icon: true })}
   </calcite-tile-group>
 `;
 
-export const allVariantsHorizontal = (): string => html`
-  <style>
-    .parent {
-      display: flex;
-      color: var(--calcite-color-text-3);
-      font-family: var(--calcite-sans-family);
-      font-size: var(--calcite-font-size-0);
-      font-weight: var(--calcite-font-weight-medium);
-    }
+function createVariantsHtmlStory(layout: TileGroup["layout"]): () => string {
+  return () => html`
+    <style>
+      .parent {
+        display: flex;
+        color: var(--calcite-color-text-3);
+        font-family: var(--calcite-sans-family);
+        font-size: var(--calcite-font-size-0);
+        font-weight: var(--calcite-font-weight-medium);
+      }
 
-    .child {
-      display: inline-flex;
-      flex-direction: column;
-      flex: 0 1 50%;
-      padding: 15px;
-    }
+      .child {
+        display: inline-flex;
+        flex-direction: column;
+        flex: 0 1 50%;
+        padding: 15px;
+      }
 
-    .right-aligned-text {
-      text-align: right;
-      flex: 0 0 21%;
-    }
+      .right-aligned-text {
+        text-align: right;
+        flex: 0 0 21%;
+      }
 
-    .screenshot-test {
-      gap: 1em;
-      padding: 0 1em;
-    }
+      .screenshot-test {
+        gap: 1em;
+        padding: 0 1em;
+      }
 
-    .spaced-column {
-      display: flex;
-      flex-direction: column;
-      gap: 1em;
-    }
+      .spaced-column {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+      }
 
-    hr {
-      margin: 25px 0;
-      border-top: 1px solid var(--calcite-color-border-2);
-    }
-  </style>
+      hr {
+        margin: 25px 0;
+        border-top: 1px solid var(--calcite-color-border-2);
+      }
+    </style>
 
-  <!-- screenshot test area -->
-  <div class="screenshot-test parent">
-    <div class="spaced-column">
-      <span>single</span>
-      <calcite-tile-group scale="s" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="m" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="l" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
+    <div class="parent">
+      <div class="child right-aligned-text"><h2>${layout}</h2></div>
     </div>
-    <div class="spaced-column">
-      <span>multiple</span>
-      <calcite-tile-group scale="s" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="m" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="l" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="spaced-column">
-      <span>none</span>
-      <calcite-tile-group scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="m">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- horizontal -->
-  <div class="parent">
-    <div class="child right-aligned-text"><h2>horizontal</h2></div>
-  </div>
+    <div class="parent">
+      <div class="child"></div>
+      <div class="child">small</div>
+      <div class="child">medium</div>
+      <div class="child">large</div>
+    </div>
 
-  <div class="parent">
-    <div class="child"></div>
-    <div class="child">small</div>
-    <div class="child">medium</div>
-    <div class="child">large</div>
-  </div>
+    <!-- single -->
+    <div class="parent">
+      <div class="child right-aligned-text">single</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "l",
+        )}
+      </div>
+    </div>
 
-  <!-- single selection-appearance="border" -->
-  <div class="parent">
-    <div class="child right-aligned-text">single selection-appearance="border"</div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="single" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- single selection-appearance="border" -->
+    <div class="parent">
+      <div class="child right-aligned-text">single selection-appearance="border"</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="single" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- multiple selection-appearance="border" -->
-  <div class="parent">
-    <div class="child right-aligned-text">multiple selection-appearance="border"</div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="multiple" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- multiple -->
+    <div class="parent">
+      <div class="child right-aligned-text">multiple</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "multiple",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "multiple",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "multiple",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group selection-appearance="border" selection-mode="multiple" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- single-persist -->
-  <div class="parent">
-    <div class="child right-aligned-text">single-persist</div>
-    <div class="child">
-      <calcite-tile-group selection-mode="single-persist" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- single-persist -->
+    <div class="parent">
+      <div class="child right-aligned-text">single-persist</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single-persist",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single-persist",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "single-persist",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group selection-mode="single-persist">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group selection-mode="single-persist" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-          selected
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-          selected
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- none -->
-  <div class="parent">
-    <div class="child right-aligned-text">none</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- none -->
+    <div class="parent">
+      <div class="child right-aligned-text">none</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- center alignment -->
-  <div class="parent">
-    <div class="child right-aligned-text">center alignment</div>
-    <div class="child">
-      <calcite-tile-group alignment="center" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" scale="s" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" scale="s" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- links -->
+    <div class="parent">
+      <div class="child right-aligned-text">links</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group alignment="center">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group alignment="center" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" scale="l" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-      <calcite-tile-group alignment="center" scale="l" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- links -->
-  <div class="parent">
-    <div class="child right-aligned-text">links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- disabled -->
+    <div class="parent">
+      <div class="child right-aligned-text">disabled</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- disabled -->
-  <div class="parent">
-    <div class="child right-aligned-text">disabled</div>
-    <div class="child">
-      <calcite-tile-group scale="s" disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- heading -->
+    <div class="parent">
+      <div class="child right-aligned-text">heading</div>
+      <div class="child">${getTileGroupHtml({ heading: true }, layout, "none", "s")}</div>
+      <div class="child">${getTileGroupHtml({ heading: true }, layout, "none", "m")}</div>
+      <div class="child">${getTileGroupHtml({ heading: true }, layout, "none", "l")}</div>
     </div>
-    <div class="child">
-      <calcite-tile-group disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l" disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- disabled links -->
-  <div class="parent">
-    <div class="child right-aligned-text">disabled links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
+    <!-- heading links -->
+    <div class="parent">
+      <div class="child right-aligned-text">heading links</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          disabled
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- heading -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
+    <!-- description -->
+    <div class="parent">
+      <div class="child right-aligned-text">description</div>
+      <div class="child">${getTileGroupHtml({ description: true }, layout, "none", "s")}</div>
+      <div class="child">${getTileGroupHtml({ description: true }, layout, "none", "m")}</div>
+      <div class="child">${getTileGroupHtml({ description: true }, layout, "none", "l")}</div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- heading links -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
+    <!-- description links -->
+    <div class="parent">
+      <div class="child right-aligned-text">description links</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- description -->
-  <div class="parent">
-    <div class="child right-aligned-text">description</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
+    <!-- heading and description -->
+    <div class="parent">
+      <div class="child right-aligned-text">heading and description</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- description links -->
-  <div class="parent">
-    <div class="child right-aligned-text">description links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
+    <!-- heading and description links -->
+    <div class="parent">
+      <div class="child right-aligned-text">heading and description links</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            description: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- heading and description -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading and description</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
+    <div class="parent">
+      <div class="child right-aligned-text">icon and heading (large visual) + none selection mode</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- heading and description links -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading and description links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
+    <div class="parent">
+      <div class="child right-aligned-text">icon and heading (large visual) + single selection mode</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+          },
+          layout,
+          "single",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- icon and heading (large visual) -->
-  <div class="parent">
-    <div class="child right-aligned-text">icon and heading (large visual)</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
+    <!-- icon and heading (large visual) links -->
+    <div class="parent">
+      <div class="child right-aligned-text">icon and heading (large visual) links</div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "s",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "m",
+        )}
+      </div>
+      <div class="child">
+        ${getTileGroupHtml(
+          {
+            heading: true,
+            icon: true,
+            link: true,
+          },
+          layout,
+          "none",
+          "l",
+        )}
+      </div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- icon and heading (large visual) links -->
-  <div class="parent">
-    <div class="child right-aligned-text">icon and heading (large visual) links</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
+    <!-- content-top slotted images -->
+    <div class="parent">
+      <div class="child right-aligned-text">content-top slotted images</div>
+      <div class="child">${getTileGroupHtml({ contentTop: true }, layout, "none", "s")}</div>
+      <div class="child">${getTileGroupHtml({ contentTop: true }, layout, "none", "m")}</div>
+      <div class="child">${getTileGroupHtml({ contentTop: true }, layout, "none", "l")}</div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- content-top slotted images -->
-  <div class="parent">
-    <div class="child right-aligned-text">content-top slotted images</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-      </calcite-tile-group>
+    <!-- content-bottom slotted images -->
+    <div class="parent">
+      <div class="child right-aligned-text">content-bottom slotted images</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true }, layout, "none", "s")}</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true }, layout, "none", "m")}</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true }, layout, "none", "l")}</div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
 
-  <!-- content-bottom slotted images -->
-  <div class="parent">
-    <div class="child right-aligned-text">content-bottom slotted images</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
+    <!-- slotted images in both slots -->
+    <div class="parent">
+      <div class="child right-aligned-text">slotted images in both slots</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true, contentTop: true }, layout, "none", "s")}</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true, contentTop: true }, layout, "none", "m")}</div>
+      <div class="child">${getTileGroupHtml({ contentBottom: true, contentTop: true }, layout, "none", "l")}</div>
     </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
+  `;
+}
 
-  <!-- slotted images in both slots -->
-  <div class="parent">
-    <div class="child right-aligned-text">slotted images in both slots</div>
-    <div class="child">
-      <calcite-tile-group scale="s">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group scale="l">
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-        <calcite-tile>
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-top" />
-          <img src="${placeholderImage({ width: 500, height: 500 })}" slot="content-bottom" />
-        </calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-`;
-
-export const allVariantsVertical = (): string => html`
-  <style>
-    .parent {
-      display: flex;
-      color: var(--calcite-color-text-3);
-      font-family: var(--calcite-sans-family);
-      font-size: var(--calcite-font-size-0);
-      font-weight: var(--calcite-font-weight-medium);
-    }
-
-    .child {
-      display: inline-flex;
-      flex-direction: column;
-      flex: 0 1 50%;
-      padding: 15px;
-    }
-
-    .right-aligned-text {
-      text-align: right;
-      flex: 0 0 21%;
-    }
-
-    .screenshot-test {
-      gap: 1em;
-      padding: 0 1em;
-    }
-
-    .spaced-column {
-      display: flex;
-      flex-direction: column;
-      gap: 1em;
-    }
-
-    hr {
-      margin: 25px 0;
-      border-top: 1px solid var(--calcite-color-border-2);
-    }
-  </style>
-
-  <!-- Vertical -->
-  <div class="parent">
-    <div class="child right-aligned-text"><h2>vertical</h2></div>
-  </div>
-
-  <div class="parent">
-    <div class="child"></div>
-    <div class="child">small</div>
-    <div class="child">medium</div>
-    <div class="child">large</div>
-  </div>
-
-  <!-- single -->
-  <div class="parent">
-    <div class="child right-aligned-text">single</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- single selection-appearance="border" -->
-  <div class="parent">
-    <div class="child right-aligned-text">single selection-appearance="border"</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-appearance="border" selection-mode="single" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-appearance="border" selection-mode="single">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-appearance="border" selection-mode="single" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- multiple -->
-  <div class="parent">
-    <div class="child right-aligned-text">multiple</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="multiple" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="multiple">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="multiple" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- single-persist -->
-  <div class="parent">
-    <div class="child right-aligned-text">single-persist</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single-persist" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single-persist">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" selection-mode="single-persist" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- none -->
-  <div class="parent">
-    <div class="child right-aligned-text">none</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Iterative approaches to corporate strategy foster collab."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- links -->
-  <div class="parent">
-    <div class="child right-aligned-text">links</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          href="/"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- disabled -->
-  <div class="parent">
-    <div class="child right-aligned-text">disabled</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s" disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l" disabled>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-        <calcite-tile
-          heading="Tile heading lorem ipsum"
-          description="Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collab on thinking to further the overall."
-          icon="layers"
-        ></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- heading -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-        <calcite-tile heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- heading links -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading links</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-        <calcite-tile href="/" heading="Tile title"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- description -->
-  <div class="parent">
-    <div class="child right-aligned-text">description</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-        <calcite-tile description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- description links -->
-  <div class="parent">
-    <div class="child right-aligned-text">description links</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-        <calcite-tile href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- heading and description -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading and description</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- heading and description links -->
-  <div class="parent">
-    <div class="child right-aligned-text">heading and description links</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-        <calcite-tile heading="Tile title" href="/" description="Tile description"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- icon and heading (large visual) -->
-  <div class="parent">
-    <div class="child right-aligned-text">icon and heading (large visual)</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-
-  <!-- icon and heading (large visual) links -->
-  <div class="parent">
-    <div class="child right-aligned-text">icon and heading (large visual) links</div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="s">
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical">
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-    <div class="child">
-      <calcite-tile-group layout="vertical" scale="l">
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-        <calcite-tile heading="Tile heading lorem ipsum" href="/" icon="layers"></calcite-tile>
-      </calcite-tile-group>
-    </div>
-  </div>
-`;
+export const allVariantsHorizontal = createVariantsHtmlStory("horizontal");
+export const allVariantsVertical = createVariantsHtmlStory("vertical");

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -32,7 +32,7 @@ calcite-link {
   color: var(--calcite-tile-text-color, var(--calcite-color-text-3));
   inline-size: var(--calcite-container-size-content-fluid);
   outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-tile-border-color, var(--calcite-color-border-2));
-  padding: var(--calcite-internal-spacing);
+  padding: var(--calcite-internal-tile-spacing);
   position: relative;
   user-select: none;
 
@@ -110,8 +110,8 @@ calcite-link {
 
   .selection-icon {
     position: absolute;
-    inset-inline-start: var(--calcite-internal-spacing);
-    inset-block-start: var(--calcite-internal-spacing);
+    inset-inline-start: var(--calcite-internal-tile-spacing);
+    inset-block-start: var(--calcite-internal-tile-spacing);
   }
 
   .text-content-container {
@@ -133,7 +133,7 @@ calcite-link {
 }
 
 :host([scale="s"]) {
-  --calcite-internal-spacing: var(--calcite-spacing-sm);
+  --calcite-internal-tile-spacing: var(--calcite-spacing-sm);
 
   max-inline-size: 400px;
   min-inline-size: 100px;
@@ -148,7 +148,7 @@ calcite-link {
 }
 
 :host([scale="m"]) {
-  --calcite-internal-spacing: var(--calcite-spacing-md);
+  --calcite-internal-tile-spacing: var(--calcite-spacing-md);
 
   max-inline-size: 460px;
   min-inline-size: 140px;
@@ -163,7 +163,7 @@ calcite-link {
 }
 
 :host([scale="l"]) {
-  --calcite-internal-spacing: var(--calcite-spacing-lg);
+  --calcite-internal-tile-spacing: var(--calcite-spacing-lg);
 
   max-inline-size: 520px;
   min-inline-size: 160px;
@@ -180,11 +180,11 @@ calcite-link {
 
 .content-container--has-content,
 .row {
-  gap: var(--calcite-internal-spacing);
+  gap: var(--calcite-internal-tile-spacing);
 }
 
 .content-container--has-only-content-top-and-bottom slot[name="content-top"]::slotted(*) {
-  margin-block-end: var(--calcite-internal-spacing);
+  margin-block-end: var(--calcite-internal-tile-spacing);
 }
 
 :host([selection-appearance="border"][layout="horizontal"]),

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -33,7 +33,6 @@ calcite-link {
   inline-size: var(--calcite-container-size-content-fluid);
   outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-tile-border-color, var(--calcite-color-border-2));
   padding: var(--calcite-internal-tile-spacing);
-  position: relative;
   user-select: none;
 
   .selection-icon {
@@ -227,6 +226,7 @@ calcite-link {
 :host([href]:hover:not([disabled])) {
   .container {
     outline-color: var(--calcite-tile-link-color, var(--calcite-color-text-link));
+    position: relative;
     z-index: var(--calcite-z-index);
   }
   .icon {

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -32,6 +32,8 @@ calcite-link {
   color: var(--calcite-tile-text-color, var(--calcite-color-text-3));
   inline-size: var(--calcite-container-size-content-fluid);
   outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-tile-border-color, var(--calcite-color-border-2));
+  padding: var(--calcite-internal-spacing);
+  position: relative;
   user-select: none;
 
   .selection-icon {
@@ -100,11 +102,18 @@ calcite-link {
   min-block-size: 12rem;
   text-align: center;
 
-  calcite-icon {
+  .icon {
     align-self: center;
     block-size: 64px;
     inline-size: 64px;
   }
+
+  .selection-icon {
+    position: absolute;
+    inset-inline-start: var(--calcite-internal-spacing);
+    inset-block-start: var(--calcite-internal-spacing);
+  }
+
   .text-content-container {
     justify-content: center;
   }
@@ -124,15 +133,10 @@ calcite-link {
 }
 
 :host([scale="s"]) {
+  --calcite-internal-spacing: var(--calcite-spacing-sm);
+
   max-inline-size: 400px;
   min-inline-size: 100px;
-  .container {
-    padding: var(--calcite-spacing-sm);
-  }
-  .content-container--has-content,
-  .row {
-    gap: var(--calcite-spacing-sm);
-  }
   .heading {
     font-size: var(--calcite-font-size--2);
     line-height: 1.03125rem;
@@ -141,21 +145,13 @@ calcite-link {
     font-size: var(--calcite-font-size--3);
     line-height: 0.85938rem;
   }
-  .content-container--has-only-content-top-and-bottom slot[name="content-top"]::slotted(*) {
-    margin-block-end: var(--calcite-spacing-sm);
-  }
 }
 
 :host([scale="m"]) {
+  --calcite-internal-spacing: var(--calcite-spacing-md);
+
   max-inline-size: 460px;
   min-inline-size: 140px;
-  .container {
-    padding: var(--calcite-spacing-md);
-  }
-  .content-container--has-content,
-  .row {
-    gap: var(--calcite-spacing-md);
-  }
   .heading {
     font-size: var(--calcite-font-size--1);
     line-height: 1.20313rem;
@@ -164,21 +160,14 @@ calcite-link {
     font-size: var(--calcite-font-size--2);
     line-height: 1.03125rem;
   }
-  .content-container--has-only-content-top-and-bottom slot[name="content-top"]::slotted(*) {
-    margin-block-end: var(--calcite-spacing-md);
-  }
 }
 
 :host([scale="l"]) {
+  --calcite-internal-spacing: var(--calcite-spacing-lg);
+
   max-inline-size: 520px;
   min-inline-size: 160px;
-  .container {
-    padding: var(--calcite-spacing-lg);
-  }
-  .content-container--has-content,
-  .row {
-    gap: var(--calcite-spacing-lg);
-  }
+
   .heading {
     font-size: var(--calcite-font-size-0);
     line-height: 1.375rem;
@@ -187,9 +176,15 @@ calcite-link {
     font-size: var(--calcite-font-size--1);
     line-height: 1.20313rem;
   }
-  .content-container--has-only-content-top-and-bottom slot[name="content-top"]::slotted(*) {
-    margin-block-end: var(--calcite-spacing-lg);
-  }
+}
+
+.content-container--has-content,
+.row {
+  gap: var(--calcite-internal-spacing);
+}
+
+.content-container--has-only-content-top-and-bottom slot[name="content-top"]::slotted(*) {
+  margin-block-end: var(--calcite-internal-spacing);
 }
 
 :host([selection-appearance="border"][layout="horizontal"]),
@@ -232,7 +227,6 @@ calcite-link {
 :host([href]:hover:not([disabled])) {
   .container {
     outline-color: var(--calcite-tile-link-color, var(--calcite-color-text-link));
-    position: relative;
     z-index: var(--calcite-z-index);
   }
   .icon {

--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -33,6 +33,7 @@ calcite-link {
   inline-size: var(--calcite-container-size-content-fluid);
   outline: var(--calcite-border-width-sm, 1px) solid var(--calcite-tile-border-color, var(--calcite-color-border-2));
   padding: var(--calcite-internal-tile-spacing);
+  position: relative;
   user-select: none;
 
   .selection-icon {
@@ -46,17 +47,15 @@ calcite-link {
     &:focus,
     &.selected {
       outline-color: var(--calcite-tile-accent-color-press, var(--calcite-color-brand));
-      position: relative;
+      z-index: var(--calcite-z-index);
+
       .selection-icon {
         color: var(--calcite-tile-accent-color-press, var(--calcite-color-brand));
       }
     }
-    &.selected {
-      z-index: var(--calcite-z-index);
-    }
     &:focus {
       box-shadow: inset 0 0 0 1px var(--calcite-tile-accent-color-press, var(--calcite-color-brand));
-      z-index: var(--calcite-z-index-sticky);
+      z-index: calc(var(--calcite-z-index) + 1);
     }
   }
 }
@@ -111,6 +110,7 @@ calcite-link {
     position: absolute;
     inset-inline-start: var(--calcite-internal-tile-spacing);
     inset-block-start: var(--calcite-internal-tile-spacing);
+    z-index: var(--calcite-z-index);
   }
 
   .text-content-container {
@@ -226,7 +226,6 @@ calcite-link {
 :host([href]:hover:not([disabled])) {
   .container {
     outline-color: var(--calcite-tile-link-color, var(--calcite-color-text-link));
-    position: relative;
     z-index: var(--calcite-z-index);
   }
   .icon {


### PR DESCRIPTION
**Related Issue:** #10931 

## Summary

Fixes an issue where large tiles (w/o `description`) would cause the selection icon to be oversized and misaligned.

### Noteworthy changes

* refactors stories to use HTML-generating functions to improve maintainability
* adds internal CSS var to reuse and simplify internal space assignments
* applies icon styling separately
* applies relative positioning to content container
* replaces sticky z-index var in favor of default + bump to keep it within the same layer