### PR TITLE
docs(time-picker): add description to time picker change event

### DIFF
--- a/packages/calcite-components/src/components/time-picker/time-picker.tsx
+++ b/packages/calcite-components/src/components/time-picker/time-picker.tsx
@@ -164,6 +164,7 @@ export class TimePicker extends LitElement implements LoadableComponent {
 
   // #region Events
 
+  /** Fires when a user changes the component's time */
   calciteTimePickerChange = createEvent({ cancelable: false });
 
   // #endregion


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Realized the `calciteTimePickerChange` event was missing a description, so this adds one.