### PR TITLE
revert(menu): revert interaction state changes

### DIFF
--- a/packages/calcite-components/src/components/menu-item/menu-item.scss
+++ b/packages/calcite-components/src/components/menu-item/menu-item.scss
@@ -59,13 +59,12 @@
   color: var(--calcite-menu-text-color, var(--calcite-internal-menu-text-color, var(--calcite-color-text-2)));
 
   &:hover {
+    @apply bg-foreground-2 text-color-2;
     border-block-end-color: var(--calcite-menu-item-accent-color, var(--calcite-color-border-2));
   }
 
   &:focus {
-    @apply focus-inset border-b-4;
-    padding-block-start: theme("spacing.1");
-    border-block-end-width: theme("spacing.1");
+    @apply bg-foreground-2 text-color-2 focus-inset;
   }
 
   &:active {


### PR DESCRIPTION
**Related Issue:** [#11760](https://github.com/Esri/calcite-design-system/issues/11760)

## Summary

Revert the following changes:

- Remove the background color on :hover and :focus to match stepper, tabs and pagination.
- Add border.2 2px bottom border on :hover to match tabs and pagination.
- Increase :active state bottom border to 4px on :focus.
