### PR TITLE
docs(text-area): update limitText description

### DIFF
--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -155,7 +155,7 @@ export class TextArea
   @property() label: string;
 
   /**
-   * When `true`, prevents input beyond the maximum length, mimicking native `<textarea>` behavior.
+   * When `true`, prevents input beyond the `maxLength` value, mimicking native text area behavior.
    */
   @property({ reflect: true }) limitText = false;
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

![image](https://github.com/user-attachments/assets/e6142315-8cc1-4923-89e0-122be3502c90)

Updates the Text Area's `limitText` prop description, currently rendering a native `text-area` on the documentation site.

