### PR TITLE
ci: default to stable tests when experimental mode is not set

### DIFF
--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -9,8 +9,8 @@ import { version } from "./package.json";
 import tailwindConfig from "./tailwind.config";
 
 const nonEsmDependencies = ["interactjs"];
-const runPuppeteerAndHappyDomTests = process.env.STABLE_TESTS === "true";
 const runBrowserTests = process.env.EXPERIMENTAL_TESTS === "true";
+const runPuppeteerAndHappyDomTests = process.env.STABLE_TESTS === "true" || !runBrowserTests;
 
 export default defineConfig({
   build: { minify: false },


### PR DESCRIPTION
**Related Issue:** #11877

## Summary

Make vitest default to the stable tests when the `EXPERIMENTAL_TESTS` environment variable is not set. Previously, `npx vitest` would not find any tests to run.

This change fixes the test runner integrations provided by some IDEs (including neovim and vscode).

> [!NOTE]
> We can probably get rid of the `STABLE_TESTS` environment variable with this change.
