### PR TITLE
ci: resolve e2e errors due to updated actions runner

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   sync-dev-to-main:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, rc, dev]
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/remove-prerelease-changelog-entries.yml
+++ b/.github/workflows/remove-prerelease-changelog-entries.yml
@@ -8,7 +8,7 @@ permissions:
 name: clean-changelog
 jobs:
   clean-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Related Issue:** https://github.com/actions/runner-images/issues/10636

## Summary

GitHub just updated the `ubuntu-latest` action runner to point to `v24.04`, which is causing a Puppeteer error:


```text
⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: Failed to launch the browser process!
[0115/215319.789774:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise seehttps://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
 
 
 TROUBLESHOOTING: https://pptr.dev/troubleshooting
```

Downgrading the impacted workflows to `ubuntu-22.04` for now.

ref: https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
