### PR TITLE
fix(input-date-picker): allow navigating between months using chevron actions in Safari

### DIFF
--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -295,6 +295,7 @@ export class Action extends LitElement implements InteractiveComponent {
         disabled={disabled}
         id={buttonId}
         ref={this.buttonEl}
+        tabIndex={disabled ? null : 0}
       >
         {buttonContent}
       </button>


### PR DESCRIPTION
**Related Issue:** #11544 

## Summary

No longer closes the `input-date-picker` when navigating between month using chevron actions.