### PR TITLE
feat(filter): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/filter/filter.e2e.ts
+++ b/packages/calcite-components/src/components/filter/filter.e2e.ts
@@ -1,10 +1,22 @@
 // @ts-strict-ignore
 import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, beforeEach } from "vitest";
-import { accessible, defaults, disabled, focusable, hidden, reflects, renders, t9n } from "../../tests/commonTests";
+import {
+  accessible,
+  defaults,
+  disabled,
+  focusable,
+  hidden,
+  reflects,
+  renders,
+  t9n,
+  themed,
+} from "../../tests/commonTests";
 import { CSS as INPUT_CSS } from "../input/resources";
 import { DEBOUNCE } from "../../utils/resources";
+import { html } from "../../../support/formatting";
 import type { Filter } from "./filter";
+import { CSS } from "./resources";
 
 describe("calcite-filter", () => {
   describe("renders", () => {
@@ -357,5 +369,68 @@ describe("calcite-filter", () => {
 
   describe("translation support", () => {
     t9n("calcite-filter");
+  });
+
+  describe("theme", () => {
+    describe("default", () => {
+      themed(html`<calcite-filter></calcite-filter>`, {
+        "--calcite-filter-content-space": {
+          targetProp: "padding",
+          shadowSelector: `.${CSS.container}`,
+        },
+        "--calcite-filter-input-background-color": {
+          targetProp: "--calcite-input-background-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-border-color": {
+          targetProp: "--calcite-input-border-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-corner-radius": {
+          targetProp: "--calcite-input-corner-radius",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-shadow": {
+          targetProp: "--calcite-input-shadow",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-icon-color": {
+          targetProp: "--calcite-input-icon-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-text-color": {
+          targetProp: "--calcite-input-text-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-placeholder-text-color": {
+          targetProp: "--calcite-input-placeholder-text-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-background-color": {
+          targetProp: "--calcite-input-actions-background-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-background-color-hover": {
+          targetProp: "--calcite-input-actions-background-color-hover",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-background-color-press": {
+          targetProp: "--calcite-input-actions-background-color-press",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-icon-color": {
+          targetProp: "--calcite-input-actions-icon-color",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-icon-color-hover": {
+          targetProp: "--calcite-input-actions-icon-color-hover",
+          shadowSelector: "calcite-input",
+        },
+        "--calcite-filter-input-actions-icon-color-press": {
+          targetProp: "--calcite-input-actions-icon-color-press",
+          shadowSelector: "calcite-input",
+        },
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -12,12 +12,12 @@
  * @prop --calcite-filter-input-text-color: Specifies the input's text color.
  * @prop --calcite-filter-input-placeholder-text-color: Specifies the input's placeholder text color.
  *
- * @prop --calcite-filter-input-actions-background-color: Specifies the background color of the input's `clearable` and `number-button-type` elements.
- * @prop --calcite-filter-input-actions-background-color-hover: Specifies the background color of the input's `clearable` and `number-button-type` elements when hovered.
- * @prop --calcite-filter-input-actions-background-color-press: Specifies the background color of the input's `clearable` and `number-button-type` elements when pressed.
- * @prop --calcite-filter-input-actions-icon-color: Specifies the icon color of the input's `clearable` and `number-button-type` elements.
- * @prop --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the input's `clearable` and `number-button-type` elements when hovered.
- * @prop --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the input's `clearable` and `number-button-type` elements when pressed.
+ * @prop --calcite-filter-input-actions-background-color: Specifies the background color of the input's `clearable` element.
+ * @prop --calcite-filter-input-actions-background-color-hover: Specifies the background color of the input's `clearable` element when hovered.
+ * @prop --calcite-filter-input-actions-background-color-press: Specifies the background color of the input's `clearable` element when pressed.
+ * @prop --calcite-filter-input-actions-icon-color: Specifies the icon color of the input's `clearable` element.
+ * @prop --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the input's `clearable` element when hovered.
+ * @prop --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the input's `clearable` element when pressed.
  */
 
 :host {

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -1,3 +1,25 @@
+/**
+ * CSS Custom Properties
+ *
+ * @prop --calcite-filter-content-space: Specifies the padding of the component's content.
+ *
+ * @prop --calcite-filter-input-background-color: Specifies the input's background color.
+ * @prop --calcite-filter-input-border-color: Specifies the input's border color.
+ * @prop --calcite-filter-input-corner-radius: Specifies the input's corner radius.
+ * @prop --calcite-filter-input-shadow: Specifies the shadow around the input.
+ *
+ * @prop --calcite-filter-input-icon-color: Specifies the input's icon color.
+ * @prop --calcite-filter-input-text-color: Specifies the input's text color.
+ * @prop --calcite-filter-input-placeholder-text-color: Specifies the input's placeholder text color.
+ *
+ * @prop --calcite-filter-input-actions-background-color: Specifies the background color of the input's `clearable` and `number-button-type` elements.
+ * @prop --calcite-filter-input-actions-background-color-hover: Specifies the background color of the input's `clearable` and `number-button-type` elements when hovered.
+ * @prop --calcite-filter-input-actions-background-color-press: Specifies the background color of the input's `clearable` and `number-button-type` elements when pressed.
+ * @prop --calcite-filter-input-actions-icon-color: Specifies the icon color of the input's `clearable` and `number-button-type` elements.
+ * @prop --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the input's `clearable` and `number-button-type` elements when hovered.
+ * @prop --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the input's `clearable` and `number-button-type` elements when pressed.
+ */
+
 :host {
   @extend %component-host;
   @apply flex w-full;
@@ -11,17 +33,17 @@
 
 :host([scale="s"]) {
   .container {
-    padding: var(--calcite-spacing-sm);
+    padding: var(--calcite-filter-content-space, var(--calcite-spacing-sm));
   }
 }
 :host([scale="m"]) {
   .container {
-    padding: var(--calcite-spacing-md);
+    padding: var(--calcite-filter-content-space, var(--calcite-spacing-md));
   }
 }
 :host([scale="l"]) {
   .container {
-    padding: var(--calcite-spacing-lg);
+    padding: var(--calcite-filter-content-space, var(--calcite-spacing-lg));
   }
 }
 

--- a/packages/calcite-components/src/components/filter/filter.scss
+++ b/packages/calcite-components/src/components/filter/filter.scss
@@ -57,6 +57,19 @@ label {
 
 calcite-input {
   @apply w-full;
+  --calcite-input-background-color: var(--calcite-filter-input-background-color);
+  --calcite-input-border-color: var(--calcite-filter-input-border-color);
+  --calcite-input-corner-radius: var(--calcite-filter-input-corner-radius);
+  --calcite-input-shadow: var(--calcite-filter-input-shadow);
+  --calcite-input-icon-color: var(--calcite-filter-input-icon-color);
+  --calcite-input-text-color: var(--calcite-filter-input-text-color);
+  --calcite-input-placeholder-text-color: var(--calcite-filter-input-placeholder-text-color);
+  --calcite-input-actions-background-color: var(--calcite-filter-input-actions-background-color);
+  --calcite-input-actions-background-color-hover: var(--calcite-filter-input-actions-background-color-hover);
+  --calcite-input-actions-background-color-press: var(--calcite-filter-input-actions-background-color-press);
+  --calcite-input-actions-icon-color: var(--calcite-filter-input-actions-icon-color);
+  --calcite-input-actions-icon-color-hover: var(--calcite-filter-input-actions-icon-color-hover);
+  --calcite-input-actions-icon-color-press: var(--calcite-filter-input-actions-icon-color-press);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -25,6 +25,7 @@ import { comboboxItem, comboboxItemTokens, selectedComboboxItem } from "./custom
 import { datePicker, datePickerRange, datePickerTokens } from "./custom-theme/date-picker";
 import { dropdown, DropdownGroupTokens, DropdownItemTokens, DropdownTokens } from "./custom-theme/dropdown";
 import { fab, fabLoading, fabTokens } from "./custom-theme/fab";
+import { filter, filterTokens } from "./custom-theme/filter";
 import { flow, flowTokens } from "./custom-theme/flow";
 import { graph, graphTokens } from "./custom-theme/graph";
 import { handle, handleTokens } from "./custom-theme/handle";
@@ -173,6 +174,9 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       <div class="demo-column">${fabLoading}</div>
     </div>
     <div class="demo-row">
+      <div class="demo-column">${filter}</div>
+    </div>
+    <div class="demo-row">
       <div class="demo-column">${inputMessage}</div>
     </div>
   </div>`;
@@ -201,6 +205,7 @@ const componentTokens = {
   ...DropdownItemTokens,
   ...DropdownGroupTokens,
   ...fabTokens,
+  ...filterTokens,
   ...flowTokens,
   ...handleTokens,
   ...inlineEditableTokens,

--- a/packages/calcite-components/src/custom-theme/filter.ts
+++ b/packages/calcite-components/src/custom-theme/filter.ts
@@ -1,0 +1,20 @@
+import { html } from "../../support/formatting";
+
+export const filterTokens = {
+  calciteFilterContentSpace: "",
+  calciteFilterInputBackgroundColor: "",
+  calciteFilterInputBorderColor: "",
+  calciteFilterInputCornerRadius: "",
+  calciteFilterInputShadow: "",
+  calciteFilterInputIconColor: "",
+  calciteFilterInputTextColor: "",
+  calciteFilterInputPlaceholderTextColor: "",
+  calciteFilterInputActionsBackgroundColor: "",
+  calciteFilterInputActionsBackgroundColorHover: "",
+  calciteFilterInputActionsBackgroundColorPress: "",
+  calciteFilterInputActionsIconColor: "",
+  calciteFilterInputActionsIconColorHover: "",
+  calciteFilterInputActionsIconColorPress: "",
+};
+
+export const filter = html`<calcite-filter></calcite-filter>`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following tokens for `filter` component.

- --calcite-filter-content-space: Specifies the padding of the component's content.
- --calcite-filter-input-background-color: Specifies the input's background color.
- --calcite-filter-input-border-color: Specifies the input's border color.
- --calcite-filter-input-corner-radius: Specifies the input's corner radius.
- --calcite-filter-input-shadow: Specifies the shadow around the input.
- --calcite-filter-input-icon-color: Specifies the input's icon color.
- --calcite-filter-input-text-color: Specifies the input's text color.
- --calcite-filter-input-placeholder-text-color: Specifies the input's placeholder text color.
- --calcite-filter-input-actions-background-color: Specifies the background color of the input's `clearable` and `number-button-type` elements.
- --calcite-filter-input-actions-background-color-hover: Specifies the background color of the input's `clearable` and `number-button-type` elements when hovered.
- --calcite-filter-input-actions-background-color-press: Specifies the background color of the input's `clearable` and `number-button-type` elements when pressed.
- --calcite-filter-input-actions-icon-color: Specifies the icon color of the input's `clearable` and `number-button-type` elements.
- --calcite-filter-input-actions-icon-color-hover: Specifies the icon color of the input's `clearable` and `number-button-type` elements when hovered.
- --calcite-filter-input-actions-icon-color-press: Specifies the icon color of the input's `clearable` and `number-button-type` elements when pressed.
/nts when pressed.