### PR TITLE
feat(input-message): add component tokens and deprecate --calcite-input-message-spacing-value

### DIFF
--- a/packages/calcite-components/src/components/input-message/input-message.e2e.ts
+++ b/packages/calcite-components/src/components/input-message/input-message.e2e.ts
@@ -155,5 +155,13 @@ describe("calcite-input-message", () => {
         },
       });
     });
+
+    describe("deprecated", () => {
+      themed(html`<calcite-input-message>Message</calcite-input-message>`, {
+        "--calcite-input-message-spacing-value": {
+          targetProp: "--calcite-input-message-spacing-value",
+        },
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/input-message/input-message.e2e.ts
+++ b/packages/calcite-components/src/components/input-message/input-message.e2e.ts
@@ -1,7 +1,8 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, hidden, renders } from "../../tests/commonTests";
+import { accessible, hidden, renders, themed } from "../../tests/commonTests";
+import { html } from "../../../support/formatting";
 import { StatusIconDefaults } from "./interfaces";
 
 describe("calcite-input-message", () => {
@@ -139,6 +140,19 @@ describe("calcite-input-message", () => {
           requestedIcon = await iconEl.getAttribute("icon");
           expect(requestedIcon).toEqual("view-hide");
         });
+      });
+    });
+  });
+
+  describe("theme", () => {
+    describe("default", () => {
+      themed(html`<calcite-input-message>Message</calcite-input-message>`, {
+        "--calcite-input-message-icon-color": {
+          targetProp: "--calcite-input-message-icon-color",
+        },
+        "--calcite-input-message-spacing": {
+          targetProp: "--calcite-input-message-spacing",
+        },
       });
     });
   });

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -10,9 +10,10 @@
 
 :host {
   @apply text-color-1 transition-default box-border flex h-auto w-full items-center font-medium opacity-100;
+
   margin-block-start: var(
     --calcite-input-message-spacing,
-    var(--calcite-input-message-spacing-value, --calcite-spacing-xxs)
+    var(--calcite-input-message-spacing-value, var(--calcite-spacing-xxs))
   );
 }
 

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -3,8 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-input-message-spacing-value: [Deprecated] Use `--calcite-input-message-spacing`.The top margin spacing above the component.
- * @prop --calcite-input-message-spacing: Specifies the top margin space above the component.
+ * @prop --calcite-input-message-spacing-value: [Deprecated] Use `--calcite-input-message-spacing`. Specifies the margin spacing at the top of the component.
+ * @prop --calcite-input-message-spacing: Specifies the margin spacing at the top of the component.
  * @prop --calcite-input-message-icon-color: Specifies the component's icon color.
  */
 

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -3,15 +3,17 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-input-message-spacing-value: The top margin spacing above the component.
+ * @prop --calcite-input-message-spacing-value: [Deprecated] Use `--calcite-input-message-spacing`.The top margin spacing above the component.
  * @prop --calcite-input-message-spacing: Specifies the top margin space above the component.
  * @prop --calcite-input-message-icon-color: Specifies the component's icon color.
  */
 
 :host {
   @apply text-color-1 transition-default box-border flex h-auto w-full items-center font-medium opacity-100;
-  --calcite-input-message-spacing: var(--calcite-spacing-xxs);
-  margin-block-start: var(--calcite-input-message-spacing);
+  margin-block-start: var(
+    --calcite-input-message-spacing,
+    var(--calcite-input-message-spacing-value, --calcite-spacing-xxs)
+  );
 }
 
 .calcite-input-message-icon {

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -23,19 +23,19 @@
 }
 
 :host([status="invalid"]) .calcite-input-message-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-danger));
+  color: var(--calcite-input-message-icon-color, var(--calcite-icon-color, var(--calcite-color-status-danger)));
 }
 
 :host([status="warning"]) .calcite-input-message-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-warning));
+  color: var(--calcite-input-message-icon-color, var(--calcite-icon-color, var(--calcite-color-status-warning)));
 }
 
 :host([status="valid"]) .calcite-input-message-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-success));
