### PR TITLE
feat(modal, popover, sheet): add `focusTrapOptions`

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -70,7 +70,7 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
 
   private dragPosition: DialogDragPosition = { ...initialDragPosition };
 
-  focusTrap = useFocusTrap<Dialog>({
+  focusTrap = useFocusTrap<this>({
     triggerProp: "open",
     focusTrapOptions: {
       // scrim closes on click, so we let it take over
@@ -160,6 +160,9 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
    * @see [Dialog Accessibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#accessibility).
    */
   @property({ reflect: true }) escapeDisabled = false;
+
+  /** Allows special focus-trap configuration. */
+  @property() focusTrapOptions;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { FocusTrap } from "focus-trap";
 import { PropertyValues } from "lit";
 import {
   LitElement,
@@ -11,6 +10,7 @@ import {
   JsxNode,
   stringOrBoolean,
 } from "@arcgis/lumina";
+import { useFocusTrap } from "../../controllers/useFocusTrap";
 import {
   dateFromISO,
   dateFromLocalizedString,
@@ -64,12 +64,6 @@ import {
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
 import { DateLocaleData, getLocaleData, getValueAsDateRange } from "../date-picker/utils";
 import { HeadingLevel } from "../functional/Heading";
-import {
-  activateFocusTrap,
-  connectFocusTrap,
-  deactivateFocusTrap,
-  FocusTrapComponent,
-} from "../../utils/focusTrapComponent";
 import { guid } from "../../utils/guid";
 import { getIconScale } from "../../utils/component";
 import { Status } from "../interfaces";
@@ -97,7 +91,6 @@ export class InputDatePicker
   extends LitElement
   implements
     FloatingUIComponent,
-    FocusTrapComponent,
     FormComponent,
     InteractiveComponent,
     LabelableComponent,
@@ -136,11 +129,27 @@ export class InputDatePicker
 
   private focusOnOpen = false;
 
-  focusTrap: FocusTrap;
+  focusTrap = useFocusTrap<this>({
+    triggerProp: "open",
+    focusTrapOptions: {
+      onActivate: () => {
+        if (this.focusOnOpen) {
+          this.datePickerEl?.setFocus();
+          this.focusOnOpen = false;
+        }
+      },
+      allowOutsideClick: true,
+      // Allow outside click and let the popover manager take care of closing the popover.
+      clickOutsideDeactivates: false,
+      initialFocus: false,
+      setReturnFocus: false,
+      onDeactivate: this.focusTrapDeactivates,
+    },
+  })(this);
 
-  private focusTrapDeactivates = (): void => {
+  private focusTrapDeactivates(): void {
     this.open = false;
-  };
+  }
 
   formEl: HTMLFormElement;
 
@@ -460,10 +469,6 @@ export class InputDatePicker
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
-    if (changes.has("focusTrapDisabled") && (this.hasUpdated || this.focusTrapDisabled !== false)) {
-      this.handleFocusTrapDisabled(this.focusTrapDisabled);
-    }
-
     if (changes.has("disabled") && (this.hasUpdated || this.disabled !== false)) {
       this.handleDisabledAndReadOnlyChange(this.disabled);
     }
@@ -523,7 +528,6 @@ export class InputDatePicker
   }
 
   override disconnectedCallback(): void {
-    deactivateFocusTrap(this);
     disconnectLabel(this);
     disconnectForm(this);
     disconnectFloatingUI(this);
@@ -532,18 +536,6 @@ export class InputDatePicker
   // #endregion
 
   // #region Private Methods
-
-  private handleFocusTrapDisabled(focusTrapDisabled: boolean): void {
-    if (!this.open) {
-      return;
-    }
-
-    if (focusTrapDisabled) {
-      deactivateFocusTrap(this);
-    } else {
-      activateFocusTrap(this);
-    }
-  }
 
   private handleDisabledAndReadOnlyChange(value: boolean): void {
     if (!value) {
@@ -699,14 +691,7 @@ export class InputDatePicker
   }
 
   onOpen(): void {
-    activateFocusTrap(this, {
-      onActivate: () => {
-        if (this.focusOnOpen) {
-          this.datePickerEl?.setFocus();
-          this.focusOnOpen = false;
-        }
-      },
-    });
+    this.focusTrap.activate();
     this.calciteInputDatePickerOpen.emit();
   }
 
@@ -717,7 +702,7 @@ export class InputDatePicker
   onClose(): void {
     this.calciteInputDatePickerClose.emit();
     hideFloatingUI(this);
-    deactivateFocusTrap(this);
+    this.focusTrap.deactivate();
     this.focusOnOpen = false;
     this.datePickerEl?.reset();
   }
@@ -840,18 +825,12 @@ export class InputDatePicker
   }
 
   private setDatePickerRef(el: DatePicker["el"]): void {
+    if (!el) {
+      return;
+    }
+
     this.datePickerEl = el;
-    connectFocusTrap(this, {
-      focusTrapEl: el,
-      focusTrapOptions: {
-        allowOutsideClick: true,
-        // Allow outside click and let the popover manager take care of closing the popover.
-        clickOutsideDeactivates: false,
-        initialFocus: false,
-        setReturnFocus: false,
-        onDeactivate: this.focusTrapDeactivates,
-      },
-    });
+    this.focusTrap.overrideFocusTrapEl(el);
   }
 
   private async loadLocaleData(): Promise<void> {

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -1079,7 +1079,7 @@ export class InputTimePicker
         <calcite-popover
           autoClose={true}
           focusTrapDisabled={this.focusTrapDisabled}
-          initialFocusTrapFocus={false}
+          focusTrapOptions={{ initialFocus: false }}
           label={messages.chooseTime}
           lang={this.messages._lang}
           oncalcitePopoverBeforeClose={this.popoverBeforeCloseHandler}

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -156,6 +156,9 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
+  /** Allows configuring focus trap. */
+  @property() focusTrapOptions;
+
   /** Sets the component to always be fullscreen. Overrides `widthScale` and `--calcite-modal-width` / `--calcite-modal-height`. */
   @property({ reflect: true }) fullscreen: boolean;
 

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -156,9 +156,6 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
-  /** Allows configuring focus trap. */
-  @property() focusTrapOptions;
-
   /** Sets the component to always be fullscreen. Overrides `widthScale` and `--calcite-modal-width` / `--calcite-modal-height`. */
   @property({ reflect: true }) fullscreen: boolean;
 

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -131,9 +131,6 @@ export class Popover
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
-  /** Allows configuring focus trap. */
-  @property() focusTrapOptions;
-
   /** The component header text. */
   @property() heading: string;
 

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -11,7 +11,6 @@ import {
   JsxNode,
   setAttribute,
 } from "@arcgis/lumina";
-import { FocusTargetOrFalse } from "focus-trap";
 import {
   connectFloatingUI,
   defaultOffsetDistance,
@@ -27,14 +26,6 @@ import {
   ReferenceElement,
   reposition,
 } from "../../utils/floating-ui";
-import {
-  activateFocusTrap,
-  connectFocusTrap,
-  deactivateFocusTrap,
-  FocusTrap,
-  FocusTrapComponent,
-  updateFocusTrapElements,
-} from "../../utils/focusTrapComponent";
 import { focusFirstTabbable, queryElementRoots, toAriaBoolean } from "../../utils/dom";
 import { guid } from "../../utils/guid";
 import { onToggleOpenCloseComponent, OpenCloseComponent } from "../../utils/openCloseComponent";
@@ -51,6 +42,7 @@ import { FloatingArrow } from "../functional/FloatingArrow";
 import { getIconScale } from "../../utils/component";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
+import { useFocusTrap } from "../../controllers/useFocusTrap";
 import PopoverManager from "./PopoverManager";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { ARIA_CONTROLS, ARIA_EXPANDED, CSS, defaultPopoverPlacement } from "./resources";
@@ -67,7 +59,7 @@ const manager = new PopoverManager();
 /** @slot - A slot for adding custom content. */
 export class Popover
   extends LitElement
-  implements FloatingUIComponent, OpenCloseComponent, FocusTrapComponent, LoadableComponent
+  implements FloatingUIComponent, OpenCloseComponent, LoadableComponent
 {
   // #region Static Members
 
@@ -85,7 +77,20 @@ export class Popover
 
   floatingEl: HTMLDivElement;
 
-  focusTrap: FocusTrap;
+  focusTrap = useFocusTrap<this>({
+    triggerProp: "open",
+    focusTrapOptions: {
+      allowOutsideClick: true,
+      escapeDeactivates: (event) => {
+        if (!event.defaultPrevented) {
+          this.open = false;
+          event.preventDefault();
+        }
+
+        return false;
+      },
+    },
+  })(this);
 
   private guid = `calcite-popover-${guid()}`;
 
@@ -126,17 +131,14 @@ export class Popover
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
+  /** Allows configuring focus trap. */
+  @property() focusTrapOptions;
+
   /** The component header text. */
   @property() heading: string;
 
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
-
-  /**
-   * Specifies whether focus should move to the popover when the focus trap is activated.
-   *  `@internal`
-   */
-  @property({ type: Boolean }) initialFocusTrapFocus: FocusTargetOrFalse;
 
   /**
    * Accessible name for the component.
@@ -251,7 +253,7 @@ export class Popover
   /** Updates the element(s) that are used within the focus-trap of the component. */
   @method()
   async updateFocusTrapElements(): Promise<void> {
-    updateFocusTrapElements(this);
+    this.focusTrap.updateContainerElements();
   }
 
   // #endregion
@@ -277,21 +279,6 @@ export class Popover
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
     this.setFilteredPlacements();
-    connectFocusTrap(this, {
-      focusTrapEl: this.el,
-      focusTrapOptions: {
-        allowOutsideClick: true,
-        escapeDeactivates: (event) => {
-          if (!event.defaultPrevented) {
-            this.open = false;
-            event.preventDefault();
-          }
-
-          return false;
-        },
-        initialFocus: this.initialFocusTrapFocus,
-      },
-    });
 
     // we set up the ref element in the next frame to ensure PopoverManager
     // event handlers are invoked after connect (mainly for `components` output target)
@@ -307,10 +294,6 @@ export class Popover
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
-    if (changes.has("focusTrapDisabled") && (this.hasUpdated || this.focusTrapDisabled !== false)) {
-      this.handleFocusTrapDisabled(this.focusTrapDisabled);
-    }
-
     if (changes.has("flipPlacements")) {
       this.flipPlacementsHandler();
     }
@@ -348,24 +331,11 @@ export class Popover
     this.mutationObserver?.disconnect();
     this.removeReferences();
     disconnectFloatingUI(this);
-    deactivateFocusTrap(this);
   }
 
   // #endregion
 
   // #region Private Methods
-
-  private handleFocusTrapDisabled(focusTrapDisabled: boolean): void {
-    if (!this.open) {
-      return;
-    }
-
-    if (focusTrapDisabled) {
-      deactivateFocusTrap(this);
-    } else {
-      activateFocusTrap(this);
-    }
-  }
 
   private flipPlacementsHandler(): void {
     this.setFilteredPlacements();
@@ -486,7 +456,7 @@ export class Popover
 
   onOpen(): void {
     this.calcitePopoverOpen.emit();
-    activateFocusTrap(this);
+    this.focusTrap.activate();
   }
 
   onBeforeClose(): void {
@@ -496,7 +466,7 @@ export class Popover
   onClose(): void {
     this.calcitePopoverClose.emit();
     hideFloatingUI(this);
-    deactivateFocusTrap(this);
+    this.focusTrap.deactivate();
   }
 
   private storeArrowEl(el: SVGSVGElement): void {

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -131,6 +131,9 @@ export class Popover
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
+  /** Allows configuring focus trap. */
+  @property() focusTrapOptions;
+
   /** The component header text. */
   @property() heading: string;
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -141,9 +141,6 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
-  /** Allows configuring focus trap. */
-  @property() focusTrapOptions;
-
   /**
    * When `position` is `"block-start"` or `"block-end"`, specifies the height of the component.
    *

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -141,6 +141,9 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
   /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
+  /** Allows configuring focus trap. */
+  @property() focusTrapOptions;
+
   /**
    * When `position` is `"block-start"` or `"block-end"`, specifies the height of the component.
    *


### PR DESCRIPTION
**Related Issue:** #11345

## Summary

Adds `focusTrapOptions` prop to align with https://github.com/Esri/calcite-design-system/pull/11453.
