### PR TITLE
feat(calcite-stepper): allow calcite-stepper to receive slotted items from wrapper component

### DIFF
--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
-import { focusElementInGroup, slotChangeGetAssignedElements } from "../../utils/dom";
+import { focusElementInGroup, getSlotAssignedElements, slotChangeGetAssignedElements } from "../../utils/dom";
 import { Position, Scale } from "../interfaces";
 import { createObserver } from "../../utils/observers";
 import { guid } from "../../utils/guid";
@@ -50,6 +50,8 @@ export class Stepper extends LitElement {
   private multipleViewMode = false;
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
+
+  private slotEl: HTMLSlotElement;
 
   // #endregion
 
@@ -301,7 +303,10 @@ export class Stepper extends LitElement {
   }
 
   private updateItems(): void {
-    this.el.querySelectorAll("calcite-stepper-item").forEach((item) => {
+    if (!this.slotEl) {
+      return;
+    }
+    getSlotAssignedElements(this.slotEl, "calcite-stepper-item").forEach((item) => {
       item.icon = this.icon;
       item.numbered = this.numbered;
       item.layout = this.layout;
@@ -394,11 +399,13 @@ export class Stepper extends LitElement {
       (el): el is StepperItem["el"] =>
         el?.tagName === "CALCITE-STEPPER-ITEM" && !isHidden(el as StepperItem["el"]),
     );
+    this.slotEl = event.target;
     this.items = items;
     const spacing = Array(items.length).fill("1fr").join(" ");
     this.containerEl.style.gridTemplateAreas = spacing;
     this.containerEl.style.gridTemplateColumns = spacing;
     this.setStepperItemNumberingSystem();
+    this.updateItems();
   }
 
   // #endregion


### PR DESCRIPTION
**Related Issue:** #

## Summary

In Field Maps, we use the `calcite-stepper` in several places, many times with accompanying forward/backward buttons.  So we've bundled them together in a wrapper web-component with a slot allowing each usage to pass in its desired `calcite-stepper-items`.  So it looks something like this:
```
<wrapper-component>
  <calcite-stepper numbered layout="horizontal">
    <slot/>
  </calcite-stepper>
  ...[code for buttons, etc.]
</wrapper-component>
```
However, this usage passes the `calcite-stepper-items` within the `calcite-stepper`'s slot, but does not pass its props to them (`numbered`, `layout`, etc.) causing them to render incorrectly.  I believe this is because the function that performs this task, `updateItems` finds the items through `this.el.querySelector`.  This doesn't work in the wrapping component scenario due to them being wrapped in a `slot`.  I have a branch [here](https://github.com/kstinson14/calcite-design-system/tree/feature/allow-stepper-wrapping-component-repro) that repros the problem on the local demo site with a dummy `stepper-wrapper` component.

I've fixed this by keeping track of the `slot` element after the slot change event and using its assigned `calcite-stepper-items` in `updateItems` instead.  I also call `updateItems` in the slot change event.  This seems to work for wrapped / unwrapped steppers.
