### PR TITLE
chore(linting): move stylelint `lint-staged` command to `calcite-components` to prevent config errors

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   "*.{json,html,yml}": ["prettier --write"],
-  "*.{s,}css": ["stylelint --fix", "prettier --write"],
+  "*.{s,}css": ["prettier --write"],
   "*.md": ["prettier --write", "markdownlint --fix"],
 };

--- a/packages/calcite-components/.lintstagedrc.js
+++ b/packages/calcite-components/.lintstagedrc.js
@@ -2,5 +2,6 @@ import baseConfig from "../../.lintstagedrc.js";
 
 export default {
   ...baseConfig,
+  "*.{s,}css": ["stylelint --fix", "prettier --write"],
   "*.{ts,tsx,mjs,cjs}": ["eslint --fix", "prettier --write"],
 };


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This came up in https://github.com/Esri/calcite-design-system/pull/11608 where committing CSS would cause the following error:

```
✔ Backed up original state in git stash (43c49791f)
⚠ Running tasks for staged files...
  ❯ .lintstagedrc.js — 12 files
    ✔ *.{json,html,yml} — 3 files
    ❯ *.css — 2 files
      ✖ stylelint --fix [FAILED]
      ◼ prettier --write
    ↓ *.md — no files
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ stylelint --fix:
Error: No configuration provided for /.../calcite-design-system/examples/components/preact/src/routes/home/style.module.css
    at configurationError (/.../calcite-design-system/node_modules/stylelint/lib/utils/configurationError.mjs:12:49)
    at getConfigForFile (/.../calcite-design-system/node_modules/stylelint/lib/getConfigForFile.mjs:67:4)
    at async isPathIgnored (/.../calcite-design-system/node_modules/stylelint/lib/isPathIgnored.mjs:23:17)
    at async lintSource (/.../calcite-design-system/node_modules/stylelint/lib/lintSource.mjs:43:20)
    at async /.../calcite-design-system/node_modules/stylelint/lib/standalone.mjs:241:27
    at async Promise.all (index 0)
    at async standalone (/.../calcite-design-system/node_modules/stylelint/lib/standalone.mjs:286:22)
husky - pre-commit script failed (code 1)
```
