### PR TITLE
fix(chip): fix inverse close color

### DIFF
--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -32,7 +32,7 @@
   }
 
   .close {
-    color: var(--calcite-color-text-3);
+    color: var(--calcite-chip-close-icon-color, var(--calcite-close-icon-color, var(--calcite-color-text-3)));
   }
 
   &:host([kind="brand"]) .container {
@@ -100,7 +100,7 @@
   }
 
   .close {
-    color: var(--calcite-color-text-3);
+    color: var(--calcite-chip-close-icon-color, var(--calcite-close-icon-color, var(--calcite-color-text-3)));
   }
 }
 

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -76,6 +76,15 @@
     .container {
       background-color: var(--calcite-chip-background-color, var(--calcite-color-inverse));
     }
+
+    .close {
+      &:hover {
+        background-color: var(--calcite-color-inverse-hover);
+      }
+      &:active {
+        background-color: var(--calcite-color-inverse-press);
+      }
+    }
   }
 
   &:host([kind="neutral"]) .container {
@@ -393,10 +402,7 @@ slot[name="image"]::slotted(*) {
 @include close-button(
   var(--calcite-internal-close-size, 1.5rem),
   0,
-  var(
-    --calcite-chip-close-icon-color,
-    var(--calcite-close-icon-color, var(--calcite-internal-chip-close-icon-color, var(--calcite-color-text-1)))
-  )
+  var(--calcite-chip-close-icon-color, var(--calcite-close-icon-color, currentColor))
 );
 @include disabled();
 @include base-component();

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -28,8 +28,11 @@
 :host([appearance="outline"]),
 :host([appearance="outline-fill"]) {
   .container {
-    --calcite-internal-chip-close-icon-color: var(--calcite-color-text-3);
     color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  }
+
+  .close {
+    color: var(--calcite-color-text-3);
   }
 
   &:host([kind="brand"]) .container {
@@ -91,10 +94,14 @@
     background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-2));
   }
 }
