### PR TITLE
chore(themed): improve matching of interaction target elements

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -493,7 +493,7 @@ describe("calcite-list-item", () => {
           "--calcite-list-background-color-press": {
             shadowSelector: `.${CSS.container}`,
             targetProp: "backgroundColor",
-            state: { press: { attribute: "class", value: CSS.content } },
+            state: { press: `calcite-list-item >>> .${CSS.content}` },
           },
           "--calcite-list-border-color": {
             shadowSelector: `.${CSS.contentContainerWrapper}`,

--- a/packages/calcite-components/src/components/navigation-logo/navigation-logo.e2e.ts
+++ b/packages/calcite-components/src/components/navigation-logo/navigation-logo.e2e.ts
@@ -113,7 +113,7 @@ describe("calcite-navigation-logo", () => {
           {
             shadowSelector: `calcite-icon`,
             targetProp: "color",
-            state: { press: { attribute: "class", value: CSS.anchor } },
+            state: { press: `calcite-navigation-logo >>> .${CSS.anchor}` },
           },
         ],
         "--calcite-navigation-logo-heading-text-color": {

--- a/packages/calcite-components/src/components/rating/rating.e2e.ts
+++ b/packages/calcite-components/src/components/rating/rating.e2e.ts
@@ -813,12 +813,12 @@ describe("calcite-rating", () => {
       });
     });
     describe("selected", () => {
-      themed(html`<calcite-rating value="2" class=${CSS.hovered}></calcite-rating>`, {
+      themed(html`<calcite-rating value="2"></calcite-rating>`, {
         "--calcite-rating-color-hover": [
           {
-            shadowSelector: `.${CSS.star}`,
+            shadowSelector: `.${CSS.star}[data-value='3']`,
             targetProp: "color",
-            state: { hover: { attribute: "class", value: CSS.hovered } },
+            state: "hover",
           },
           {
             shadowSelector: `.${CSS.selected}`,

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -148,7 +148,7 @@ export function themed(componentTestSetup: ComponentTestSetup, tokens: Component
         testTargets.push({
           target,
           targetProp,
-          interactionSelector: interactionSelector,
+          interactionSelector,
           state: stateName,
           expectedValue: tokens[token].expectedValue || setTokens[token],
           token: token as CalciteCSSCustomProp,

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -50,7 +50,7 @@ export type ComponentTestTokens = Record<CalciteCSSCustomProp, TestSelectToken |
  *     "--calcite-action-menu-trigger-background-color-active": {
  *        shadowSelector: "calcite-action",
  *        targetProp: "--calcite-action-background-color",
- *        state: { press: { attribute: "class", value: CSS.defaultTrigger } },
+ *        state: { press: `calcite-action-menu >>> .${CSS.defaultTrigger}`,
  *      },
  *      "--calcite-action-menu-trigger-background-color-focus": {
  *        shadowSelector: "calcite-action",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This adds support for `find` string selectors for testing stateful interactions. 

### Notable changes

* deprecates the `attribute`/`value` matching since `find` string selectors:
  * accomplish the same
  * align better with E2E tests
  * simpler to wire up
  * provide more precise matching
* changes the existing `attribute`/`value` matching to be scoped to the targeted element:
  * improves reliability of matches
  * encourages using `find` string selectors for more complex cases
 