### PR TITLE
fix(dialog): toggle focus-trap on DOM connect and disconnect

### DIFF
--- a/packages/calcite-components/src/controllers/useFocusTrap.ts
+++ b/packages/calcite-components/src/controllers/useFocusTrap.ts
@@ -24,11 +24,6 @@ export interface UseFocusTrap {
   overrideFocusTrapEl: (el: HTMLElement) => void;
 
   /**
-   * Returns true if the focus trap is ready
-   */
-  readonly ready: boolean;
-
-  /**
    * Updates focusable elements within the trap.
    *
    * @see https://github.com/focus-trap/focus-trap#trapupdatecontainerelements
@@ -91,9 +86,6 @@ export const useFocusTrap = <T extends LitElement>(
         }
 
         focusTrapEl = el;
-      },
-      get ready(): boolean {
-        return !!focusTrap;
       },
       updateContainerElements: () => {
         const targetEl = focusTrapEl || component.el;

--- a/packages/calcite-components/src/controllers/useFocusTrap.ts
+++ b/packages/calcite-components/src/controllers/useFocusTrap.ts
@@ -1,0 +1,104 @@
+import { makeGenericController } from "@arcgis/components-controllers";
+import { createFocusTrap, FocusTrap, Options as FocusTrapOptions } from "focus-trap";
+import { LitElement } from "@arcgis/lumina";
+import { createFocusTrapOptions } from "../utils/focusTrapComponent";
+
+export interface UseFocusTrap {
+  /**
+   * Activates the focus trap.
+   *
+   * @see https://github.com/focus-trap/focus-trap#trapactivate
+   */
+  activate: (options?: Parameters<FocusTrap["activate"]>[0]) => void;
+
+  /**
+   * Deactivates the focus trap.
+   *
+   * @see https://github.com/focus-trap/focus-trap#trapdeactivate
+   */
+  deactivate: (options?: Parameters<FocusTrap["deactivate"]>[0]) => void;
+
+  /**
+   * By default, the host element will be used as the focus-trap element, but if the focus-trap element needs to be a different element, use this method prior to activating to set the focus-trap element.
+   */
+  overrideFocusTrapEl: (el: HTMLElement) => void;
+
+  /**
+   * Returns true if the focus trap is ready
+   */
+  readonly ready: boolean;
+
+  /**
+   * Updates focusable elements within the trap.
+   *
+   * @see https://github.com/focus-trap/focus-trap#trapupdatecontainerelements
+   */
+  updateContainerElements: () => void;
+}
+
+interface UseFocusTrapOptions<T extends LitElement = LitElement> {
+  /**
+   * The name of the prop that will trigger the focus trap to activate.
+   */
+  triggerProp: keyof T;
+
+  /**
+   * Options to pass to the focus-trap library.
+   */
+  focusTrapOptions?: FocusTrapOptions;
+}
+
+/**
+ * A controller for managing focus traps.
+ *
+ * Note: traps will be deactivated automatically when the component is disconnected.
+ *
+ * @param options
+ */
+export const useFocusTrap = <T extends LitElement>(
+  options: UseFocusTrapOptions<T>,
+): ReturnType<typeof makeGenericController<UseFocusTrap, T>> => {
+  return makeGenericController<UseFocusTrap, T>((component, controller) => {
+    let focusTrap: FocusTrap;
+    let focusTrapEl: HTMLElement;
+    const { focusTrapOptions } = options;
+
+    controller.onConnected(() => {
+      if (component[options.triggerProp] && focusTrap) {
+        focusTrap.activate();
+      }
+    });
+    controller.onDisconnected(() => focusTrap?.deactivate());
+
+    return {
+      activate: (options?: Parameters<FocusTrap["activate"]>[0]) => {
+        const targetEl = focusTrapEl || component.el;
+
+        if (!targetEl.isConnected) {
+          return;
+        }
+
+        if (!focusTrap) {
+          focusTrap = createFocusTrap(targetEl, createFocusTrapOptions(targetEl, focusTrapOptions));
+        }
+
+        focusTrap.activate(options);
+      },
+      deactivate: (options?: Parameters<FocusTrap["deactivate"]>[0]) => focusTrap?.deactivate(options),
+      overrideFocusTrapEl: (el: HTMLElement) => {
+        if (focusTrap) {
+          throw new Error("Focus trap already created");
+        }
+
+        focusTrapEl = el;
+      },
+      get ready(): boolean {
+        return !!focusTrap;
+      },
+      updateContainerElements: () => {
+        const targetEl = focusTrapEl || component.el;
+        return focusTrap?.updateContainerElements(targetEl);
+      },
+    };
+  });
+};

--- a/packages/calcite-components/src/utils/focusTrapComponent.ts
+++ b/packages/calcite-components/src/utils/focusTrapComponent.ts
@@ -45,22 +45,32 @@ export function connectFocusTrap(component: FocusTrapComponent, options?: Connec
     return;
   }
 
-  const focusTrapOptions: FocusTrapOptions = {
+  component.focusTrap = createFocusTrap(focusTrapNode, createFocusTrapOptions(el, options?.focusTrapOptions));
+}
+
+/**
+ * Helper to create the FocusTrap options.
+ *
+ * @param hostEl
+ * @param options
+ */
+export function createFocusTrapOptions(hostEl: HTMLElement, options?: FocusTrapOptions): FocusTrapOptions {
+  const focusTrapNode = options?.fallbackFocus || hostEl;
+
+  return {
     clickOutsideDeactivates: true,
     fallbackFocus: focusTrapNode,
     setReturnFocus: (el) => {
       focusElement(el as FocusableElement);
       return false;
     },
-    ...options?.focusTrapOptions,
+    ...options,
 
     // the following options are not overridable
-    document: el.ownerDocument,
+    document: hostEl.ownerDocument,
     tabbableOptions,
     trapStack: focusTrapStack,
   };
-
-  component.focusTrap = createFocusTrap(focusTrapNode, focusTrapOptions);
 }
 
 /**


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Fixes an issue where a `focus-trap` instance might be left active after the dialog is removed.

### Relevant changes

* Adds `useFocusTrap` controller
* Extracts and exports function to create default `focus-trap` options