### PR TITLE
fix(tab): fix focus outline placement on scrolling tabs

### DIFF
--- a/packages/calcite-components/src/components/tab/tab.e2e.ts
+++ b/packages/calcite-components/src/components/tab/tab.e2e.ts
@@ -8,7 +8,7 @@ describe("calcite-tab", () => {
 
   describe("renders", () => {
     renders(tabHtml, { display: "none", visible: false });
-    renders(tabHtmlSelected, { display: "block", visible: true });
+    renders(tabHtmlSelected, { display: "flex", visible: true });
   });
 
   describe("honors hidden attribute", () => {
@@ -28,7 +28,7 @@ describe("calcite-tab", () => {
       themed("calcite-tab", {
         "--calcite-tab-content-space-y": {
           shadowSelector: `.${CSS.content}`,
-          targetProp: "paddingBlock",
+          targetProp: "marginBlock",
         },
       });
     });

--- a/packages/calcite-components/src/components/tab/tab.e2e.ts
+++ b/packages/calcite-components/src/components/tab/tab.e2e.ts
@@ -28,7 +28,7 @@ describe("calcite-tab", () => {
       themed("calcite-tab", {
         "--calcite-tab-content-space-y": {
           shadowSelector: `.${CSS.content}`,
-          targetProp: "marginBlock",
+          targetProp: "paddingBlock",
         },
       });
     });

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -18,6 +18,11 @@
 
 .content {
   @apply box-border;
+
+  padding-block: var(
+    --calcite-tab-content-space-y,
+    var(--calcite-tab-content-block-padding, var(--calcite-internal-tab-content-space-y))
+  );
 }
 
 .scale-s {
@@ -42,11 +47,6 @@
 }
 
 .container {
-  margin-block: var(
-    --calcite-tab-content-space-y,
-    var(--calcite-tab-content-block-padding, var(--calcite-internal-tab-content-space-y))
-  );
-
   @apply focus-base hidden h-full w-full overflow-auto;
 
   &:focus {

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -11,22 +11,13 @@
   @apply hidden h-full w-full;
 }
 
-:host([selected]) {
-  @apply block h-full w-full overflow-auto;
-
-  section,
-  .container {
-    @apply block;
-  }
+:host([selected]),
+:host([selected]) .container {
+  @apply flex flex-col;
 }
 
 .content {
   @apply box-border;
-
-  padding-block: var(
-    --calcite-tab-content-space-y,
-    var(--calcite-tab-content-block-padding, var(--calcite-internal-tab-content-space-y))
-  );
 }
 
 .scale-s {
@@ -50,13 +41,13 @@
   line-height: 1.25rem;
 }
 
-section,
 .container {
-  @apply hidden h-full w-full;
-}
+  margin-block: var(
+    --calcite-tab-content-space-y,
+    var(--calcite-tab-content-block-padding, var(--calcite-internal-tab-content-space-y))
+  );
 
-.container {
-  @apply focus-base;
+  @apply focus-base hidden h-full w-full overflow-auto;
 
   &:focus {
     @apply focus-inset;

--- a/packages/calcite-components/src/components/tab/tab.scss
+++ b/packages/calcite-components/src/components/tab/tab.scss
@@ -8,7 +8,13 @@
  */
 
 :host {
-  @apply hidden h-full w-full;
+  @apply hidden;
+}
+
+:host,
+.container,
+.content {
+  @apply h-full w-full;
 }
 
 :host([selected]),


### PR DESCRIPTION
**Related Issue:** #10419 

## Summary  

Fixes an issue where the focus outline would be included in the scrolled content.