### PR TITLE
feat(fab): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/fab/fab.e2e.ts
+++ b/packages/calcite-components/src/components/fab/fab.e2e.ts
@@ -180,7 +180,7 @@ describe("calcite-fab", () => {
       themed(html`<calcite-fab loading></calcite-fab>`, {
         "--calcite-fab-loader-color": {
           targetProp: "color",
-          shadowSelector: `.${CSS.button} >>> calcite-loader`,
+          shadowSelector: `.${CSS.button} >>> button >>> calcite-loader`,
         },
       });
     });

--- a/packages/calcite-components/src/components/fab/fab.e2e.ts
+++ b/packages/calcite-components/src/components/fab/fab.e2e.ts
@@ -154,19 +154,19 @@ describe("calcite-fab", () => {
     describe("default", () => {
       themed(html`<calcite-fab></calcite-fab>`, {
         "--calcite-fab-background-color": {
-          targetProp: "backgroundColor",
+          targetProp: "--calcite-button-background-color",
           shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-border-color": {
-          targetProp: "borderColor",
+          targetProp: "--calcite-button-border-color",
           shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-corner-radius": {
-          targetProp: "borderRadius",
+          targetProp: "--calcite-button-corner-radius",
           shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-text-color": {
-          targetProp: "color",
+          targetProp: "--calcite-button-text-color",
           shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-shadow": {
@@ -179,7 +179,7 @@ describe("calcite-fab", () => {
     describe("loader", () => {
       themed(html`<calcite-fab loading></calcite-fab>`, {
         "--calcite-fab-loader-color": {
-          targetProp: "color",
+          targetProp: "--calcite-button-loader-color",
           shadowSelector: `.${CSS.button} >>> button >>> calcite-loader`,
         },
       });

--- a/packages/calcite-components/src/components/fab/fab.e2e.ts
+++ b/packages/calcite-components/src/components/fab/fab.e2e.ts
@@ -1,7 +1,8 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, defaults, disabled, hidden, renders } from "../../tests/commonTests";
+import { accessible, defaults, disabled, hidden, renders, themed } from "../../tests/commonTests";
 import { findAll } from "../../tests/utils";
+import { html } from "../../../support/formatting";
 import { CSS } from "./resources";
 
 describe("calcite-fab", () => {
@@ -145,6 +146,42 @@ describe("calcite-fab", () => {
         });
         const fab = await page.find(`calcite-fab >>> .${CSS.button}`);
         expect(fab.getAttribute("appearance")).toBe("outline-fill");
+      });
+    });
+  });
+
+  describe("theme", () => {
+    describe("default", () => {
+      themed(html`<calcite-fab></calcite-fab>`, {
+        "--calcite-fab-background-color": {
+          targetProp: "backgroundColor",
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-fab-border-color": {
+          targetProp: "borderColor",
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-fab-corner-radius": {
+          targetProp: "borderRadius",
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-fab-text-color": {
+          targetProp: "color",
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-fab-shadow": {
+          targetProp: "boxShadow",
+          shadowSelector: `.${CSS.button}`,
+        },
+      });
+
+      describe("loader", () => {
+        themed(html`<calcite-fab loading></calcite-fab>`, {
+          "--calcite-fab-loader-color": {
+            targetProp: "color",
+            shadowSelector: `.${CSS.button} >>> calcite-loader`,
+          },
+        });
       });
     });
   });

--- a/packages/calcite-components/src/components/fab/fab.e2e.ts
+++ b/packages/calcite-components/src/components/fab/fab.e2e.ts
@@ -155,19 +155,19 @@ describe("calcite-fab", () => {
       themed(html`<calcite-fab></calcite-fab>`, {
         "--calcite-fab-background-color": {
           targetProp: "--calcite-button-background-color",
-          shadowSelector: `.${CSS.button} >>> button`,
+          shadowSelector: `.${CSS.button}`,
         },
         "--calcite-fab-border-color": {
           targetProp: "--calcite-button-border-color",
-          shadowSelector: `.${CSS.button} >>> button`,
+          shadowSelector: `.${CSS.button}`,
         },
         "--calcite-fab-corner-radius": {
           targetProp: "--calcite-button-corner-radius",
-          shadowSelector: `.${CSS.button} >>> button`,
+          shadowSelector: `.${CSS.button}`,
         },
         "--calcite-fab-text-color": {
           targetProp: "--calcite-button-text-color",
-          shadowSelector: `.${CSS.button} >>> button`,
+          shadowSelector: `.${CSS.button}`,
         },
         "--calcite-fab-shadow": {
           targetProp: "boxShadow",
@@ -180,7 +180,7 @@ describe("calcite-fab", () => {
       themed(html`<calcite-fab loading></calcite-fab>`, {
         "--calcite-fab-loader-color": {
           targetProp: "--calcite-button-loader-color",
-          shadowSelector: `.${CSS.button} >>> button >>> calcite-loader`,
+          shadowSelector: `.${CSS.button}`,
         },
       });
     });

--- a/packages/calcite-components/src/components/fab/fab.e2e.ts
+++ b/packages/calcite-components/src/components/fab/fab.e2e.ts
@@ -155,33 +155,33 @@ describe("calcite-fab", () => {
       themed(html`<calcite-fab></calcite-fab>`, {
         "--calcite-fab-background-color": {
           targetProp: "backgroundColor",
-          shadowSelector: `.${CSS.button}`,
+          shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-border-color": {
           targetProp: "borderColor",
-          shadowSelector: `.${CSS.button}`,
+          shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-corner-radius": {
           targetProp: "borderRadius",
-          shadowSelector: `.${CSS.button}`,
+          shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-text-color": {
           targetProp: "color",
-          shadowSelector: `.${CSS.button}`,
+          shadowSelector: `.${CSS.button} >>> button`,
         },
         "--calcite-fab-shadow": {
           targetProp: "boxShadow",
           shadowSelector: `.${CSS.button}`,
         },
       });
+    });
 
-      describe("loader", () => {
-        themed(html`<calcite-fab loading></calcite-fab>`, {
-          "--calcite-fab-loader-color": {
-            targetProp: "color",
-            shadowSelector: `.${CSS.button} >>> calcite-loader`,
-          },
-        });
+    describe("loader", () => {
+      themed(html`<calcite-fab loading></calcite-fab>`, {
+        "--calcite-fab-loader-color": {
+          targetProp: "color",
+          shadowSelector: `.${CSS.button} >>> calcite-loader`,
+        },
       });
     });
   });

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -12,7 +12,9 @@
  */
 
 :host {
-  @apply flex bg-transparent;
+  @apply flex;
+
+  background-color: transparent;
 }
 
 @include disabled();
@@ -32,10 +34,7 @@ calcite-button {
   --calcite-button-border-color: var(--calcite-fab-border-color);
   --calcite-button-corner-radius: var(--calcite-fab-corner-radius);
   --calcite-button-text-color: var(--calcite-fab-text-color);
-
-  calcite-loader {
-    --calcite-button-loader-color: var(--calcite-fab-loader-color);
-  }
+  --calcite-button-loader-color: var(--calcite-fab-loader-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/fab/fab.scss
+++ b/packages/calcite-components/src/components/fab/fab.scss
@@ -1,3 +1,16 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-fab-background-color: Specifies the component's background color.
+ * @prop --calcite-fab-border-color: Specifies the component's border color.
+ * @prop --calcite-fab-corner-radius: Specifies the component's corner radius.
+ * @prop --calcite-fab-text-color: Specifies the component's text color.
+ * @prop --calcite-fab-loader-color: Specifies the component's loader color.
+ * @prop --calcite-fab-shadow: Specifies the component's shadow.
+ */
+
 :host {
   @apply flex bg-transparent;
 }
@@ -5,12 +18,23 @@
 @include disabled();
 
 calcite-button {
-  @apply shadow-2;
+  --calcite-fab-shadow-internal: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--calcite-fab-shadow, var(--calcite-fab-shadow-internal));
+
   &:hover {
     @apply shadow-2-lg;
   }
   &:active {
     @apply shadow-2-sm;
+  }
+
+  --calcite-button-background-color: var(--calcite-fab-background-color);
+  --calcite-button-border-color: var(--calcite-fab-border-color);
+  --calcite-button-corner-radius: var(--calcite-fab-corner-radius);
+  --calcite-button-text-color: var(--calcite-fab-text-color);
+
+  calcite-loader {
+    --calcite-button-loader-color: var(--calcite-fab-loader-color);
   }
 }
 

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -24,7 +24,7 @@ import { chips, chipTokens } from "./custom-theme/chips";
 import { comboboxItem, comboboxItemTokens, selectedComboboxItem } from "./custom-theme/combobox-item";
 import { datePicker, datePickerRange, datePickerTokens } from "./custom-theme/date-picker";
 import { dropdown, DropdownGroupTokens, DropdownItemTokens, DropdownTokens } from "./custom-theme/dropdown";
-import { fab, fabTokens } from "./custom-theme/fab";
+import { fab, fabLoading, fabTokens } from "./custom-theme/fab";
 import { flow, flowTokens } from "./custom-theme/flow";
 import { graph, graphTokens } from "./custom-theme/graph";
 import { handle, handleTokens } from "./custom-theme/handle";
@@ -169,6 +169,7 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
     </div>
     <div class="demo-row">
       <div class="demo-column">${fab}</div>
+      <div class="demo-column">${fabLoading}</div>
     </div>
     <div class="demo-row">
       <div class="demo-column">${inputMessage}</div>

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -24,6 +24,7 @@ import { chips, chipTokens } from "./custom-theme/chips";
 import { comboboxItem, comboboxItemTokens, selectedComboboxItem } from "./custom-theme/combobox-item";
 import { datePicker, datePickerRange, datePickerTokens } from "./custom-theme/date-picker";
 import { dropdown, DropdownGroupTokens, DropdownItemTokens, DropdownTokens } from "./custom-theme/dropdown";
+import { fab, fabTokens } from "./custom-theme/fab";
 import { flow, flowTokens } from "./custom-theme/flow";
 import { graph, graphTokens } from "./custom-theme/graph";
 import { handle, handleTokens } from "./custom-theme/handle";
@@ -167,6 +168,9 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       <div class="demo-column">${datePickerRange}</div>
     </div>
     <div class="demo-row">
+      <div class="demo-column">${fab}</div>
+    </div>
+    <div class="demo-row">
       <div class="demo-column">${inputMessage}</div>
     </div>
   </div>`;
@@ -194,6 +198,7 @@ const componentTokens = {
   ...DropdownTokens,
   ...DropdownItemTokens,
   ...DropdownGroupTokens,
+  ...fabTokens,
   ...flowTokens,
   ...handleTokens,
   ...inlineEditableTokens,

--- a/packages/calcite-components/src/custom-theme/fab.ts
+++ b/packages/calcite-components/src/custom-theme/fab.ts
@@ -9,4 +9,5 @@ export const fabTokens = {
   calciteFabShadow: "",
 };
 
-export const fab = html` <calcite-fab></calcite-fab> `;
+export const fab = html`<calcite-fab></calcite-fab>`;
+export const fabLoading = html`<calcite-fab loading></calcite-fab>`;

--- a/packages/calcite-components/src/custom-theme/fab.ts
+++ b/packages/calcite-components/src/custom-theme/fab.ts
@@ -2,6 +2,10 @@ import { html } from "../../support/formatting";
 
 export const fabTokens = {
   calciteFabBackgroundColor: "",
+  calciteFabBorderColor: "",
+  calciteFabCornerRadius: "",
+  calciteFabTextColor: "",
+  calciteFabLoaderColor: "",
   calciteFabShadow: "",
 };
 

--- a/packages/calcite-components/src/custom-theme/fab.ts
+++ b/packages/calcite-components/src/custom-theme/fab.ts
@@ -1,0 +1,8 @@
+import { html } from "../../support/formatting";
+
+export const fabTokens = {
+  calciteFabBackgroundColor: "",
+  calciteFabShadow: "",
+};
+
+export const fab = html` <calcite-fab></calcite-fab> `;


### PR DESCRIPTION
**Related Issue:** #7180 

Adds the following tokens for `fab` component.

`--calcite-fab-background-color`: Specifies the component's background color.
`--calcite-fab-border-color`: Specifies the component's border color.
`--calcite-fab-corner-radius`: Specifies the component's corner radius.
`--calcite-fab-text-color`: Specifies the component's text color.
`--calcite-fab-loader-color`: Specifies the component's loader color.
`--calcite-fab-shadow`: Specifies the component's shadow.