-:host([kind="neutral"]) .container {
-  --calcite-internal-chip-close-icon-color: var(--calcite-color-text-3);
+:host([kind="neutral"]) {
+  .container {
+    color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  }
 
-  color: var(--calcite-chip-text-color, var(--calcite-color-text-1));
+  .close {
+    color: var(--calcite-color-text-3);
+  }
 }
 
 :host([selected]) .select-icon {
@@ -103,15 +110,15 @@
 
 :host([scale="s"]) {
   .container {
-    --calcite-internal-chip-block-size: 1.5rem /* 24px */;
-    --calcite-internal-chip-container-space-x-end: 0.25rem /* 4px */;
-    --calcite-internal-chip-container-space-x-start: 0.25rem /* 4px */;
+    --calcite-internal-chip-block-size: var(--calcite-size-sm, 1.5rem) /* 24px */;
+    --calcite-internal-chip-container-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+    --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
     --calcite-internal-chip-font-size: var(--calcite-font-size--2);
-    --calcite-internal-chip-icon-size: 1rem /* 16px */;
-    --calcite-internal-chip-icon-space: 0.25rem /* 4px */;
-    --calcite-internal-chip-image-size: 1.25rem /* 20px */;
-    --calcite-internal-chip-title-space: 0.25rem /* 4px */;
-    --calcite-internal-close-size: 1rem /* 16px */;
+    --calcite-internal-chip-icon-size: var(--calcite-size-xs, 1rem) /* 16px */;
+    --calcite-internal-chip-icon-space: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+    --calcite-internal-chip-image-size: var(--calcite-spacing-xl, 1.25rem) /* 20px */;
+    --calcite-internal-chip-title-space: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+    --calcite-internal-close-size: var(--calcite-size-xs, 1rem) /* 16px */;
 
     &:not(.closable) {
       &.is-circle {
@@ -124,7 +131,7 @@
       &:has(.chip-icon),
       &.text--slotted,
       &.closable {
-        --calcite-internal-chip-image-space-x-end: 0.25rem /* 4px */;
+        --calcite-internal-chip-image-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
       }
       &:not(.text--slotted, :has(.chip-icon)),
       &:not(.selectable) {
@@ -137,8 +144,8 @@
         --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-px);
       }
       &.selected {
-        --calcite-internal-chip-select-space-x-end: 0.375rem /* 6px */;
-        --calcite-internal-chip-select-space-x-start: 0;
+        --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
+        --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-none, 0);
 
         &.image--slotted {
           --calcite-internal-chip-select-space-x-end: 0.5rem /* 8px */;
@@ -148,17 +155,17 @@
     }
 
     &.multiple:not(.is-circle) {
-      --calcite-internal-chip-container-space-x-start: 0.25rem /* 4px */;
-      --calcite-internal-chip-select-space-x-end: 0.25rem /* 4px */;
-      --calcite-internal-chip-select-space-x-start: 0.25rem /* 4px */;
+      --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+      --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+      --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
 
       &.image--slotted {
         --calcite-internal-chip-select-space-x-end: 0.5rem /* 8px */;
-        --calcite-internal-chip-select-space-x-start: 0.375rem /* 6px */;
+        --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
         --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-px);
 
         &:not(.text--slotted) {
-          --calcite-internal-chip-select-space-x-start: 0.375rem /* 6px */;
+          --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
         }
       }
     }
@@ -167,15 +174,15 @@
 
 :host([scale="m"]) {
   .container {
-    --calcite-internal-chip-block-size: 2rem /* 32px */;
-    --calcite-internal-chip-container-space-x-end: 0.375rem /* 6px */;
-    --calcite-internal-chip-container-space-x-start: 0.375rem /* 6px */;
+    --calcite-internal-chip-block-size: var(--calcite-size-md, 2rem) /* 32px */;
+    --calcite-internal-chip-container-space-x-end: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
+    --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
     --calcite-internal-chip-font-size: var(--calcite-font-size--1);
-    --calcite-internal-chip-icon-size: 1.5rem /* 24px */;
-    --calcite-internal-chip-icon-space: 0.375rem /* 6px */;
-    --calcite-internal-chip-image-size: 1.5rem /* 24px */;
-    --calcite-internal-chip-title-space: 0.375rem /* 6px */;
-    --calcite-internal-close-size: 1.5rem /* 24px */;
+    --calcite-internal-chip-icon-size: var(--calcite-size-sm, 1.5rem) /* 24px */;
+    --calcite-internal-chip-icon-space: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
+    --calcite-internal-chip-image-size: var(--calcite-size-sm, 1.5rem) /* 24px */;
+    --calcite-internal-chip-title-space: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
+    --calcite-internal-close-size: var(--calcite-size-sm, 1.5rem) /* 24px */;
 
     &:not(.closable) {
       &.is-circle {
@@ -186,27 +193,27 @@
 
     &.image--slotted {
       &:not(.is-circle) {
-        --calcite-internal-chip-container-space-x-start: 0.25rem /* 4px */;
+        --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
       }
 
       &:has(.chip-icon),
       &.text--slotted,
       &.closable {
-        --calcite-internal-chip-image-space-x-end: 0.375rem /* 6px */;
+        --calcite-internal-chip-image-space-x-end: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
       }
     }
 
     &.selectable.single:not(.is-circle) {
       &.image--slotted {
-        --calcite-internal-chip-container-space-x-start: 0.25rem /* 4px */;
+        --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
       }
       &.selected {
         --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-px);
-        --calcite-internal-chip-select-space-x-start: 0;
+        --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-none, 0);
 
         &.image--slotted {
-          --calcite-internal-chip-select-space-x-end: 0.25rem /* 4px */;
-          --calcite-internal-chip-select-space-x-start: 0.375rem /* 6px */;
+          --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+          --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
         }
       }
     }
@@ -217,12 +224,12 @@
 
       &.image--slotted {
         --calcite-internal-chip-select-space-x-end: 0.5rem /* 8px */;
-        --calcite-internal-chip-select-space-x-start: 0.25rem /* 4px */;
+        --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
       }
     }
 
     &.closable:not(.is-circle) {
-      --calcite-internal-chip-container-space-x-end: 0.25rem /* 4px */;
+      --calcite-internal-chip-container-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
     }
   }
 }
@@ -233,22 +240,22 @@
     --calcite-internal-chip-container-space-x-end: 0.5rem /* 8px */;
     --calcite-internal-chip-container-space-x-start: 0.5rem /* 8px */;
     --calcite-internal-chip-font-size: var(--calcite-font-size-0);
-    --calcite-internal-chip-icon-size: 2rem /* 32px */;
+    --calcite-internal-chip-icon-size: var(--calcite-size-md, 2rem) /* 32px */;
     --calcite-internal-chip-icon-space: 0.5rem /* 8px */;
-    --calcite-internal-chip-image-size: 2rem /* 32px */;
+    --calcite-internal-chip-image-size: var(--calcite-size-md, 2rem) /* 32px */;
     --calcite-internal-chip-title-space: 0.5rem /* 8px */;
-    --calcite-internal-close-size: 2rem /* 32px */;
+    --calcite-internal-close-size: var(--calcite-size-md, 2rem) /* 32px */;
 
     &:not(.closable) {
       &.is-circle {
-        --calcite-internal-chip-container-space-x-end: 0.25rem /* 4px */;
-        --calcite-internal-chip-container-space-x-start: 0.25rem /* 4px */;
+        --calcite-internal-chip-container-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+        --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
       }
     }
 
     &.image--slotted {
       &:not(.is-circle) {
-        --calcite-internal-chip-container-space-x-start: 0.375rem /* 6px */;
+        --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
       }
 
       &:has(.chip-icon),
@@ -260,14 +267,14 @@
 
     &.selectable.single:not(.is-circle) {
       &.image--slotted {
-        --calcite-internal-chip-container-space-x-start: 0.375rem /* 6px */;
+        --calcite-internal-chip-container-space-x-start: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
       }
       &.selected {
-        --calcite-internal-chip-select-space-x-end: 0.25rem /* 4px */;
-        --calcite-internal-chip-select-space-x-start: 0;
+        --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+        --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-none, 0);
 
         &.image--slotted {
-          --calcite-internal-chip-select-space-x-end: 0.375rem /* 6px */;
+          --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
           --calcite-internal-chip-select-space-x-start: 0.5rem /* 8px */;
         }
       }
@@ -276,8 +283,8 @@
     &.multiple:not(.is-circle) {
       --calcite-internal-chip-container-space-x-start: 0.5rem /* 8px */;
 
-      --calcite-internal-chip-select-space-x-end: 0.25rem /* 4px */;
-      --calcite-internal-chip-select-space-x-start: 0.25rem /* 4px */;
+      --calcite-internal-chip-select-space-x-end: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
+      --calcite-internal-chip-select-space-x-start: var(--calcite-spacing-xxs, 0.25rem) /* 4px */;
 
       &.image--slotted {
         --calcite-internal-chip-select-space-x-end: 0.75rem /* 12px */;
@@ -285,7 +292,7 @@
     }
 
     &.closable:not(.is-circle) {
-      --calcite-internal-chip-container-space-x-end: 0.375rem /* 6px */;
+      --calcite-internal-chip-container-space-x-end: var(--calcite-spacing-xs, 0.375rem) /* 6px */;
     }
   }
 }
@@ -312,7 +319,7 @@
   min-inline-size: var(--calcite-internal-chip-block-size, auto);
 
   &:hover .select-icon--active {
-    opacity: 1;
+    opacity: var(--calcite-opacity-full, 1);
   }
 
   &.selectable {
@@ -334,7 +341,7 @@
   &.is-circle {
     .chip-icon,
     .image-container {
-      padding: 0;
+      padding: var(--calcite-spacing-none, 0);
     }
   }
 }
@@ -348,16 +355,16 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  block-size: var(--calcite-internal-chip-image-size, 1.5rem /* 24px */);
-  inline-size: var(--calcite-internal-chip-image-size, 1.5rem /* 24px */);
-  padding-inline-start: 0;
+  block-size: var(--calcite-internal-chip-image-size, var(--calcite-spacing-xxl, 1.5rem) /* 24px */);
+  inline-size: var(--calcite-internal-chip-image-size, var(--calcite-spacing-xxl, 1.5rem) /* 24px */);
+  padding-inline-start: var(--calcite-spacing-none, 0);
   padding-inline-end: var(--calcite-internal-chip-image-space-x-end, 0);
 }
 
 .chip-icon {
   @apply relative my-0 inline-flex duration-150 ease-in-out;
   color: var(--calcite-chip-icon-color, var(--calcite-chip-text-color, var(--calcite-icon-color, currentColor)));
-  padding-inline: var(--calcite-internal-chip-icon-space, 0.375rem /* 6px */);
+  padding-inline: var(--calcite-internal-chip-icon-space, var(--calcite-spacing-xs, 0.375rem) /* 6px */);
 }
 
 .select-icon {
@@ -378,7 +385,7 @@
   &.select-icon--active {
     position: relative;
     visibility: visible;
-    opacity: 0.5;
+    opacity: var(--calcite-opacity-half, 0.5);
     color: var(--calcite-chip-select-icon-color-pressed, var(--calcite-chip-select-icon-color, currentColor));
   }
 }
@@ -391,8 +398,8 @@
 .single .select-icon--active {
   padding-inline-start: var(--calcite-internal-chip-select-space-x-start);
   padding-inline-end: var(--calcite-internal-chip-select-space-x-end);
-  block-size: var(--calcite-internal-chip-icon-size, 1.5rem /* 24px */);
-  inline-size: var(--calcite-internal-chip-icon-size, 1.5rem /* 24px */);
+  block-size: var(--calcite-internal-chip-icon-size, var(--calcite-spacing-xxl, 1.5rem) /* 24px */);
+  inline-size: var(--calcite-internal-chip-icon-size, var(--calcite-spacing-xxl, 1.5rem) /* 24px */);
 }
 
 slot[name="image"]::slotted(*) {
@@ -400,7 +407,7 @@ slot[name="image"]::slotted(*) {
 }
 
 @include close-button(
-  var(--calcite-internal-close-size, 1.5rem),
+  var(--calcite-internal-close-size, var(--calcite-spacing-xxl, 1.5rem)),
   0,
   var(--calcite-chip-close-icon-color, var(--calcite-close-icon-color, currentColor))
 );

--- a/packages/calcite-components/src/components/chip/chip.stories.ts
+++ b/packages/calcite-components/src/components/chip/chip.stories.ts
@@ -103,9 +103,58 @@ export const withAvatarAndIcon = (): string => {
   `;
 };
 
+// <div style="background-color:var(--calcite-color-foreground-current); padding:50px; display=inline-grid; grid-template-columns: 1fr; gap:var(--calcite-spacing-xxs);">
+
 export const withClosable = (args: ChipStoryArgs): string => html`
-  <div style="background-color:white;padding:100px">
+  <div
+    style="display: grid; background-color:var(--calcite-color-foreground-current); padding: 50px; gap:var(--calcite-spacing-xxs);"
+  >
     <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="neutral" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="brand" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="solid" kind="inverse" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="outline" kind="neutral" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="outline" kind="brand" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip icon="${iconNames[0]}" scale="m" appearance="outline" kind="inverse" label="${args.label}" closable>
+      My great chip</calcite-chip
+    >
+    <calcite-chip
+      icon="${iconNames[0]}"
+      scale="m"
+      appearance="outline-fill"
+      kind="neutral"
+      label="${args.label}"
+      closable
+    >
+      My great chip</calcite-chip
+    >
+    <calcite-chip
+      icon="${iconNames[0]}"
+      scale="m"
+      appearance="outline-fill"
+      kind="brand"
+      label="${args.label}"
+      closable
+    >
+      My great chip</calcite-chip
+    >
+    <calcite-chip
+      icon="${iconNames[0]}"
+      scale="m"
+      appearance="outline-fill"
+      kind="inverse"
+      label="${args.label}"
+      closable
+    >
       My great chip</calcite-chip
     >
   </div>


### PR DESCRIPTION
**Related Issue:** #11353

## Summary

Resolves issue where close button was not visible on a chip with `kind="inverse"`.
Updates the `withClosable` storybook test to include all versions of chip with `closable` to cover future use cases.