### PR TITLE
ci(actions): add action to close issues without enough information

### DIFF
--- a/.github/scripts/closeNeedMoreInfoIssues.js
+++ b/.github/scripts/closeNeedMoreInfoIssues.js
@@ -7,6 +7,7 @@ const {
 module.exports = async ({ github, context }) => {
   const { repo, owner } = context.repo;
   const DAYS_BEFORE_CLOSE = 14;
+  const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
   console.log(`Checking for issues with the label: "${planning.needsInfo}" that are stale.`);
 
@@ -22,7 +23,7 @@ module.exports = async ({ github, context }) => {
 
   for (const issue of issues) {
     const lastUpdated = new Date(issue.updated_at);
-    const daysSinceUpdate = Math.round((now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24));
+    const daysSinceUpdate = Math.round((now.getTime() - lastUpdated.getTime()) / MILLISECONDS_IN_A_DAY);
 
     if (daysSinceUpdate >= DAYS_BEFORE_CLOSE) {
       console.log(`Closing issue #${issue.number} - No updates for ${Math.round(daysSinceUpdate)} days`);
@@ -31,7 +32,7 @@ module.exports = async ({ github, context }) => {
         owner: owner,
         repo: repo,
         issue_number: issue.number,
-        body: "Closing this issue due to inactivity. If this is still an issue, it can be reopened once additional information has been provided.",
+        body: "Closing this issue due to inactivity. If the issue persists, feel free to reopen it with additional details.",
       });
 
       await github.rest.issues.update({

--- a/.github/scripts/closeNeedMoreInfoIssues.js
+++ b/.github/scripts/closeNeedMoreInfoIssues.js
@@ -1,0 +1,51 @@
+// @ts-check
+const {
+  labels: { planning },
+} = require("./support/resources");
+
+/** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+module.exports = async ({ github, context }) => {
+  const { repo, owner } = context.repo;
+  const DAYS_BEFORE_CLOSE = 14;
+
+  console.log(`Checking for issues with the label: "${planning.needsInfo}" that are stale.`);
+
+  // Get all issues with the specific label
+  const { data: issues } = await github.rest.issues.listForRepo({
+    owner: owner,
+    repo: repo,
+    state: "open",
+    labels: planning.needsInfo,
+    per_page: 100,
+  });
+
+  const now = new Date();
+
+  for (const issue of issues) {
+    const lastUpdated = new Date(issue.updated_at);
+    const daysSinceUpdate = Math.round((now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24));
+
+    //remove this later
+    console.log(`Days since update: ${daysSinceUpdate}`);
+
+    if (daysSinceUpdate >= DAYS_BEFORE_CLOSE) {
+      console.log(`Closing issue #${issue.number} - No updates for ${Math.round(daysSinceUpdate)} days`);
+
+      await github.rest.issues.createComment({
+        owner: owner,
+        repo: repo,
+        issue_number: issue.number,
+        body: "Closing this issue due to inactivity. If this is still an issue, it can be reopened once additional information has been provided.",
+      });
+
+      await github.rest.issues.update({
+        issue_number: issue.number,
+        owner: owner,
+        repo: repo,
+        state: "closed",
+      });
+    }
+  }
+
+  console.log("Finished checking for issues without enough information.");
+};

--- a/.github/scripts/closeNeedMoreInfoIssues.js
+++ b/.github/scripts/closeNeedMoreInfoIssues.js
@@ -10,7 +10,6 @@ module.exports = async ({ github, context }) => {
 
   console.log(`Checking for issues with the label: "${planning.needsInfo}" that are stale.`);
 
-  // Get all issues with the specific label
   const { data: issues } = await github.rest.issues.listForRepo({
     owner: owner,
     repo: repo,
@@ -24,9 +23,6 @@ module.exports = async ({ github, context }) => {
   for (const issue of issues) {
     const lastUpdated = new Date(issue.updated_at);
     const daysSinceUpdate = Math.round((now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24));
-
-    //remove this later
-    console.log(`Days since update: ${daysSinceUpdate}`);
 
     if (daysSinceUpdate >= DAYS_BEFORE_CLOSE) {
       console.log(`Closing issue #${issue.number} - No updates for ${Math.round(daysSinceUpdate)} days`);

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -27,6 +27,7 @@ const resources = {
     planning: {
       needsTriage: "needs triage",
       needsMilestone: "needs milestone",
+      needsInfo: "needs more info",
       spike: "spike",
       spikeComplete: "spike complete",
       noChangelogEntry: "no changelog entry",

--- a/.github/workflows/close-needs-more-info-issues.yml
+++ b/.github/workflows/close-needs-more-info-issues.yml
@@ -1,0 +1,23 @@
+name: Close Need More Info Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
+
+permissions:
+  issues: write
+
+jobs:
+  close-needs-more-info-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Close issue if more info is not provided
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const action = require('${{ github.workspace }}/.github/scripts/closeNeedMoreInfoIssues.js')
+            await action({github, context, core})

--- a/.github/workflows/close-needs-more-info-issues.yml
+++ b/.github/workflows/close-needs-more-info-issues.yml
@@ -3,7 +3,7 @@ name: Close Need More Info Issues
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # Runs daily at midnight UTC
+    - cron: "0 0 * * 1" # Runs every Monday at midnight UTC
 
 permissions:
   issues: write


### PR DESCRIPTION
**Related Issue:** #11235 

## Summary
- Adds action to run daily at midnight UTC that will check for issues with the `need more info` and close them if it's been 2 weeks or more without any updates. 

- Tested in personal action testing repo.