### PR TITLE
fix(dialog, modal, popover): add type to `focusTrapOptions` prop

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -169,7 +169,7 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions;
+  @property() focusTrapOptions: ExtendedFocusTrapOptions;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -20,7 +20,7 @@ import { HeadingLevel } from "../functional/Heading";
 import type { OverlayPositioning } from "../../utils/floating-ui";
 import { useT9n } from "../../controllers/useT9n";
 import type { Panel } from "../panel/panel";
-import { ExtendedFocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
+import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import {
   CSS,
@@ -169,7 +169,7 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: ExtendedFocusTrapOptions;
+  @property() focusTrapOptions: FocusTrapOptions;
 
   /** The component header text. */
   @property() heading: string;
@@ -289,7 +289,7 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
    */
   @method()
   async updateFocusTrapElements(
-    extraContainers?: ExtendedFocusTrapOptions["extraContainers"],
+    extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
     this.focusTrap.updateContainerElements(extraContainers);
   }

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -169,7 +169,7 @@ export class Dialog extends LitElement implements OpenCloseComponent, LoadableCo
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: FocusTrapOptions;
+  @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -30,7 +30,7 @@ import { Kind, Scale } from "../interfaces";
 import { getIconScale } from "../../utils/component";
 import { logger } from "../../utils/logger";
 import { useT9n } from "../../controllers/useT9n";
-import { ExtendedFocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
+import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, ICONS, SLOTS } from "./resources";
 import { styles } from "./modal.scss";
@@ -164,7 +164,7 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: ExtendedFocusTrapOptions;
+  @property() focusTrapOptions: FocusTrapOptions;
 
   /** Sets the component to always be fullscreen. Overrides `widthScale` and `--calcite-modal-width` / `--calcite-modal-height`. */
   @property({ reflect: true }) fullscreen: boolean;
@@ -251,7 +251,7 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
    */
   @method()
   async updateFocusTrapElements(
-    extraContainers?: ExtendedFocusTrapOptions["extraContainers"],
+    extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
     this.focusTrap.updateContainerElements(extraContainers);
   }

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -164,7 +164,7 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions;
+  @property() focusTrapOptions: ExtendedFocusTrapOptions;
 
   /** Sets the component to always be fullscreen. Overrides `widthScale` and `--calcite-modal-width` / `--calcite-modal-height`. */
   @property({ reflect: true }) fullscreen: boolean;

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -164,7 +164,7 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: FocusTrapOptions;
+  @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
   /** Sets the component to always be fullscreen. Overrides `widthScale` and `--calcite-modal-width` / `--calcite-modal-height`. */
   @property({ reflect: true }) fullscreen: boolean;

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -139,7 +139,7 @@ export class Popover
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: FocusTrapOptions;
+  @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -42,7 +42,7 @@ import { FloatingArrow } from "../functional/FloatingArrow";
 import { getIconScale } from "../../utils/component";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
-import { useFocusTrap } from "../../controllers/useFocusTrap";
+import { ExtendedFocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import PopoverManager from "./PopoverManager";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { ARIA_CONTROLS, ARIA_EXPANDED, CSS, defaultPopoverPlacement } from "./resources";
@@ -139,7 +139,7 @@ export class Popover
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions;
+  @property() focusTrapOptions: ExtendedFocusTrapOptions;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -42,7 +42,7 @@ import { FloatingArrow } from "../functional/FloatingArrow";
 import { getIconScale } from "../../utils/component";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
-import { ExtendedFocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
+import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import PopoverManager from "./PopoverManager";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { ARIA_CONTROLS, ARIA_EXPANDED, CSS, defaultPopoverPlacement } from "./resources";
@@ -139,7 +139,7 @@ export class Popover
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: ExtendedFocusTrapOptions;
+  @property() focusTrapOptions: FocusTrapOptions;
 
   /** The component header text. */
   @property() heading: string;

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -150,7 +150,7 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions;
+  @property() focusTrapOptions: ExtendedFocusTrapOptions;
 
   /**
    * When `position` is `"block-start"` or `"block-end"`, specifies the height of the component.

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -150,7 +150,7 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: FocusTrapOptions;
+  @property() focusTrapOptions: Partial<FocusTrapOptions>;
 
   /**
    * When `position` is `"block-start"` or `"block-end"`, specifies the height of the component.

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -26,7 +26,7 @@ import { Height, LogicalFlowPosition, Scale, Width } from "../interfaces";
 import { CSS_UTILITY } from "../../utils/resources";
 import { clamp } from "../../utils/math";
 import { useT9n } from "../../controllers/useT9n";
-import { ExtendedFocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
+import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import { CSS, sheetResizeStep, sheetResizeShiftStep } from "./resources";
 import { DisplayMode, ResizeValues } from "./interfaces";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -150,7 +150,7 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
    * `"returnFocusOnDeactivate"` returns focus when not active, and
    * `"extraContainers"` specifies additional focusable elements external to the trap (e.g., 3rd-party components appending elements to the document body).
    */
-  @property() focusTrapOptions: ExtendedFocusTrapOptions;
+  @property() focusTrapOptions: FocusTrapOptions;
 
   /**
    * When `position` is `"block-start"` or `"block-end"`, specifies the height of the component.
@@ -232,7 +232,7 @@ export class Sheet extends LitElement implements OpenCloseComponent, LoadableCom
    */
   @method()
   async updateFocusTrapElements(
-    extraContainers?: ExtendedFocusTrapOptions["extraContainers"],
+    extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
     this.focusTrap.updateContainerElements(extraContainers);
   }

--- a/packages/calcite-components/src/controllers/useFocusTrap.ts
+++ b/packages/calcite-components/src/controllers/useFocusTrap.ts
@@ -1,5 +1,5 @@
 import { makeGenericController } from "@arcgis/components-controllers";
-import { createFocusTrap, FocusTrap, Options as FocusTrapOptions } from "focus-trap";
+import { createFocusTrap, FocusTrap, Options as Options } from "focus-trap";
 import { LitElement } from "@arcgis/lumina";
 import { createFocusTrapOptions } from "../utils/focusTrapComponent";
 
@@ -28,7 +28,7 @@ export interface UseFocusTrap {
    *
    * @see https://github.com/focus-trap/focus-trap#trapupdatecontainerelements
    */
-  updateContainerElements: (extraContainers?: ExtendedFocusTrapOptions["extraContainers"]) => void;
+  updateContainerElements: (extraContainers?: FocusTrapOptions["extraContainers"]) => void;
 }
 
 interface UseFocusTrapOptions<T extends LitElement = LitElement> {
@@ -40,7 +40,7 @@ interface UseFocusTrapOptions<T extends LitElement = LitElement> {
   /**
    * Options to pass to the focus-trap library.
    */
-  focusTrapOptions?: FocusTrapOptions;
+  focusTrapOptions?: Options;
 }
 
 interface FocusTrapComponent extends LitElement {
@@ -57,14 +57,14 @@ interface FocusTrapComponent extends LitElement {
   /**
    * Additional options to configure the focus trap.
    */
-  focusTrapOptions?: ExtendedFocusTrapOptions;
+  focusTrapOptions?: FocusTrapOptions;
 }
 
-export type ExtendedFocusTrapOptions =
+export type FocusTrapOptions =
   /**
    * @see https://github.com/focus-trap/focus-trap#createoptions
    */
-  Pick<FocusTrapOptions, "allowOutsideClick" | "initialFocus" | "returnFocusOnDeactivate"> & {
+  Pick<Options, "allowOutsideClick" | "initialFocus" | "returnFocusOnDeactivate"> & {
     /**
      * Additional elements to include in the focus trap. This is useful for including elements that may have related parts rendered outside the main focus-trap element.
      */
@@ -74,7 +74,7 @@ export type ExtendedFocusTrapOptions =
 function getEffectiveContainerElements(
   targetEl: HTMLElement,
   { focusTrapOptions }: FocusTrapComponent,
-  extraContainers?: ExtendedFocusTrapOptions["extraContainers"],
+  extraContainers?: FocusTrapOptions["extraContainers"],
 ) {
   if (!focusTrapOptions?.extraContainers && !extraContainers) {
     return targetEl;
@@ -83,7 +83,7 @@ function getEffectiveContainerElements(
   return [targetEl, ...toContainerArray(focusTrapOptions?.extraContainers), ...toContainerArray(extraContainers)];
 }
 
-function toContainerArray(containers: ExtendedFocusTrapOptions["extraContainers"] = []) {
+function toContainerArray(containers: FocusTrapOptions["extraContainers"] = []) {
   return Array.isArray(containers) ? containers : [containers];
 }
 
@@ -146,7 +146,7 @@ export const useFocusTrap = <T extends FocusTrapComponent>(
 
         focusTrapEl = el;
       },
-      updateContainerElements: (extraContainers?: ExtendedFocusTrapOptions["extraContainers"]) => {
+      updateContainerElements: (extraContainers?: FocusTrapOptions["extraContainers"]) => {
         const targetEl = focusTrapEl || component.el;
         return focusTrap?.updateContainerElements(getEffectiveContainerElements(targetEl, component, extraContainers));
       },

--- a/packages/calcite-components/src/controllers/useFocusTrap.ts
+++ b/packages/calcite-components/src/controllers/useFocusTrap.ts
@@ -57,7 +57,7 @@ interface FocusTrapComponent extends LitElement {
   /**
    * Additional options to configure the focus trap.
    */
-  focusTrapOptions?: FocusTrapOptions;
+  focusTrapOptions?: Partial<FocusTrapOptions>;
 }
 
 export type FocusTrapOptions =


### PR DESCRIPTION
**Related Issue:** #11345 

## Summary

Adds missing type to newly added `focusTrapOptions` props.