### PR TITLE
refactor(chip): simplify component's interactivity states css

### DIFF
--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -36,28 +36,26 @@
     color: var(--calcite-chip-close-icon-color, var(--calcite-close-icon-color, var(--calcite-color-text-3)));
   }
 
-  &:host([kind="brand"]) .container {
-    border-color: var(--calcite-chip-border-color, var(--calcite-color-brand));
+  &:host([kind="brand"]) {
+    --calcite-internal-chip-border-color: var(--calcite-chip-border-color, var(--calcite-color-brand));
   }
 
-  &:host([kind="inverse"]) .container {
-    border-color: var(--calcite-chip-border-color, var(--calcite-color-border-inverse));
+  &:host([kind="inverse"]) {
+    --calcite-internal-chip-border-color: var(--calcite-chip-border-color, var(--calcite-color-border-inverse));
   }
 
-  &:host([kind="neutral"]) .container {
-    border-color: var(--calcite-chip-border-color, var(--calcite-color-border-1));
+  &:host([kind="neutral"]) {
+    --calcite-internal-chip-border-color: var(--calcite-chip-border-color, var(--calcite-color-border-1));
   }
 }
-:host([appearance="outline"]) .container {
-  @apply bg-transparent;
+:host([appearance="outline"]) {
+  --calcite-internal-chip-background-color: transparent;
 }
-:host([appearance="outline-fill"]) .container {
-  background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-1));
+:host([appearance="outline-fill"]) {
+  --calcite-internal-chip-background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-1));
 }
 :host([appearance="solid"]) {
-  .container {
-    border-color: transparent;
-  }
+  --calcite-internal-chip-border-color: transparent;
 
   &:host([kind="brand"]),
   &:host([kind="inverse"]) {
@@ -71,15 +69,11 @@
   }
 
   &:host([kind="brand"]) {
-    .container {
-      background-color: var(--calcite-chip-background-color, var(--calcite-color-brand));
-    }
+    --calcite-internal-chip-background-color: var(--calcite-chip-background-color, var(--calcite-color-brand));
   }
 
   &:host([kind="inverse"]) {
-    .container {
-      background-color: var(--calcite-chip-background-color, var(--calcite-color-inverse));
-    }
+    --calcite-internal-chip-background-color: var(--calcite-chip-background-color, var(--calcite-color-inverse));
 
     .close {
       &:hover {
@@ -91,8 +85,8 @@
     }
   }
 
-  &:host([kind="neutral"]) .container {
-    background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-2));
+  &:host([kind="neutral"]) {
+    --calcite-internal-chip-background-color: var(--calcite-chip-background-color, var(--calcite-color-foreground-2));
   }
 }
 :host([kind="neutral"]) {
@@ -110,91 +104,49 @@
 }
 
 :host([appearance="solid"]) {
-  &:host([kind="neutral"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-foreground-3);
-      }
-      &:active {
-        background-color: var(--calcite-color-border-3);
-      }
-    }
+  &:host([kind="neutral"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-foreground-3);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-border-3);
   }
 
-  &:host([kind="inverse"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-inverse-hover);
-      }
-      &:active {
-        background-color: var(--calcite-color-inverse-press);
-      }
-    }
+  &:host([kind="inverse"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-inverse-hover);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-inverse-press);
   }
 
-  &:host([kind="brand"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-brand-hover);
-      }
-      &:active {
-        background-color: var(--calcite-color-brand-press);
-      }
-    }
+  &:host([kind="brand"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-brand-hover);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-brand-press);
   }
 }
 
 :host([appearance="outline-fill"]) {
-  &:host([kind="neutral"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-foreground-2);
-        border-color: var(--calcite-color-border-input);
-      }
-      &:active {
-        background-color: var(--calcite-color-foreground-3);
-        border-color: var(--calcite-color-text-3);
-      }
-    }
+  &:host([kind="neutral"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-foreground-2);
+    --calcite-internal-chip-selectable-hover-border-color: var(--calcite-color-border-input);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-foreground-3);
+    --calcite-internal-chip-selectable-active-border-color: var(--calcite-color-text-3);
   }
 
-  &:host([kind="inverse"]) .container,
-  &:host([kind="brand"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-foreground-2);
-      }
-      &:active {
-        background-color: var(--calcite-color-foreground-3);
-      }
-    }
+  &:host([kind="inverse"]),
+  &:host([kind="brand"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-foreground-2);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-foreground-3);
   }
 }
 
 :host([appearance="outline"]) {
-  &:host([kind="neutral"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-transparent-hover);
-        border-color: var(--calcite-color-border-input);
-      }
-      &:active {
-        background-color: var(--calcite-color-transparent-press);
-        border-color: var(--calcite-color-text-3);
-      }
-    }
+  &:host([kind="neutral"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-transparent-hover);
+    --calcite-internal-chip-selectable-hover-border-color: var(--calcite-color-border-input);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-transparent-press);
+    --calcite-internal-chip-selectable-active-border-color: var(--calcite-color-text-3);
   }
 
-  &:host([kind="inverse"]) .container,
-  &:host([kind="brand"]) .container {
-    &.selectable {
-      &:hover {
-        background-color: var(--calcite-color-transparent-hover);
-      }
-      &:active {
-        background-color: var(--calcite-color-transparent-press);
-      }
-    }
+  &:host([kind="inverse"]),
+  &:host([kind="brand"]) {
+    --calcite-internal-chip-selectable-hover-background-color: var(--calcite-color-transparent-hover);
+    --calcite-internal-chip-selectable-active-background-color: var(--calcite-color-transparent-press);
   }
 }
 
@@ -398,6 +350,8 @@
   box-border
   font-medium;
 
+  background-color: var(--calcite-internal-chip-background-color);
+  border-color: var(--calcite-internal-chip-border-color);
   border-radius: var(--calcite-chip-corner-radius, 9999px);
   border-width: var(--calcite-border-width-sm);
   border-style: solid;
@@ -414,6 +368,15 @@
 
   &.selectable {
     @apply cursor-pointer;
+
+    &:hover {
+      background-color: var(--calcite-internal-chip-selectable-hover-background-color);
+      border-color: var(--calcite-internal-chip-selectable-hover-border-color);
+    }
+    &:active {
+      background-color: var(--calcite-internal-chip-selectable-active-background-color);
+      border-color: var(--calcite-internal-chip-selectable-active-border-color);
+    }
   }
   &:not(.non-interactive):focus {
     @apply focus-outset;


### PR DESCRIPTION
**Related Issue:** [#11732](https://github.com/Esri/calcite-design-system/issues/11732)

## Summary

Add internal css tokens to simplify component's interactivity states.
