### PR TITLE
perf(combobox): fix initialization performance regression

### DIFF
--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -166,9 +166,9 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
     Please refactor your code to reduce the need for this check.
     Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
     if (
-      (changes.has("disabled") && (this.hasUpdated || this.disabled !== false)) ||
-      (changes.has("selected") && (this.hasUpdated || this.selected !== false)) ||
-      changes.has("textLabel")
+      (changes.has("disabled") && this.hasUpdated) ||
+      (changes.has("selected") && this.hasUpdated) ||
+      (changes.has("textLabel") && this.hasUpdated)
     ) {
       this.calciteInternalComboboxItemChange.emit();
     }

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -134,7 +134,11 @@ export class Combobox
       item && filteredData.some(({ el }) => item === el);
 
     return debounce((text: string, setOpenToEmptyState = false, emit = true): void => {
-      const filteredData = filter([...this.data, ...this.groupData], text, this.effectiveFilterProps);
+      const filteredData = filter(
+        [...this.data, ...this.groupData],
+        text,
+        this.effectiveFilterProps,
+      );
       const itemsAndGroups = this.getItemsAndGroups();
 
       const matchAll = text === "";
@@ -551,7 +555,6 @@ export class Combobox
     this.internalValueChangeFlag = false;
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
 
-    this.updateItems();
     this.setFilteredPlacements();
 
     if (this.open) {
@@ -564,7 +567,6 @@ export class Combobox
 
   async load(): Promise<void> {
     setUpLoadableComponent(this);
-    this.updateItems();
     this.filterItems(this.filterText, false, false);
   }
 
@@ -592,10 +594,7 @@ export class Combobox
       this.reposition(true);
     }
 
-    if (
-      (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "multiple")) ||
-      (changes.has("scale") && (this.hasUpdated || this.scale !== "m"))
-    ) {
+    if (changes.has("selectionMode") || changes.has("scale")) {
       this.updateItems();
     }
 
@@ -1233,7 +1232,7 @@ export class Combobox
     return this.filterText === "" ? this.items : this.items.filter((item) => !item.hidden);
   }
 
-  private updateItems(): void {
+  private updateItems = debounce((): void => {
     this.items = this.getItems();
     this.groupItems = this.getGroupItems();
     this.data = this.getData();
@@ -1264,7 +1263,7 @@ export class Combobox
         nextGroupItem.afterEmptyGroup = groupItem.children.length === 0;
       }
     });
-  }
+  }, DEBOUNCE.nextTick);
 
   private getData(): ItemData[] {
     return this.items.map((item) => ({


### PR DESCRIPTION
**Related Issue:** #10731  

## Summary  

https://github.com/Esri/calcite-design-system/pull/10952 increased the frequency of `combobox`'s item-updating logic.  

This improves performance by:  

* reducing the number of initial item update calls  
* debouncing the item update function to the next tick  