### PR TITLE
fix(modal): fix issue caused by early opening logic calls

### DIFF
--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -406,8 +406,14 @@ export class Modal extends LitElement implements OpenCloseComponent, LoadableCom
   }
 
   private handleOpenedChange(value: boolean): void {
+    const { transitionEl } = this;
+
+    if (!transitionEl) {
+      return;
+    }
+
     const idleClass = value ? CSS.openingIdle : CSS.closingIdle;
-    this.transitionEl.classList.add(idleClass);
+    transitionEl.classList.add(idleClass);
     onToggleOpenCloseComponent(this);
   }
 


### PR DESCRIPTION
**Related Issue:** #10731 

## Summary

Fixes an issue where the modal’s opening logic was invoked before the transition element was available. This adds a simple guard for now, but I’ll revisit later to ensure the method isn’t called until after the component updates.

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE