### PR TITLE
fix(dialog, modal, popover, sheet): fixes an issue that caused extra containers to be lost after internal trap updates

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -767,7 +767,7 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   }
 
   private handleMutationObserver(): void {
-    this.updateFocusTrapElements();
+    this.focusTrap.updateContainerElements();
   }
 
   // #endregion

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -87,7 +87,7 @@ export class Modal extends LitElement implements OpenCloseComponent {
   private modalContent = createRef<HTMLDivElement>();
 
   private mutationObserver: MutationObserver = createObserver("mutation", () =>
-    this.updateFocusTrapElements(),
+    this.focusTrap.updateContainerElements(),
   );
 
   private _open = false;

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -89,7 +89,7 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
   private hasLoaded = false;
 
   private mutationObserver: MutationObserver = createObserver("mutation", () =>
-    this.updateFocusTrapElements(),
+    this.focusTrap.updateContainerElements(),
   );
 
   transitionProp = "opacity" as const;

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -581,7 +581,7 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   }
 
   private handleMutationObserver(): void {
-    this.updateFocusTrapElements();
+    this.focusTrap.updateContainerElements();
   }
 
   // #endregion


### PR DESCRIPTION
**Related Issue:** #11523 

## Summary

https://github.com/Esri/calcite-design-system/pull/11548 missed calling the internal update focus trap method, using the public method instead, which clears user-specified `extraContainers`.