### PR TITLE
feat(input-time-picker): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -20,6 +20,7 @@ import {
   reflects,
   renders,
   t9n,
+  themed,
 } from "../../tests/commonTests";
 import {
   getFocusedElementProp,
@@ -32,6 +33,7 @@ import { html } from "../../../support/formatting";
 import { openClose } from "../../tests/commonTests";
 import { supportedLocales } from "../../utils/locale";
 import { CSS as PopoverCSS } from "../popover/resources";
+import { CSS } from "./resources";
 
 async function getInputValue(page: E2EPage): Promise<string> {
   return page.evaluate(
@@ -917,5 +919,21 @@ describe("calcite-input-time-picker", () => {
     popover = await page.find("calcite-input-time-picker >>> calcite-popover");
 
     expect(await popover.getProperty("open")).toBe(false);
+  });
+
+  describe("themed", () => {
+    describe("default", () => {
+      themed(html`<calcite-input-time-picker></calcite-input-time-picker>`, {
+        "--calcite-input-time-picker-icon-color": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "--calcite-icon-color",
+        },
+        "--calcite-input-time-picker-icon-color-hover": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          state: "hover",
+          targetProp: "--calcite-icon-color",
+        },
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -1,3 +1,12 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-input-time-picker-icon-color: Specifies the component's icon color.
+ * @prop --calcite-input-time-picker-icon-color-hover: Specifies the component's icon color when hovered or focused.
+ */
+
 :host {
   @apply inline-block
     select-none;
@@ -7,22 +16,24 @@
 @include hidden-form-input();
 
 @function get-trailing-text-input-padding($chevron-spacing) {
-  @return calc(var(--calcite-toggle-spacing) + $chevron-spacing);
+  @return calc(var(--calcite-internal-input-time-picker-toggle-spacing) + $chevron-spacing);
 }
 
 :host([scale="s"]) {
-  --calcite-toggle-spacing: theme("spacing.2");
-  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(theme("spacing.4"))};
+  --calcite-internal-input-time-picker-toggle-spacing: var(--calcite-spacing-sm);
+  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(var(--calcite-spacing-lg))};
 }
 
 :host([scale="m"]) {
-  --calcite-toggle-spacing: theme("spacing.3");
-  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(theme("spacing.6"))};
+  --calcite-internal-input-time-picker-toggle-spacing: var(--calcite-spacing-md);
+  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(var(--calcite-spacing-xxl))};
 }
 
 :host([scale="l"]) {
-  --calcite-toggle-spacing: theme("spacing.4");
-  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(theme("spacing.8"))};
+  --calcite-internal-input-time-picker-toggle-spacing: var(--calcite-spacing-lg);
+  --calcite-internal-input-text-input-padding-inline-end: #{get-trailing-text-input-padding(
+      var(--calcite-spacing-xxxl)
+    )};
 }
 
 .input-wrapper {
@@ -33,13 +44,13 @@
   @apply absolute flex cursor-pointer items-center;
   inset-inline-end: 0;
   inset-block: 0;
-  padding-inline: var(--calcite-toggle-spacing);
-  --calcite-icon-color: var(--calcite-color-text-3);
+  padding-inline: var(--calcite-internal-input-time-picker-toggle-spacing);
+  --calcite-icon-color: var(--calcite-input-time-picker-icon-color, var(--calcite-color-text-3));
 }
 
 .input-wrapper:hover .toggle-icon,
 calcite-input-text:focus + .toggle-icon {
-  --calcite-icon-color: var(--calcite-color-text-1);
+  --calcite-icon-color: var(--calcite-input-time-picker-icon-color, var(--calcite-color-text-1));
 }
 
 @include form-validation-message();

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.scss
@@ -50,7 +50,7 @@
 
 .input-wrapper:hover .toggle-icon,
 calcite-input-text:focus + .toggle-icon {
-  --calcite-icon-color: var(--calcite-input-time-picker-icon-color, var(--calcite-color-text-1));
+  --calcite-icon-color: var(--calcite-input-time-picker-icon-color-hover, var(--calcite-color-text-1));
 }
 
 @include form-validation-message();

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -34,6 +34,7 @@ import { input, inputTokens } from "./custom-theme/input";
 import { inputMessage, inputMessageTokens } from "./custom-theme/input-message";
 import { inputNumber } from "./custom-theme/input-number";
 import { inputText } from "./custom-theme/input-text";
+import { inputTimePicker, inputTimePickerTokens } from "./custom-theme/input-time-picker";
 import { label, labelTokens } from "./custom-theme/label";
 import { link, linkTokens } from "./custom-theme/link";
 import { list, listTokens } from "./custom-theme/list";
@@ -143,7 +144,7 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
           <div style="width: 40px; height: 40px;">${actionMenu}</div>
           ${icon}
         </div>
-        ${inlineEditable} ${input} ${inputNumber} ${inputText} ${select} ${singleSelectCombobox}
+        ${inlineEditable} ${input} ${inputNumber} ${inputText} ${inputTimePicker} ${select} ${singleSelectCombobox}
         ${comboboxWithPlaceHolderIcon} ${defaultCombobox}
       </div>
       <div class="demo-column">
@@ -211,6 +212,7 @@ const componentTokens = {
   ...graphTokens,
   ...inputTokens,
   ...inputMessageTokens,
+  ...inputTimePickerTokens,
   ...labelTokens,
   ...linkTokens,
   ...listTokens,

--- a/packages/calcite-components/src/custom-theme/input-time-picker.ts
+++ b/packages/calcite-components/src/custom-theme/input-time-picker.ts
@@ -1,0 +1,8 @@
+import { html } from "../../support/formatting";
+
+export const inputTimePickerTokens = {
+  calciteInputTimePickerIconColor: "",
+  calciteInputTimePickerIconColorHover: "",
+};
+
+export const inputTimePicker = html`<calcite-input-time-picker></calcite-input-time-picker>`;


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following tokens for `input-time-picker` component.

- --calcite-input-time-picker-icon-color: Specifies the component's icon color.
- --calcite-input-time-picker-icon-color-hover: Specifies the component's icon color when hovered or focused.