### PR TITLE
feat(split-button): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -243,8 +243,6 @@
   a {
     --calcite-internal-button-border-color: var(--calcite-color-transparent);
 
-    @apply border-solid;
-
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -312,6 +310,7 @@
 :host([appearance="outline"]) {
   a,
   button {
+    @apply border-solid;
     box-shadow: inset 0 0 0 1px
       var(--calcite-button-shadow-color, var(--calcite-internal-button-shadow-color, transparent));
 
@@ -437,10 +436,9 @@
 :host([appearance="outline"]) {
   button,
   a {
-    --calcite-internal-button-background-color: var(--calcite-color-transparent);
-
     @apply border-solid;
     border-width: var(--calcite-button-border-size, 1px);
+    background-color: transparent;
   }
 }
 :host([appearance="outline"][kind="brand"]) {
@@ -448,7 +446,6 @@
   a {
     --calcite-internal-button-border-color: var(--calcite-color-brand);
     --calcite-internal-button-text-color: theme("colors.brand");
-    --calcite-internal-button-background-color: var(--calcite-color-transparent);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-brand-hover);
@@ -475,7 +472,6 @@
   a {
     --calcite-internal-button-border-color: var(--calcite-color-status-danger);
     --calcite-internal-button-text-color: theme("colors.danger");
-    --calcite-internal-button-background-color: var(--calcite-color-transparent);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-hover);
@@ -501,7 +497,7 @@
   button,
   a {
     --calcite-internal-button-text-color: var(--calcite-color-text-1);
-    --calcite-internal-button-background-color: var(--calcite-color-transparent);
+
     --calcite-internal-button-border-color: theme("borderColor.color.1");
 
     &:hover {
@@ -519,7 +515,7 @@
   button,
   a {
     --calcite-internal-button-text-color: var(--calcite-color-text-1);
-    --calcite-internal-button-background-color: var(--calcite-color-transparent);
+
     --calcite-internal-button-border-color: var(--calcite-color-inverse);
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-hover);
@@ -553,6 +549,7 @@
   button,
   a {
     background-color: var(--calcite-color-transparent);
+
     &:hover,
     &:focus {
       background-color: var(--calcite-color-transparent-hover);

--- a/packages/calcite-components/src/components/split-button/split-button.e2e.ts
+++ b/packages/calcite-components/src/components/split-button/split-button.e2e.ts
@@ -2,9 +2,10 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, disabled, focusable, hidden, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, disabled, focusable, hidden, reflects, renders, themed } from "../../tests/commonTests";
 import { CSS as DropdownCSS } from "../dropdown/resources";
 import { findAll } from "../../tests/utils";
+import { ComponentTestTokens } from "../../tests/commonTests/themed";
 
 describe("calcite-split-button", () => {
   describe("defaults", () => {
@@ -260,5 +261,29 @@ describe("calcite-split-button", () => {
     await page.keyboard.press("Enter");
     await dropdownCloseEvent;
     expect(await positionContainer.isVisible()).toBe(false);
+  });
+
+  describe("theme", () => {
+    const tokens: ComponentTestTokens = {
+      "--calcite-split-button-background-color": {
+        shadowSelector: "calcite-button",
+        targetProp: "--calcite-button-background-color",
+      },
+      "--calcite-split-button-background-color-hover": {
+        shadowSelector: "calcite-button",
+        targetProp: "--calcite-button-background-color",
+        state: "hover",
+      },
+      "--calcite-split-button-background-color-press": {
+        shadowSelector: "calcite-button",
+        targetProp: "--calcite-button-background-color",
+        state: { press: "calcite-split-button >>> calcite-button" },
+      },
+      "--calcite-split-button-divider-color": {
+        shadowSelector: ".divider",
+        targetProp: "backgroundColor",
+      },
+    };
+    themed(`calcite-split-button`, tokens);
   });
 });

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -1,5 +1,40 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-split-button-background-color: Specifies the component's background color when appearance="solid" or appearance="outline-fill".
+ * @prop --calcite-split-button-background-color-hover: Specifies the component's background color when appearance="solid" or appearance="outline-fill" and hovered.
+ * @prop --calcite-split-button-background-color-press: Specifies the component's background color when appearance="solid" or appearance="outline-fill" and active.
+ * @prop --calcite-split-button-divider-color: Specifies the component's divider color.
+ */
+
 :host {
   @apply inline-block;
+}
+
+calcite-button {
+  --calcite-button-background-color: var(
+    --calcite-split-button-background-color,
+    var(--calcite-internal-split-button-background-color)
+  );
+  --calcite-button-border-color: var(
+    --calcite-split-button-divider-color,
+    var(--calcite-internal-split-button-divider-color)
+  );
+
+  &:hover {
+    --calcite-button-background-color: var(
+      --calcite-split-button-background-color-hover,
+      var(--calcite-internal-split-button-background-color-hover)
+    );
+  }
+  &:active {
+    --calcite-button-background-color: var(
+      --calcite-split-button-background-color-press,
+      var(--calcite-internal-split-button-background-color-press)
+    );
+  }
 }
 
 :host([width="auto"]) {
@@ -15,47 +50,59 @@
 }
 
 :host([kind="brand"]) {
-  --calcite-internal-split-button-background: theme("colors.brand");
-  --calcite-internal-split-button-divider: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color: theme("colors.brand");
+  --calcite-internal-split-button-divider-color: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color-press: theme("colors.brand-press");
+  --calcite-internal-split-button-background-color-hover: theme("colors.brand-hover");
 }
 
 :host([kind="danger"]) {
-  --calcite-internal-split-button-background: theme("colors.danger");
-  --calcite-internal-split-button-divider: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color: theme("colors.danger");
+  --calcite-internal-split-button-divider-color: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color-press: theme("colors.danger-press");
+  --calcite-internal-split-button-background-color-hover: theme("colors.danger-hover");
 }
 
 :host([kind="neutral"]) {
-  --calcite-internal-split-button-background: theme("colors.background.foreground.3");
-  --calcite-internal-split-button-divider: theme("colors.color.1");
+  --calcite-internal-split-button-background-color: theme("colors.background.foreground.3");
+  --calcite-internal-split-button-divider-color: theme("colors.color.1");
+  --calcite-internal-split-button-background-color-hover: theme("colors.background.foreground.2");
+  --calcite-internal-split-button-background-color-press: theme("colors.background.foreground.1");
 }
 
 :host([kind="inverse"]) {
-  --calcite-internal-split-button-background: var(--calcite-color-inverse);
-  --calcite-internal-split-button-divider: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color: var(--calcite-color-inverse);
+  --calcite-internal-split-button-divider-color: theme("colors.background.foreground.1");
+  --calcite-internal-split-button-background-color-hover: var(--calcite-color-inverse-hover);
+  --calcite-internal-split-button-background-color-press: var(--calcite-color-inverse-press);
 }
 
 :host([appearance="transparent"]) {
-  --calcite-internal-split-button-background: transparent;
   &:host([kind="brand"]) {
-    --calcite-internal-split-button-divider: theme("colors.brand");
+    --calcite-internal-split-button-divider-color: theme("colors.brand");
   }
   &:host([kind="danger"]) {
-    --calcite-internal-split-button-divider: theme("colors.danger");
+    --calcite-internal-split-button-divider-color: theme("colors.danger");
   }
   &:host([kind="neutral"]) {
-    --calcite-internal-split-button-divider: theme("colors.color.1");
+    --calcite-internal-split-button-divider-color: theme("colors.color.1");
   }
   &:host([kind="inverse"]) {
-    --calcite-internal-split-button-divider: theme("colors.background.foreground.1");
+    --calcite-internal-split-button-divider-color: theme("colors.background.foreground.1");
+  }
+
+  .divider-container {
+    background-color: transparent;
   }
 }
 
-:host([appearance="outline"]) {
+:host([appearance="outline"]),
+:host([appearance="transparent"]) {
   &:host([kind="brand"]),
   &:host([kind="danger"]),
   &:host([kind="neutral"]),
   &:host([kind="inverse"]) {
-    --calcite-internal-split-button-background: transparent;
+    --calcite-internal-split-button-background-color: transparent;
   }
 }
 
@@ -64,23 +111,32 @@
   &:host([kind="danger"]),
   &:host([kind="neutral"]),
   &:host([kind="inverse"]) {
-    --calcite-internal-split-button-background: var(--calcite-color-background);
+    --calcite-internal-split-button-background-color: var(--calcite-color-background);
   }
 }
 
 :host([appearance="outline"]),
 :host([appearance="outline-fill"]) {
   &:host([kind="brand"]) {
-    --calcite-internal-split-button-divider: theme("colors.brand");
+    --calcite-internal-split-button-divider-color: theme("colors.brand");
   }
   &:host([kind="danger"]) {
-    --calcite-internal-split-button-divider: theme("colors.danger");
+    --calcite-internal-split-button-divider-color: theme("colors.danger");
   }
   &:host([kind="neutral"]) {
-    --calcite-internal-split-button-divider: theme("borderColor.color.1");
+    --calcite-internal-split-button-divider-color: theme("borderColor.color.1");
   }
   &:host([kind="inverse"]) {
-    --calcite-internal-split-button-divider: var(--calcite-color-inverse);
+    --calcite-internal-split-button-divider-color: var(--calcite-color-inverse);
+  }
+
+  &:host(:focus-within) {
+    &:host([kind="brand"]) {
+      --calcite-internal-split-button-divider-color: theme("colors.brand-press");
+    }
+    &:host([kind="danger"]) {
+      --calcite-internal-split-button-divider-color: theme("colors.danger-press");
+    }
   }
 }
 
@@ -93,41 +149,37 @@
 
 .divider-container {
   @apply transition-default flex w-px items-stretch;
-  background-color: var(--calcite-internal-split-button-background);
+  background-color: var(--calcite-split-button-background-color, var(--calcite-internal-split-button-background-color));
 }
 
 .divider {
   @apply my-1 inline-block w-px;
-  background-color: var(--calcite-internal-split-button-divider);
+  background-color: var(--calcite-split-button-divider-color, var(--calcite-internal-split-button-divider-color));
 }
 
 :host([appearance="outline-fill"]),
-:host([appearance="outline"]) {
-  .divider-container {
-    border-block: 1px solid var(--calcite-internal-split-button-divider);
-  }
-  &:hover .divider-container {
-    background-color: var(--calcite-internal-split-button-divider);
-  }
-}
-
 :host([appearance="outline-fill"]:hover),
-:host([appearance="outline"]:hover) {
+:host([appearance="outline-fill"]:focus-within) {
   .divider-container {
-    background-color: var(--calcite-internal-split-button-divider);
+    background-color: var(
+      --calcite-split-button-background-color,
+      var(--calcite-internal-split-button-background-color)
+    );
   }
 }
 
-:host([appearance="outline-fill"]:focus-within),
+:host([appearance="outline"]),
+:host([appearance="outline"]:hover),
 :host([appearance="outline"]:focus-within) {
-  &:host([kind="brand"]) {
-    --calcite-internal-split-button-divider: theme("colors.brand-press");
-  }
-  &:host([kind="danger"]) {
-    --calcite-internal-split-button-divider: theme("colors.danger-press");
-  }
   .divider-container {
-    background-color: var(--calcite-internal-split-button-divider);
+    background-color: var(--calcite-split-button-divider-color, var(--calcite-internal-split-button-divider-color));
+  }
+}
+
+:host(:is([appearance="outline-fill"], [appearance="outline"])) {
+  .divider-container {
+    border-block: 1px solid
+      var(--calcite-split-button-divider-color, var(--calcite-internal-split-button-divider-color));
   }
 }
 
@@ -136,7 +188,7 @@
     @apply pointer-events-none;
   }
   &:host([appearance="outline-fill"]) .divider-container {
-    background-color: var(--calcite-color-background);
+    background-color: var(--calcite-split-button-background-color, var(--calcite-color-background));
   }
   &:host([appearance="outline"]) .divider-container {
     background-color: transparent;

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -15,7 +15,7 @@ import { accordionItemTokens } from "./custom-theme/accordion-item";
 import { accordion, accordionTokens } from "./custom-theme/accordion";
 import { autocomplete, autocompleteTokens } from "./custom-theme/autocomplete";
 import { block, blockTokens } from "./custom-theme/block";
-import { buttons } from "./custom-theme/button";
+import { buttons, buttonTokens } from "./custom-theme/button";
 import { blockSection, blockSectionTokens } from "./custom-theme/block-section";
 import { calciteSwitch } from "./custom-theme/switch";
 import { card, cardThumbnail, cardTokens } from "./custom-theme/card";
@@ -45,6 +45,7 @@ import { select, selectTokens } from "./custom-theme/select";
 import { rating, ratingTokens } from "./custom-theme/rating";
 import { slider, sliderTokens } from "./custom-theme/slider";
 import { switchTokens } from "./custom-theme/switch";
+import { splitButton, splitButtonTokens } from "./custom-theme/switch";
 import { tabs, tabsBordered, tabsTokens } from "./custom-theme/tabs";
 import { textArea, textAreaTokens } from "./custom-theme/text-area";
 import { tooltip, tooltipTokens } from "./custom-theme/tooltip";
@@ -141,7 +142,7 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
         ${comboboxItem}
       </div>
       <div class="demo-column">
-        ${navigation} ${navigationLogos} ${navigationUsers} ${blockSection} ${block} ${rating}
+        ${navigation} ${navigationLogos} ${navigationUsers} ${blockSection} ${block} ${rating} ${splitButton}
       </div>
       <div class="demo-column"><div class="demo-column">${alert}</div></div>
       <div class="demo-column">${menuItem}</div>
@@ -162,6 +163,7 @@ const componentTokens = {
   ...avatarTokens,
   ...blockSectionTokens,
   ...blockTokens,
+  ...buttonTokens,
   ...cardTokens,
   ...checkboxTokens,
   ...chipTokens,
@@ -185,6 +187,7 @@ const componentTokens = {
   ...ratingTokens,
   ...selectTokens,
   ...sliderTokens,
+  ...splitButtonTokens,
   ...switchTokens,
   ...tabsTokens,
   ...textAreaTokens,

--- a/packages/calcite-components/src/custom-theme/button.ts
+++ b/packages/calcite-components/src/custom-theme/button.ts
@@ -2,6 +2,15 @@ import { html } from "../../support/formatting";
 
 const buttonProps: [args: string, content: string] = ["", ""];
 
+export const buttonTokens = {
+  calciteButtonBackgroundColor: "",
+  calciteButtonBorderColor: "",
+  calciteButtonCornerRadius: "",
+  calciteButtonLoaderColor: "",
+  calciteButtonShadowColor: "",
+  calciteButtonTextColor: "",
+};
+
 export const button = (props: { kind?: string; appearance?: string }): string => {
   const [buttonArgs, content] = Object.entries(props)
     .filter(([key, value]) => key && value && value !== "")

--- a/packages/calcite-components/src/custom-theme/split-button.ts
+++ b/packages/calcite-components/src/custom-theme/split-button.ts
@@ -1,0 +1,24 @@
+import { html } from "../../support/formatting";
+
+const splitButtonProps: [args: string, content: string] = ["", ""];
+
+export const splitButtonTokens = {
+  calciteSplitButtonBackgroundColor: "",
+  calciteSplitButtonBackgroundColorHover: "",
+  calciteSplitButtonBackgroundColorPress: "",
+  calciteSplitButtonDividerColor: "",
+};
+
+export const splitButton = (props: { kind?: string; appearance?: string }): string => {
+  const [splitButtonArgs, content] = Object.entries(props)
+    .filter(([key, value]) => key && value && value !== "")
+    .reduce(([args, content], [key, value]) => {
+      args += `${key}="${value}" `;
+      content += `${value} `;
+      return [args, content];
+    }, splitButtonProps);
+
+  return html`<calcite-split-button ${splitButtonArgs.trim()}>${content.trim()}</calcite-split-button>`;
+};
+
+export const splitButtons = html`${splitButton({ appearance: "outline" })} ${splitButton({ kind: "danger" })}`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Add component tokens

--calcite-split-button-background-color: Specifies the component's background color when appearance="solid" or appearance="outline-fill".
--calcite-split-button-background-color-hover: Specifies the component's background color when appearance="solid" or appearance="outline-fill" and hovered.
--calcite-split-button-background-color-press: Specifies the component's background color when appearance="solid" or appearance="outline-fill" and active.
--calcite-split-button-divider-color: Specifies the component's divider color.