### PR TITLE
feat(list-item): enhance component's interactivity states

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -46,7 +46,7 @@
 }
 
 .container:active {
-  background-color: var(--calcite-list-background-color-press, var(--calcite-color-foreground-1));
+  background-color: var(--calcite-list-background-color-press, var(--calcite-color-foreground-3));
 }
 
 .container--border {
@@ -65,14 +65,6 @@
 .container--border-selected {
   &::before {
     background-color: var(--calcite-list-selection-border-color, var(--calcite-color-brand));
-  }
-}
-
-.container:hover {
-  &.container--border-unselected {
-    &::before {
-      background-color: var(--calcite-list-selection-border-color, var(--calcite-color-border-1));
-    }
   }
 }
 
@@ -158,6 +150,11 @@
 .icon {
   align-self: center;
   color: var(--calcite-list-icon-color, var(--calcite-color-text-3));
+
+  &:hover,
+  &:active {
+    color: var(--calcite-color-text-1);
+  }
 }
 
 :host([display-mode="flat"][drag-handle]:is([selection-mode="none"], [selection-appearance="border"])) {
@@ -378,7 +375,7 @@
   padding-inline: var(--calcite-spacing-xxs);
 }
 
-:host(:not([disabled])) .container:hover .expanded-container {
+:host(:not([disabled])) .expanded-container:hover {
   color: var(--calcite-list-icon-color, var(--calcite-color-text-1));
 }
 


### PR DESCRIPTION
**Related Issue:** [#10018](https://github.com/Esri/calcite-design-system/issues/10018)

## Summary

- Update `:active` background color to `--calcite-color-foreground-3`.
- Update icon-start | end to `--calcite-color-text-1` when `:hover` / `:active`.
- Remove `:hover` ghosted selection border in `selection-appearance=“border”`.
- Update chevron to change to `--calcite-color-text-1` only when hovering its hit area.
