### PR TITLE
refactor(segmented-control-item): use --calcite-z-index css token instead of hardcoded value

### DIFF
--- a/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
+++ b/packages/calcite-components/src/components/segmented-control-item/segmented-control-item.scss
@@ -45,7 +45,7 @@
 :host(:focus) {
   @apply focus-inset;
   outline-offset: -1px;
-  z-index: 1;
+  z-index: var(--calcite-z-index);
 }
 
 .label--scale-s {


### PR DESCRIPTION
**Related Issue:** [#11578](https://github.com/Esri/calcite-design-system/issues/11578)

## Summary
Use `--calcite-z-index` css token instead of hardcoded value to correctly display focus ring.
