### PR TITLE
test(dropdown, accordion, stepper): fix tests for inheritable props

### DIFF
--- a/packages/calcite-components/src/components/accordion/accordion.e2e.ts
+++ b/packages/calcite-components/src/components/accordion/accordion.e2e.ts
@@ -87,18 +87,17 @@ describe("calcite-accordion", () => {
     ]);
   });
 
-  it.skip("inheritable props: `iconPosition`, `iconType`, `selectionMode`, and `scale` modified on the parent get passed into items", async () => {
+  it("inheritable props: `iconPosition`, `iconType`, `selectionMode`, and `scale` modified on the parent get passed into items", async () => {
     const page = await newE2EPage();
     await page.setContent(`
-    <calcite-accordion icon-position="start" icon-type="plus-minus" selection-mode="single-persist" scale="l">
+    <calcite-accordion icon-position="start" icon-type="plus-minus" scale="l">
     ${accordionContentInheritablePropsNonDefault}
     </calcite-accordion>`);
-    const accordionItems = await findAll(page, "calcite-accordion-items");
+    const accordionItems = await findAll(page, "calcite-accordion-item");
 
     for (const item of accordionItems) {
       expect(await item.getProperty("iconPosition")).toBe("start");
       expect(await item.getProperty("iconType")).toBe("plus-minus");
-      expect(await item.getProperty("selectionMode")).toBe("single-persist");
       expect(await item.getProperty("scale")).toBe("l");
     }
   });

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -137,10 +137,10 @@ describe("calcite-dropdown", () => {
     expect(group1).toEqualAttribute("selection-mode", "multiple");
   });
 
-  it.skip("inheritable non-default props `selectionMode` and `scale` set on parent get passed into items", async () => {
+  it("inheritable non-default props `selectionMode` and `scale` set on parent get passed into items", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
-      <calcite-dropdown selection-mode="single-persist" scale="s">
+      <calcite-dropdown selection-mode="single" scale="s">
         <calcite-button slot="trigger">Open dropdown</calcite-button>
         <calcite-dropdown-group id="group-1">
           <calcite-dropdown-item id="item-1">Content</calcite-dropdown-item>
@@ -149,10 +149,10 @@ describe("calcite-dropdown", () => {
         </calcite-dropdown-group>
       </calcite-dropdown>
     `);
-    const dropdownItems = await findAll(page, "calcite-dropdown-items");
+    const dropdownItems = await findAll(page, "calcite-dropdown-item");
 
     for (const item of dropdownItems) {
-      expect(await item.getProperty("selectionMode")).toBe("single-persist");
+      expect(await item.getProperty("selectionMode")).toBe("single");
       expect(await item.getProperty("scale")).toBe("s");
     }
   });

--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -98,7 +98,7 @@ describe("calcite-stepper", () => {
     expect((await containerEl.getComputedStyle()).display).toBe("grid");
   });
 
-  it.skip("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to items from parents", async () => {
+  it.only("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to items from parents", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-stepper layout="vertical" scale="l" numbered icon>
@@ -116,7 +116,7 @@ describe("calcite-stepper", () => {
         </calcite-stepper-item>
       </calcite-stepper>
     `);
-    const stepperItems = await findAll(page, "calcite-stepper-items");
+    const stepperItems = await findAll(page, "calcite-stepper-item");
 
     for (const item of stepperItems) {
       expect(await item.getProperty("icon")).toBe(true);

--- a/packages/calcite-components/src/components/stepper/stepper.e2e.ts
+++ b/packages/calcite-components/src/components/stepper/stepper.e2e.ts
@@ -98,7 +98,7 @@ describe("calcite-stepper", () => {
     expect((await containerEl.getComputedStyle()).display).toBe("grid");
   });
 
-  it.only("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to items from parents", async () => {
+  it("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to items from parents", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
       <calcite-stepper layout="vertical" scale="l" numbered icon>


### PR DESCRIPTION
**Related Issue:** #11407

## Summary
Fix tests for inheritable props getting passed to items from parents.