### PR TITLE
fix(carousel): Ensure correct `autoplay` display and animation

### DIFF
--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -1057,7 +1057,59 @@ describe("calcite-carousel", () => {
     expect(animationStartSpy).toHaveReceivedEventTimes(8);
     expect(animationEndSpy).toHaveReceivedEventTimes(8);
   });
+
+  it("item slide animation finishes between paging/selection with autoplay", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-carousel label="carousel" autoplay>
+        <calcite-carousel-item label="item 1" selected><p>first</p></calcite-carousel-item>
+        <calcite-carousel-item label="item 2"><p>second</p></calcite-carousel-item>
+        <calcite-carousel-item label="item 3"><p>third</p></calcite-carousel-item>
+      </calcite-carousel>`,
+    );
+
+    const container = await page.find(`calcite-carousel >>> .${CSS.container}`);
+    const animationStartSpy = await container.spyOnEvent("animationstart");
+    const animationEndSpy = await container.spyOnEvent("animationend");
+    const nextButton = await page.find(`calcite-carousel >>> .${CSS.pageNext}`);
+
+    await nextButton.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+    await nextButton.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(2);
+    expect(animationEndSpy).toHaveReceivedEventTimes(2);
+
+    const previousButton = await page.find(`calcite-carousel >>> .${CSS.pagePrevious}`);
+    await previousButton.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+    await previousButton.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(4);
+    expect(animationEndSpy).toHaveReceivedEventTimes(4);
+
+    const [item1, item2, item3] = await page.findAll(`calcite-carousel >>> .${CSS.paginationItemIndividual}`);
+
+    await item2.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+    await item3.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(6);
+    expect(animationEndSpy).toHaveReceivedEventTimes(6);
+
+    await item2.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+    await item1.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(8);
+    expect(animationEndSpy).toHaveReceivedEventTimes(8);
+  });
 });
+
 describe("renders the expected number of pagination items when overflowing", () => {
   it("correctly limits the number of slide pagination items shown when overflowing xxsmall first selected", async () => {
     const page = await newE2EPage();

--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -6,8 +6,7 @@ import { html } from "../../../support/formatting";
 import { breakpoints } from "../../utils/responsive";
 import { CSS, centerItemsByBreakpoint } from "./resources";
 
-const slideDuration = 1000;
-const slideDurationWaitTimer = slideDuration + 100;
+const customDuration = 1000;
 
 describe("calcite-carousel", () => {
   describe("renders", () => {
@@ -48,7 +47,7 @@ describe("calcite-carousel", () => {
 
   describe("accessible with autoplay paused", () => {
     accessible(
-      html`<calcite-carousel autoplay="paused" label="Carousel example" autoplay-duration="${slideDuration}"
+      html`<calcite-carousel autoplay="paused" label="Carousel example" autoplay-duration="${customDuration}"
         ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
         ><calcite-carousel-item label="Carousel Item 2"
           ><p>carousel item content</p></calcite-carousel-item
@@ -59,7 +58,7 @@ describe("calcite-carousel", () => {
 
   describe("accessible with autoplay when autoplay", () => {
     accessible(
-      html`<calcite-carousel autoplay label="Carousel example" autoplay-duration="${slideDuration}"
+      html`<calcite-carousel autoplay label="Carousel example" autoplay-duration="${customDuration}"
         ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
         ><calcite-carousel-item label="Carousel Item 2"
           ><p>carousel item content</p></calcite-carousel-item
@@ -249,7 +248,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -294,7 +293,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -381,7 +380,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -467,7 +466,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -483,13 +482,15 @@ describe("calcite-carousel", () => {
       expect(playSpy).not.toHaveReceivedEvent();
       expect(stopSpy).not.toHaveReceivedEvent();
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
       expect(playSpy).not.toHaveReceivedEvent();
       expect(stopSpy).not.toHaveReceivedEvent();
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("one");
       expect(playSpy).not.toHaveReceivedEvent();
@@ -534,7 +535,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -552,7 +553,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).not.toHaveReceivedEvent();
       expect(await carousel.getProperty("paused")).toBe(false);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -563,7 +565,8 @@ describe("calcite-carousel", () => {
       expect(await carousel.getProperty("paused")).toBe(true);
       expect(selectedItem.id).toEqual("three");
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -575,7 +578,8 @@ describe("calcite-carousel", () => {
 
       expect(selectedItem.id).toEqual("three");
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("one");
     });
@@ -584,7 +588,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay="paused" id="example-carousel"  autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay="paused" id="example-carousel"  autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -614,7 +618,8 @@ describe("calcite-carousel", () => {
       expect(resumeSpy).not.toHaveReceivedEvent();
       expect(await page.evaluate(() => document.activeElement.id)).toEqual(carousel.id);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
 
@@ -627,7 +632,8 @@ describe("calcite-carousel", () => {
       expect(await carousel.getProperty("paused")).toBe(false);
       expect(selectedItem.id).toEqual("two");
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -654,7 +660,8 @@ describe("calcite-carousel", () => {
       expect(selectedItem.id).toEqual("three");
 
       await page.waitForChanges();
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(playSpy).toHaveReceivedEventTimes(1);
       expect(stopSpy).toHaveReceivedEventTimes(1);
@@ -717,7 +724,8 @@ describe("calcite-carousel", () => {
       expect(resumeSpy).not.toHaveReceivedEvent();
       expect(await page.evaluate(() => document.activeElement.id)).toEqual(carousel.id);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
 
@@ -731,7 +739,8 @@ describe("calcite-carousel", () => {
       expect(await carousel.getProperty("paused")).toBe(undefined);
       expect(selectedItem.id).toEqual("two");
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
 
@@ -854,7 +863,7 @@ describe("calcite-carousel", () => {
     it("plays and stops correctly when autoplay", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -876,7 +885,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).not.toHaveReceivedEvent();
       expect(await carousel.getProperty("paused")).toBe(false);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -892,7 +902,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).toHaveReceivedEventTimes(1);
       expect(await carousel.getProperty("paused")).toBe(true);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -918,7 +929,7 @@ describe("calcite-carousel", () => {
     it("plays and stops correctly when autoplay is paused", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay="paused" autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay="paused" autoplay-duration="${customDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -940,7 +951,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).not.toHaveReceivedEvent();
       expect(await carousel.getProperty("paused")).toBe(false);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
 
@@ -950,7 +962,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).toHaveReceivedEventTimes(1);
       expect(await carousel.getProperty("paused")).toBe(true);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
     });
@@ -986,7 +999,8 @@ describe("calcite-carousel", () => {
       expect(playSpy).not.toHaveReceivedEvent();
       expect(stopSpy).not.toHaveReceivedEvent();
       expect(await carousel.getProperty("paused")).toBe(undefined);
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
 
@@ -1002,7 +1016,8 @@ describe("calcite-carousel", () => {
       expect(stopSpy).not.toHaveReceivedEvent();
       expect(await carousel.getProperty("paused")).toBe(undefined);
 
-      await page.waitForTimeout(slideDurationWaitTimer);
+      await page.waitForTimeout(customDuration);
+      await page.waitForChanges();
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
     });
@@ -1062,7 +1077,7 @@ describe("calcite-carousel", () => {
   it("item slide animation finishes between paging/selection with autoplay", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      html`<calcite-carousel label="carousel" autoplay autoplay-duration="${slideDuration}">
+      html`<calcite-carousel label="carousel" autoplay autoplay-duration="${customDuration}">
         <calcite-carousel-item label="item 1" selected><p>first</p></calcite-carousel-item>
         <calcite-carousel-item label="item 2"><p>second</p></calcite-carousel-item>
         <calcite-carousel-item label="item 3"><p>third</p></calcite-carousel-item>
@@ -1075,14 +1090,16 @@ describe("calcite-carousel", () => {
     const nextButton = await page.find(`calcite-carousel >>> .${CSS.pageNext}`);
 
     await nextButton.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
 
     expect(animationStartSpy).toHaveReceivedEventTimes(1);
     expect(animationEndSpy).toHaveReceivedEventTimes(1);
 
     const previousButton = await page.find(`calcite-carousel >>> .${CSS.pagePrevious}`);
     await previousButton.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
 
     expect(animationStartSpy).toHaveReceivedEventTimes(2);
     expect(animationEndSpy).toHaveReceivedEventTimes(2);
@@ -1090,22 +1107,28 @@ describe("calcite-carousel", () => {
     const [item1, item2, item3] = await page.findAll(`calcite-carousel >>> .${CSS.paginationItemIndividual}`);
 
     await item2.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
-    await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
 
     expect(animationStartSpy).toHaveReceivedEventTimes(3);
     expect(animationEndSpy).toHaveReceivedEventTimes(3);
 
     await item3.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
-    await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
 
     expect(animationStartSpy).toHaveReceivedEventTimes(4);
     expect(animationEndSpy).toHaveReceivedEventTimes(4);
 
     await item1.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
-    await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
+    await page.waitForTimeout(customDuration);
+    await page.waitForChanges();
 
     expect(animationStartSpy).toHaveReceivedEventTimes(5);
     expect(animationEndSpy).toHaveReceivedEventTimes(5);

--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -500,7 +500,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
+        `<calcite-carousel label="Carousel example" autoplay>
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>

--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -4,9 +4,10 @@ import { describe, expect, it } from "vitest";
 import { accessible, hidden, renders, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { breakpoints } from "../../utils/responsive";
-import { CSS, DURATION, centerItemsByBreakpoint } from "./resources";
+import { CSS, centerItemsByBreakpoint } from "./resources";
 
-const slideDurationWaitTimer = DURATION + 250;
+const slideDuration = 1000;
+const slideDurationWaitTimer = slideDuration + 100;
 
 describe("calcite-carousel", () => {
   describe("renders", () => {
@@ -47,7 +48,7 @@ describe("calcite-carousel", () => {
 
   describe("accessible with autoplay paused", () => {
     accessible(
-      html`<calcite-carousel autoplay="paused" label="Carousel example"
+      html`<calcite-carousel autoplay="paused" label="Carousel example" autoplay-duration="${slideDuration}"
         ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
         ><calcite-carousel-item label="Carousel Item 2"
           ><p>carousel item content</p></calcite-carousel-item
@@ -58,7 +59,7 @@ describe("calcite-carousel", () => {
 
   describe("accessible with autoplay when autoplay", () => {
     accessible(
-      html`<calcite-carousel autoplay label="Carousel example"
+      html`<calcite-carousel autoplay label="Carousel example" autoplay-duration="${slideDuration}"
         ><calcite-carousel-item label="Carousel Item 1"><p>carousel item content</p></calcite-carousel-item
         ><calcite-carousel-item label="Carousel Item 2"
           ><p>carousel item content</p></calcite-carousel-item
@@ -248,7 +249,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -293,7 +294,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -380,7 +381,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -466,7 +467,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -495,11 +496,11 @@ describe("calcite-carousel", () => {
       expect(stopSpy).not.toHaveReceivedEvent();
     });
 
-    it("correctly rotates to a new carousel item after custom duration elapses", async () => {
+    it("correctly rotates to a new carousel item after default duration elapses", async () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="2000">
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -509,20 +510,20 @@ describe("calcite-carousel", () => {
       const carousel = await page.find("calcite-carousel");
       const playSpy = await page.spyOnEvent("calciteCarouselPlay");
       const stopSpy = await page.spyOnEvent("calciteCarouselStop");
-      const customSlideDurationWaitTimer = parseInt(await carousel.getProperty("autoplayDuration")) + 250;
+      const defaultSlideDurationWaitTimer = parseInt(await carousel.getProperty("autoplayDuration")) + 250;
 
       let selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("two");
       expect(playSpy).not.toHaveReceivedEvent();
       expect(stopSpy).not.toHaveReceivedEvent();
 
-      await page.waitForTimeout(customSlideDurationWaitTimer);
+      await page.waitForTimeout(defaultSlideDurationWaitTimer);
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("three");
       expect(playSpy).not.toHaveReceivedEvent();
       expect(stopSpy).not.toHaveReceivedEvent();
 
-      await page.waitForTimeout(customSlideDurationWaitTimer);
+      await page.waitForTimeout(defaultSlideDurationWaitTimer);
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
       expect(selectedItem.id).toEqual("one");
       expect(playSpy).not.toHaveReceivedEvent();
@@ -533,7 +534,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -583,7 +584,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay="paused" id="example-carousel>
+        `<calcite-carousel label="Carousel example" autoplay="paused" id="example-carousel"  autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -686,7 +687,7 @@ describe("calcite-carousel", () => {
       const page = await newE2EPage();
 
       await page.setContent(
-        `<calcite-carousel label="Carousel example" id="example-carousel>
+        `<calcite-carousel label="Carousel example" id="example-carousel">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -853,7 +854,7 @@ describe("calcite-carousel", () => {
     it("plays and stops correctly when autoplay", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay>
+        `<calcite-carousel label="Carousel example" autoplay  autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -917,7 +918,7 @@ describe("calcite-carousel", () => {
     it("plays and stops correctly when autoplay is paused", async () => {
       const page = await newE2EPage();
       await page.setContent(
-        `<calcite-carousel label="Carousel example" autoplay="paused">
+        `<calcite-carousel label="Carousel example" autoplay="paused" autoplay-duration="${slideDuration}">
           <calcite-carousel-item label="Carousel Item 1" id="one"><p>no pre-selected attribute</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 2" id="two" selected><p>pre-selected and not first</p></calcite-carousel-item>
           <calcite-carousel-item label="Carousel Item 3" id="three"><p>no pre-selected attribute</p></calcite-carousel-item>
@@ -1061,7 +1062,7 @@ describe("calcite-carousel", () => {
   it("item slide animation finishes between paging/selection with autoplay", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      html`<calcite-carousel label="carousel" autoplay>
+      html`<calcite-carousel label="carousel" autoplay autoplay-duration="${slideDuration}">
         <calcite-carousel-item label="item 1" selected><p>first</p></calcite-carousel-item>
         <calcite-carousel-item label="item 2"><p>second</p></calcite-carousel-item>
         <calcite-carousel-item label="item 3"><p>third</p></calcite-carousel-item>
@@ -1075,38 +1076,39 @@ describe("calcite-carousel", () => {
 
     await nextButton.click();
     await page.waitForTimeout(slideDurationWaitTimer);
-    await nextButton.click();
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(1);
+    expect(animationEndSpy).toHaveReceivedEventTimes(1);
+
+    const previousButton = await page.find(`calcite-carousel >>> .${CSS.pagePrevious}`);
+    await previousButton.click();
     await page.waitForTimeout(slideDurationWaitTimer);
 
     expect(animationStartSpy).toHaveReceivedEventTimes(2);
     expect(animationEndSpy).toHaveReceivedEventTimes(2);
 
-    const previousButton = await page.find(`calcite-carousel >>> .${CSS.pagePrevious}`);
-    await previousButton.click();
+    const [item1, item2, item3] = await page.findAll(`calcite-carousel >>> .${CSS.paginationItemIndividual}`);
+
+    await item2.click();
     await page.waitForTimeout(slideDurationWaitTimer);
-    await previousButton.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
+
+    expect(animationStartSpy).toHaveReceivedEventTimes(3);
+    expect(animationEndSpy).toHaveReceivedEventTimes(3);
+
+    await item3.click();
+    await page.waitForTimeout(slideDurationWaitTimer);
     await page.waitForTimeout(slideDurationWaitTimer);
 
     expect(animationStartSpy).toHaveReceivedEventTimes(4);
     expect(animationEndSpy).toHaveReceivedEventTimes(4);
 
-    const [item1, item2, item3] = await page.findAll(`calcite-carousel >>> .${CSS.paginationItemIndividual}`);
-
-    await item2.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
-    await item3.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
-
-    expect(animationStartSpy).toHaveReceivedEventTimes(6);
-    expect(animationEndSpy).toHaveReceivedEventTimes(6);
-
-    await item2.click();
-    await page.waitForTimeout(slideDurationWaitTimer);
     await item1.click();
     await page.waitForTimeout(slideDurationWaitTimer);
+    await page.waitForTimeout(slideDurationWaitTimer);
 
-    expect(animationStartSpy).toHaveReceivedEventTimes(8);
-    expect(animationEndSpy).toHaveReceivedEventTimes(8);
+    expect(animationStartSpy).toHaveReceivedEventTimes(5);
+    expect(animationEndSpy).toHaveReceivedEventTimes(5);
   });
 });
 

--- a/packages/calcite-components/src/components/carousel/carousel.e2e.ts
+++ b/packages/calcite-components/src/components/carousel/carousel.e2e.ts
@@ -432,34 +432,44 @@ describe("calcite-carousel", () => {
       await page.waitForChanges();
       expect(changeSpy).toHaveReceivedEventTimes(2);
       expect(playSpy).toHaveReceivedEventTimes(1);
-      expect(stopSpy).toHaveReceivedEventTimes(1);
-      selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
-      expect(selectedItem.id).toEqual("one");
+      expect(stopSpy).toHaveReceivedEventTimes(2);
       expect(await carousel.getProperty("paused")).toBe(true);
 
+      selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
+      expect(selectedItem.id).toEqual("one");
+
       await autoplayControl.click();
+      await page.waitForTimeout(customDuration);
       await page.waitForChanges();
       expect(changeSpy).toHaveReceivedEventTimes(2);
       expect(playSpy).toHaveReceivedEventTimes(2);
-      expect(stopSpy).toHaveReceivedEventTimes(1);
+      expect(stopSpy).toHaveReceivedEventTimes(2);
       expect(await carousel.getProperty("paused")).toBe(false);
 
+      selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
+      expect(selectedItem.id).toEqual("two");
+
       await prevButton.click();
+      await page.waitForTimeout(customDuration);
       await page.waitForChanges();
       expect(changeSpy).toHaveReceivedEventTimes(3);
       expect(playSpy).toHaveReceivedEventTimes(2);
-      expect(stopSpy).toHaveReceivedEventTimes(1);
+      expect(stopSpy).toHaveReceivedEventTimes(3);
       expect(await carousel.getProperty("paused")).toBe(true);
 
       selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
-      expect(selectedItem.id).toEqual("three");
+      expect(selectedItem.id).toEqual("one");
 
       await autoplayControl.click();
+      await page.waitForTimeout(customDuration);
       await page.waitForChanges();
       expect(changeSpy).toHaveReceivedEventTimes(3);
       expect(playSpy).toHaveReceivedEventTimes(3);
-      expect(stopSpy).toHaveReceivedEventTimes(1);
+      expect(stopSpy).toHaveReceivedEventTimes(3);
       expect(await carousel.getProperty("paused")).toBe(false);
+
+      selectedItem = await carousel.find(`calcite-carousel-item[selected]`);
+      expect(selectedItem.id).toEqual("two");
     });
 
     it("correctly rotates to a new carousel item after duration elapses", async () => {
@@ -1139,7 +1149,7 @@ describe("renders the expected number of pagination items when overflowing", () 
   it("correctly limits the number of slide pagination items shown when overflowing xxsmall first selected", async () => {
     const page = await newE2EPage();
     await page.setContent(
-      html`<calcite-carousel label="carousel" style="width:200px")">
+      html`<calcite-carousel label="carousel" style="width:12.5rem")">
         <calcite-carousel-item label="item 1" selected><p>first</p></calcite-carousel-item>
         <calcite-carousel-item label="item 2"><p>second</p></calcite-carousel-item>
         <calcite-carousel-item label="item 3"><p>third</p></calcite-carousel-item>

--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -573,6 +573,7 @@ export class Carousel extends LitElement implements InteractiveComponent, Loadab
 
   private renderRotationControl(): JsxNode {
     const text = this.playing ? this.messages.pause : this.messages.play;
+    const formattedValue = this.slideDurationRemaining * 100;
     return (
       <button
         ariaLabel={text}
@@ -588,7 +589,7 @@ export class Carousel extends LitElement implements InteractiveComponent, Loadab
           <calcite-progress
             class={CSS.autoplayProgress}
             label={this.messages.carouselItemProgress}
-            value={this.slideDurationRemaining * 100}
+            value={formattedValue}
           />
         )}
       </button>

--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -406,6 +406,11 @@ export class Carousel extends LitElement implements InteractiveComponent, Loadab
 
   private handleArrowClick(event: MouseEvent): void {
     const direction = (event.target as HTMLDivElement).dataset.direction;
+
+    if (this.playing) {
+      this.handlePause(true);
+    }
+
     if (direction === "next") {
       this.direction = "forward";
       this.nextItem(true);

--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -78,6 +78,7 @@ export class Carousel extends LitElement implements InteractiveComponent, Loadab
     if (notSuspended) {
       if (time <= 0.01) {
         time = 1;
+        this.direction = "forward";
         this.nextItem(false);
       } else {
         time = time - 0.01;
@@ -587,7 +588,7 @@ export class Carousel extends LitElement implements InteractiveComponent, Loadab
           <calcite-progress
             class={CSS.autoplayProgress}
             label={this.messages.carouselItemProgress}
-            value={this.slideDurationRemaining}
+            value={this.slideDurationRemaining * 100}
           />
         )}
       </button>


### PR DESCRIPTION
**Related Issue:** #11317 

## Summary
Ensures the animation is correctly applied when `autoplay` advances through Carousel Items.
Also updates the Progress component to adhere to the new `value` format / breaking change for 3.x: https://github.com/Esri/calcite-design-system/pull/10622 / logged in internal tracking discussion