### PR TITLE
fix(dialog, modal, sheet): preserve focus-trap extra containers across internal trap updates

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -286,7 +286,8 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   async updateFocusTrapElements(
     extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
-    this.focusTrap.updateContainerElements(extraContainers);
+    this.focusTrap.setExtraContainers(extraContainers);
+    this.focusTrap.updateContainerElements();
   }
 
   /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -248,7 +248,8 @@ export class Modal extends LitElement implements OpenCloseComponent {
   async updateFocusTrapElements(
     extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
-    this.focusTrap.updateContainerElements(extraContainers);
+    this.focusTrap.setExtraContainers(extraContainers);
+    this.focusTrap.updateContainerElements();
   }
 
   // #endregion

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -229,7 +229,8 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   async updateFocusTrapElements(
     extraContainers?: FocusTrapOptions["extraContainers"],
   ): Promise<void> {
-    this.focusTrap.updateContainerElements(extraContainers);
+    this.focusTrap.setExtraContainers(extraContainers);
+    this.focusTrap.updateContainerElements();
   }
 
   // #endregion


### PR DESCRIPTION
**Related Issue:** #11523 

## Summary

Internal calls to `updateFocusTrap` caused user-provided `extraContainers` to be lost. This updates `useFocusTrap` to maintain stateful focusable containers for subsequent updates.