### PR TITLE
chore: remove unrelated jest-axe expect extensions

### DIFF
--- a/packages/calcite-components/src/tests/commonTests/defaults.ts
+++ b/packages/calcite-components/src/tests/commonTests/defaults.ts
@@ -1,9 +1,6 @@
-import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { getTagAndPage } from "./utils";
 import { ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper for asserting that a property's value is its default

--- a/packages/calcite-components/src/tests/commonTests/disabled.ts
+++ b/packages/calcite-components/src/tests/commonTests/disabled.ts
@@ -1,13 +1,11 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { SetFieldType } from "type-fest";
 import { E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it } from "vitest";
 import { IntrinsicElementsWithProp, skipAnimations } from "../utils";
 import { getTagAndPage } from "./utils";
 import { ComponentTestSetup, DisabledOptions, FocusTarget, TabAndClickFocusTargets } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper to test the disabled prop disabling user interaction.

--- a/packages/calcite-components/src/tests/commonTests/floatingUI.ts
+++ b/packages/calcite-components/src/tests/commonTests/floatingUI.ts
@@ -1,10 +1,8 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { expect, it } from "vitest";
 import { getTag, simplePageSetup } from "./utils";
 import { ComponentTag, TagOrHTML } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * This helper will test if a floating-ui-owning component has configured the floating-ui correctly.

--- a/packages/calcite-components/src/tests/commonTests/focusable.ts
+++ b/packages/calcite-components/src/tests/commonTests/focusable.ts
@@ -1,11 +1,9 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import {} from "../utils";
 import { expect, it } from "vitest";
 import { getTagAndPage } from "./utils";
 import { ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 export interface FocusableOptions {
   /**

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { KeyInput } from "puppeteer";
 import { newE2EPage, E2EPage, E2EElement, EventSpy } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it } from "vitest";
@@ -15,8 +15,6 @@ import { closestElementCrossShadowBoundary } from "../../utils/dom";
 import { GlobalTestProps } from "../utils";
 import { isHTML, getTag, getTagOrHTMLWithBeforeContent } from "./utils";
 import { TagOrHTMLWithBeforeContent, TagOrHTML } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 interface FormAssociatedOptions {
   /** This value will be set on the component and submitted by the form. */

--- a/packages/calcite-components/src/tests/commonTests/hidden.ts
+++ b/packages/calcite-components/src/tests/commonTests/hidden.ts
@@ -1,9 +1,6 @@
-import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { getTagAndPage } from "./utils";
 import { ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper for asserting that a component is not visible when hidden

--- a/packages/calcite-components/src/tests/commonTests/labelable.ts
+++ b/packages/calcite-components/src/tests/commonTests/labelable.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
@@ -8,8 +8,6 @@ import { isHTML, getTag, getTagOrHTMLWithBeforeContent } from "./utils";
 export { TagOrHTMLWithBeforeContent } from "./interfaces";
 import { FocusableOptions } from "./focusable";
 import { TagOrHTMLWithBeforeContent, TagOrHTML } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 export async function assertLabelable({
   page,

--- a/packages/calcite-components/src/tests/commonTests/openClose.ts
+++ b/packages/calcite-components/src/tests/commonTests/openClose.ts
@@ -1,12 +1,10 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it } from "vitest";
 import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations, toElementHandle } from "../utils";
 import { getBeforeContent, getTagAndPage, noopBeforeContent } from "./utils";
 import { ComponentTag, ComponentTestSetup, WithBeforeContent } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 type CollapseAxis = "horizontal" | "vertical";
 

--- a/packages/calcite-components/src/tests/commonTests/reflects.ts
+++ b/packages/calcite-components/src/tests/commonTests/reflects.ts
@@ -1,10 +1,7 @@
-import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { skipAnimations } from "../utils";
 import { getTagAndPage, propToAttr } from "./utils";
 import { ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper for asserting that a component reflects

--- a/packages/calcite-components/src/tests/commonTests/renders.ts
+++ b/packages/calcite-components/src/tests/commonTests/renders.ts
@@ -1,9 +1,6 @@
-import { toHaveNoViolations } from "jest-axe";
 import { expect, it } from "vitest";
 import { getTagAndPage, HYDRATED_ATTR } from "./utils";
 import { ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Note that this helper should be used within a describe block.

--- a/packages/calcite-components/src/tests/commonTests/slots.ts
+++ b/packages/calcite-components/src/tests/commonTests/slots.ts
@@ -1,10 +1,8 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { expect, it } from "vitest";
 import { getTag, simplePageSetup } from "./utils";
 import { TagOrHTML } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper for asserting slots.

--- a/packages/calcite-components/src/tests/commonTests/t9n.ts
+++ b/packages/calcite-components/src/tests/commonTests/t9n.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import { LitElement, PublicLitElement } from "@arcgis/lumina";
 import { E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it, beforeEach } from "vitest";
@@ -7,8 +7,6 @@ import { MessageBundle } from "../../utils/t9n";
 import { IntrinsicElementsWithProp, newProgrammaticE2EPage } from "../utils";
 import { getTagAndPage } from "./utils";
 import { ComponentTag, ComponentTestSetup } from "./interfaces";
-
-expect.extend(toHaveNoViolations);
 
 /**
  * Helper to test t9n component setup.

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { toHaveNoViolations } from "jest-axe";
+
 import type { RequireExactlyOne } from "type-fest";
 import { E2EElement, E2EPage, FindSelector } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { expect, it } from "vitest";
@@ -7,8 +7,6 @@ import { getTokenValue } from "../utils/cssTokenValues";
 import { skipAnimations, toElementHandle } from "../utils";
 import type { ComponentTestSetup } from "./interfaces";
 import { getTagAndPage } from "./utils";
-
-expect.extend(toHaveNoViolations);
 
 interface TargetInfo {
   el: E2EElement;
@@ -174,7 +172,7 @@ export function themed(componentTestSetup: ComponentTestSetup, tokens: Component
 }
 
 /**
- * @deprecatd use FindSelector instead
+ * @deprecated use FindSelector instead
  */
 type ElementMatcher = { attribute: string; value: string };
 

--- a/packages/calcite-components/src/tests/commonTests/utils.ts
+++ b/packages/calcite-components/src/tests/commonTests/utils.ts
@@ -1,6 +1,4 @@
-import { toHaveNoViolations } from "jest-axe";
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
-import { expect } from "vitest";
 import type {
   ComponentTag,
   TagOrHTML,
@@ -11,7 +9,6 @@ import type {
   WithBeforeContent,
   ComponentTestContent,
 } from "./interfaces";
-expect.extend(toHaveNoViolations);
 
 export const HYDRATED_ATTR = "calcite-hydrated";
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Removes `jest-axe`-related setup for non-`accessible` common test helpers.