### PR TITLE
test(input-date-picker): date selection is independent of days in month

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -524,7 +524,7 @@ describe("calcite-input-date-picker", () => {
       await page.waitForChanges();
       expect(await calendar.isVisible()).toBe(true);
 
-      await selectDayInMonthByIndex(page, 30);
+      await selectDayInMonthByIndex(page, 28);
       expect(await calendar.isVisible()).toBe(false);
     });
 


### PR DESCRIPTION
**Related Issue:** # N/A

## Summary

Fixes the below test failure for `February` month.

https://github.com/Esri/calcite-design-system/blob/f208961506ebb5edc7a21ac40277b77b214ce883/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts#L513

