### PR TITLE
ci: increase release-please commit search depth

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "tag-separator": "@",
   "draft-pull-request": true,
   "include-v-in-tag": false,
+  "commit-search-depth": 1000,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

By default, release-please only checks 500 commits when searching for the previous release. That number can be increased with the `commit-search-depth` [manifest] option. Changing the value to 1000 will be more than enough according to my calculation:

```sh
git rev-list @esri/calcite-components@2.13.2...origin/main | wc -l # => 793
```

[manifest]: https://github.com/googleapis/release-please/blob/90058f543cd82858539fdc7d1b34eabd348edbee/docs/manifest-releaser.md?plain=1#L243-L249
