### PR TITLE
docs: update `required`, `max`, `min`, `maxLength` + `minLength` to include parent form

### DIFF
--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -203,7 +203,8 @@ export class Autocomplete
   @property({ reflect: true }) loading = false;
 
   /**
-   * Specifies the maximum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the maximum length of text for the component's value.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
    */
@@ -213,7 +214,8 @@ export class Autocomplete
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the minimum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the minimum length of text for the component's value.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
    */
@@ -273,7 +275,10 @@ export class Autocomplete
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -277,7 +277,7 @@ export class Autocomplete
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -107,7 +107,10 @@ export class Checkbox
    */
   @property({ reflect: true }) name: string;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/checkbox/checkbox.tsx
+++ b/packages/calcite-components/src/components/checkbox/checkbox.tsx
@@ -109,7 +109,7 @@ export class Checkbox
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -388,7 +388,7 @@ export class Combobox
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -386,7 +386,10 @@ export class Combobox
   /** When `true`, the component's value can be read, but controls are not accessible and the value cannot be modified. */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -100,7 +100,7 @@ export class DatePicker extends LitElement implements LoadableComponent {
 
   /**
    * When the component resides in a form,
-   *  specifies the latest allowed date (`"yyyy-mm-dd"`).
+   * specifies the latest allowed date (`"yyyy-mm-dd"`).
    */
   @property({ reflect: true }) max: string;
 
@@ -119,7 +119,7 @@ export class DatePicker extends LitElement implements LoadableComponent {
 
   /**
    * When the component resides in a form,
-   *  specifies the earliest allowed date (`"yyyy-mm-dd"`).
+   * specifies the earliest allowed date (`"yyyy-mm-dd"`).
    */
   @property({ reflect: true }) min: string;
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -98,7 +98,10 @@ export class DatePicker extends LitElement implements LoadableComponent {
   /** Defines the layout of the component. */
   @property({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
 
-  /** Specifies the latest allowed date (`"yyyy-mm-dd"`). */
+  /**
+   * When the component resides in a form,
+   *  specifies the latest allowed date (`"yyyy-mm-dd"`).
+   */
   @property({ reflect: true }) max: string;
 
   /** Specifies the latest allowed date as a full date object (`new Date("yyyy-mm-dd")`). */
@@ -114,7 +117,10 @@ export class DatePicker extends LitElement implements LoadableComponent {
    */
   messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  /** Specifies the earliest allowed date (`"yyyy-mm-dd"`). */
+  /**
+   * When the component resides in a form,
+   *  specifies the earliest allowed date (`"yyyy-mm-dd"`).
+   */
   @property({ reflect: true }) min: string;
 
   /** Specifies the earliest allowed date as a full date object (`new Date("yyyy-mm-dd")`). */

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -202,7 +202,10 @@ export class InputDatePicker
   /** Defines the layout of the component. */
   @property({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
 
-  /** Specifies the latest allowed date ("yyyy-mm-dd"). */
+  /**
+   * When the component resides in a form,
+   *  specifies the latest allowed date ("yyyy-mm-dd").
+   */
   @property({ reflect: true }) max: string;
 
   /** Specifies the latest allowed date as a full date object. */
@@ -218,7 +221,10 @@ export class InputDatePicker
    */
   messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  /** Specifies the earliest allowed date ("yyyy-mm-dd"). */
+  /**
+   * When the component resides in a form,
+   *  specifies the earliest allowed date ("yyyy-mm-dd").
+   */
   @property({ reflect: true }) min: string;
 
   /** Specifies the earliest allowed date as a full date object. */
@@ -272,7 +278,10 @@ export class InputDatePicker
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -204,7 +204,7 @@ export class InputDatePicker
 
   /**
    * When the component resides in a form,
-   *  specifies the latest allowed date ("yyyy-mm-dd").
+   * specifies the latest allowed date ("yyyy-mm-dd").
    */
   @property({ reflect: true }) max: string;
 
@@ -223,7 +223,7 @@ export class InputDatePicker
 
   /**
    * When the component resides in a form,
-   *  specifies the earliest allowed date ("yyyy-mm-dd").
+   * specifies the earliest allowed date ("yyyy-mm-dd").
    */
   @property({ reflect: true }) min: string;
 
@@ -280,7 +280,7 @@ export class InputDatePicker
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -291,7 +291,7 @@ export class InputNumber
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -214,14 +214,16 @@ export class InputNumber
   @property() localeFormat = false;
 
   /**
-   * Specifies the maximum value.
+   * When the component resides in a form,
+   * specifies the maximum value.
    *
    * @mdn [max](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max)
    */
   @property({ reflect: true }) max: number;
 
   /**
-   * Specifies the maximum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the maximum length of text for the component's value.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
    * @deprecated This property has no effect on the component.
@@ -239,14 +241,16 @@ export class InputNumber
   messages = useT9n<typeof T9nStrings>();
 
   /**
-   * Specifies the minimum value.
+   * When the component resides in a form,
+   * specifies the minimum value.
    *
    * @mdn [min](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min)
    */
   @property({ reflect: true }) min: number;
 
   /**
-   * Specifies the minimum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the minimum length of text for the component's value.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
    * @deprecated This property has no effect on the component.
@@ -285,7 +289,10 @@ export class InputNumber
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -179,7 +179,8 @@ export class InputText
   @property({ reflect: true }) loading = false;
 
   /**
-   * Specifies the maximum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the maximum length of text for the component's value.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
    */
@@ -196,7 +197,8 @@ export class InputText
   messages = useT9n<typeof T9nStrings>();
 
   /**
-   * Specifies the minimum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the minimum length of text for the component's value.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
    */
@@ -237,7 +239,10 @@ export class InputText
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -241,7 +241,7 @@ export class InputText
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -228,7 +228,8 @@ export class InputTimePicker
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 
   /**
-   * Specifies the maximum value.
+   * When the component resides in a form,
+   * specifies the maximum value.
    *
    * @mdn [max](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#max)
    */
@@ -245,7 +246,8 @@ export class InputTimePicker
   messages = useT9n<typeof T9nStrings>();
 
   /**
-   * Specifies the minimum value.
+   * When the component resides in a form,
+   * specifies the minimum value.
    *
    * @mdn [min](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time#min)
    */
@@ -279,7 +281,10 @@ export class InputTimePicker
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -283,7 +283,7 @@ export class InputTimePicker
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -174,7 +174,8 @@ export class InputTimeZone
   @property() referenceDate: Date | string;
 
   /**
-   * When `true`, the component must have a value in order for the form to submit.
+   * When `true` and the component resides in a form,
+   * the component must have a value in order for the form to submit.
    *
    * @private
    */

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -328,7 +328,7 @@ export class Input
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -235,14 +235,16 @@ export class Input
   @property() localeFormat = false;
 
   /**
-   * Specifies the maximum value for type "number".
+   * When the component resides in a form,
+   * specifies the maximum value for `type="number"`.
    *
    * @mdn [max](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max)
    */
   @property({ reflect: true }) max: number;
 
   /**
-   * Specifies the maximum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the maximum length of text for the component's value.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength)
    */
@@ -259,14 +261,16 @@ export class Input
   messages = useT9n<typeof T9nStrings>();
 
   /**
-   * Specifies the minimum value for `type="number"`.
+   * When the component resides in a form,
+   * specifies the minimum value for `type="number"`.
    *
    * @mdn [min](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min)
    */
   @property({ reflect: true }) min: number;
 
   /**
-   * Specifies the minimum length of text for the component's value.
+   * When the component resides in a form,
+   * specifies the minimum length of text for the component's value.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength)
    */
@@ -322,7 +326,10 @@ export class Input
    */
   @property({ reflect: true }) readOnly = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
@@ -70,7 +70,7 @@ export class RadioButtonGroup extends LitElement implements LoadableComponent {
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/calcite-components/src/components/radio-button-group/radio-button-group.tsx
@@ -68,7 +68,10 @@ export class RadioButtonGroup extends LitElement implements LoadableComponent {
    */
   @property({ reflect: true }) name: string;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/radio-button/radio-button.tsx
+++ b/packages/calcite-components/src/components/radio-button/radio-button.tsx
@@ -101,7 +101,10 @@ export class RadioButton
    */
   @property({ reflect: true }) name: string;
 
-  /** When `true`, the component must have a value selected from the `calcite-radio-button-group` in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value selected from the `calcite-radio-button-group` in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component inherited from the `calcite-radio-button-group`. */

--- a/packages/calcite-components/src/components/radio-button/radio-button.tsx
+++ b/packages/calcite-components/src/components/radio-button/radio-button.tsx
@@ -103,7 +103,7 @@ export class RadioButton
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value selected from the `calcite-radio-button-group` in order for the form to submit.
+   * the component must have a value selected from the `calcite-radio-button-group` in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/rating/rating.tsx
+++ b/packages/calcite-components/src/components/rating/rating.tsx
@@ -126,7 +126,8 @@ export class Rating
   @property({ reflect: true }) readOnly = false;
 
   /**
-   * When `true`, the component must have a value in order for the form to submit.
+   * When `true` and the component resides in a form,
+   * the component must have a value in order for the form to submit.
    *
    * @private
    */

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -97,7 +97,10 @@ export class SegmentedControl
    */
   @property({ reflect: true }) name: string;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/calcite-components/src/components/segmented-control/segmented-control.tsx
@@ -99,7 +99,7 @@ export class SegmentedControl
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/select/select.tsx
+++ b/packages/calcite-components/src/components/select/select.tsx
@@ -113,7 +113,7 @@ export class Select
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/select/select.tsx
+++ b/packages/calcite-components/src/components/select/select.tsx
@@ -111,7 +111,10 @@ export class Select
    */
   @property({ reflect: true }) name: string;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -273,7 +273,7 @@ export class Slider
 
   /**
    * When `true` and the component resides in a form,
-   *  the component must have a value in order for the form to submit.
+   * the component must have a value in order for the form to submit.
    */
   @property({ reflect: true }) required = false;
 

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -271,7 +271,10 @@ export class Slider
   /** When `true`, sets a finer point for handles. */
   @property({ reflect: true }) precise = false;
 
-  /** When `true`, the component must have a value in order for the form to submit. */
+  /**
+   * When `true` and the component resides in a form,
+   *  the component must have a value in order for the form to submit.
+   */
   @property({ reflect: true }) required = false;
 
   /** Specifies the size of the component. */

--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -162,7 +162,8 @@ export class TextArea
   @property() label: string;
 
   /**
-   * Specifies the maximum number of characters allowed.
+   * When the component resides in a form,
+   * specifies the maximum number of characters allowed.
    *
    * @mdn [maxlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-maxlength)
    */
@@ -179,7 +180,8 @@ export class TextArea
   messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
-   * Specifies the minimum number of characters allowed.
+   * When the component resides in a form,
+   * specifies the minimum number of characters allowed.
    *
    * @mdn [minlength](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-minlength)
    */
@@ -210,7 +212,8 @@ export class TextArea
   @property({ reflect: true }) readOnly = false;
 
   /**
-   * When `true`, the component must have a value in order for the form to submit.
+   * When `true` and the component resides in a form,
+   * the component must have a value in order for the form to submit.
    *
    * @mdn [required]https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required
    */


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/pull/11285#pullrequestreview-2551247008

## Summary
Updates the `required`, `max`, `min`, `maxLength` and `minLength` props where a parent form element is needed.