### PR TITLE
chore(icon): improve icon load error message

### DIFF
--- a/packages/calcite-components/src/components/icon/utils.ts
+++ b/packages/calcite-components/src/components/icon/utils.ts
@@ -1,6 +1,7 @@
 import { CalciteIconPath } from "@esri/calcite-ui-icons";
 import { Scale } from "../interfaces";
 import { getAssetPath } from "../../runtime";
+import { logger } from "../../utils/logger";
 import { IconNameOrString } from "./interfaces";
 
 export interface FetchIconProps {
@@ -51,7 +52,7 @@ export async function fetchIcon(props: FetchIconProps): Promise<CalciteIconPath>
     requestCache[cachedIconKey] = fetch(getAssetPath(`./assets/icon/${cachedIconKey}.json`))
       .then((resp) => resp.json())
       .catch(() => {
-        console.error(`"${cachedIconKey}" is not a valid calcite-ui-icon name`);
+        logger.error(`could not load "${props.icon}" (${props.scale}) icon`);
         return "";
       });
   }

--- a/packages/calcite-components/src/components/icon/utils.ts
+++ b/packages/calcite-components/src/components/icon/utils.ts
@@ -52,7 +52,7 @@ export async function fetchIcon(props: FetchIconProps): Promise<CalciteIconPath>
     requestCache[cachedIconKey] = fetch(getAssetPath(`./assets/icon/${cachedIconKey}.json`))
       .then((resp) => resp.json())
       .catch(() => {
-        logger.error(`could not load "${props.icon}" (${props.scale}) icon`);
+        logger.error(`${props.icon} (${props.scale}) icon failed to load.`);
         return "";
       });
   }

--- a/packages/calcite-components/src/components/icon/utils.ts
+++ b/packages/calcite-components/src/components/icon/utils.ts
@@ -52,7 +52,7 @@ export async function fetchIcon(props: FetchIconProps): Promise<CalciteIconPath>
     requestCache[cachedIconKey] = fetch(getAssetPath(`./assets/icon/${cachedIconKey}.json`))
       .then((resp) => resp.json())
       .catch(() => {
-        logger.error(`${props.icon} (${props.scale}) icon failed to load.`);
+        logger.error(`${props.icon} (${props.scale}) icon failed to load`);
         return "";
       });
   }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This improves clarity by displaying the icon name and scale separately in the error message instead of an internal key used by icon utils:

```sh
"measure16" is not a valid calcite-ui-icon name
```

⬇️

```sh
measure (s) icon failed to load.
```

Also, this now uses the logger to display the `calcite` badge for additional context.