### PR TITLE
fix(list-item): refine visual focus behavior around content when clicking with the mouse

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -577,6 +577,10 @@ export class ListItem
     }
 
     this.toggleSelected(event.shiftKey);
+
+    if (this.active && event.currentTarget === this.contentEl.value) {
+      this.containerEl.value.focus();
+    }
   }
 
   private async toggleSelected(shiftKey: boolean): Promise<void> {
@@ -970,7 +974,7 @@ export class ListItem
       <div
         ariaLabel={label}
         class={{
-          [CSS.gridCell]: true,
+          [CSS.gridCell]: this.el.shadowRoot.activeElement === this.contentEl.value && true,
           [CSS.contentContainer]: true,
           [CSS.contentContainerUnavailable]: unavailable,
           [CSS.contentContainerSelectable]: selectionMode !== "none",


### PR DESCRIPTION
**Related Issue:** #11078 

## Summary

This PR simplifies and standardizes the focus behavior when clicking `list-item`s, allowing the content area to remain focusable with the keyboard for accessibility while visually showing focus on the entire list item instead of just the content area when clicking it with the mouse.