### PR TITLE
feat(combobox-item): Add support for `content-start` slot

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -284,8 +284,8 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
         >
           <li class={classes} id={this.guid} onClick={this.itemClickHandler}>
             {this.renderSelectIndicator(selectionIcon)}
-            {this.renderIcon(icon)}
             <slot name={SLOTS.contentStart} />
+            {this.renderIcon(icon)}
             <div class={CSS.centerContent}>
               <div class={CSS.title}>
                 {highlightText({

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -26,6 +26,7 @@ declare global {
 /**
  * @slot - A slot for adding nested `calcite-combobox-item`s.
  * @slot content-end - A slot for adding non-actionable elements after the component's content.
+ * @slot content-start - A slot for adding non-actionable elements before the component's content.
  */
 export class ComboboxItem extends LitElement implements InteractiveComponent {
   // #region Static Members
@@ -284,6 +285,7 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
           <li class={classes} id={this.guid} onClick={this.itemClickHandler}>
             {this.renderSelectIndicator(selectionIcon)}
             {this.renderIcon(icon)}
+            <slot name={SLOTS.contentStart} />
             <div class={CSS.centerContent}>
               <div class={CSS.title}>
                 {highlightText({

--- a/packages/calcite-components/src/components/combobox-item/resources.ts
+++ b/packages/calcite-components/src/components/combobox-item/resources.ts
@@ -19,4 +19,5 @@ export const CSS = {
 
 export const SLOTS = {
   contentEnd: "content-end",
+  contentStart: "content-start",
 };

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -904,7 +904,7 @@ export const filterHighlighting = (): string => html`
 export const withDescriptionIconsAndContentSlots = (): string => html`
   <calcite-combobox open>
     <calcite-combobox-item
-      icon-start="layer"
+      icon="layer"
       description="the first installment in this thrilling series"
       selected
       short-heading="#1"
@@ -915,7 +915,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
     </calcite-combobox-item>
     <calcite-combobox-item
-      icon-start="layer"
+      icon="layer"
       description="the sequel to the smash hit 'one'"
       short-heading="#2"
       text-label="2woo"
@@ -925,7 +925,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
     </calcite-combobox-item>
     <calcite-combobox-item
-      icon-start="layer"
+      icon="layer"
       description="the thrilling conclusion to the number series"
       short-heading="#3"
       text-label="Thr333"

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -901,7 +901,43 @@ export const filterHighlighting = (): string => html`
   </calcite-combobox>
 `;
 
-export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
+export const withDescriptionIconsAndContentSlots = (): string => html`
+  <calcite-combobox open>
+    <calcite-combobox-item
+      icon-start="layer"
+      description="the first installment in this thrilling series"
+      selected
+      short-heading="#1"
+      text-label="1ne"
+      value="one"
+    >
+      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
+    </calcite-combobox-item>
+    <calcite-combobox-item
+      icon-start="layer"
+      description="the sequel to the smash hit 'one'"
+      short-heading="#2"
+      text-label="2woo"
+      value="two"
+    >
+      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
+    </calcite-combobox-item>
+    <calcite-combobox-item
+      icon-start="layer"
+      description="the thrilling conclusion to the number series"
+      short-heading="#3"
+      text-label="Thr333"
+      value="three"
+    >
+      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
+    </calcite-combobox-item>
+  </calcite-combobox>
+`;
+
+export const withDescriptionShortLabelAndContentSlots = (): string => html`
   <calcite-combobox-item
     description="the first installment in this thrilling series"
     selected
@@ -909,7 +945,8 @@ export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
     text-label="1ne"
     value="one"
   >
-    <calcite-icon icon="number-circle-1" slot="content-end"></calcite-icon>
+    <calcite-icon icon="number-circle-1" slot="content-start" scale="s"></calcite-icon>
+    <calcite-icon icon="number-circle-2" slot="content-end" scale="s"></calcite-icon>
   </calcite-combobox-item>
   <calcite-combobox-item
     description="the sequel to the smash hit 'one'"
@@ -917,7 +954,8 @@ export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
     text-label="2woo"
     value="two"
   >
-    <calcite-icon icon="number-circle-2" slot="content-end"></calcite-icon>
+    <calcite-icon icon="number-circle-3" slot="content-start" scale="s"></calcite-icon>
+    <calcite-icon icon="number-circle-4" slot="content-end" scale="s"></calcite-icon>
   </calcite-combobox-item>
   <calcite-combobox-item
     description="the thrilling conclusion to the number series"
@@ -925,13 +963,14 @@ export const withDescriptionShortLabelAndContentEndSlot = (): string => html`
     text-label="Thr333"
     value="three"
   >
-    <calcite-icon icon="number-circle-3" slot="content-end"></calcite-icon>
+    <calcite-icon icon="number-circle-5" slot="content-start" scale="s"></calcite-icon>
+    <calcite-icon icon="number-circle-6" slot="content-end" scale="s"></calcite-icon>
   </calcite-combobox-item>
 `;
-withDescriptionShortLabelAndContentEndSlot.args = {
+withDescriptionShortLabelAndContentSlots.args = {
   selectionMode: ["single", "multiple"],
 };
-withDescriptionShortLabelAndContentEndSlot.decorators = [allScaleComboboxBuilder];
-withDescriptionShortLabelAndContentEndSlot.parameters = {
+withDescriptionShortLabelAndContentSlots.decorators = [allScaleComboboxBuilder];
+withDescriptionShortLabelAndContentSlots.parameters = {
   chromatic: { delay: 1000 },
 };

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -911,7 +911,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       text-label="1ne"
       value="one"
     >
-      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
       <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
     </calcite-combobox-item>
     <calcite-combobox-item
@@ -921,7 +921,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       text-label="2woo"
       value="two"
     >
-      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
       <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
     </calcite-combobox-item>
     <calcite-combobox-item
@@ -931,7 +931,7 @@ export const withDescriptionIconsAndContentSlots = (): string => html`
       text-label="Thr333"
       value="three"
     >
-      <calcite-icon icon="narrow-left" slot="content-start" scale="s"></calcite-icon>
+      <calcite-icon icon="arrow-left" slot="content-start" scale="s"></calcite-icon>
       <calcite-icon icon="arrow-right" slot="content-end" scale="s"></calcite-icon>
     </calcite-combobox-item>
   </calcite-combobox>

--- a/packages/calcite-components/src/components/combobox/combobox.stories.ts
+++ b/packages/calcite-components/src/components/combobox/combobox.stories.ts
@@ -389,7 +389,7 @@ export const longItemsAllSelectionModes = (): string => html`
       <calcite-combobox open selection-mode="single" style="margin-right: 20px;">
         <calcite-combobox-item text-label="Layers">
         <calcite-combobox-item text-label="Enriched USA Census Tract Areas Aug29"></calcite-combobox-item>
-        <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item>ß</calcite-combobox-item>
+        <calcite-combobox-item text-label="Viewer_Reservable_Equipments_Capacity_V2_WFL1"></calcite-combobox-item></calcite-combobox-item>
       </calcite-combobox>
 
       <calcite-combobox open selection-mode="single-persist">


### PR DESCRIPTION
**Related Issue:** #9322 

## Summary
Adds support for `content-start` slot. @SkyeSeitz @ashetland can you confirm the "kitchen sink" case spacing with icon prop, slotted content, etc.