### PR TITLE
docs(licensing): refer users to the licensing documentation page

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/README.md
+++ b/README.md
@@ -16,420 +16,420 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 <!-- readme: contributors,calcite-admin/- -start -->
 <table>
- <tbody>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/driskull">
-                    <img src="https://avatars.githubusercontent.com/u/1231455?v=4" width="100;" alt="driskull"/>
-                    <br />
-                    <sub><b>Matt Driscoll</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/jcfranco">
-                    <img src="https://avatars.githubusercontent.com/u/197440?v=4" width="100;" alt="jcfranco"/>
-                    <br />
-                    <sub><b>JC Franco</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/benelan">
-                    <img src="https://avatars.githubusercontent.com/u/10986395?v=4" width="100;" alt="benelan"/>
-                    <br />
-                    <sub><b>Ben Elan</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/macandcheese">
-                    <img src="https://avatars.githubusercontent.com/u/4733155?v=4" width="100;" alt="macandcheese"/>
-                    <br />
-                    <sub><b>Adam Tirella</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/paulcpederson">
-                    <img src="https://avatars.githubusercontent.com/u/1031758?v=4" width="100;" alt="paulcpederson"/>
-                    <br />
-                    <sub><b>Paul Pederson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/eriklharper">
-                    <img src="https://avatars.githubusercontent.com/u/821864?v=4" width="100;" alt="eriklharper"/>
-                    <br />
-                    <sub><b>Erik Harper</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/anveshmekala">
-                    <img src="https://avatars.githubusercontent.com/u/88453586?v=4" width="100;" alt="anveshmekala"/>
-                    <br />
-                    <sub><b>Anveshreddy mekala</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/Elijbet">
-                    <img src="https://avatars.githubusercontent.com/u/19231036?v=4" width="100;" alt="Elijbet"/>
-                    <br />
-                    <sub><b>Eliza Khachatryan</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/geospatialem">
-                    <img src="https://avatars.githubusercontent.com/u/5023024?v=4" width="100;" alt="geospatialem"/>
-                    <br />
-                    <sub><b>Kitty Hurley</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/asangma">
-                    <img src="https://avatars.githubusercontent.com/u/12503298?v=4" width="100;" alt="asangma"/>
-                    <br />
-                    <sub><b>Alan Sangma</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/patrickarlt">
-                    <img src="https://avatars.githubusercontent.com/u/378557?v=4" width="100;" alt="patrickarlt"/>
-                    <br />
-                    <sub><b>Patrick Arlt</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/alisonailea">
-                    <img src="https://avatars.githubusercontent.com/u/3362490?v=4" width="100;" alt="alisonailea"/>
-                    <br />
-                    <sub><b>Ali Stump</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/caripizza">
-                    <img src="https://avatars.githubusercontent.com/u/42423180?v=4" width="100;" alt="caripizza"/>
-                    <br />
-                    <sub><b>Cari Palazzolo</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/kstinson14">
-                    <img src="https://avatars.githubusercontent.com/u/17748358?v=4" width="100;" alt="kstinson14"/>
-                    <br />
-                    <sub><b>Katrina Stinson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/aPreciado88">
-                    <img src="https://avatars.githubusercontent.com/u/165730205?v=4" width="100;" alt="aPreciado88"/>
-                    <br />
-                    <sub><b>Abraham Preciado Morales</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/ManahariDahal">
-                    <img src="https://avatars.githubusercontent.com/u/23712621?v=4" width="100;" alt="ManahariDahal"/>
-                    <br />
-                    <sub><b>Manahari Dahal</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/arowles">
-                    <img src="https://avatars.githubusercontent.com/u/157734991?v=4" width="100;" alt="arowles"/>
-                    <br />
-                    <sub><b>Ashley Rowles</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/DitwanP">
-                    <img src="https://avatars.githubusercontent.com/u/60022782?v=4" width="100;" alt="DitwanP"/>
-                    <br />
-                    <sub><b>Ditwan Price</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/kumarGayu">
-                    <img src="https://avatars.githubusercontent.com/u/9862218?v=4" width="100;" alt="kumarGayu"/>
-                    <br />
-                    <sub><b>Kumar Jayaram Gayatri</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/kat10140">
-                    <img src="https://avatars.githubusercontent.com/u/48069902?v=4" width="100;" alt="kat10140"/>
-                    <br />
-                    <sub><b>Katy Robinson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/pr3tori4n">
-                    <img src="https://avatars.githubusercontent.com/u/12614215?v=4" width="100;" alt="pr3tori4n"/>
-                    <br />
-                    <sub><b>Harry Robbins</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/josercarcamo">
-                    <img src="https://avatars.githubusercontent.com/u/138070439?v=4" width="100;" alt="josercarcamo"/>
-                    <br />
-                    <sub><b>Jose Carcamo</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/justinhough">
-                    <img src="https://avatars.githubusercontent.com/u/9469422?v=4" width="100;" alt="justinhough"/>
-                    <br />
-                    <sub><b>Justin Hough</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/maxpatiiuk">
-                    <img src="https://avatars.githubusercontent.com/u/40512816?v=4" width="100;" alt="maxpatiiuk"/>
-                    <br />
-                    <sub><b>Max Patiiuk</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/ffaubry">
-                    <img src="https://avatars.githubusercontent.com/u/3506166?v=4" width="100;" alt="ffaubry"/>
-                    <br />
-                    <sub><b>Frederic Aubry</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/mpriour">
-                    <img src="https://avatars.githubusercontent.com/u/142636?v=4" width="100;" alt="mpriour"/>
-                    <br />
-                    <sub><b>Matt Priour</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/vcolavin">
-                    <img src="https://avatars.githubusercontent.com/u/5898204?v=4" width="100;" alt="vcolavin"/>
-                    <br />
-                    <sub><b>Vincent Colavin</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/y0n4">
-                    <img src="https://avatars.githubusercontent.com/u/25360903?v=4" width="100;" alt="y0n4"/>
-                    <br />
-                    <sub><b>Yona N</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/bpatterson88">
-                    <img src="https://avatars.githubusercontent.com/u/15875886?v=4" width="100;" alt="bpatterson88"/>
-                    <br />
-                    <sub><b>Ben Patterson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/jrowlingson">
-                    <img src="https://avatars.githubusercontent.com/u/3051781?v=4" width="100;" alt="jrowlingson"/>
-                    <br />
-                    <sub><b>Jack Rowlingson</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/crowjonah">
-                    <img src="https://avatars.githubusercontent.com/u/1634397?v=4" width="100;" alt="crowjonah"/>
-                    <br />
-                    <sub><b>Crow Norlander</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/jgibson02">
-                    <img src="https://avatars.githubusercontent.com/u/5069711?v=4" width="100;" alt="jgibson02"/>
-                    <br />
-                    <sub><b>John Gibson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/MikeTschudi">
-                    <img src="https://avatars.githubusercontent.com/u/2125181?v=4" width="100;" alt="MikeTschudi"/>
-                    <br />
-                    <sub><b>Mike Tschudi</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/brandentheintern">
-                    <img src="https://avatars.githubusercontent.com/u/158607603?v=4" width="100;" alt="brandentheintern"/>
-                    <br />
-                    <sub><b>Branden Chong</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/ethanbdev">
-                    <img src="https://avatars.githubusercontent.com/u/52869490?v=4" width="100;" alt="ethanbdev"/>
-                    <br />
-                    <sub><b>Ethan Borgen</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/gpbmike">
-                    <img src="https://avatars.githubusercontent.com/u/8754?v=4" width="100;" alt="gpbmike"/>
-                    <br />
-                    <sub><b>Mike Horn</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/Apahadi73">
-                    <img src="https://avatars.githubusercontent.com/u/36856709?v=4" width="100;" alt="Apahadi73"/>
-                    <br />
-                    <sub><b>Amir Pahadi</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/tomwayson">
-                    <img src="https://avatars.githubusercontent.com/u/662944?v=4" width="100;" alt="tomwayson"/>
-                    <br />
-                    <sub><b>Tom Wayson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/cosbyr">
-                    <img src="https://avatars.githubusercontent.com/u/11748268?v=4" width="100;" alt="cosbyr"/>
-                    <br />
-                    <sub><b>Ryan Cosby</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/rpanichakit9541">
-                    <img src="https://avatars.githubusercontent.com/u/44479773?v=4" width="100;" alt="rpanichakit9541"/>
-                    <br />
-                    <sub><b>Rachapong Panichakit</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/alexabreu">
-                    <img src="https://avatars.githubusercontent.com/u/91140?v=4" width="100;" alt="alexabreu"/>
-                    <br />
-                    <sub><b>Alex Abreu</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/annierm18">
-                    <img src="https://avatars.githubusercontent.com/u/25759835?v=4" width="100;" alt="annierm18"/>
-                    <br />
-                    <sub><b>Aine Fitzgerald Coleman</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/anveshrmekala">
-                    <img src="https://avatars.githubusercontent.com/u/107427943?v=4" width="100;" alt="anveshrmekala"/>
-                    <br />
-                    <sub><b>anvesh mekala</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/timmorey">
-                    <img src="https://avatars.githubusercontent.com/u/2340894?v=4" width="100;" alt="timmorey"/>
-                    <br />
-                    <sub><b>Timothy Morey</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/timsun123">
-                    <img src="https://avatars.githubusercontent.com/u/5298143?v=4" width="100;" alt="timsun123"/>
-                    <br />
-                    <sub><b>Tim Sun</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/noahmulfinger">
-                    <img src="https://avatars.githubusercontent.com/u/6539297?v=4" width="100;" alt="noahmulfinger"/>
-                    <br />
-                    <sub><b>Noah Mulfinger</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/Ninkuk">
-                    <img src="https://avatars.githubusercontent.com/u/20276256?v=4" width="100;" alt="Ninkuk"/>
-                    <br />
-                    <sub><b>Ninad Kulkarni</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/nwhittaker">
-                    <img src="https://avatars.githubusercontent.com/u/421496?v=4" width="100;" alt="nwhittaker"/>
-                    <br />
-                    <sub><b>Nathan Whittaker</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/oknoway">
-                    <img src="https://avatars.githubusercontent.com/u/354970?v=4" width="100;" alt="oknoway"/>
-                    <br />
-                    <sub><b>Nate Bedortha</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/kevindoshier">
-                    <img src="https://avatars.githubusercontent.com/u/11093161?v=4" width="100;" alt="kevindoshier"/>
-                    <br />
-                    <sub><b>Kevin Doshier</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/ptmdmusique">
-                    <img src="https://avatars.githubusercontent.com/u/37349324?v=4" width="100;" alt="ptmdmusique"/>
-                    <br />
-                    <sub><b>Duc Phan</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/dasa">
-                    <img src="https://avatars.githubusercontent.com/u/828058?v=4" width="100;" alt="dasa"/>
-                    <br />
-                    <sub><b>Dasa Paddock</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/bsvensson">
-                    <img src="https://avatars.githubusercontent.com/u/808357?v=4" width="100;" alt="bsvensson"/>
-                    <br />
-                    <sub><b>Bjorn Svensson</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/drewdaemon">
-                    <img src="https://avatars.githubusercontent.com/u/315764?v=4" width="100;" alt="drewdaemon"/>
-                    <br />
-                    <sub><b>Drew Tate</b></sub>
-                </a>
-            </td>
-  </tr>
-  <tr>
-            <td align="center">
-                <a href="https://github.com/allieorth">
-                    <img src="https://avatars.githubusercontent.com/u/48034760?v=4" width="100;" alt="allieorth"/>
-                    <br />
-                    <sub><b>Allie Raney</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/ashetland">
-                    <img src="https://avatars.githubusercontent.com/u/108549080?v=4" width="100;" alt="ashetland"/>
-                    <br />
-                    <sub><b>Aaron Shetland</b></sub>
-                </a>
-            </td>
-  </tr>
- <tbody>
+<tbody>
+<tr>
+  <td align="center">
+    <a href="https://github.com/driskull">
+      <img src="https://avatars.githubusercontent.com/u/1231455?v=4" width="100;" alt="driskull"/>
+      <br />
+      <sub><b>Matt Driscoll</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/jcfranco">
+      <img src="https://avatars.githubusercontent.com/u/197440?v=4" width="100;" alt="jcfranco"/>
+      <br />
+      <sub><b>JC Franco</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/benelan">
+      <img src="https://avatars.githubusercontent.com/u/10986395?v=4" width="100;" alt="benelan"/>
+      <br />
+      <sub><b>Ben Elan</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/macandcheese">
+      <img src="https://avatars.githubusercontent.com/u/4733155?v=4" width="100;" alt="macandcheese"/>
+      <br />
+      <sub><b>Adam Tirella</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/paulcpederson">
+      <img src="https://avatars.githubusercontent.com/u/1031758?v=4" width="100;" alt="paulcpederson"/>
+      <br />
+      <sub><b>Paul Pederson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/eriklharper">
+      <img src="https://avatars.githubusercontent.com/u/821864?v=4" width="100;" alt="eriklharper"/>
+      <br />
+      <sub><b>Erik Harper</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/anveshmekala">
+      <img src="https://avatars.githubusercontent.com/u/88453586?v=4" width="100;" alt="anveshmekala"/>
+      <br />
+      <sub><b>Anveshreddy mekala</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/Elijbet">
+      <img src="https://avatars.githubusercontent.com/u/19231036?v=4" width="100;" alt="Elijbet"/>
+      <br />
+      <sub><b>Eliza Khachatryan</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/geospatialem">
+      <img src="https://avatars.githubusercontent.com/u/5023024?v=4" width="100;" alt="geospatialem"/>
+      <br />
+      <sub><b>Kitty Hurley</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/asangma">
+      <img src="https://avatars.githubusercontent.com/u/12503298?v=4" width="100;" alt="asangma"/>
+      <br />
+      <sub><b>Alan Sangma</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/patrickarlt">
+      <img src="https://avatars.githubusercontent.com/u/378557?v=4" width="100;" alt="patrickarlt"/>
+      <br />
+      <sub><b>Patrick Arlt</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/alisonailea">
+      <img src="https://avatars.githubusercontent.com/u/3362490?v=4" width="100;" alt="alisonailea"/>
+      <br />
+      <sub><b>Ali Stump</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/caripizza">
+      <img src="https://avatars.githubusercontent.com/u/42423180?v=4" width="100;" alt="caripizza"/>
+      <br />
+      <sub><b>Cari Palazzolo</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/kstinson14">
+      <img src="https://avatars.githubusercontent.com/u/17748358?v=4" width="100;" alt="kstinson14"/>
+      <br />
+      <sub><b>Katrina Stinson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/aPreciado88">
+      <img src="https://avatars.githubusercontent.com/u/165730205?v=4" width="100;" alt="aPreciado88"/>
+      <br />
+      <sub><b>Abraham Preciado Morales</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/ManahariDahal">
+      <img src="https://avatars.githubusercontent.com/u/23712621?v=4" width="100;" alt="ManahariDahal"/>
+      <br />
+      <sub><b>Manahari Dahal</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/arowles">
+      <img src="https://avatars.githubusercontent.com/u/157734991?v=4" width="100;" alt="arowles"/>
+      <br />
+      <sub><b>Ashley Rowles</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/DitwanP">
+      <img src="https://avatars.githubusercontent.com/u/60022782?v=4" width="100;" alt="DitwanP"/>
+      <br />
+      <sub><b>Ditwan Price</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/kumarGayu">
+      <img src="https://avatars.githubusercontent.com/u/9862218?v=4" width="100;" alt="kumarGayu"/>
+      <br />
+      <sub><b>Kumar Jayaram Gayatri</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/kat10140">
+      <img src="https://avatars.githubusercontent.com/u/48069902?v=4" width="100;" alt="kat10140"/>
+      <br />
+      <sub><b>Katy Robinson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/pr3tori4n">
+      <img src="https://avatars.githubusercontent.com/u/12614215?v=4" width="100;" alt="pr3tori4n"/>
+      <br />
+      <sub><b>Harry Robbins</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/josercarcamo">
+      <img src="https://avatars.githubusercontent.com/u/138070439?v=4" width="100;" alt="josercarcamo"/>
+      <br />
+      <sub><b>Jose Carcamo</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/justinhough">
+      <img src="https://avatars.githubusercontent.com/u/9469422?v=4" width="100;" alt="justinhough"/>
+      <br />
+      <sub><b>Justin Hough</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/maxpatiiuk">
+      <img src="https://avatars.githubusercontent.com/u/40512816?v=4" width="100;" alt="maxpatiiuk"/>
+      <br />
+      <sub><b>Max Patiiuk</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/ffaubry">
+      <img src="https://avatars.githubusercontent.com/u/3506166?v=4" width="100;" alt="ffaubry"/>
+      <br />
+      <sub><b>Frederic Aubry</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/mpriour">
+      <img src="https://avatars.githubusercontent.com/u/142636?v=4" width="100;" alt="mpriour"/>
+      <br />
+      <sub><b>Matt Priour</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/vcolavin">
+      <img src="https://avatars.githubusercontent.com/u/5898204?v=4" width="100;" alt="vcolavin"/>
+      <br />
+      <sub><b>Vincent Colavin</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/y0n4">
+      <img src="https://avatars.githubusercontent.com/u/25360903?v=4" width="100;" alt="y0n4"/>
+      <br />
+      <sub><b>Yona N</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/bpatterson88">
+      <img src="https://avatars.githubusercontent.com/u/15875886?v=4" width="100;" alt="bpatterson88"/>
+      <br />
+      <sub><b>Ben Patterson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/jrowlingson">
+      <img src="https://avatars.githubusercontent.com/u/3051781?v=4" width="100;" alt="jrowlingson"/>
+      <br />
+      <sub><b>Jack Rowlingson</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/crowjonah">
+      <img src="https://avatars.githubusercontent.com/u/1634397?v=4" width="100;" alt="crowjonah"/>
+      <br />
+      <sub><b>Crow Norlander</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/jgibson02">
+      <img src="https://avatars.githubusercontent.com/u/5069711?v=4" width="100;" alt="jgibson02"/>
+      <br />
+      <sub><b>John Gibson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/MikeTschudi">
+      <img src="https://avatars.githubusercontent.com/u/2125181?v=4" width="100;" alt="MikeTschudi"/>
+      <br />
+      <sub><b>Mike Tschudi</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/brandentheintern">
+      <img src="https://avatars.githubusercontent.com/u/158607603?v=4" width="100;" alt="brandentheintern"/>
+      <br />
+      <sub><b>Branden Chong</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/ethanbdev">
+      <img src="https://avatars.githubusercontent.com/u/52869490?v=4" width="100;" alt="ethanbdev"/>
+      <br />
+      <sub><b>Ethan Borgen</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/gpbmike">
+      <img src="https://avatars.githubusercontent.com/u/8754?v=4" width="100;" alt="gpbmike"/>
+      <br />
+      <sub><b>Mike Horn</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/Apahadi73">
+      <img src="https://avatars.githubusercontent.com/u/36856709?v=4" width="100;" alt="Apahadi73"/>
+      <br />
+      <sub><b>Amir Pahadi</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/tomwayson">
+      <img src="https://avatars.githubusercontent.com/u/662944?v=4" width="100;" alt="tomwayson"/>
+      <br />
+      <sub><b>Tom Wayson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/cosbyr">
+      <img src="https://avatars.githubusercontent.com/u/11748268?v=4" width="100;" alt="cosbyr"/>
+      <br />
+      <sub><b>Ryan Cosby</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/rpanichakit9541">
+      <img src="https://avatars.githubusercontent.com/u/44479773?v=4" width="100;" alt="rpanichakit9541"/>
+      <br />
+      <sub><b>Rachapong Panichakit</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/alexabreu">
+      <img src="https://avatars.githubusercontent.com/u/91140?v=4" width="100;" alt="alexabreu"/>
+      <br />
+      <sub><b>Alex Abreu</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/annierm18">
+      <img src="https://avatars.githubusercontent.com/u/25759835?v=4" width="100;" alt="annierm18"/>
+      <br />
+      <sub><b>Aine Fitzgerald Coleman</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/anveshrmekala">
+      <img src="https://avatars.githubusercontent.com/u/107427943?v=4" width="100;" alt="anveshrmekala"/>
+      <br />
+      <sub><b>anvesh mekala</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/timmorey">
+      <img src="https://avatars.githubusercontent.com/u/2340894?v=4" width="100;" alt="timmorey"/>
+      <br />
+      <sub><b>Timothy Morey</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/timsun123">
+      <img src="https://avatars.githubusercontent.com/u/5298143?v=4" width="100;" alt="timsun123"/>
+      <br />
+      <sub><b>Tim Sun</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/noahmulfinger">
+      <img src="https://avatars.githubusercontent.com/u/6539297?v=4" width="100;" alt="noahmulfinger"/>
+      <br />
+      <sub><b>Noah Mulfinger</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/Ninkuk">
+      <img src="https://avatars.githubusercontent.com/u/20276256?v=4" width="100;" alt="Ninkuk"/>
+      <br />
+      <sub><b>Ninad Kulkarni</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/nwhittaker">
+      <img src="https://avatars.githubusercontent.com/u/421496?v=4" width="100;" alt="nwhittaker"/>
+      <br />
+      <sub><b>Nathan Whittaker</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/oknoway">
+      <img src="https://avatars.githubusercontent.com/u/354970?v=4" width="100;" alt="oknoway"/>
+      <br />
+      <sub><b>Nate Bedortha</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/kevindoshier">
+      <img src="https://avatars.githubusercontent.com/u/11093161?v=4" width="100;" alt="kevindoshier"/>
+      <br />
+      <sub><b>Kevin Doshier</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/ptmdmusique">
+      <img src="https://avatars.githubusercontent.com/u/37349324?v=4" width="100;" alt="ptmdmusique"/>
+      <br />
+      <sub><b>Duc Phan</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/dasa">
+      <img src="https://avatars.githubusercontent.com/u/828058?v=4" width="100;" alt="dasa"/>
+      <br />
+      <sub><b>Dasa Paddock</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/bsvensson">
+      <img src="https://avatars.githubusercontent.com/u/808357?v=4" width="100;" alt="bsvensson"/>
+      <br />
+      <sub><b>Bjorn Svensson</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/drewdaemon">
+      <img src="https://avatars.githubusercontent.com/u/315764?v=4" width="100;" alt="drewdaemon"/>
+      <br />
+      <sub><b>Drew Tate</b></sub>
+    </a>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <a href="https://github.com/allieorth">
+      <img src="https://avatars.githubusercontent.com/u/48034760?v=4" width="100;" alt="allieorth"/>
+      <br />
+      <sub><b>Allie Raney</b></sub>
+    </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/ashetland">
+      <img src="https://avatars.githubusercontent.com/u/108549080?v=4" width="100;" alt="ashetland"/>
+      <br />
+      <sub><b>Aaron Shetland</b></sub>
+    </a>
+  </td>
+</tr>
+<tbody>
 </table>
 <!-- readme: contributors,calcite-admin/- -end -->
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
 
 <!-- readme: contributors,calcite-admin/- -start -->
 <table>
