### PR TITLE
fix(text-area): make `readOnly` prop writable

### DIFF
--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -205,7 +205,6 @@ export class TextArea
   /**
    * When `true`, the component's `value` can be read, but cannot be modified.
    *
-   * @readonly
    * @mdn [readOnly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly)
    */
   @property({ reflect: true }) readOnly = false;


### PR DESCRIPTION
**Related Issue:** #11217 #10731

## Summary

Removes unintentional `@readonly` on `readOnly` prop. 

For context, with #10310 any props with the `@readonly` tag will be made read-only.