### PR TITLE
ci: ensure contributors workflow runs on dev

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,7 @@ name: Update Contributors
 on:
   push:
     branches:
-      - main
+      - dev
 jobs:
   update-readme-contributors:
     runs-on: ubuntu-latest
@@ -16,3 +16,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           readme_path: readme.md
+          commit_message: "docs: update list of contributors"
+          committer_username: "github-actions[bot]"
+          committer_email: "github-actions[bot]@users.noreply.github.com"
+          pr_title_on_protected: "docs: update list of contributors"


### PR DESCRIPTION
**Related Issue:** #11503 #11502 #11499 

## Summary

The contributors action was running on `main` when it should run on `dev`.
