### PR TITLE
feat(action): enhance component's interactivity states

### DIFF
--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -162,7 +162,7 @@
 
 :host([appearance="transparent"]) {
   &:host([active]) .button {
-    background-color: var(--calcite-color-transparent-hover);
+    background-color: var(--calcite-color-transparent-press);
   }
 
   .button {

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -74,8 +74,7 @@
   flex: 1 0 auto;
   cursor: inherit;
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: var(--calcite-action-background-color-hover, var(--calcite-color-foreground-2));
     color: var(
       --calcite-action-text-color-press,
@@ -172,8 +171,7 @@
       duration-150
       ease-in-out;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background-color: var(--calcite-color-transparent-hover);
     }
 


### PR DESCRIPTION
**Related Issue:** [#10007](https://github.com/Esri/calcite-design-system/issues/10007)

## Summary

- Remove `hover` styling from the `focus` state.
- Update `active` state `background-color` to `--calcite-color-transparent-press` when `appearance="transparent"`.