### PR TITLE
docs(examples): update module imports after 3x breaking change

### DIFF
--- a/examples/components/angular/README.md
+++ b/examples/components/angular/README.md
@@ -32,10 +32,10 @@ Next, import the components used in your application:
 
 ```ts
 // src/app/app.component.ts
-import "@esri/calcite-components/dist/components/calcite-button.js";
-import "@esri/calcite-components/dist/components/calcite-icon.js";
-import "@esri/calcite-components/dist/components/calcite-loader.js";
-import "@esri/calcite-components/dist/components/calcite-slider.js";
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-loader";
+import "@esri/calcite-components/dist/components/calcite-slider";
 ```
 
 Then, import the global Calcite components stylesheet (only do this once):

--- a/examples/components/angular/src/app/app.component.ts
+++ b/examples/components/angular/src/app/app.component.ts
@@ -6,10 +6,10 @@ import {
   OnInit,
 } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import '@esri/calcite-components/dist/components/calcite-button.js';
-import '@esri/calcite-components/dist/components/calcite-icon.js';
-import '@esri/calcite-components/dist/components/calcite-loader.js';
-import '@esri/calcite-components/dist/components/calcite-slider.js';
+import '@esri/calcite-components/dist/components/calcite-button';
+import '@esri/calcite-components/dist/components/calcite-icon';
+import '@esri/calcite-components/dist/components/calcite-loader';
+import '@esri/calcite-components/dist/components/calcite-slider';
 
 @Component({
   selector: 'app-root',

--- a/examples/components/react/README.md
+++ b/examples/components/react/README.md
@@ -39,9 +39,9 @@ Next, import the components used in your application:
 
 ```tsx
 // define the custom elements on the browser
-import "@esri/calcite-components/dist/components/calcite-button.js";
-import "@esri/calcite-components/dist/components/calcite-icon.js";
-import "@esri/calcite-components/dist/components/calcite-slider.js";
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-slider";
 
 // import the React wrapper components
 import { CalciteButton, CalciteIcon, CalciteSlider } from "@esri/calcite-components-react";

--- a/examples/components/react/src/App.tsx
+++ b/examples/components/react/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import "@esri/calcite-components/dist/components/calcite-button.js";
-import "@esri/calcite-components/dist/components/calcite-icon.js";
-import "@esri/calcite-components/dist/components/calcite-slider.js";
+import "@esri/calcite-components/dist/components/calcite-button";
+import "@esri/calcite-components/dist/components/calcite-icon";
+import "@esri/calcite-components/dist/components/calcite-slider";
 import { CalciteButton, CalciteIcon, CalciteSlider } from "@esri/calcite-components-react";
 import "./App.css";
 


### PR DESCRIPTION
## Summary

Update the react and angular examples to fix module import errors due to changes in the v3 release.
