### PR TITLE
fix(list-item): align elements to the left of the item's content

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -399,6 +399,13 @@
   }
 }
 
+.drag-container,
+.selection-container,
+.expanded-container,
+.actions-start {
+  padding-block-end: var(--calcite-spacing-px);
+}
+
 .expanded-container,
 .selection-container {
   @apply cursor-pointer;

--- a/packages/calcite-components/src/components/list-item/list-item.scss
+++ b/packages/calcite-components/src/components/list-item/list-item.scss
@@ -401,8 +401,7 @@
 
 .drag-container,
 .selection-container,
-.expanded-container,
-.actions-start {
+.expanded-container {
   padding-block-end: var(--calcite-spacing-px);
 }
 


### PR DESCRIPTION
**Related Issue:** [#11031](https://github.com/Esri/calcite-design-system/issues/11031)

## Summary

Add bottom spacing to fix misalignment of elements to the left of the item's content.
