### PR TITLE
fix(stepper-item): keep initial focus on newly selected item

### DIFF
--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -213,6 +213,11 @@ export class StepperItem extends LitElement implements InteractiveComponent, Loa
 
   override updated(): void {
     updateHostInteraction(this);
+    setAttribute(
+      this.el,
+      "tabindex",
+      this.disabled || this.layout.includes("horizontal") ? null : 0,
+    );
   }
 
   loaded(): void {
@@ -327,7 +332,6 @@ export class StepperItem extends LitElement implements InteractiveComponent, Loa
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.ariaCurrent = this.selected ? "step" : "false";
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, add a check for this.el.hasAttribute() before calling setAttribute() here */
-    setAttribute(this.el, "tabIndex", this.disabled ? -1 : 0);
 
     // use local var to bypass logic-changing compiler transformation
     const innerDisplayContextTabIndex = this.layout === "horizontal" && !this.disabled ? 0 : null;

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -213,11 +213,7 @@ export class StepperItem extends LitElement implements InteractiveComponent, Loa
 
   override updated(): void {
     updateHostInteraction(this);
-    setAttribute(
-      this.el,
-      "tabindex",
-      this.disabled || this.layout?.includes("horizontal") ? null : 0,
-    );
+    setAttribute(this.el, "tabindex", this.disabled || this.layout === "horizontal" ? null : 0);
   }
 
   loaded(): void {

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -330,7 +330,9 @@ export class StepperItem extends LitElement implements InteractiveComponent, Loa
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, add a check for this.el.hasAttribute() before calling setAttribute() here */
 
     // use local var to bypass logic-changing compiler transformation
-    const innerDisplayContextTabIndex = this.layout === "horizontal" && !this.disabled ? 0 : null;
+    const innerDisplayContextTabIndex =
+      /* additional tab index logic needed because of display: contents for horizontal layout */
+      this.layout === "horizontal" && !this.disabled ? 0 : null;
 
     return (
       <InteractiveContainer disabled={this.disabled}>

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -216,7 +216,7 @@ export class StepperItem extends LitElement implements InteractiveComponent, Loa
     setAttribute(
       this.el,
       "tabindex",
-      this.disabled || this.layout.includes("horizontal") ? null : 0,
+      this.disabled || this.layout?.includes("horizontal") ? null : 0,
     );
   }
 


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Applies `tabindex` on the host for vertical layout items only, as horizontal ones rely on an internal focusable container.