### PR TITLE
fix(list): drag event properties `newIndex` and `oldIndex` should only reflect list item indexes

### DIFF
--- a/packages/calcite-components/src/components/list-item/utils.ts
+++ b/packages/calcite-components/src/components/list-item/utils.ts
@@ -64,10 +64,6 @@ export function getDepth(element: HTMLElement, includeGroup = false): number {
   return result.snapshotLength;
 }
 
-function isListItem(element: Element): element is ListItem["el"] {
+export function isListItem(element: Element): element is ListItem["el"] {
   return element?.tagName === "CALCITE-LIST-ITEM";
-}
-
-export function isDraggableListItem(element: Element): boolean {
-  return isListItem(element) && !element.closed && !element.hidden && !element.filterHidden;
 }

--- a/packages/calcite-components/src/components/list-item/utils.ts
+++ b/packages/calcite-components/src/components/list-item/utils.ts
@@ -63,3 +63,11 @@ export function getDepth(element: HTMLElement, includeGroup = false): number {
 
   return result.snapshotLength;
 }
+
+function isListItem(element: Element): element is ListItem["el"] {
+  return element?.tagName === "CALCITE-LIST-ITEM";
+}
+
+export function isDraggableListItem(element: Element): boolean {
+  return isListItem(element) && !element.closed && !element.hidden && !element.filterHidden;
+}

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -1479,6 +1479,15 @@ describe("calcite-list", () => {
       const page = await newE2EPage();
       await page.setContent(
         html`<calcite-list drag-enabled id="list1">
+          <calcite-action
+            slot="filter-actions-end"
+            scale="s"
+            id="filter-action-test"
+            icon="show-all-parameters"
+          ></calcite-action>
+          <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+            >Mind if I offset your index?</calcite-tooltip
+          >
           <calcite-list-item id="one" value="one" label="One"></calcite-list-item>
           <calcite-list-item id="two" value="two" label="Two"></calcite-list-item>
           <calcite-list-item id="three" value="three" label="Three"></calcite-list-item>
@@ -1582,20 +1591,56 @@ describe("calcite-list", () => {
       const page = await newE2EPage();
       await page.setContent(html`
         <calcite-list id="first-letters" drag-enabled group="letters">
+          <calcite-action
+            slot="filter-actions-end"
+            scale="s"
+            id="filter-action-test"
+            icon="show-all-parameters"
+          ></calcite-action>
+          <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+            >Mind if I offset your index?</calcite-tooltip
+          >
           <calcite-list-item value="a" label="A"></calcite-list-item>
           <calcite-list-item value="b" label="B"></calcite-list-item>
         </calcite-list>
 
         <calcite-list id="numbers" drag-enabled group="numbers">
+          <calcite-action
+            slot="filter-actions-end"
+            scale="s"
+            id="filter-action-test"
+            icon="show-all-parameters"
+          ></calcite-action>
+          <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+            >Mind if I offset your index?</calcite-tooltip
+          >
           <calcite-list-item value="1" label="One"></calcite-list-item>
           <calcite-list-item value="2" label="Two"></calcite-list-item>
         </calcite-list>
 
         <calcite-list id="no-group" drag-enabled>
+          <calcite-action
+            slot="filter-actions-end"
+            scale="s"
+            id="filter-action-test"
+            icon="show-all-parameters"
+          ></calcite-action>
+          <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+            >Mind if I offset your index?</calcite-tooltip
+          >
           <calcite-list-item value="no-group" label="No group"></calcite-list-item>
         </calcite-list>
 
         <calcite-list id="second-letters" drag-enabled group="letters">
+          <calcite-action
+            slot="filter-actions-end"
+            scale="s"
+            id="filter-action-test"
+            icon="show-all-parameters"
+          ></calcite-action>
+          <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+            >Mind if I offset your index?</calcite-tooltip
+          >
           <calcite-list-item value="c" label="C"></calcite-list-item>
           <calcite-list-item value="d" label="D"></calcite-list-item>
           <calcite-list-item value="e" label="E"></calcite-list-item>
@@ -1758,10 +1803,28 @@ describe("calcite-list", () => {
       const group = "my-group";
       await page.setContent(
         html`<calcite-list id="list1" group="${group}" drag-enabled>
+            <calcite-action
+              slot="filter-actions-end"
+              scale="s"
+              id="filter-action-test"
+              icon="show-all-parameters"
+            ></calcite-action>
+            <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+              >Mind if I offset your index?</calcite-tooltip
+            >
             <calcite-list-item id="one" value="one" label="One"></calcite-list-item>
             <calcite-list-item id="two" value="two" label="Two"></calcite-list-item>
           </calcite-list>
           <calcite-list id="list2" group="${group}" drag-enabled>
+            <calcite-action
+              slot="filter-actions-end"
+              scale="s"
+              id="filter-action-test"
+              icon="show-all-parameters"
+            ></calcite-action>
+            <calcite-tooltip label="scary tooltip" reference-element="filter-action-test"
+              >Mind if I offset your index?</calcite-tooltip
+            >
             <calcite-list-item id="three" value="three" label="Three"></calcite-list-item>
           </calcite-list>`,
       );

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -949,7 +949,6 @@ export class List
     const fromEl = dragEl?.parentElement as List["el"];
     const toEl = moveTo.element as List["el"];
     const fromElItems = Array.from(fromEl.children).filter(isListItem);
-    const toElItems = Array.from(toEl.children).filter(isListItem);
     const oldIndex = fromElItems.indexOf(dragEl);
 
     if (!fromEl) {
@@ -962,6 +961,7 @@ export class List
 
     toEl.prepend(dragEl);
     openAncestors(dragEl);
+    const toElItems = Array.from(toEl.children).filter(isListItem);
     const newIndex = toElItems.indexOf(dragEl);
 
     this.updateListItems();

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -13,6 +13,7 @@ import { createObserver } from "../../utils/observers";
 import { SelectionMode, InteractionMode, Scale } from "../interfaces";
 import { ItemData } from "../list-item/interfaces";
 import {
+  isDraggableListItem,
   listItemGroupSelector,
   listItemSelector,
   listSelector,
@@ -73,7 +74,7 @@ export class List
 
   // #region Private Properties
 
-  dragSelector = listItemSelector;
+  dragSelector = `${listItemSelector}:not([closed]):not([hidden]):not([filter-hidden])`;
 
   filterEl: Filter["el"];
 
@@ -946,8 +947,10 @@ export class List
 
     const dragEl = event.target as ListItem["el"];
     const fromEl = dragEl?.parentElement as List["el"];
-    const oldIndex = Array.from(fromEl.children).indexOf(dragEl);
     const toEl = moveTo.element as List["el"];
+    const fromElItems = Array.from(fromEl.children).filter(isDraggableListItem);
+    const toElItems = Array.from(toEl.children).filter(isDraggableListItem);
+    const oldIndex = fromElItems.indexOf(dragEl);
 
     if (!fromEl) {
       return;
@@ -959,7 +962,7 @@ export class List
 
     toEl.prepend(dragEl);
     openAncestors(dragEl);
-    const newIndex = Array.from(toEl.children).indexOf(dragEl);
+    const newIndex = toElItems.indexOf(dragEl);
 
     this.updateListItems();
     this.connectObserver();
@@ -985,7 +988,7 @@ export class List
 
     dragEl.sortHandleOpen = false;
 
-    const sameParentItems = this.filteredItems.filter((item) => item.parentElement === parentEl);
+    const sameParentItems = Array.from(parentEl.children).filter(isDraggableListItem);
 
     const lastIndex = sameParentItems.length - 1;
     const oldIndex = sameParentItems.indexOf(dragEl);

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -13,7 +13,7 @@ import { createObserver } from "../../utils/observers";
 import { SelectionMode, InteractionMode, Scale } from "../interfaces";
 import { ItemData } from "../list-item/interfaces";
 import {
-  isDraggableListItem,
+  isListItem,
   listItemGroupSelector,
   listItemSelector,
   listSelector,
@@ -74,7 +74,7 @@ export class List
 
   // #region Private Properties
 
-  dragSelector = `${listItemSelector}:not([closed]):not([hidden]):not([filter-hidden])`;
+  dragSelector = listItemSelector;
 
   filterEl: Filter["el"];
 
@@ -948,8 +948,8 @@ export class List
     const dragEl = event.target as ListItem["el"];
     const fromEl = dragEl?.parentElement as List["el"];
     const toEl = moveTo.element as List["el"];
-    const fromElItems = Array.from(fromEl.children).filter(isDraggableListItem);
-    const toElItems = Array.from(toEl.children).filter(isDraggableListItem);
+    const fromElItems = Array.from(fromEl.children).filter(isListItem);
+    const toElItems = Array.from(toEl.children).filter(isListItem);
     const oldIndex = fromElItems.indexOf(dragEl);
 
     if (!fromEl) {
@@ -988,7 +988,7 @@ export class List
 
     dragEl.sortHandleOpen = false;
 
-    const sameParentItems = Array.from(parentEl.children).filter(isDraggableListItem);
+    const sameParentItems = Array.from(parentEl.children).filter(isListItem);
 
     const lastIndex = sameParentItems.length - 1;
     const oldIndex = sameParentItems.indexOf(dragEl);

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -135,8 +135,8 @@ export function connectSortableComponent(component: SortableComponent): void {
       onGlobalDragEnd();
       component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
-    onSort: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
-      component.onDragSort({ fromEl, dragEl, toEl, newIndex, oldIndex });
+    onSort: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
+      component.onDragSort({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
     },
   });
 }

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -107,12 +107,24 @@ export function connectSortableComponent(component: SortableComponent): void {
       group: {
         name: group,
         ...(!!component.canPull && {
-          pull: (to, from, dragEl, { newIndex, oldIndex }) =>
-            component.canPull({ toEl: to.el, fromEl: from.el, dragEl, newIndex, oldIndex }),
+          pull: (to, from, dragEl, { newDraggableIndex, oldDraggableIndex }) =>
+            component.canPull({
+              toEl: to.el,
+              fromEl: from.el,
+              dragEl,
+              newIndex: newDraggableIndex,
+              oldIndex: oldDraggableIndex,
+            }),
         }),
         ...(!!component.canPut && {
-          put: (to, from, dragEl, { newIndex, oldIndex }) =>
-            component.canPut({ toEl: to.el, fromEl: from.el, dragEl, newIndex, oldIndex }),
+          put: (to, from, dragEl, { newDraggableIndex, oldDraggableIndex }) =>
+            component.canPut({
+              toEl: to.el,
+              fromEl: from.el,
+              dragEl,
+              newIndex: newDraggableIndex,
+              oldIndex: oldDraggableIndex,
+            }),
         }),
       },
     }),
@@ -125,15 +137,15 @@ export function connectSortableComponent(component: SortableComponent): void {
     },
     handle,
     filter: `${handle}[disabled]`,
-    onStart: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
+    onStart: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
       dragState.active = true;
       onGlobalDragStart();
-      component.onDragStart({ fromEl, dragEl, toEl, newIndex, oldIndex });
+      component.onDragStart({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
     },
-    onEnd: ({ from: fromEl, item: dragEl, to: toEl, newIndex, oldIndex }) => {
+    onEnd: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
       dragState.active = false;
       onGlobalDragEnd();
-      component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
+      component.onDragEnd({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
     },
     onSort: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
       component.onDragSort({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -107,23 +107,23 @@ export function connectSortableComponent(component: SortableComponent): void {
       group: {
         name: group,
         ...(!!component.canPull && {
-          pull: (to, from, dragEl, { newDraggableIndex, oldDraggableIndex }) =>
+          pull: (to, from, dragEl, { newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) =>
             component.canPull({
               toEl: to.el,
               fromEl: from.el,
               dragEl,
-              newIndex: newDraggableIndex,
-              oldIndex: oldDraggableIndex,
+              newIndex,
+              oldIndex,
             }),
         }),
         ...(!!component.canPut && {
-          put: (to, from, dragEl, { newDraggableIndex, oldDraggableIndex }) =>
+          put: (to, from, dragEl, { newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) =>
             component.canPut({
               toEl: to.el,
               fromEl: from.el,
               dragEl,
-              newIndex: newDraggableIndex,
-              oldIndex: oldDraggableIndex,
+              newIndex,
+              oldIndex,
             }),
         }),
       },
@@ -137,18 +137,18 @@ export function connectSortableComponent(component: SortableComponent): void {
     },
     handle,
     filter: `${handle}[disabled]`,
-    onStart: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
+    onStart: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
       dragState.active = true;
       onGlobalDragStart();
-      component.onDragStart({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
+      component.onDragStart({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
-    onEnd: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
+    onEnd: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
       dragState.active = false;
       onGlobalDragEnd();
-      component.onDragEnd({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
+      component.onDragEnd({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
-    onSort: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex, oldDraggableIndex }) => {
-      component.onDragSort({ fromEl, dragEl, toEl, newIndex: newDraggableIndex, oldIndex: oldDraggableIndex });
+    onSort: ({ from: fromEl, item: dragEl, to: toEl, newDraggableIndex: newIndex, oldDraggableIndex: oldIndex }) => {
+      component.onDragSort({ fromEl, dragEl, toEl, newIndex, oldIndex });
     },
   });
 }


### PR DESCRIPTION
**Related Issue:** #11397

## Summary

- use `oldDraggableIndex` and `newDraggableIndex` from https://github.com/SortableJS/Sortable?tab=readme-ov-file#event-object-demo in order to only track the relevant indexes of draggable items via mouse.
- updates keyboard logic for indexes to only consider applicable items.
- updates tests to add slotted content which should not affect event `newIndex/oldIndex`.