### PR TITLE
feat(time-picker): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
-import { accessible, defaults, focusable, hidden, renders, t9n } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests";
 import { formatTimePart, getLocaleHourFormat, localizeTimeStringToParts } from "../../utils/time";
 import { getElementXY, getFocusedElementProp } from "../../tests/utils";
 import { supportedLocales } from "../../utils/locale";
@@ -1446,6 +1446,49 @@ describe("calcite-time-picker", () => {
             }
           });
         });
+      });
+    });
+  });
+
+  describe("theme", () => {
+    describe("default", () => {
+      themed(html`<calcite-time-picker></calcite-time-picker>`, {
+        "--calcite-time-picker-background-color": {
+          targetProp: "backgroundColor",
+          shadowSelector: `.${CSS.timePicker}`,
+        },
+        "--calcite-time-picker-corner-radius": {
+          targetProp: "borderRadius",
+          shadowSelector: `.${CSS.timePicker}`,
+        },
+        "--calcite-time-picker-button-background-color-hover": {
+          targetProp: "backgroundColor",
+          state: "hover",
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-time-picker-button-background-color-press": {
+          targetProp: "backgroundColor",
+          state: { press: { attribute: "class", value: CSS.button } },
+          shadowSelector: `.${CSS.button}`,
+        },
+        "--calcite-time-picker-color": {
+          targetProp: "color",
+          shadowSelector: `.${CSS.timePicker}`,
+        },
+        "--calcite-time-picker-icon-color": {
+          targetProp: "color",
+          shadowSelector: "calcite-icon",
+        },
+        // "--calcite-time-picker-input-border-color-press": {
+        //   targetProp: "boxShadow",
+        //   state: { press: { attribute: "class", value: CSS.hour } },
+        //   shadowSelector: `.${CSS.hour}`,
+        // },
+        "--calcite-time-picker-input-border-color-hover": {
+          targetProp: "boxShadow",
+          state: "hover",
+          shadowSelector: `.${CSS.input}`,
+        },
       });
     });
   });

--- a/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/time-picker/time-picker.e2e.ts
@@ -1479,17 +1479,30 @@ describe("calcite-time-picker", () => {
           targetProp: "color",
           shadowSelector: "calcite-icon",
         },
-        // "--calcite-time-picker-input-border-color-press": {
-        //   targetProp: "boxShadow",
-        //   state: { press: { attribute: "class", value: CSS.hour } },
-        //   shadowSelector: `.${CSS.hour}`,
-        // },
         "--calcite-time-picker-input-border-color-hover": {
           targetProp: "boxShadow",
           state: "hover",
           shadowSelector: `.${CSS.input}`,
         },
       });
+    });
+
+    describe("hour input focused", () => {
+      themed(
+        async () => {
+          const page = await newE2EPage();
+          await page.setContent(html`<calcite-time-picker></calcite-time-picker>`);
+          const timePickerHour = await page.find(`calcite-time-picker >>> .${CSS.hour}`);
+          await timePickerHour.focus();
+          return { page, tag: "calcite-time-picker" };
+        },
+        {
+          "--calcite-time-picker-input-border-color-press": {
+            targetProp: "boxShadow",
+            shadowSelector: `.${CSS.hour}`,
+          },
+        },
+      );
     });
   });
 });

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -3,15 +3,15 @@
 }
 
 .time-picker {
-  @apply bg-foreground-1
-    shadow-2
-    text-color-1
+  @apply bg-foreground-1 // todo
+    shadow-2 // todo
+    text-color-1 // todo
     flex
     select-none
     items-center
     font-medium;
 
-  border-radius: var(--calcite-border-radius);
+  border-radius: var(--calcite-border-radius); // todo
 
   .column {
     @apply flex
@@ -23,48 +23,48 @@
   }
 
   .button {
-    @apply bg-foreground-1
+    @apply bg-foreground-1 // todo
       inline-flex
       cursor-pointer
       items-center
       justify-center;
     &:hover,
     &:focus {
-      @apply bg-foreground-2
+      @apply bg-foreground-2 // todo
         outline-none;
-      z-index: theme("zIndex.header");
+      z-index: theme("zIndex.header"); // todo
       outline-offset: 0;
     }
     &:active {
-      @apply bg-foreground-3;
+      @apply bg-foreground-3; // todo
     }
     &.top-left {
-      border-start-start-radius: var(--calcite-border-radius);
+      border-start-start-radius: var(--calcite-border-radius); // todo
     }
     &.bottom-left {
-      border-end-start-radius: var(--calcite-border-radius);
+      border-end-start-radius: var(--calcite-border-radius); // todo
     }
     &.top-right {
-      border-start-end-radius: var(--calcite-border-radius);
+      border-start-end-radius: var(--calcite-border-radius); // todo
     }
     &.bottom-right {
-      border-end-end-radius: var(--calcite-border-radius);
+      border-end-end-radius: var(--calcite-border-radius); // todo
     }
     calcite-icon {
-      @apply text-color-3;
+      @apply text-color-3; // todo
     }
   }
 
   .input {
-    @apply bg-foreground-1
+    @apply bg-foreground-1 // todo
       inline-flex
       cursor-pointer
       items-center
       justify-center
-      font-medium;
+      font-medium; // todo
     &:hover {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-foreground-2);
-      z-index: theme("zIndex.header");
+      box-shadow: inset 0 0 0 2px var(--calcite-color-foreground-2); // todo
+      z-index: theme("zIndex.header"); // todo
     }
     &:focus,
     &:hover:focus {
@@ -73,8 +73,8 @@
     }
     &.inputFocus,
     &:hover.inputFocus {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-brand);
-      z-index: theme("zIndex.header");
+      box-shadow: inset 0 0 0 2px var(--calcite-color-brand); // todo
+      z-index: theme("zIndex.header"); // todo
     }
   }
 
