### PR TITLE
fix(docs): use updated translation bundle paths to generate `translations.json`

### DIFF
--- a/packages/calcite-components/support/generateT9nDocsJSON.ts
+++ b/packages/calcite-components/support/generateT9nDocsJSON.ts
@@ -24,7 +24,7 @@
         Object.keys(messagesFileMain).forEach((key) => (data[component][key] = {}));
 
         const messagesFilenames = (await readdir(t9nPath, { withFileTypes: true })).map((dirent) => dirent.name);
-        const messagesFilenameRegex = new RegExp(`${component}\\.t9n\\.(.*)\\.json`);
+        const messagesFilenameRegex = new RegExp(`messages\\.(.*)\\.json`);
 
         for (const messagesFilename of messagesFilenames) {
           const messagesFilenameMatch = messagesFilename.match(messagesFilenameRegex);


### PR DESCRIPTION
**Related Issue:** #10731

## Summary

Updates `generateT9nDocsJSON.ts` to reference the updated translations bundle file name (see https://github.com/Esri/calcite-design-system/pull/11054).

