### PR TITLE
feat(shell): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/shell/shell.e2e.ts
+++ b/packages/calcite-components/src/components/shell/shell.e2e.ts
@@ -1,6 +1,6 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, hidden, renders, slots } from "../../tests/commonTests";
+import { accessible, hidden, renders, slots, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import { CSS, SLOTS } from "./resources";
 
@@ -139,5 +139,57 @@ describe("calcite-shell", () => {
     const contentBottom = await page.find(`calcite-shell >>> .${CSS.contentBottom}`);
 
     expect(contentBottom).not.toBeNull();
+  });
+
+  describe("theme", () => {
+    describe("default", () => {
+      themed(
+        html`<calcite-shell>
+          <calcite-panel slot="panel-start" heading="Example">Hello world</calcite-panel>
+          <calcite-flow slot="panel-end">
+            <calcite-flow-item heading="Example">Hello world</calcite-flow-item>
+          </calcite-flow>
+          <calcite-shell-center-row slot="center-row">Hello world </calcite-shell-center-row>
+        </calcite-shell>`,
+        {
+          "--calcite-shell-border-color": [
+            {
+              targetProp: "borderColor",
+              selector: "calcite-panel",
+            },
+            {
+              targetProp: "borderColor",
+              selector: "calcite-flow",
+            },
+            {
+              targetProp: "borderColor",
+              selector: "calcite-shell-center-row",
+            },
+          ],
+        },
+      );
+    });
+    describe("deprecated", () => {
+      themed(
+        html` <calcite-shell
+          ><calcite-tip-manager slot="center-row" id="tip-manager" hidden>
+            <calcite-tip heading="The lack of imagery">
+              <p>This tip has no image. As such, the content area will take up the entire width of the tip.</p>
+              <p>
+                This is the next paragraph and should show how wide the content area is now. Of course, the width of the
+                overall tip will affect things. In astronomy, the terms object and body are often used interchangeably.
+              </p>
+              <a href="http://www.esri.com">View Esri</a>
+            </calcite-tip>
+          </calcite-tip-manager>
+        </calcite-shell>`,
+        {
+          "--calcite-shell-tip-spacing": {
+            targetProp: "insetInline",
+            selector: "calcite-tip-manager",
+          },
+        },
+      );
+    });
   });
 });

--- a/packages/calcite-components/src/components/shell/shell.scss
+++ b/packages/calcite-components/src/components/shell/shell.scss
@@ -3,7 +3,8 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-shell-tip-spacing: The left and right spacing of the `calcite-tip-manager` when slotted in the component.
+ * @prop --calcite-shell-border-color: Specifies the component's border color.
+ * @prop --calcite-shell-tip-spacing: [Deprecated] This component has been deprecated. The left and right spacing of the `calcite-tip-manager` when slotted in the component.
  */
 
 :host {
@@ -15,7 +16,6 @@
     w-full
     flex-col
     overflow-hidden;
-  --calcite-shell-tip-spacing: 26vw;
 }
 
 .main {
@@ -83,17 +83,19 @@ slot[name="panel-end"]::slotted(calcite-shell-panel) {
 
 ::slotted(calcite-panel),
 ::slotted(calcite-flow) {
-  @apply border-color-3
-  border
-  border-l-0
-  border-r-0
-  border-solid;
+  border-width: var(--calcite-border-width-sm);
+  border-color: var(--calcite-shell-border-color, var(--calcite-color-border-3));
+  border-inline-start-width: var(--calcite-border-width-none);
+  border-inline-end-width: var(--calcite-border-width-none);
+  border-style: solid;
 }
 
 slot[name="center-row"]::slotted(calcite-shell-center-row:not([detached])),
 slot[name="panel-top"]::slotted(calcite-shell-center-row:not([detached])),
 slot[name="panel-bottom"]::slotted(calcite-shell-center-row:not([detached])) {
-  @apply border-color-3 border-l border-r;
+  border-color: var(--calcite-shell-border-color, var(--calcite-color-border-3));
+  border-inline-start-width: var(--calcite-border-width-sm);
+  border-inline-end-width: var(--calcite-border-width-sm);
 }
 
 .center-content {
@@ -114,6 +116,7 @@ slot[name="panel-bottom"]::slotted(calcite-shell-center-row:not([detached])) {
   align-self: stretch;
 }
 
+// deprecated
 ::slotted(calcite-tip-manager) {
   @apply shadow-2
   animate-in-up
@@ -122,7 +125,7 @@ slot[name="panel-bottom"]::slotted(calcite-shell-center-row:not([detached])) {
   rounded
   z-toast;
   inset-block-end: theme("spacing.2");
-  inset-inline: var(--calcite-shell-tip-spacing);
+  inset-inline: var(--calcite-shell-tip-spacing, 26vw); // deprecated
 }
 
 slot[name="center-row"]::slotted(calcite-shell-center-row),


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following tokens for `shell` component.

- --calcite-shell-border-color: Specifies the component's border color.
- --calcite-shell-tip-spacing: [Deprecated] This component has been deprecated. The left and right spacing of the `calcite-tip-manager` when slotted in the component.