@@ -82,12 +82,12 @@
     @apply text-n1;
     .button,
     .input {
-      @apply px-3
-        py-1;
+      @apply px-3 // todo
+        py-1; // todo
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.3");
+        padding-inline-end: theme("spacing.3"); // todo
       }
     }
   }
@@ -96,12 +96,12 @@
     @apply text-0;
     .button,
     .input {
-      @apply px-4
-        py-2;
+      @apply px-4 // todo
+        py-2; // todo
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.4");
+        padding-inline-end: theme("spacing.4"); // todo
       }
     }
   }
@@ -110,12 +110,12 @@
     @apply text-1;
     .button,
     .input {
-      @apply px-5
-        py-3;
+      @apply px-5 // todo
+        py-3; // todo
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.5");
+        padding-inline-end: theme("spacing.5"); // todo
       }
     }
   }

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -7,7 +7,7 @@
  * @prop --calcite-time-picker-corner-radius: The border radius of the time picker.
  * @prop --calcite-time-picker-button-background-color-hover: Specifies the button's background color when hovered or focused.
  * @prop --calcite-time-picker-button-background-color-press: Specifies the button's background color when active.
- * @prop --calcite-time-picker-color: Specifies the component's background color.
+ * @prop --calcite-time-picker-color: Specifies the component's text color.
  * @prop --calcite-time-picker-icon-color: Specifies the component's icon color.
  * @prop --calcite-time-picker-input-border-color-press: Specifies the input's border color when active.
  * @prop --calcite-time-picker-input-border-color-hover: Specifies the input's border color when hovered.

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -1,17 +1,32 @@
+/**
+ * CSS Custom Properties
+ *
+ * These properties can be overridden using the component's tag as selector.
+ *
+ * @prop --calcite-time-picker-background-color: The background color of the time picker.
+ * @prop --calcite-time-picker-border-radius: The border radius of the time picker.
+ * @prop --calcite-time-picker-button-background-color-hover: Specifies the button's background color when hovered or focused.
+ * @prop --calcite-time-picker-button-background-color-press: Specifies the button's background color when active.
+ * @prop --calcite-time-picker-color: Specifies the component's background color.
+ * @prop --calcite-time-picker-icon-color: Specifies the component's icon color.
+ * @prop --calcite-time-picker-input-border-color-focus: Specifies the input's border color when focused.
+ * @prop --calcite-time-picker-input-border-color-hover: Specifies the input's border color when hovered.
+ */
+
 :host {
   @apply inline-block;
 }
 
 .time-picker {
-  @apply bg-foreground-1 // todo
-    shadow-2 // todo
-    text-color-1 // todo
-    flex
+  @apply flex
+    shadow-2
     select-none
     items-center
     font-medium;
 
-  border-radius: var(--calcite-border-radius); // todo
+  border-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+  color: var(--calcite-time-picker-color, var(--calcite-color-text-1));
+  background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
 
   .column {
     @apply flex
@@ -23,48 +38,52 @@
   }
 
   .button {
-    @apply bg-foreground-1 // todo
-      inline-flex
+    @apply inline-flex
       cursor-pointer
       items-center
       justify-center;
+
+    background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
+
     &:hover,
     &:focus {
-      @apply bg-foreground-2 // todo
-        outline-none;
-      z-index: theme("zIndex.header"); // todo
+      @apply outline-none;
+      z-index: var(--calcite-z-index-header);
       outline-offset: 0;
+      background-color: var(--calcite-time-picker-button-background-color-hover, var(--calcite-color-foreground-2));
     }
     &:active {
-      @apply bg-foreground-3; // todo
+      background-color: var(--calcite-time-picker-button-background-color-press, var(--calcite-color-foreground-3));
     }
     &.top-left {
-      border-start-start-radius: var(--calcite-border-radius); // todo
+      border-start-start-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
     }
     &.bottom-left {
-      border-end-start-radius: var(--calcite-border-radius); // todo
+      border-end-start-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
     }
     &.top-right {
-      border-start-end-radius: var(--calcite-border-radius); // todo
+      border-start-end-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
     }
     &.bottom-right {
-      border-end-end-radius: var(--calcite-border-radius); // todo
+      border-end-end-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
     }
     calcite-icon {
-      @apply text-color-3; // todo
+      color: var(--calcite-time-picker-icon-color, var(--calcite-color-text-3));
     }
   }
 
   .input {
-    @apply bg-foreground-1 // todo
-      inline-flex
+    @apply inline-flex
       cursor-pointer
       items-center
-      justify-center
-      font-medium; // todo
+      justify-center;
+
+    font-weight: var(--calcite-font-weight-medium);
+    background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
+
     &:hover {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-foreground-2); // todo
-      z-index: theme("zIndex.header"); // todo
+      box-shadow: inset 0 0 0 2px var(--calcite-time-picker-input-border-color-hover, var(--calcite-color-foreground-2));
+      z-index: var(--calcite-z-index-header);
     }
     &:focus,
     &:hover:focus {
@@ -73,8 +92,8 @@
     }
     &.inputFocus,
     &:hover.inputFocus {
-      box-shadow: inset 0 0 0 2px var(--calcite-color-brand); // todo
-      z-index: theme("zIndex.header"); // todo
+      box-shadow: inset 0 0 0 2px var(--calcite-time-picker-input-border-color-focus, var(--calcite-color-brand));
+      z-index: var(--calcite-z-index-header);
     }
   }
 
