### PR TITLE
fix(flow): process items on loaded

### DIFF
--- a/packages/calcite-components/src/components/flow/flow.tsx
+++ b/packages/calcite-components/src/components/flow/flow.tsx
@@ -33,8 +33,10 @@ export class Flow extends LitElement implements LoadableComponent {
   private frameEl: HTMLDivElement;
 
   private itemMutationObserver: MutationObserver = createObserver("mutation", () =>
-    this.handleMutationObserverChange(),
+    this.updateItemsAndProps(),
   );
+
+  private items: FlowItemLikeElement[] = [];
 
   private selectedIndex = -1;
 
@@ -43,8 +45,6 @@ export class Flow extends LitElement implements LoadableComponent {
   // #region State Properties
 
   @state() flowDirection: FlowDirection = "standby";
-
-  @state() items: FlowItemLikeElement[] = [];
 
   // #endregion
 
@@ -120,7 +120,6 @@ export class Flow extends LitElement implements LoadableComponent {
 
   override connectedCallback(): void {
     this.itemMutationObserver?.observe(this.el, { childList: true, subtree: true });
-    this.handleMutationObserverChange();
   }
 
   load(): void {
@@ -139,6 +138,7 @@ export class Flow extends LitElement implements LoadableComponent {
 
   loaded(): void {
     setComponentLoaded(this);
+    this.updateItemsAndProps();
   }
 
   override disconnectedCallback(): void {
@@ -194,7 +194,7 @@ export class Flow extends LitElement implements LoadableComponent {
     return newSelectedIndex < oldSelectedIndex ? "retreating" : "advancing";
   }
 
-  private handleMutationObserverChange(): void {
+  private updateItemsAndProps(): void {
     const { customItemSelectors, el } = this;
 
     const newItems = Array.from<FlowItemLikeElement>(
@@ -206,7 +206,6 @@ export class Flow extends LitElement implements LoadableComponent {
     this.items = newItems;
 
     this.ensureSelectedFlowItemExists();
-
     this.updateFlowProps();
   }
 


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

This moves `flow-item` processing to `loaded`, so all items are guaranteed to be ready.

**Note**: `items` is no longer decorated with `@state`, as it is not used in rendering.