### PR TITLE
refactor(text-area): clear maxLength instead of directly setting it to the default

### DIFF
--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -467,7 +467,7 @@ export class TextArea
           }}
           cols={this.columns}
           disabled={this.disabled}
-          maxLength={this.limitText ? this.maxLength : -1}
+          maxLength={this.limitText ? this.maxLength : undefined}
           name={this.name}
           onChange={this.handleChange}
           onInput={this.handleInput}


### PR DESCRIPTION
**Related Issue:** #10175

## Summary

Ensures `maxLength` is properly cleared in the internal `<textarea>` when `inputText` is set to `false`. Otherwise, it would be set to `-1`, which could interfere with external test utils.