### PR TITLE
refactor(list, list-item): use constant for querySelector and remove unnecessary conditional

### DIFF
--- a/packages/calcite-components/src/components/list-item/utils.ts
+++ b/packages/calcite-components/src/components/list-item/utils.ts
@@ -42,7 +42,7 @@ export function getListItemChildren(slotEl: HTMLSlotElement): {
 export function updateListItemChildren(slotEl: HTMLSlotElement): void {
   const listItemChildren = slotEl
     .assignedElements({ flatten: true })
-    .filter((el): el is ListItem["el"] => el?.matches(listItemSelector));
+    .filter((el): el is ListItem["el"] => el.matches(listItemSelector));
 
   listItemChildren.forEach((listItem) => {
     listItem.setPosition = listItemChildren.indexOf(listItem) + 1;
@@ -65,5 +65,5 @@ export function getDepth(element: HTMLElement, includeGroup = false): number {
 }
 
 export function isListItem(element: Element): element is ListItem["el"] {
-  return element?.tagName === "CALCITE-LIST-ITEM";
+  return element.tagName === "CALCITE-LIST-ITEM";
 }

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -846,9 +846,9 @@ export class List
     const rootNode = getRootNode(el);
 
     const lists = group
-      ? Array.from(rootNode.querySelectorAll<List["el"]>(`calcite-list[group="${group}"]`)).filter(
-          (list) => !list.disabled && list.dragEnabled,
-        )
+      ? Array.from(
+          rootNode.querySelectorAll<List["el"]>(`${listSelector}[group="${group}"]`),
+        ).filter((list) => !list.disabled && list.dragEnabled)
       : [];
 
     this.moveToItems = lists.map((element) => ({


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

use constant for querySelector and remove unnecessary conditional