### PR TITLE
chore: add design-tokens as dev dependency for Lerna updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36871,8 +36871,11 @@
       "name": "@esri/calcite-tailwind-preset",
       "version": "0.2.0-next.0",
       "license": "SEE LICENSE.md",
+      "dependencies": {
+        "@esri/calcite-design-tokens": "3.0.2-next.8"
+      },
       "peerDependencies": {
-        "@esri/calcite-design-tokens": "^3.0.2-next.3",
+        "@esri/calcite-design-tokens": "^3.0.2-next.8",
         "tailwindcss": "^3.0.0 < 4.0.0"
       }
     },

--- a/packages/calcite-tailwind-preset/package.json
+++ b/packages/calcite-tailwind-preset/package.json
@@ -22,8 +22,11 @@
     "lint:md": "prettier --write \"**/*.md\" >/dev/null && markdownlint \"**/*.md\" --fix --dot --ignore-path .gitignore --ignore-path ../../.gitignore",
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
+  "dependencies": {
+    "@esri/calcite-design-tokens": "3.0.2-next.8"
+  },
   "peerDependencies": {
-    "@esri/calcite-design-tokens": "^3.0.2-next.3",
+    "@esri/calcite-design-tokens": "^3.0.2-next.8",
     "tailwindcss": "^3.0.0 < 4.0.0"
   },
   "volta": {


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Adding explicit `calcite-design-tokens` dev dependency to the Tailwind preset package so Lerna can detect changes and update local packages correctly (see https://github.com/lerna/lerna/issues/955#issuecomment-323260292).

This resolves `next` [deployment issues](https://github.com/Esri/calcite-design-system/actions/runs/14537811536/job/40789636366) caused by missing peer dependencies.