### PR TITLE
docs(checkbox): update icon color prop context

### DIFF
--- a/packages/calcite-components/src/components/checkbox/checkbox.scss
+++ b/packages/calcite-components/src/components/checkbox/checkbox.scss
@@ -6,7 +6,7 @@
  * @prop --calcite-checkbox-size: Specifies the component's height and width.
  * @prop --calcite-checkbox-border-color: Specifies the component's color.
  * @prop --calcite-checkbox-border-color-hover: Specifies the component's color when hovered.
- * @prop --calcite-checkbox-icon-color: Specifies the component's font color.
+ * @prop --calcite-checkbox-icon-color: Specifies the component's icon color.
  */
 
 :host([scale="s"]) {


### PR DESCRIPTION
**Related Issue:** #11934

## Summary
Updates the `--calcite-checkbox-icon-color` documentation to include the scope of the component's icon color.