### PR TITLE
fix(combobox): update internal state after custom value is added

### DIFF
--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -56,7 +56,7 @@ import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/open
 import { DEBOUNCE } from "../../utils/resources";
 import { Scale, SelectionMode, Status } from "../interfaces";
 import { CSS as XButtonCSS, XButton } from "../functional/XButton";
-import { getIconScale } from "../../utils/component";
+import { getIconScale, isHidden } from "../../utils/component";
 import { Validation } from "../functional/Validation";
 import { IconNameOrString } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
@@ -64,7 +64,6 @@ import type { Chip } from "../chip/chip";
 import type { ComboboxItemGroup as HTMLCalciteComboboxItemGroupElement } from "../combobox-item-group/combobox-item-group";
 import type { ComboboxItem as HTMLCalciteComboboxItemElement } from "../combobox-item/combobox-item";
 import type { Label } from "../label/label";
-import { isHidden } from "../../utils/component";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { ComboboxChildElement, GroupData, ItemData, SelectionDisplay } from "./interfaces";
 import { ComboboxItemGroupSelector, ComboboxItemSelector, CSS, IDS } from "./resources";
@@ -1317,8 +1316,8 @@ export class Combobox
       );
       item.value = value;
       item.heading = value;
-      item.selected = true;
       this.el.prepend(item);
+      this.updateItems();
       this.toggleSelection(item, true);
       this.open = true;
       if (focus) {

--- a/packages/calcite-components/src/tests/utils.ts
+++ b/packages/calcite-components/src/tests/utils.ts
@@ -530,6 +530,35 @@ export async function toElementHandle(element: E2EElement): Promise<ElementHandl
  *
  * Note: values returned can only be serializable values.
  *
+ * @example
+ *
+ * it("props are updated on change emit", async () => {
+ *   const page = await newE2EPage();
+ *   await page.setContent(html`
+ *     <calcite-combobox>
+ *       <!-- ... -->
+ *     </calcite-combobox>
+ *   `);
+ *   const propValueAsserter = await createEventTimePropValuesAsserter<Combobox>(
+ *     page,
+ *     {
+ *       selector: "calcite-combobox",
+ *       eventName: "calciteComboboxChange",
+ *       props: ["value", "selectedItems"],
+ *     },
+ *     async (propValues) => {
+ *       expect(propValues.value).toBe("K");
+ *       expect(propValues.selectedItems).toHaveLength(1);
+ *     },
+ *   );
+ *   const combobox = await page.find("calcite-combobox");
+ *   await combobox.callMethod("setFocus");
+ *   await combobox.press("K");
+ *   await combobox.press("Enter");
+ *
+ *   await expect(propValueAsserter()).resolves.toBe(undefined);
+ * });
+ *
  * @param page
  * @param propValuesTarget
  * @param propValuesTarget.selector


### PR DESCRIPTION
**Related Issue:** #10731, #11382

## Summary

This updates the combobox internal state after an custom item is added.

**Note**: this also adds `createEventTimePropValuesAsserter` to help assert on event-emit time component state.
