### PR TITLE
docs(sheet): add default slot for docs

### DIFF
--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -44,7 +44,7 @@ declare global {
     "calcite-sheet": Sheet;
   }
 }
-
+/** @slot - A slot for adding custom content. */
 export class Sheet
   extends LitElement
   implements OpenCloseComponent, FocusTrapComponent, LoadableComponent


### PR DESCRIPTION
**Related Issue:** #11452

## Summary
Adds the `sheet`'s default slot for inclusion in our documentation pages.
