### PR TITLE
fix(card-group): Restore default gap spacing

### DIFF
--- a/packages/calcite-components/src/components/card-group/card-group.scss
+++ b/packages/calcite-components/src/components/card-group/card-group.scss
@@ -14,7 +14,7 @@
 .container {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--calcite-card-group-space, var(--calcite-card-group-gap, var(--calcite-spacing-base)));
+  gap: var(--calcite-card-group-space, var(--calcite-card-group-gap, var(--calcite-spacing-md)));
 }
 
 @include base-component();


### PR DESCRIPTION
**Related Issue:** #11637 

## Summary
Updates token to restore card group gap