### PR TITLE
ci: stop running icon diff check on pr review submit

### DIFF
--- a/.github/scripts/iconTeamDiffCheck.js
+++ b/.github/scripts/iconTeamDiffCheck.js
@@ -37,13 +37,6 @@ module.exports = async ({ github, context, core }) => {
 
   core.debug(`Members of "${admins}" GitHub Team: ${JSON.stringify(adminTeamMembers)}`);
 
-  // passes when an admin approves the PR
-  if (github.event?.review?.state == "APPROVED" && adminTeamMembers.includes(github.event?.review?.user?.login)) {
-    core.debug(`Approved by admin: ${github.event?.review?.user?.login}`);
-    core.debug("Passing because an admin has approved this pull request");
-    process.exit(0);
-  }
-
   // passes if the author isn't on the icon designers team or if the author is on the admin team
   // admin(s) may be on the icon designers team for maintenance purposes
   if (adminTeamMembers.includes(author) || !iconTeamMembers.includes(author)) {
@@ -55,7 +48,7 @@ module.exports = async ({ github, context, core }) => {
 
   // passes if there was a previous approval from an admin
   reviews.forEach((review) => {
-    if (review.state == "APPROVED" && adminTeamMembers.includes(review.user.login)) {
+    if (review.state == "APPROVED" && review?.user?.login && adminTeamMembers.includes(review.user.login)) {
       core.debug(`Approved by admin: ${review.user.login}`);
       core.debug("Passing because an admin has approved this pull request");
       process.exit(0);

--- a/.github/workflows/icons-diff-check.yml
+++ b/.github/workflows/icons-diff-check.yml
@@ -2,8 +2,6 @@ name: Icon Team Diff Check
 on:
   pull_request:
     branches: [dev]
-  pull_request_review:
-    types: [submitted]
 jobs:
   check-diff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Remove the `pull_request_review` trigger event from the `Icon Team Diff Check` workflow. 

### Background 

The `Icon Team Diff Check` workflow fails if members of the `calcite-icon-designers` team change files outside of the `packages/calcite-ui-icons` path. On failure, the `calcite-design-system-admins` team is assigned for review. 

Previously, the workflow ran on `pull_request_review` approvals and the check passed if the approver was a `calcite-design-system-admins` team member. However, the workflow ran on all PR approvals, which prevented merging for around 20 seconds.

Moving forward, when admins are automatically assigned to review an icon designer's PR, the new action items are:

1. Review the PR to make sure the changes outside of `packages/calcite-ui-icons` make sense. 
    - For example, there could be changes to `package.json` and/or `package-lock.json` due to installing a new dependency.

2. If you approve the PR, rerun the `Icon Team Diff Check / check-diff` PR check.
    - This is the new step that was previously automated. However, the automation was more painful than the manual solution.

Note that we can't use a [path filter] for the `pull_request` event because it would skip the check completely. Since the check is required, it must run and exit successfully. However, other workflows that run on the same event (e.g. `e2e`) take longer, so this isn't an issue.

[path filter]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore