### PR TITLE
fix(docs): add docs package export

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -19,6 +19,7 @@
     "./types/*": "./dist/types/*.d.ts",
     "./hydrate": "./hydrate/index.js",
     "./calcite/calcite.css": "./dist/calcite/calcite.css",
+    "./docs/*": "./dist/docs/*",
     "./dist/calcite/calcite.css": "./dist/calcite/calcite.css",
     "./dist/loader": "./dist/loader.js",
     "./dist/components": "./dist/index.js",


### PR DESCRIPTION
**Related Issue:** #10731

## Summary

Adds package export to support doc-related ESM imports.