### PR TITLE
fix(dropdown): avoid showing scroller when max-items equals items

### DIFF
--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -1,6 +1,5 @@
 :host {
-  // we make the host relative, so items can consistently compute their offsetTop based on the group
-  @apply block relative;
+  @apply block;
 }
 
 .container {

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import dedent from "dedent";
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
@@ -1043,12 +1042,12 @@ describe("calcite-dropdown", () => {
   });
 
   describe("accessible", () => {
-    accessible(dedent`${dropdownSelectionModeContent}`);
+    accessible(html`${dropdownSelectionModeContent}`);
   });
 
   it("correct role and aria properties are applied based on selection type", async () => {
     const page = await newE2EPage();
-    await page.setContent(dedent`${dropdownSelectionModeContent}`);
+    await page.setContent(html`${dropdownSelectionModeContent}`);
     await page.waitForChanges();
 
     const element = await page.find("calcite-dropdown");

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -23,6 +23,7 @@ import {
 } from "../../tests/utils";
 import type { DropdownItem } from "../dropdown-item/dropdown-item";
 import type { Button } from "../button/button";
+import { CSS } from "./resources";
 
 describe("calcite-dropdown", () => {
   const simpleDropdownHTML = html`
@@ -654,6 +655,10 @@ describe("calcite-dropdown", () => {
       for (let i = 0; i < items.length; i++) {
         expect(await items[i].isIntersectingViewport()).toBe(true);
       }
+
+      // no scroller should be present when max-items === items
+      const scroller = await page.find(`calcite-dropdown >>> .${CSS.content}`);
+      expect(await scroller.getProperty("scrollHeight")).toBe(await scroller.getProperty("clientHeight"));
     });
   });
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -647,7 +647,7 @@ export class Dropdown
           <div
             aria-labelledby={`${guid}-menubutton`}
             class={{
-              ["calcite-dropdown-content"]: true,
+              [CSS.content]: true,
               [FloatingCSS.animation]: true,
               [FloatingCSS.animationActive]: open,
             }}

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -476,7 +476,6 @@ export class Dropdown
       return;
     }
 
-    this.reposition(true);
     const maxScrollerHeight = this.getMaxScrollerHeight();
     scrollerEl.style.maxBlockSize = maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "";
     this.reposition(true);

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
-import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
+import { createEvent, JsxNode, LitElement, method, property } from "@arcgis/lumina";
 import { focusElement, focusElementInGroup, focusFirstTabbable } from "../../utils/dom";
 import {
   connectFloatingUI,
@@ -261,7 +261,7 @@ export class Dropdown
       this.flipPlacementsHandler();
     }
 
-    if (changes.has("maxItems") && (this.hasUpdated || this.maxItems !== 0)) {
+    if (changes.has("maxItems") && this.hasUpdated) {
       this.setMaxScrollerHeight();
     }
 
@@ -451,6 +451,11 @@ export class Dropdown
   private resizeObserverCallback(entries: ResizeObserverEntry[]): void {
     entries.forEach((entry) => {
       const { target } = entry;
+
+      if (!this.hasUpdated) {
+        return;
+      }
+
       if (target === this.referenceEl) {
         this.setDropdownWidth();
       } else if (target === this.scrollerEl) {
@@ -463,23 +468,15 @@ export class Dropdown
     const { referenceEl, scrollerEl } = this;
     const referenceElWidth = referenceEl?.clientWidth;
 
-    if (!referenceElWidth || !scrollerEl) {
-      return;
-    }
-
     scrollerEl.style.minWidth = `${referenceElWidth}px`;
   }
 
   private setMaxScrollerHeight(): void {
-    const { scrollerEl } = this;
-    if (!scrollerEl) {
-      return;
-    }
-
     const maxScrollerHeight = this.getMaxScrollerHeight();
-    scrollerEl.style.maxBlockSize = maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "";
+    this.scrollerEl.style.maxBlockSize = maxScrollerHeight > 0 ? `${maxScrollerHeight}px` : "";
     this.reposition(true);
   }
+
   private setScrollerAndTransitionEl(el: HTMLDivElement): void {
     if (el) {
       this.resizeObserver?.observe(el);
@@ -562,7 +559,9 @@ export class Dropdown
   private getMaxScrollerHeight(): number {
     const { maxItems, items } = this;
 
-    return items.length >= maxItems ? this.getYDistance(this.scrollerEl, items[maxItems - 1]) : 0;
+    return items.length >= maxItems && maxItems > 0
+      ? this.getYDistance(this.scrollerEl, items[maxItems - 1])
+      : 0;
   }
 
   private getYDistance(parent: HTMLElement, child: HTMLElement): number {

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
-import { createEvent, JsxNode, LitElement, method, property } from "@arcgis/lumina";
+import { createEvent, h, JsxNode, LitElement, method, property } from "@arcgis/lumina";
 import { focusElement, focusElementInGroup, focusFirstTabbable } from "../../utils/dom";
 import {
   connectFloatingUI,

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -562,30 +562,14 @@ export class Dropdown
 
   private getMaxScrollerHeight(): number {
     const { maxItems, items } = this;
-    let itemsToProcess = 0;
-    let maxScrollerHeight = 0;
-    let groupHeaderHeight: number;
 
-    this.groups.forEach((group) => {
-      if (maxItems > 0 && itemsToProcess < maxItems) {
-        Array.from(group.children).forEach((item: DropdownItem["el"], index) => {
-          if (index === 0) {
-            if (isNaN(groupHeaderHeight)) {
-              groupHeaderHeight = item.offsetTop;
-            }
+    return items.length >= maxItems ? this.getYDistance(this.scrollerEl, items[maxItems - 1]) : 0;
+  }
 
-            maxScrollerHeight += groupHeaderHeight;
-          }
-
-          if (itemsToProcess < maxItems) {
-            maxScrollerHeight += item.offsetHeight;
-            itemsToProcess += 1;
-          }
-        });
-      }
-    });
-
-    return items.length >= maxItems ? maxScrollerHeight : 0;
+  private getYDistance(parent: HTMLElement, child: HTMLElement): number {
+    const parentRect = parent.getBoundingClientRect();
+    const childRect = child.getBoundingClientRect();
+    return childRect.bottom - parentRect.top;
   }
 
   private closeCalciteDropdown(focusTrigger = true) {

--- a/packages/calcite-components/src/components/dropdown/resources.ts
+++ b/packages/calcite-components/src/components/dropdown/resources.ts
@@ -3,5 +3,6 @@ export const SLOTS = {
 };
 
 export const CSS = {
+  content: "calcite-dropdown-content",
   wrapper: "calcite-dropdown-wrapper",
 };


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Fixes regression caused by https://github.com/Esri/calcite-design-system/pull/10971.