-	<tbody>
-		<tr>
+ <tbody>
+  <tr>
             <td align="center">
                 <a href="https://github.com/driskull">
                     <img src="https://avatars.githubusercontent.com/u/1231455?v=4" width="100;" alt="driskull"/>
@@ -60,8 +60,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Erik Harper</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/anveshmekala">
                     <img src="https://avatars.githubusercontent.com/u/88453586?v=4" width="100;" alt="anveshmekala"/>
@@ -104,8 +104,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Ali Stump</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/caripizza">
                     <img src="https://avatars.githubusercontent.com/u/42423180?v=4" width="100;" alt="caripizza"/>
@@ -148,8 +148,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Ditwan Price</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/kumarGayu">
                     <img src="https://avatars.githubusercontent.com/u/9862218?v=4" width="100;" alt="kumarGayu"/>
@@ -192,8 +192,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Max Patiiuk</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/ffaubry">
                     <img src="https://avatars.githubusercontent.com/u/3506166?v=4" width="100;" alt="ffaubry"/>
@@ -236,8 +236,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Jack Rowlingson</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/crowjonah">
                     <img src="https://avatars.githubusercontent.com/u/1634397?v=4" width="100;" alt="crowjonah"/>
@@ -280,8 +280,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Mike Horn</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/Apahadi73">
                     <img src="https://avatars.githubusercontent.com/u/36856709?v=4" width="100;" alt="Apahadi73"/>
