### PR TITLE
refactor: remove unnecessary @readonly tags

### DIFF
--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -87,7 +87,6 @@ export class DatePickerMonthHeader extends LitElement {
    * Made into a prop for testing purposes only.
    *
    * @private
-   * @readonly
    */
   @property() messages: DatePicker["messages"]["_overrides"];
 

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -66,7 +66,6 @@ export class Handle extends LitElement implements LoadableComponent, Interactive
    * Made into a prop for testing purposes only.
    *
    * @private
-   * @readonly
    */
   messages = useT9n<typeof T9nStrings>({ blocking: true });
 

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -63,7 +63,6 @@ export class SortHandle extends LitElement implements LoadableComponent, Interac
    * Made into a prop for testing purposes only.
    *
    * @private
-   * @readonly
    */
   @property() messages = useT9n<typeof T9nStrings>({ blocking: true });
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

For consistency, removes `@readonly` JSDoc tags on internal `messages` props (t9n).