@@ -82,12 +101,12 @@
     @apply text-n1;
     .button,
     .input {
-      @apply px-3 // todo
-        py-1; // todo
+      padding-inline: var(--calcite-spacing-md);
+      padding-block: var(--calcite-spacing-xxs);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.3"); // todo
+        padding-inline-end: var(--calcite-spacing-md);
       }
     }
   }
@@ -96,12 +115,12 @@
     @apply text-0;
     .button,
     .input {
-      @apply px-4 // todo
-        py-2; // todo
+      padding-inline: var(--calcite-spacing-xl);
+      padding-block: var(--calcite-spacing-sm);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.4"); // todo
+        padding-inline-end: var(--calcite-spacing-xl);
       }
     }
   }
@@ -110,12 +129,12 @@
     @apply text-1;
     .button,
     .input {
-      @apply px-5 // todo
-        py-3; // todo
+      padding-inline: var(--calcite-spacing-xxl);
+      padding-block: var(--calcite-spacing-md);
     }
     &:not(.show-meridiem) {
       .delimiter:last-child {
-        padding-inline-end: theme("spacing.5"); // todo
+        padding-inline-end: var(--calcite-spacing-xxl);
       }
     }
   }

--- a/packages/calcite-components/src/components/time-picker/time-picker.scss
+++ b/packages/calcite-components/src/components/time-picker/time-picker.scss
@@ -4,12 +4,12 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-time-picker-background-color: The background color of the time picker.
- * @prop --calcite-time-picker-border-radius: The border radius of the time picker.
+ * @prop --calcite-time-picker-corner-radius: The border radius of the time picker.
  * @prop --calcite-time-picker-button-background-color-hover: Specifies the button's background color when hovered or focused.
  * @prop --calcite-time-picker-button-background-color-press: Specifies the button's background color when active.
  * @prop --calcite-time-picker-color: Specifies the component's background color.
  * @prop --calcite-time-picker-icon-color: Specifies the component's icon color.
- * @prop --calcite-time-picker-input-border-color-focus: Specifies the input's border color when focused.
+ * @prop --calcite-time-picker-input-border-color-press: Specifies the input's border color when active.
  * @prop --calcite-time-picker-input-border-color-hover: Specifies the input's border color when hovered.
  */
 
@@ -24,7 +24,7 @@
     items-center
     font-medium;
 
-  border-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+  border-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
   color: var(--calcite-time-picker-color, var(--calcite-color-text-1));
   background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
 