@@ -324,8 +324,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Aine Fitzgerald Coleman</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/anveshrmekala">
                     <img src="https://avatars.githubusercontent.com/u/107427943?v=4" width="100;" alt="anveshrmekala"/>
@@ -368,8 +368,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Nathan Whittaker</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/oknoway">
                     <img src="https://avatars.githubusercontent.com/u/354970?v=4" width="100;" alt="oknoway"/>
@@ -412,8 +412,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Drew Tate</b></sub>
                 </a>
             </td>
-		</tr>
-		<tr>
+  </tr>
+  <tr>
             <td align="center">
                 <a href="https://github.com/allieorth">
                     <img src="https://avatars.githubusercontent.com/u/48034760?v=4" width="100;" alt="allieorth"/>
@@ -428,8 +428,8 @@ We welcome contributions to this project. See [CONTRIBUTING.md](./CONTRIBUTING.m
                     <sub><b>Aaron Shetland</b></sub>
                 </a>
             </td>
-		</tr>
-	<tbody>
+  </tr>
+ <tbody>
 </table>
 <!-- readme: contributors,calcite-admin/- -end -->
 
@@ -443,6 +443,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/calcite-components-react/LICENSE.md
+++ b/packages/calcite-components-react/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/calcite-components-react/README.md
+++ b/packages/calcite-components-react/README.md
@@ -110,7 +110,7 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>
 

--- a/packages/calcite-components/LICENSE.md
+++ b/packages/calcite-components/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/calcite-components/README.md
+++ b/packages/calcite-components/README.md
@@ -65,7 +65,7 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>
 

--- a/packages/calcite-design-tokens/LICENSE.md
+++ b/packages/calcite-design-tokens/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/calcite-design-tokens/README.md
+++ b/packages/calcite-design-tokens/README.md
@@ -38,7 +38,7 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>
 

--- a/packages/calcite-ui-icons/LICENSE.md
+++ b/packages/calcite-ui-icons/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/calcite-ui-icons/README.md
+++ b/packages/calcite-ui-icons/README.md
@@ -195,7 +195,7 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>
 

--- a/packages/eslint-config-calcite/LICENSE.md
+++ b/packages/eslint-config-calcite/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/eslint-plugin-calcite-components/LICENSE.md
+++ b/packages/eslint-plugin-calcite-components/LICENSE.md
@@ -8,6 +8,6 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>

--- a/packages/eslint-plugin-calcite-components/README.md
+++ b/packages/eslint-plugin-calcite-components/README.md
@@ -67,7 +67,7 @@ This material is licensed for use under the Esri Master License Agreement (MLA),
 
 See use restrictions at <http://www.esri.com/legal/pdfs/mla_e204_e300/english>
 
-For additional information, contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
+For additional information, refer to [Calcite's licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing) and contact: Environmental Systems Research Institute, Inc. Attn: Contracts and Legal Services Department 380 New York Street Redlands, California, USA 92373 USA
 
 email: <contracts@esri.com>
 


### PR DESCRIPTION
**Related Issue:** #8950

## Summary
Directs users to Calcite's [Licensing](https://developers.arcgis.com/calcite-design-system/resources/licensing/) page, and licensing requirements - which is Calcite's source of truth for licensing.

cc @juliepowell