+  color: var(--calcite-input-message-icon-color, var(--calcite-icon-color, var(--calcite-color-status-success)));
 }
 
 :host([status="idle"]) .calcite-input-message-icon {
-  color: var(--calcite-input-message-icon-color, var(--calcite-color-brand));
+  color: var(--calcite-input-message-icon-color, var(--calcite-icon-color, var(--calcite-color-brand)));
 }
 
 :host([scale="s"]) {

--- a/packages/calcite-components/src/components/input-message/input-message.scss
+++ b/packages/calcite-components/src/components/input-message/input-message.scss
@@ -4,33 +4,35 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-input-message-spacing-value: The top margin spacing above the component.
+ * @prop --calcite-input-message-spacing: Specifies the top margin space above the component.
+ * @prop --calcite-input-message-icon-color: Specifies the component's icon color.
  */
 
 :host {
   @apply text-color-1 transition-default box-border flex h-auto w-full items-center font-medium opacity-100;
-  --calcite-input-message-spacing-value: theme("spacing.1");
-  margin-block-start: var(--calcite-input-message-spacing-value);
+  --calcite-input-message-spacing: var(--calcite-spacing-xxs);
+  margin-block-start: var(--calcite-input-message-spacing);
 }
 
 .calcite-input-message-icon {
   @apply transition-default pointer-events-none inline-flex flex-shrink-0;
-  margin-inline-end: theme("margin.2");
+  margin-inline-end: var(--calcite-spacing-sm);
 }
 
 :host([status="invalid"]) .calcite-input-message-icon {
-  color: var(--calcite-color-status-danger);
+  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-danger));
 }
 
 :host([status="warning"]) .calcite-input-message-icon {
-  color: var(--calcite-color-status-warning);
+  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-warning));
 }
 
 :host([status="valid"]) .calcite-input-message-icon {
-  color: var(--calcite-color-status-success);
+  color: var(--calcite-input-message-icon-color, var(--calcite-color-status-success));
 }
 
 :host([status="idle"]) .calcite-input-message-icon {
-  color: var(--calcite-color-brand);
+  color: var(--calcite-input-message-icon-color, var(--calcite-color-brand));
 }
 
 :host([scale="s"]) {

--- a/packages/calcite-components/src/components/input-message/resources.ts
+++ b/packages/calcite-components/src/components/input-message/resources.ts
@@ -1,0 +1,3 @@
+export const CSS = {
+  calciteInputMessageIcon: "calcite-input-message-icon",
+};

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -30,6 +30,7 @@ import { handle, handleTokens } from "./custom-theme/handle";
 import { icon } from "./custom-theme/icon";
 import { inlineEditable, inlineEditableTokens } from "./custom-theme/inline-editable";
 import { input, inputTokens } from "./custom-theme/input";
+import { inputMessage, inputMessageTokens } from "./custom-theme/input-message";
 import { inputNumber } from "./custom-theme/input-number";
 import { inputText } from "./custom-theme/input-text";
 import { label, labelTokens } from "./custom-theme/label";
@@ -157,6 +158,9 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       <div class="demo-column">${datePicker}</div>
       <div class="demo-column">${datePickerRange}</div>
     </div>
+    <div class="demo-row">
+      <div class="demo-column">${inputMessage}</div>
+    </div>
   </div>`;
 
 const componentTokens = {
@@ -185,6 +189,7 @@ const componentTokens = {
   ...inlineEditableTokens,
   ...graphTokens,
   ...inputTokens,
+  ...inputMessageTokens,
   ...labelTokens,
   ...linkTokens,
   ...listTokens,

--- a/packages/calcite-components/src/custom-theme/input-message.ts
+++ b/packages/calcite-components/src/custom-theme/input-message.ts
@@ -3,6 +3,7 @@ import { html } from "../../support/formatting";
 export const inputMessageTokens = {
   calciteInputMessageIconColor: "",
   calciteInputMessageSpacing: "",
+  calciteInputMessageSpacingValue: "",
 };
 
 export const inputMessage = html`<calcite-input-message status="invalid" icon="frown">Message</calcite-input-message>`;

--- a/packages/calcite-components/src/custom-theme/input-message.ts
+++ b/packages/calcite-components/src/custom-theme/input-message.ts
@@ -1,0 +1,8 @@
+import { html } from "../../support/formatting";
+
+export const inputMessageTokens = {
+  calciteInputMessageIconColor: "",
+  calciteInputMessageSpacing: "",
+};
+
+export const inputMessage = html`<calcite-input-message status="invalid" icon="frown">Message</calcite-input-message>`;


### PR DESCRIPTION
**Related Issue:** #7180 

Adds the following tokens to `input-message` component:

`--calcite-input-message-icon-color`: Specifies the component's icon color.
`--calcite-input-message-spacing`: Specifies the top margin space above the component.

Deprecates `--calcite-input-message-spacing-value`: Specifies the top margin space above the component.