@@ -56,16 +56,16 @@
       background-color: var(--calcite-time-picker-button-background-color-press, var(--calcite-color-foreground-3));
     }
     &.top-left {
-      border-start-start-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+      border-start-start-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
     }
     &.bottom-left {
-      border-end-start-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+      border-end-start-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
     }
     &.top-right {
-      border-start-end-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+      border-start-end-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
     }
     &.bottom-right {
-      border-end-end-radius: var(--calcite-time-picker-border-radius, var(--calcite-border-radius-round));
+      border-end-end-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
     }
     calcite-icon {
       color: var(--calcite-time-picker-icon-color, var(--calcite-color-text-3));
@@ -92,7 +92,7 @@
     }
     &.inputFocus,
     &:hover.inputFocus {
-      box-shadow: inset 0 0 0 2px var(--calcite-time-picker-input-border-color-focus, var(--calcite-color-brand));
+      box-shadow: inset 0 0 0 2px var(--calcite-time-picker-input-border-color-press, var(--calcite-color-brand));
       z-index: var(--calcite-z-index-header);
     }
   }

--- a/packages/calcite-components/src/custom-theme.stories.ts
+++ b/packages/calcite-components/src/custom-theme.stories.ts
@@ -55,6 +55,7 @@ import { avatarIcon, avatarInitials, avatarThumbnail, avatarTokens } from "./cus
 import { navigationLogoTokens, navigationLogos } from "./custom-theme/navigation-logo";
 import { navigationUserTokens, navigationUsers } from "./custom-theme/navigation-user";
 import { tileTokens, tile } from "./custom-theme/tile";
+import { timePicker, timePickerTokens } from "./custom-theme/time-picker";
 import { navigationTokens, navigation } from "./custom-theme/navigation";
 import { menuItem, menuItemTokens } from "./custom-theme/menu-item";
 import {
@@ -156,8 +157,8 @@ const kitchenSink = (args: Record<string, string>, useTestValues = false) =>
       </div>
       <div class="demo-column">
         ${tabs} ${tabsBordered} ${label} ${link} ${list} ${loader} ${calciteSwitch} ${avatarIcon} ${avatarInitials}
-        ${avatarThumbnail} ${progress} ${handle} ${graph} ${textArea} ${popover} ${tile} ${tooltip} ${comboboxItem}
-        ${selectedComboboxItem}
+        ${avatarThumbnail} ${progress} ${handle} ${graph} ${textArea} ${popover} ${tile} ${timePicker} ${tooltip}
+        ${comboboxItem} ${selectedComboboxItem}
       </div>
       <div class="demo-column">
         ${navigation} ${navigationLogos} ${navigationUsers} ${blockSection} ${block} ${rating} ${panel} ${shellPanel}
@@ -231,6 +232,7 @@ const componentTokens = {
   ...tabsTokens,
   ...textAreaTokens,
   ...tileTokens,
+  ...timePickerTokens,
   ...tooltipTokens,
   ...treeTokens,
   ...menuItemTokens,

--- a/packages/calcite-components/src/custom-theme/time-picker.ts
+++ b/packages/calcite-components/src/custom-theme/time-picker.ts
@@ -1,0 +1,14 @@
+import { html } from "../../support/formatting";
+
+export const timePickerTokens = {
+  calciteTimePickerBackgroundColor: "",
+  calciteTimePickerCornerRadius: "",
+  calciteTimePickerButtonBackgroundColorHover: "",
+  calciteTimePickerButtonBackgroundColorPress: "",
+  calciteTimePickerColor: "",
+  calciteTimePickerIconColor: "",
+  calciteTimePickerInputBorderColorFocus: "",
+  calciteTimePickerInputBorderColorHover: "",
+};
+
+export const timePicker = html`<calcite-time-picker></calcite-time-picker>`;

--- a/packages/calcite-components/src/custom-theme/time-picker.ts
+++ b/packages/calcite-components/src/custom-theme/time-picker.ts
@@ -7,7 +7,7 @@ export const timePickerTokens = {
   calciteTimePickerButtonBackgroundColorPress: "",
   calciteTimePickerColor: "",
   calciteTimePickerIconColor: "",
-  calciteTimePickerInputBorderColorFocus: "",
+  calciteTimePickerInputBorderColorPress: "",
   calciteTimePickerInputBorderColorHover: "",
 };
 


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following tokens for `time-picker` component.

- --calcite-time-picker-background-color: The background color of the time picker.
- --calcite-time-picker-corner-radius: The border radius of the time picker.
- --calcite-time-picker-button-background-color-hover: Specifies the button's background color when hovered or focused.
 - --calcite-time-picker-button-background-color-press: Specifies the button's background color when active.
- --calcite-time-picker-color: Specifies the component's background color.
- --calcite-time-picker-icon-color: Specifies the component's icon color.
- --calcite-time-picker-input-border-color-press: Specifies the input's border color when active.
- --calcite-time-picker-input-border-color-hover: Specifies the input's border color when hovered.