### PR TITLE
fix(list-item): display selection border when item is focused

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -589,10 +589,17 @@ describe("calcite-list-item", () => {
           icon-end="banana"
         ></calcite-list-item>`,
         {
-          "--calcite-list-selection-border-color": {
-            shadowSelector: `.${CSS.container}::before`,
-            targetProp: "backgroundColor",
-          },
+          "--calcite-list-selection-border-color": [
+            {
+              shadowSelector: `.${CSS.container}::before`,
+              targetProp: "backgroundColor",
+            },
+            {
+              shadowSelector: `.${CSS.containerBorderSelected}`,
+              targetProp: "boxShadow",
+              state: "focus",
+            },
+          ],
         },
       );
     });

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -66,6 +66,10 @@
   &::before {
     background-color: var(--calcite-list-selection-border-color, var(--calcite-color-brand));
   }
+
+  &:focus {
+    box-shadow: inset 4px 0 0 0 var(--calcite-list-selection-border-color, var(--calcite-color-brand));
+  }
 }
 
 .nested-container {


### PR DESCRIPTION
**Related Issue:** [#11835](https://github.com/Esri/calcite-design-system/issues/11835)

## Summary

Display selection border when item is selected + focused.
