### PR TITLE
fix(date-picker): remove outline for header actions

### DIFF
--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -63,7 +63,6 @@
     items-center
     justify-center
     border-none
-    outline-none
     transition-default 
     w-full 
     h-full;


### PR DESCRIPTION
**Related Issue:** #11371 

## Summary

Removes outline for header actions which is causing transition on focus shift. 

This is introduced with https://github.com/Esri/calcite-design-system/pull/10836/ where outline exclusion from transition is ignored in Tailwind util.

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE