### PR TITLE
chore: exclude token source from formatting

### DIFF
--- a/packages/calcite-design-tokens/.prettierignore
+++ b/packages/calcite-design-tokens/.prettierignore
@@ -1,0 +1,2 @@
+# source tokens are managed by the Tokens Studio plugin, which syncs directly to GitHub
+src/tokens/**/*.json


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Source tokens are managed by the Tokens Studio plugin, which syncs directly with GitHub. This bypasses pre-commit hooks, so it's not able to lint the JSON as expected, leading to inconsistent diffs in design token PRs.