### PR TITLE
fix(input): update files property on input event when type="file"

### DIFF
--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -679,6 +679,11 @@ export class Input
     if (this.disabled || this.readOnly) {
       return;
     }
+
+    if (this.type === "file") {
+      this.files = (this.childEl as HTMLInputElement).files;
+    }
+
     this.setValue({
       nativeEvent,
       origin: "user",

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -669,12 +669,6 @@ export class Input
     this.calciteInternalInputFocus.emit();
   }
 
-  private inputChangeHandler(): void {
-    if (this.type === "file") {
-      this.files = (this.childEl as HTMLInputElement).files;
-    }
-  }
-
   private inputInputHandler(nativeEvent: InputEvent): void {
     if (this.disabled || this.readOnly) {
       return;
@@ -1126,7 +1120,6 @@ export class Input
           multiple={this.multiple}
           name={this.name}
           onBlur={this.inputBlurHandler}
-          onChange={this.inputChangeHandler}
           onFocus={this.inputFocusHandler}
           onInput={this.inputInputHandler}
           onKeyDown={this.inputKeyDownHandler}


### PR DESCRIPTION
**Related Issue:** #9581

## Summary

Ensure the `files` property is updated before `calciteInputInput` is emitted for `type="file"` inputs.
