### PR TITLE
test: avoid timestamp comparison regardless of build or test context

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -32,8 +32,6 @@ jobs:
           node-version-file: package.json
       - if: steps.diff-check.outputs.SKIP == 'false'
         name: Run tests for testable changes
-        env:
-          MODE: test
         run: npm install && npm run build && npm run test
       - if: steps.diff-check.outputs.SKIP == 'true'
         name: Skip visual snapshots for non-testable changes

--- a/packages/calcite-design-tokens/package.json
+++ b/packages/calcite-design-tokens/package.json
@@ -29,9 +29,7 @@
   "license": "SEE LICENSE.md",
   "scripts": {
     "build": "echo $MODE $GITHUB_ACTION && tsx src/build-tokens.ts",
-    "build:test": "MODE='test' npm run build",
     "build:watch": "tsx --watch src/build-tokens.ts",
-    "build:watch:test": "MODE='test' npm run build:watch",
     "clean": "rimraf node_modules dist .turbo",
     "lint:json": "prettier --write \"**/*.json\" >/dev/null",
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path ../../.gitignore",

--- a/packages/calcite-design-tokens/src/build/format/docs.ts
+++ b/packages/calcite-design-tokens/src/build/format/docs.ts
@@ -1,14 +1,12 @@
 import prettierSync from "@prettier/sync";
-import { FormatFn } from "style-dictionary/types";
+import { FormatFn, TransformedToken } from "style-dictionary/types";
 import StyleDictionary from "style-dictionary";
 import { RegisterFn } from "../types/interfaces.js";
 import { cleanAttributes } from "./utils/index.js";
 
 export const formatDocsPlatform: FormatFn = async ({ dictionary }) => {
-  const timestamp = process.env.MODE === "test" ? "TEST_TIMESTAMP" : Date.now();
-
   const output = {
-    timestamp,
+    timestamp: Date.now(),
     tokens: dictionary.allTokens.map((token) => {
       token.value = typeof token.value !== "string" ? JSON.stringify(token.value) : token.value;
 

--- a/packages/calcite-design-tokens/tests/spec/index.spec.ts
+++ b/packages/calcite-design-tokens/tests/spec/index.spec.ts
@@ -59,7 +59,22 @@ function generateTests(platform: Platform, files: string[], internal = false) {
  */
 function assertOutput(outputFilePath: string) {
   const filePath = resolve(__dirname, "..", "..", "dist", outputFilePath);
-  let content = readFileSync(filePath, "utf-8");
-  content = content.slice(content.indexOf("*/") + 1);
+  const content = preprocessContent(readFileSync(filePath, "utf-8"), outputFilePath.split(".").pop());
   expect(content).toMatchSnapshot();
+}
+
+/**
+ * Preprocess the output file before snapshot comparison
+ *
+ * @param content
+ * @param extension
+ */
+function preprocessContent(content: string, extension: string): string {
+  content = content.slice(content.indexOf("*/") + 1);
+
+  if (extension === "json") {
+    content = content.replace(/"timestamp": \d+,\n/, '"timestamp": "TEST_TIMESTAMP",\n');
+  }
+
+  return content;
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": ["MODE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

This ensures token snapshot tests run consistently by always replacing the timestamp field in JSON files, if present.  

The workflow introduced in https://github.com/Esri/calcite-design-system/pull/11831 requires a special test build before running tests, which isn't always applicable. This was causing failures in the `deploy-prerelease` action ([example](https://github.com/Esri/calcite-design-system/actions/runs/14274033634/job/40013441322)), which runs token tests after a production build.  