### PR TITLE
fix(table): Fix `bordered` styling in Firefox

### DIFF
--- a/packages/calcite-components/src/components/table-cell/resources.ts
+++ b/packages/calcite-components/src/components/table-cell/resources.ts
@@ -6,5 +6,6 @@ export const CSS = {
   selectedCell: "selected-cell",
   assistiveText: "assistive-text",
   lastCell: "last-cell",
+  lastRow: "last-row",
   staticCell: "static-cell",
 };

--- a/packages/calcite-components/src/components/table-cell/table-cell.scss
+++ b/packages/calcite-components/src/components/table-cell/table-cell.scss
@@ -70,7 +70,7 @@ td.last-cell {
 /* Workaround for Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
 /* ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️ */
 @-moz-document url-prefix() {
-  .number-cell:not(.last-row) {
+  .number-cell:not(.last-row):not(.footer-cell) {
     box-shadow: inset 0 -1px 0 0 var(--calcite-internal-table-row-border-color);
   }
 }

--- a/packages/calcite-components/src/components/table-cell/table-cell.scss
+++ b/packages/calcite-components/src/components/table-cell/table-cell.scss
@@ -67,6 +67,14 @@ td.last-cell {
   min-inline-size: 2rem;
 }
 
+/* Workaround for Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=688556 */
+/* ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️ */
+@-moz-document url-prefix() {
+  .number-cell:not(.last-row) {
+    box-shadow: inset 0 -1px 0 0 var(--calcite-internal-table-row-border-color);
+  }
+}
+
 .selection-cell {
   @apply text-color-3;
   inset-inline-start: 2rem;

--- a/packages/calcite-components/src/components/table-cell/table-cell.tsx
+++ b/packages/calcite-components/src/components/table-cell/table-cell.tsx
@@ -86,6 +86,9 @@ export class TableCell extends LitElement implements InteractiveComponent, Loada
   @property() parentRowAlignment: Alignment = "start";
 
   /** @private */
+  @property() parentRowIsLast: boolean;
+
+  /** @private */
   @property() parentRowIsSelected: boolean;
 
   /** @private */
@@ -185,6 +188,7 @@ export class TableCell extends LitElement implements InteractiveComponent, Loada
             [CSS.numberCell]: this.numberCell,
             [CSS.selectionCell]: this.selectionCell,
             [CSS.selectedCell]: this.parentRowIsSelected,
+            [CSS.lastRow]: this.parentRowIsLast,
             [CSS.lastCell]: this.lastCell && (!this.rowSpan || (this.colSpan && !!this.rowSpan)),
             [CSS_UTILITY.rtl]: dir === "rtl",
             [CSS.staticCell]: staticCell,

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -319,6 +319,7 @@ export class TableRow extends LitElement implements InteractiveComponent {
         if (cell.nodeName === "CALCITE-TABLE-CELL") {
           (cell as TableCell["el"]).readCellContentsToAT = this.readCellContentsToAT;
           (cell as TableCell["el"]).disabled = this.disabled;
+          (cell as TableCell["el"]).parentRowIsLast = this.lastVisibleRow;
         }
       });
     }

--- a/packages/calcite-components/src/components/table/table.e2e.ts
+++ b/packages/calcite-components/src/components/table/table.e2e.ts
@@ -2103,13 +2103,13 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.selectionCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowRight");
     await page.waitForChanges();
@@ -2198,13 +2198,13 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.numberCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.numberCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowRight");
     await page.waitForChanges();
@@ -2299,19 +2299,19 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.selectionCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowLeft");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.numberCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowRight");
     await page.waitForChanges();
@@ -2406,13 +2406,13 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.selectionCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row2.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowRight");
     await page.waitForChanges();
@@ -2431,7 +2431,7 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.numberCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.down("ControlLeft");
     await page.keyboard.press("Home");
@@ -2534,19 +2534,19 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.numberCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row2.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.numberCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowRight");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row2.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
@@ -2561,7 +2561,7 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.numberCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.down("ControlRight");
     await page.keyboard.press("Home");
@@ -2621,19 +2621,19 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.selectionCell, "2": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row4.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowLeft");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row4.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.numberCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.down("ControlRight");
     await page.keyboard.press("End");
@@ -2648,7 +2648,7 @@ describe("keyboard navigation", () => {
         `#${rowFoot.id}`,
         (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList,
       ),
-    ).toEqual({ "0": CELL_CSS.footerCell, "1": CSS.numberCell });
+    ).toEqual({ "0": CELL_CSS.footerCell, "1": CELL_CSS.numberCell, "2": CELL_CSS.lastRow });
   });
 
   it("navigates correctly when number and selection column present numbered and interaction-mode static - only focusing selection cells", async () => {
@@ -2731,12 +2731,12 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
     expect(
       await page.$eval(`#${row3.id}`, (el) => el.shadowRoot?.activeElement.shadowRoot?.querySelector("td").classList),
-    ).toEqual({ "0": CSS.selectionCell });
+    ).toEqual({ "0": CELL_CSS.selectionCell, "1": CELL_CSS.lastRow });
   });
 });


### PR DESCRIPTION
**Related Issue:** #11464 / Follow up from PR https://github.com/Esri/calcite-design-system/pull/11466

## Summary
A small cleanup / property addition to support border on the `numbered` cells which are internally rendered. This is just to support FF - no changes in other browsers should occur.

| Before    | After |
| -------- | ------- |
|  ![Screenshot 2025-02-06 at 9 16 56 AM](https://github.com/user-attachments/assets/a1f21b4a-8322-44b8-9945-539e80b1167b) |  ![Screenshot 2025-02-06 at 9 16 46 AM](https://github.com/user-attachments/assets/8b017764-fb68-472d-a78e-5cf492bf4594) |


BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE