### PR TITLE
refactor(block, loader, progress): remove unnecessary sass import

### DIFF
--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -24,7 +24,6 @@
 
 @include disabled();
 
-@import "../../assets/styles/animation";
 @import "../../assets/styles/header";
 
 .header {

--- a/packages/calcite-components/src/components/loader/loader.scss
+++ b/packages/calcite-components/src/components/loader/loader.scss
@@ -15,8 +15,6 @@
  * @prop --calcite-loader-track-color: Specifies the component's track color.
  */
 
-@import "../../assets/styles/animation";
-
 :host {
   @apply flex relative mx-auto items-center justify-center opacity-100;
   flex-direction: column;

--- a/packages/calcite-components/src/components/progress/progress.scss
+++ b/packages/calcite-components/src/components/progress/progress.scss
@@ -8,8 +8,6 @@
 * @prop --calcite-progress-text-color: Specifies the component's text color.
 */
 
-@import "../../assets/styles/animation";
-
 :host {
   @apply relative block w-full;
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

- Remove unnecessary import
- This import is already imported in the includes sass file
