### PR TITLE
fix(date-picker): no longer disable min/max value month in select menu

### DIFF
--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -322,7 +322,7 @@ export class DatePickerMonthHeader extends LitElement {
     });
   }
 
-  private isValidMonth(index: number): boolean {
+  private isMonthInRange(index: number): boolean {
     const newActiveDate = getDateInMonth(this.activeDate, index);
 
     if ((!this.min && !this.max) || inRange(newActiveDate, this.min, this.max)) {
@@ -458,7 +458,7 @@ export class DatePickerMonthHeader extends LitElement {
         {monthData.map((month: string, index: number) => {
           return (
             <calcite-option
-              disabled={!this.isValidMonth(index)}
+              disabled={!this.isMonthInRange(index)}
               selected={index === activeMonth}
               value={month}
             >

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -322,13 +322,16 @@ export class DatePickerMonthHeader extends LitElement {
     });
   }
 
-  private isMonthInRange(index: number): boolean {
+  private isValidMonth(index: number): boolean {
     const newActiveDate = getDateInMonth(this.activeDate, index);
 
-    if (!this.min && !this.max) {
+    if ((!this.min && !this.max) || inRange(newActiveDate, this.min, this.max)) {
       return true;
     }
-    return (!!this.max && newActiveDate < this.max) || (!!this.min && newActiveDate > this.min);
+
+    return (
+      hasSameMonthAndYear(newActiveDate, this.max) || hasSameMonthAndYear(newActiveDate, this.min)
+    );
   }
 
   private async handlePenultimateValidMonth(event: MouseEvent | KeyboardEvent): Promise<void> {
@@ -455,7 +458,7 @@ export class DatePickerMonthHeader extends LitElement {
         {monthData.map((month: string, index: number) => {
           return (
             <calcite-option
-              disabled={!this.isMonthInRange(index)}
+              disabled={!this.isValidMonth(index)}
               selected={index === activeMonth}
               value={month}
             >

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -256,6 +256,28 @@ describe("calcite-date-picker", () => {
       await setActiveDate(page, dateBeforeMin);
       expect(await getActiveDate(page)).toEqual(new Date(dateBeforeMin).toISOString());
     });
+
+    it("should not disable min & max month option", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`<calcite-date-picker value="2025-03-20"></calcite-date-picker>`);
+
+      const datePicker = await page.find("calcite-date-picker");
+
+      datePicker.setProperty("min", "2025-02-15");
+      datePicker.setProperty("max", "2025-04-15");
+      await page.waitForChanges();
+
+      const monthSelect = await page.find(
+        "calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-month-header >>> calcite-select",
+      );
+      const monthOptions = await monthSelect.findAll("calcite-option");
+
+      expect(await monthOptions[0].getProperty("disabled")).toBe(true);
+      expect(await monthOptions[1].getProperty("disabled")).toBe(false);
+      expect(await monthOptions[2].getProperty("disabled")).toBe(false);
+      expect(await monthOptions[3].getProperty("disabled")).toBe(false);
+      expect(await monthOptions[4].getProperty("disabled")).toBe(true);
+    });
   });
 
   describe("translation support", () => {


### PR DESCRIPTION
**Related Issue:** #11321 

## Summary

No longer disable min,max month's in select menu of date-picker.