### PR TITLE
fix(popover, tooltip): drop relative-positioning to reduce risk of clipping

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -11,7 +11,7 @@
  */
 
 :host {
-  @apply relative block;
+  @apply block;
   --calcite-floating-ui-z-index: var(--calcite-popover-z-index, theme("zIndex.popover"));
 }
 

--- a/packages/calcite-components/src/components/tooltip/tooltip.scss
+++ b/packages/calcite-components/src/components/tooltip/tooltip.scss
@@ -11,7 +11,7 @@
  */
 
 :host {
-  @apply relative block;
+  @apply block;
   --calcite-floating-ui-z-index: var(--calcite-tooltip-z-index, theme("zIndex.tooltip"));
 }
 


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Removes legacy `position: relative` to reduce chance of clipping (see https://floating-ui.com/docs/misc#clipping).

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE