### PR TITLE
fix(meter): add fill style for high-contrast mode

### DIFF
--- a/packages/calcite-components/src/components/meter/meter.scss
+++ b/packages/calcite-components/src/components/meter/meter.scss
@@ -118,3 +118,12 @@
 .solid .fill-warning {
   box-shadow: 0 0 0 1px var(--calcite-color-status-warning);
 }
+
+@media (forced-colors: active) {
+  .fill,
+  .fill-danger,
+  .fill-success,
+  .fill-warning {
+    background-color: Highlight;
+  }
+}


### PR DESCRIPTION
**Related Issue:** #10571 

## Summary

Add `forced-colors` media query to the styles to define a solid color when in high-contrast accessibility mode.