### PR TITLE
fix(input-number): ensure change event correctly fires for all locales

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -1672,15 +1672,9 @@ describe("calcite-input-number", () => {
     const inputEl = await page.find("calcite-input-number");
     const clearButtonEl = await page.find("calcite-input-number >>> .clear-button");
 
-    await page.evaluate(async () => {
-      await customElements.whenDefined("calcite-input-number");
-      const el = await document.querySelector("calcite-input-number").componentOnReady();
-      requestAnimationFrame(() => {
-        el.value = "49.173126";
-      });
-    });
-
+    inputEl.setProperty("value", "49.173126");
     await page.waitForChanges();
+
     expect(await inputEl.getProperty("value")).toBe("49.173126");
 
     await clearButtonEl.click();

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -1662,6 +1662,34 @@ describe("calcite-input-number", () => {
     expect(calciteInputNumberInput).toHaveReceivedEventTimes(1);
   });
 
+  it("emits change event when value set directly and then cleared in 'de' locale", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <calcite-input-number lang="de" value="0" clearable></calcite-input-number>
+    `);
+
+    const calciteInputNumberChange = await page.spyOnEvent("calciteInputNumberChange");
+    const inputEl = await page.find("calcite-input-number");
+    const clearButtonEl = await page.find("calcite-input-number >>> .clear-button");
+
+    await page.evaluate(async () => {
+      await customElements.whenDefined("calcite-input-number");
+      const el = await document.querySelector("calcite-input-number").componentOnReady();
+      requestAnimationFrame(() => {
+        el.value = "49.173126";
+      });
+    });
+
+    await page.waitForChanges();
+    expect(await inputEl.getProperty("value")).toBe("49.173126");
+
+    await clearButtonEl.click();
+    await page.waitForChanges();
+
+    expect(await inputEl.getProperty("value")).toBe("");
+    expect(calciteInputNumberChange).toHaveReceivedEventTimes(1);
+  });
+
   it("sanitize leading zeros from value", async () => {
     const page = await newE2EPage();
     await page.setContent(`

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -869,11 +869,12 @@ export class InputNumber
     this.userChangedValue = origin === "user" && this.value !== newValue;
     // don't sanitize the start of negative/decimal numbers, but
     // don't set value to an invalid number
-    this.value = ["-", "."].includes(newValue) ? "" : newValue;
+    const validNewValue = ["-", "."].includes(newValue) ? "" : newValue;
+    this.value = validNewValue;
 
     if (origin === "direct") {
       this.setInputNumberValue(newLocalizedValue);
-      this.setPreviousEmittedNumberValue(newLocalizedValue);
+      this.setPreviousEmittedNumberValue(validNewValue);
     }
 
     if (nativeEvent) {


### PR DESCRIPTION
**Related Issue:** #11324 

## Summary

Resolve an issue where inputs in some locales would not fire the change event when clearing a value that was set programmatically via the property.
