### PR TITLE
ci(linting): fix typescript parser issue

### DIFF
--- a/packages/calcite-components/eslint.config.mjs
+++ b/packages/calcite-components/eslint.config.mjs
@@ -38,7 +38,6 @@ export default tseslint.config(
       parser: tseslint.parser,
       parserOptions: {
         tsconfigRootDir: __dirname,
-        projectService: true,
         project: ["tsconfig-eslint.json"],
       },
     },

--- a/packages/calcite-design-tokens/eslint.config.mjs
+++ b/packages/calcite-design-tokens/eslint.config.mjs
@@ -45,7 +45,6 @@ export default tseslint.config(
 
       parserOptions: {
         tsconfigRootDir: __dirname,
-        projectService: true,
         project: ["tsconfig-eslint.json"],
       },
     },


### PR DESCRIPTION
## Summary

Resolve a lint-staged error reported by @macandcheese:

```text
✖ eslint --fix:

/Users/adam9519/Documents/git-repositories/calcite-design-system/packages/calcite-components/src/components/combobox/combobox.stories.ts
  0:0  error  Parsing error: /Users/adam9519/Documents/git-repositories/calcite-design-system/packages/calcite-components/src/components/combobox/combobox.stories.ts was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject

✖ 1 problem (1 error, 0 warnings)

husky - pre-commit script failed (code 1)
Hook process exited.
```

It seems like the projectService option is using `tsconfig.json` (which excludes stories) instead of `tsconfig-eslint.json`. Disabling the option for now.


ref: https://typescript-eslint.io/getting-started/typed-linting/
