### PR TITLE
chore(linting): fix `lint-staged` errors

### DIFF
--- a/.github/scripts/lint-staged.config.mjs
+++ b/.github/scripts/lint-staged.config.mjs
@@ -1,5 +1,9 @@
 import baseConfig from "../../lint-staged.config.mjs";
 
+/**
+ * @filename: lint-staged.config.mjs
+ * @type {import('lint-staged').Configuration}
+ */
 export default {
   ...baseConfig,
   "*.{m,c,}js": ["eslint --fix", "prettier --write"],

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,5 @@
 export default {
   "*.{json,html,yml}": ["prettier --write"],
   "*.{s,}css": ["prettier --write"],
-  "*.md": ["prettier --write", "markdownlint-cli2 --fix"],
+  "*.md": ["prettier --write", "markdownlint-cli2 --fix --config ../../.markdownlint-cli2.jsonc"],
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,21 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const __filename = fileURLToPath(import.meta.url);
+export const __dirname = dirname(__filename);
+
+/**
+ * @filename: lint-staged.config.mjs
+ * @type {import('lint-staged').Configuration}
+ */
 export default {
   "*.{json,html,yml}": ["prettier --write"],
   "*.{s,}css": ["prettier --write"],
-  "*.md": ["prettier --write", "markdownlint-cli2 --fix --config ../../.markdownlint-cli2.jsonc"],
+  "*.md": (absolutePaths) => {
+    const files = absolutePaths.join(" ");
+    return [
+      `prettier --write ${files}`,
+      `markdownlint-cli2 --fix --config ${resolve(__dirname, "./.markdownlint-cli2.jsonc")} ${files}`
+    ];
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "typescript-eslint": "8.29.0",
         "typescript-strict-plugin": "2.4.4",
         "vite": "5.4.16",
+        "vite-plugin-dts": "4.5.3",
         "vitest": "2.1.9"
       },
       "optionalDependencies": {
@@ -36599,23 +36600,7 @@
     "packages/calcite-design-tokens": {
       "name": "@esri/calcite-design-tokens",
       "version": "3.0.2-next.2",
-      "license": "SEE LICENSE.md",
-      "devDependencies": {
-        "type-fest": "4.37.0"
-      }
-    },
-    "packages/calcite-design-tokens/node_modules/type-fest": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
-      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "SEE LICENSE.md"
     },
     "packages/calcite-ui-icons": {
       "name": "@esri/calcite-ui-icons",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "typescript-eslint": "8.29.0",
     "typescript-strict-plugin": "2.4.4",
     "vite": "5.4.16",
+    "vite-plugin-dts": "4.5.3",
     "vitest": "2.1.9"
   },
   "license": "SEE LICENSE.md",

--- a/packages/calcite-components/lint-staged.config.mjs
+++ b/packages/calcite-components/lint-staged.config.mjs
@@ -1,5 +1,9 @@
 import baseConfig from "../../lint-staged.config.mjs";
 
+/**
+ * @filename: lint-staged.config.mjs
+ * @type {import('lint-staged').Configuration}
+ */
 export default {
   ...baseConfig,
   "*.{s,}css": ["stylelint --fix", "prettier --write"],

--- a/packages/calcite-design-tokens/lint-staged.config.mjs
+++ b/packages/calcite-design-tokens/lint-staged.config.mjs
@@ -1,5 +1,9 @@
 import baseConfig from "../../lint-staged.config.mjs";
 
+/**
+ * @filename: lint-staged.config.mjs
+ * @type {import('lint-staged').Configuration}
+ */
 export default {
   ...baseConfig,
   "*.{ts,tsx,mjs,cjs}": ["eslint --fix", "prettier --write"],

--- a/packages/calcite-design-tokens/package.json
+++ b/packages/calcite-design-tokens/package.json
@@ -41,8 +41,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "devDependencies": {
-    "type-fest": "4.37.0"
   }
 }

--- a/packages/calcite-design-tokens/tsconfig-eslint.json
+++ b/packages/calcite-design-tokens/tsconfig-eslint.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "allowJs": true
+  },
   "extends": "./tsconfig-base.json",
   "include": ["**/*", "*.config.mjs"]
 }


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Fixes errors that came up after recent linting-related updates.

### Notes  

* Resolves `markdownlint-cli2` config path properly
* Ensures `.mjs` files are included in ESLint configs (TS-related)
* Prevents `markdownlint-cli2` from processing `node_modules` in packages by moving dev dependencies to the root
* Adds type annotations to `lint-staged.config.mjs` files