### PR TITLE
fix: remove unused dragging styles (#11883)

### DIFF
--- a/packages/calcite-components/src/assets/styles/_sortable.scss
+++ b/packages/calcite-components/src/assets/styles/_sortable.scss
@@ -1,8 +1,5 @@
 @mixin sortable-helper-classes() {
-  .calcite-sortable--chosen,
-  .calcite-sortable--ghost,
-  .calcite-sortable--drag,
-  .calcite-sortable--fallback {
+  .calcite-sortable--ghost {
     position: relative;
     overflow: hidden;
   }


### PR DESCRIPTION
**Related Issue:** #11871

## Summary

- In FF, the `overflow:hidden` on the chosen class was causing the drag
and drop to break
- In this PR, unnecessary styles are removed in order to prevent the
breakage and any future breakage
- No tests are present because our testing is chromium based