### PR TITLE
fix(form): add ariaHidden property to the hidden form input

### DIFF
--- a/packages/calcite-components/src/components/autocomplete/autocomplete.e2e.ts
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.e2e.ts
@@ -35,6 +35,16 @@ const simpleHTML = html`
   </calcite-autocomplete>
 `;
 
+export const simpleFormHTML = html`<form>
+  <calcite-autocomplete name="test" label="Item list" id="myAutocomplete">
+    <calcite-autocomplete-item label="Item one" value="one" heading="Item one"></calcite-autocomplete-item>
+    <calcite-autocomplete-item label="Item two" value="two" heading="Item two"></calcite-autocomplete-item>
+    <calcite-autocomplete-item label="Item three" value="three" heading="Item three"></calcite-autocomplete-item>
+    <calcite-autocomplete-item label="Item four" value="four" heading="Item four"></calcite-autocomplete-item>
+    <calcite-autocomplete-item disabled label="Item five" value="five" heading="Item five"></calcite-autocomplete-item>
+  </calcite-autocomplete>
+</form>`;
+
 const simpleHTMLDisabledItems = html`
   <calcite-autocomplete label="Item list" id="myAutocomplete">
     <calcite-autocomplete-item label="Item one" value="one" heading="Item one"></calcite-autocomplete-item>
@@ -413,6 +423,8 @@ describe("calcite-autocomplete", () => {
 
   describe("accessible", () => {
     accessible(simpleHTML);
+    accessible(simpleFormHTML);
+    accessible(simpleGroupHTML);
     accessible(simpleGroupHTML);
   });
 

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -98,8 +98,8 @@ export function formAssociated(
     await page.waitForChanges();
     const component = await page.find(tag);
 
-    await assertValueSubmissionType(page, component, options);
     await assertAriaHidden(page, component);
+    await assertValueSubmissionType(page, component, options);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
 
@@ -127,8 +127,8 @@ export function formAssociated(
     await page.waitForChanges();
     const component = await page.find(tag);
 
-    await assertValueSubmissionType(page, component, options);
     await assertAriaHidden(page, component);
+    await assertValueSubmissionType(page, component, options);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
 

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -98,7 +98,7 @@ export function formAssociated(
     await page.waitForChanges();
     const component = await page.find(tag);
 
-    await assertAriaHidden(page, component);
+    await assertHiddenFormInputProps(page, component);
     await assertValueSubmissionType(page, component, options);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
@@ -127,7 +127,7 @@ export function formAssociated(
     await page.waitForChanges();
     const component = await page.find(tag);
 
-    await assertAriaHidden(page, component);
+    await assertHiddenFormInputProps(page, component);
     await assertValueSubmissionType(page, component, options);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
@@ -245,15 +245,15 @@ export function formAssociated(
     }
   }
 
-  async function assertAriaHidden(page: E2EPage, component: E2EElement): Promise<void> {
+  async function assertHiddenFormInputProps(page: E2EPage, component: E2EElement): Promise<void> {
     const name = await component.getProperty("name");
-    const ariaHidden = await page.evaluate(
-      async (inputName: string, hiddenFormInputSlotName: string): Promise<string> => {
+    const { ariaHidden } = await page.evaluate(
+      async (inputName: string, hiddenFormInputSlotName: string): Promise<{ ariaHidden: string }> => {
         const hiddenFormInput = document.querySelector<HTMLInputElement>(
           `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`,
         );
 
-        return hiddenFormInput.ariaHidden;
+        return { ariaHidden: hiddenFormInput.ariaHidden };
       },
       name,
       hiddenFormInputSlotName,

--- a/packages/calcite-components/src/tests/commonTests/formAssociated.ts
+++ b/packages/calcite-components/src/tests/commonTests/formAssociated.ts
@@ -99,6 +99,7 @@ export function formAssociated(
     const component = await page.find(tag);
 
     await assertValueSubmissionType(page, component, options);
+    await assertAriaHidden(page, component);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
 
@@ -127,6 +128,7 @@ export function formAssociated(
     const component = await page.find(tag);
 
     await assertValueSubmissionType(page, component, options);
+    await assertAriaHidden(page, component);
     await assertValueResetOnFormReset(page, component, options);
     await assertValueSubmittedOnFormSubmit(page, component, options);
 
@@ -241,6 +243,23 @@ export function formAssociated(
     } else {
       expect(hiddenFormInputType).toMatch(inputType);
     }
+  }
+
+  async function assertAriaHidden(page: E2EPage, component: E2EElement): Promise<void> {
+    const name = await component.getProperty("name");
+    const ariaHidden = await page.evaluate(
+      async (inputName: string, hiddenFormInputSlotName: string): Promise<string> => {
+        const hiddenFormInput = document.querySelector<HTMLInputElement>(
+          `[name="${inputName}"] input[slot=${hiddenFormInputSlotName}]`,
+        );
+
+        return hiddenFormInput.ariaHidden;
+      },
+      name,
+      hiddenFormInputSlotName,
+    );
+
+    expect(ariaHidden).toMatch("true");
   }
 
   async function assertValueResetOnFormReset(

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -499,7 +499,7 @@ function syncHiddenFormInput(component: FormComponent): void {
 
     if (!input) {
       input = ownerDocument.createElement("input");
-      input.setAttribute("aria-hidden", "true");
+      input.ariaHidden = "true";
       input.slot = hiddenFormInputSlotName;
     }
 

--- a/packages/calcite-components/src/utils/form.tsx
+++ b/packages/calcite-components/src/utils/form.tsx
@@ -499,6 +499,7 @@ function syncHiddenFormInput(component: FormComponent): void {
 
     if (!input) {
       input = ownerDocument.createElement("input");
+      input.setAttribute("aria-hidden", "true");
       input.slot = hiddenFormInputSlotName;
     }
 


### PR DESCRIPTION
**Related Issue:** #11419

## Summary

- adds `ariaHidden = "true"` property to the hidden form input when it is created
- adds test in autocomplete
- add formAssociated test to make sure hidden inputs are setting ariaHidden properly