### PR TITLE
docs(list, sortable-list): remove consecutive spaces in documentation

### DIFF
--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -190,7 +190,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
 
   // #region Public Properties
 
-  /** When provided, the method will be called to determine whether the element can  move from the list. */
+  /** When provided, the method will be called to determine whether the element can move from the list. */
   @property() canPull: (detail: ListDragDetail) => boolean;
 
   /** When provided, the method will be called to determine whether the element can be added from another list. */

--- a/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
+++ b/packages/calcite-components/src/components/sortable-list/sortable-list.tsx
@@ -53,7 +53,7 @@ export class SortableList extends LitElement implements InteractiveComponent, So
 
   // #region Public Properties
 
-  /** When provided, the method will be called to determine whether the element can  move from the list. */
+  /** When provided, the method will be called to determine whether the element can move from the list. */
   @property() canPull: (detail: DragDetail) => boolean;
 
   /** When provided, the method will be called to determine whether the element can be added from another list. */


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

- removes unnecessary spacing
