### PR TITLE
refactor(popover): fix casing inconsistency

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -88,7 +88,7 @@
   color: var(--calcite-popover-text-color, var(--calcite-color-text-1));
 }
 
-.headerContainer {
+.header-container {
   @apply relative
     flex
     h-full

--- a/packages/calcite-components/src/components/popover/resources.ts
+++ b/packages/calcite-components/src/components/popover/resources.ts
@@ -7,7 +7,7 @@ export const CSS = {
   content: "content",
   hasHeader: "has-header",
   header: "header",
-  headerContainer: "headerContainer",
+  headerContainer: "header-container",
   headerContent: "header-content",
   heading: "heading",
 };


### PR DESCRIPTION
**Related Issue:** #N/A

## Summary
Fix casing inconsistency to ensure the `header-container` class is consistently applied and styled across the `popover` component.