### PR TITLE
chore(utility-network-layer, crosshair): add font codepoints

### DIFF
--- a/packages/calcite-ui-icons/fantasticonrc.json
+++ b/packages/calcite-ui-icons/fantasticonrc.json
@@ -1187,6 +1187,8 @@
     "collapse-relationships": 61724,
     "collapse-entities": 61725,
     "cluster-radius": 61726,
-    "add-link-chart-root-nodes": 61727
+    "add-link-chart-root-nodes": 61727,
+    "utility-network-layer": 61728,
+    "crosshair": 61729
   }
 }


### PR DESCRIPTION
**Related Issue:** #11331 #11299

## Summary

The changes to `fantasticonrc.json` were not committed in the PRs linked above. @arowles, can you please make sure the additions to `fantasticonrc.json` are included in your PR whenever you add icons? Otherwise the fonts will not have consistent codepoints.

Please see this comment for more context: https://github.com/Esri/calcite-design-system/pull/10996#pullrequestreview-2503379692
