### PR TITLE
refactor: tidy up

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,8 +1,4 @@
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
-export const __filename = fileURLToPath(import.meta.url);
-export const __dirname = dirname(__filename);
+import { resolve } from "node:path";
 
 /**
  * @filename: lint-staged.config.mjs
@@ -15,7 +11,7 @@ export default {
     const files = absolutePaths.join(" ");
     return [
       `prettier --write ${files}`,
-      `markdownlint-cli2 --fix --config ${resolve(__dirname, "./.markdownlint-cli2.jsonc")} ${files}`
+      `markdownlint-cli2 --fix --config ${resolve(import.meta.dirname, "./.markdownlint-cli2.jsonc")} ${files}`
     ];
   }
 };

--- a/packages/calcite-components/support/generateSupportedBrowsersJSON.ts
+++ b/packages/calcite-components/support/generateSupportedBrowsersJSON.ts
@@ -1,14 +1,12 @@
 (async () => {
-  const { dirname, resolve } = await import("path");
-  const { fileURLToPath } = await import("url");
+  const { resolve } = await import("path");
   const {
     promises: { writeFile },
   } = await import("fs");
   const { default: browserslist } = await import("browserslist");
 
   try {
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-    const outFile = resolve(__dirname, "..", "dist", "docs", "supported-browsers.json");
+    const outFile = resolve(import.meta.dirname, "..", "dist", "docs", "supported-browsers.json");
     const supportedBrowsers = browserslist();
     await writeFile(outFile, JSON.stringify(supportedBrowsers), "utf-8");
   } catch (err) {

--- a/packages/calcite-components/support/generateT9nDocsJSON.ts
+++ b/packages/calcite-components/support/generateT9nDocsJSON.ts
@@ -1,16 +1,13 @@
 // generates a JSON file containing the per component t9n translation values
 (async () => {
-  const { dirname, resolve } = await import("path");
-  const { fileURLToPath } = await import("url");
+  const { resolve } = await import("path");
   const {
     existsSync,
     promises: { readFile, readdir, writeFile },
   } = await import("fs");
   try {
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-
-    const outFile = resolve(__dirname, "..", "dist", "docs", "translations.json");
-    const assetsPaths = resolve(__dirname, "..", "dist", "calcite", "assets");
+    const outFile = resolve(import.meta.dirname, "..", "dist", "docs", "translations.json");
+    const assetsPaths = resolve(import.meta.dirname, "..", "dist", "calcite", "assets");
     const components = await readdir(assetsPaths);
 
     const data = {};

--- a/packages/calcite-design-tokens/src/build/utils/node.ts
+++ b/packages/calcite-design-tokens/src/build/utils/node.ts
@@ -1,5 +1,0 @@
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-export const __filename = fileURLToPath(import.meta.url);
-export const __dirname = dirname(__filename);

--- a/packages/calcite-design-tokens/tests/spec/index.spec.ts
+++ b/packages/calcite-design-tokens/tests/spec/index.spec.ts
@@ -1,10 +1,6 @@
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { readFileSync } from "node:fs";
-import { describe, it, expect } from "vitest";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { describe, expect, it } from "vitest";
 
 enum Platform {
   CSS = "css",
@@ -58,7 +54,7 @@ function generateTests(platform: Platform, files: string[], internal = false) {
  * @param outputFilePath - The path to the output file to test, relative to the dist directory
  */
 function assertOutput(outputFilePath: string) {
-  const filePath = resolve(__dirname, "..", "..", "dist", outputFilePath);
+  const filePath = resolve(import.meta.dirname, "..", "..", "dist", outputFilePath);
   const content = preprocessContent(readFileSync(filePath, "utf-8"), outputFilePath.split(".").pop());
   expect(content).toMatchSnapshot();
 }


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Uses [`import.meta.dirname`](https://nodejs.org/api/esm.html#importmeta) to replace

```tsx
dirname(fileURLToPath(import.meta.url));
```