### PR TITLE
fix(table): Fix `bordered` styling in Firefox

### DIFF
--- a/packages/calcite-components/src/components/table-row/table-row.scss
+++ b/packages/calcite-components/src/components/table-row/table-row.scss
@@ -26,8 +26,12 @@ tr {
   background-color: var(--calcite-internal-table-row-background);
 }
 
-/* Workaround for Firefox hhttps://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
-// ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️
+tr.last-visible-row {
+  border-block-end: 0;
+}
+
+/* Workaround for Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+/* ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️ */
 @-moz-document url-prefix() {
   tr {
     box-shadow: inset 0 -1px 0 0 var(--calcite-internal-table-row-border-color);
@@ -35,10 +39,6 @@ tr {
   tr.last-visible-row {
     box-shadow: inset 0 -1px 0 0 transparent;
   }
-}
-
-tr.last-visible-row {
-  border-block-end: 0;
 }
 
 @include item-hidden();

--- a/packages/calcite-components/src/components/table-row/table-row.scss
+++ b/packages/calcite-components/src/components/table-row/table-row.scss
@@ -26,6 +26,17 @@ tr {
   background-color: var(--calcite-internal-table-row-background);
 }
 
+/* Workaround for Firefox hhttps://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+// ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️
+@-moz-document url-prefix() {
+  tr {
+    box-shadow: inset 0 -1px 0 0 var(--calcite-internal-table-row-border-color);
+  }
+  tr.last-visible-row {
+    box-shadow: inset 0 -1px 0 0 transparent;
+  }
+}
+
 tr.last-visible-row {
   border-block-end: 0;
 }

--- a/packages/calcite-components/src/components/table/table.scss
+++ b/packages/calcite-components/src/components/table/table.scss
@@ -39,6 +39,15 @@ table {
   overflow-x: scroll;
 }
 
+/* Workaround for Firefox hhttps://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+// ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️
+@-moz-document url-prefix() {
+  table {
+    @apply border-separate;
+    border-spacing: 0;
+  }
+}
+
 .table--fixed {
   @apply table-fixed;
 }

--- a/packages/calcite-components/src/components/table/table.scss
+++ b/packages/calcite-components/src/components/table/table.scss
@@ -39,8 +39,8 @@ table {
   overflow-x: scroll;
 }
 
-/* Workaround for Firefox hhttps://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
-// ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️
+/* Workaround for Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+/* ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️ */
 @-moz-document url-prefix() {
   table {
     @apply border-separate;

--- a/packages/calcite-components/src/demos/table.html
+++ b/packages/calcite-components/src/demos/table.html
@@ -30,7 +30,7 @@
         margin: 2rem auto;
       }
 
-      calcite-modal calcite-table {
+      calcite-dialog calcite-table {
         margin: 0;
         width: auto;
       }
@@ -237,8 +237,8 @@
 
   <body>
     <demo-dom-swapper>
-      <calcite-modal id="modal" open>
-        <div slot="content" class="table-wrapper">
+      <calcite-dialog id="dialog" modal open>
+        <div class="table-wrapper">
           <calcite-table caption="Simple">
             <calcite-table-row slot="table-header">
               <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
@@ -382,7 +382,7 @@
             </calcite-table-row>
           </calcite-table>
         </div>
-      </calcite-modal>
+      </calcite-dialog>
       <h3>Programmatic row selection testing</h3>
 
       <calcite-table

--- a/packages/calcite-components/src/demos/table.html
+++ b/packages/calcite-components/src/demos/table.html
@@ -238,150 +238,148 @@
   <body>
     <demo-dom-swapper>
       <calcite-dialog id="dialog" modal open>
-        <div class="table-wrapper">
-          <calcite-table caption="Simple">
-            <calcite-table-row slot="table-header">
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
-              <calcite-table-header heading="Last Heading" alignment="end"></calcite-table-header>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-            <calcite-table-row>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell>cell content</calcite-table-cell>
-              <calcite-table-cell alignment="end">cell content</calcite-table-cell>
-            </calcite-table-row>
-          </calcite-table>
-        </div>
+        <calcite-table caption="Simple">
+          <calcite-table-row slot="table-header">
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Heading" description="Description"></calcite-table-header>
+            <calcite-table-header heading="Last Heading" alignment="end"></calcite-table-header>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+          <calcite-table-row>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell>cell content</calcite-table-cell>
+            <calcite-table-cell alignment="end">cell content</calcite-table-cell>
+          </calcite-table-row>
+        </calcite-table>
       </calcite-dialog>
       <h3>Programmatic row selection testing</h3>
 


### PR DESCRIPTION
**Related Issue:** #11464

## Summary
Adds a set of styling rules to address a Firefox-specific styling bug with a "not best practice" disclaimer.
Also updates the Table "local demo" to use Dialog instead of Modal.

Note: in FF - the Table ends up being slightly taller because of this adjustment - however, prior to this change, there was a greater difference in height ...


| Before    | After |
| -------- | ------- |
| ![Screenshot 2025-02-05 at 3 11 36 PM](https://github.com/user-attachments/assets/86677e1e-2415-4244-886e-3671cbd01ee1)  | ![Screenshot 2025-02-05 at 3 10 24 PM](https://github.com/user-attachments/assets/159c5310-a8bc-4f94-a388-8ab52accef25)  |

 