### PR TITLE
ci: prevent contributors PRs due to formatting

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Update Contributor List
-        uses: benelan/contributors-readme-action@no-commit-or-push
+        uses: benelan/contributors-readme-action@calcite
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:


### PR DESCRIPTION
**Related Issue:** #11853

## Summary

I removed hardcoded tabs from the contributors action, which should fix the formatting related pull requests.

ref: https://github.com/benelan/contributors-readme-action/commit/c26b918f4f14ace216690e1d64daae255c00e70b
