### PR TITLE
feat(tokens): update core neutral color values

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/core/color.json
+++ b/packages/calcite-design-tokens/src/tokens/core/color.json
@@ -10,28 +10,28 @@
           }
         },
         "blk-005": {
-          "value": "#f8f8f8",
+          "value": "#f7f7f7",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-010": {
-          "value": "#f3f3f3",
+          "value": "#f2f2f2",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-020": {
-          "value": "#eaeaea",
+          "value": "#ebebeb",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-030": {
-          "value": "#dfdfdf",
+          "value": "#dedede",
           "type": "color",
           "attributes": {
             "category": "color"
@@ -45,7 +45,7 @@
           }
         },
         "blk-050": {
-          "value": "#cacaca",
+          "value": "#c9c9c9",
           "type": "color",
           "attributes": {
             "category": "color"
@@ -66,14 +66,14 @@
           }
         },
         "blk-080": {
-          "value": "#aaaaaa",
+          "value": "#ababab",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-090": {
-          "value": "#9f9f9f",
+          "value": "#9e9e9e",
           "type": "color",
           "attributes": {
             "category": "color"
@@ -108,21 +108,21 @@
           }
         },
         "blk-140": {
-          "value": "#6a6a6a",
+          "value": "#6b6b6b",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-150": {
-          "value": "#606060",
+          "value": "#616161",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-160": {
-          "value": "#555555",
+          "value": "#545454",
           "type": "color",
           "attributes": {
             "category": "color"
@@ -143,7 +143,7 @@
           }
         },
         "blk-190": {
-          "value": "#353535",
+          "value": "#363636",
           "type": "color",
           "attributes": {
             "category": "color"
@@ -157,28 +157,28 @@
           }
         },
         "blk-210": {
-          "value": "#202020",
+          "value": "#212121",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-220": {
-          "value": "#151515",
+          "value": "#141414",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-230": {
-          "value": "#0b0b0b",
+          "value": "#0a0a0a",
           "type": "color",
           "attributes": {
             "category": "color"
           }
         },
         "blk-235": {
-          "value": "#060606",
+          "value": "#050505",
           "type": "color",
           "attributes": {
             "category": "color"

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -317,31 +317,31 @@ exports[`generated tokens > CSS > core should match 1`] = `
 
 :root {
   --calcite-color-neutral-blk-000: #ffffff;
-  --calcite-color-neutral-blk-005: #f8f8f8;
-  --calcite-color-neutral-blk-010: #f3f3f3;
-  --calcite-color-neutral-blk-020: #eaeaea;
-  --calcite-color-neutral-blk-030: #dfdfdf;
+  --calcite-color-neutral-blk-005: #f7f7f7;
+  --calcite-color-neutral-blk-010: #f2f2f2;
+  --calcite-color-neutral-blk-020: #ebebeb;
+  --calcite-color-neutral-blk-030: #dedede;
   --calcite-color-neutral-blk-040: #d4d4d4;
-  --calcite-color-neutral-blk-050: #cacaca;
+  --calcite-color-neutral-blk-050: #c9c9c9;
   --calcite-color-neutral-blk-060: #bfbfbf;
   --calcite-color-neutral-blk-070: #b5b5b5;
-  --calcite-color-neutral-blk-080: #aaaaaa;
-  --calcite-color-neutral-blk-090: #9f9f9f;
+  --calcite-color-neutral-blk-080: #ababab;
+  --calcite-color-neutral-blk-090: #9e9e9e;
   --calcite-color-neutral-blk-100: #949494;
   --calcite-color-neutral-blk-110: #8a8a8a;
   --calcite-color-neutral-blk-120: #808080;
   --calcite-color-neutral-blk-130: #757575;
-  --calcite-color-neutral-blk-140: #6a6a6a;
-  --calcite-color-neutral-blk-150: #606060;
-  --calcite-color-neutral-blk-160: #555555;
+  --calcite-color-neutral-blk-140: #6b6b6b;
+  --calcite-color-neutral-blk-150: #616161;
+  --calcite-color-neutral-blk-160: #545454;
   --calcite-color-neutral-blk-170: #4a4a4a;
   --calcite-color-neutral-blk-180: #404040;
-  --calcite-color-neutral-blk-190: #353535;
+  --calcite-color-neutral-blk-190: #363636;
   --calcite-color-neutral-blk-200: #2b2b2b;
-  --calcite-color-neutral-blk-210: #202020;
-  --calcite-color-neutral-blk-220: #151515;
-  --calcite-color-neutral-blk-230: #0b0b0b;
-  --calcite-color-neutral-blk-235: #060606;
+  --calcite-color-neutral-blk-210: #212121;
+  --calcite-color-neutral-blk-220: #141414;
+  --calcite-color-neutral-blk-230: #0a0a0a;
+  --calcite-color-neutral-blk-235: #050505;
   --calcite-color-neutral-blk-240: #000000;
   --calcite-color-low-saturation-blue-l-bb-010: #edf3f7;
   --calcite-color-low-saturation-blue-l-bb-020: #d7e1e7;
@@ -901,11 +901,11 @@ exports[`generated tokens > CSS > dark should match 1`] = `
  */
 
 :root {
-  --calcite-color-background: #353535;
+  --calcite-color-background: #363636;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
   --calcite-color-foreground-1: #2b2b2b;
-  --calcite-color-foreground-2: #202020;
-  --calcite-color-foreground-3: #151515;
+  --calcite-color-foreground-2: #212121;
+  --calcite-color-foreground-3: #141414;
   --calcite-color-foreground-current: #214155;
   --calcite-color-transparent: rgba(255, 255, 255, 0);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
@@ -930,20 +930,20 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-status-danger: #fe583e;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger-press: #d90012;
-  --calcite-color-inverse: #f8f8f8;
+  --calcite-color-inverse: #f7f7f7;
   --calcite-color-inverse-hover: #ffffff;
-  --calcite-color-inverse-press: #f3f3f3;
+  --calcite-color-inverse-press: #f2f2f2;
   --calcite-color-text-1: #ffffff;
   --calcite-color-text-2: #bfbfbf;
-  --calcite-color-text-3: #9f9f9f;
-  --calcite-color-text-inverse: #151515;
+  --calcite-color-text-3: #9e9e9e;
+  --calcite-color-text-inverse: #141414;
   --calcite-color-text-link: #00a0ff;
-  --calcite-color-border-1: #555555;
+  --calcite-color-border-1: #545454;
   --calcite-color-border-2: #4a4a4a;
   --calcite-color-border-3: #404040;
   --calcite-color-border-input: #757575;
   --calcite-color-border-ghost: rgba(117, 117, 117, 0.3);
-  --calcite-color-border-white: #f8f8f8;
+  --calcite-color-border-white: #f7f7f7;
 }
 "
 `;
@@ -1081,17 +1081,17 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dfdfdf;
+  --calcite-color-border-3: #dedede;
   --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #cacaca;
+  --calcite-color-border-1: #c9c9c9;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
-  --calcite-color-text-3: #6a6a6a;
+  --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
-  --calcite-color-text-1: #151515;
-  --calcite-color-inverse-press: #202020;
+  --calcite-color-text-1: #141414;
+  --calcite-color-inverse-press: #212121;
   --calcite-color-inverse-hover: #2b2b2b;
-  --calcite-color-inverse: #353535;
+  --calcite-color-inverse: #363636;
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
@@ -1116,28 +1116,28 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
   --calcite-color-foreground-current: #c7eaff;
-  --calcite-color-foreground-3: #eaeaea;
-  --calcite-color-foreground-2: #f3f3f3;
+  --calcite-color-foreground-3: #ebebeb;
+  --calcite-color-foreground-2: #f2f2f2;
   --calcite-color-foreground-1: #ffffff;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f8f8f8;
+  --calcite-color-background: #f7f7f7;
 }
 @media (prefers-color-scheme: light) {
   .calcite-mode-auto {
     --calcite-color-border-white: #ffffff;
     --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
     --calcite-color-border-input: #949494;
-    --calcite-color-border-3: #dfdfdf;
+    --calcite-color-border-3: #dedede;
     --calcite-color-border-2: #d4d4d4;
-    --calcite-color-border-1: #cacaca;
+    --calcite-color-border-1: #c9c9c9;
     --calcite-color-text-link: #00619b;
     --calcite-color-text-inverse: #ffffff;
-    --calcite-color-text-3: #6a6a6a;
+    --calcite-color-text-3: #6b6b6b;
     --calcite-color-text-2: #4a4a4a;
-    --calcite-color-text-1: #151515;
-    --calcite-color-inverse-press: #202020;
+    --calcite-color-text-1: #141414;
+    --calcite-color-inverse-press: #212121;
     --calcite-color-inverse-hover: #2b2b2b;
-    --calcite-color-inverse: #353535;
+    --calcite-color-inverse: #363636;
     --calcite-color-status-danger-press: #7c1d13;
     --calcite-color-status-danger-hover: #a82b1e;
     --calcite-color-status-danger: #d83020;
@@ -1162,30 +1162,30 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
     --calcite-color-transparent: rgba(0, 0, 0, 0);
     --calcite-color-foreground-current: #c7eaff;
-    --calcite-color-foreground-3: #eaeaea;
-    --calcite-color-foreground-2: #f3f3f3;
+    --calcite-color-foreground-3: #ebebeb;
+    --calcite-color-foreground-2: #f2f2f2;
     --calcite-color-foreground-1: #ffffff;
     --calcite-color-background-none: rgba(255, 255, 255, 0);
-    --calcite-color-background: #f8f8f8;
+    --calcite-color-background: #f7f7f7;
   }
 }
 @media (prefers-color-scheme: dark) {
   .calcite-mode-auto {
     --calcite-color-foreground-current: #214155;
-    --calcite-color-border-white: #f8f8f8;
+    --calcite-color-border-white: #f7f7f7;
     --calcite-color-border-ghost: rgba(117, 117, 117, 0.3);
     --calcite-color-border-input: #757575;
     --calcite-color-border-3: #404040;
     --calcite-color-border-2: #4a4a4a;
-    --calcite-color-border-1: #555555;
+    --calcite-color-border-1: #545454;
     --calcite-color-text-link: #00a0ff;
-    --calcite-color-text-inverse: #151515;
-    --calcite-color-text-3: #9f9f9f;
+    --calcite-color-text-inverse: #141414;
+    --calcite-color-text-3: #9e9e9e;
     --calcite-color-text-2: #bfbfbf;
     --calcite-color-text-1: #ffffff;
-    --calcite-color-inverse-press: #f3f3f3;
+    --calcite-color-inverse-press: #f2f2f2;
     --calcite-color-inverse-hover: #ffffff;
-    --calcite-color-inverse: #f8f8f8;
+    --calcite-color-inverse: #f7f7f7;
     --calcite-color-status-danger-press: #d90012;
     --calcite-color-status-danger-hover: #ff0015;
     --calcite-color-status-danger: #fe583e;
@@ -1209,28 +1209,28 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
     --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
     --calcite-color-transparent: rgba(255, 255, 255, 0);
-    --calcite-color-foreground-3: #151515;
-    --calcite-color-foreground-2: #202020;
+    --calcite-color-foreground-3: #141414;
+    --calcite-color-foreground-2: #212121;
     --calcite-color-foreground-1: #2b2b2b;
     --calcite-color-background-none: rgba(255, 255, 255, 0);
-    --calcite-color-background: #353535;
+    --calcite-color-background: #363636;
   }
 }
 .calcite-mode-light {
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dfdfdf;
+  --calcite-color-border-3: #dedede;
   --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #cacaca;
+  --calcite-color-border-1: #c9c9c9;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
-  --calcite-color-text-3: #6a6a6a;
+  --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
-  --calcite-color-text-1: #151515;
-  --calcite-color-inverse-press: #202020;
+  --calcite-color-text-1: #141414;
+  --calcite-color-inverse-press: #212121;
   --calcite-color-inverse-hover: #2b2b2b;
-  --calcite-color-inverse: #353535;
+  --calcite-color-inverse: #363636;
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
@@ -1255,28 +1255,28 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
   --calcite-color-foreground-current: #c7eaff;
-  --calcite-color-foreground-3: #eaeaea;
-  --calcite-color-foreground-2: #f3f3f3;
+  --calcite-color-foreground-3: #ebebeb;
+  --calcite-color-foreground-2: #f2f2f2;
   --calcite-color-foreground-1: #ffffff;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f8f8f8;
+  --calcite-color-background: #f7f7f7;
 }
 .calcite-mode-dark {
   --calcite-color-foreground-current: #214155;
-  --calcite-color-border-white: #f8f8f8;
+  --calcite-color-border-white: #f7f7f7;
   --calcite-color-border-ghost: rgba(117, 117, 117, 0.3);
   --calcite-color-border-input: #757575;
   --calcite-color-border-3: #404040;
   --calcite-color-border-2: #4a4a4a;
-  --calcite-color-border-1: #555555;
+  --calcite-color-border-1: #545454;
   --calcite-color-text-link: #00a0ff;
-  --calcite-color-text-inverse: #151515;
-  --calcite-color-text-3: #9f9f9f;
+  --calcite-color-text-inverse: #141414;
+  --calcite-color-text-3: #9e9e9e;
   --calcite-color-text-2: #bfbfbf;
   --calcite-color-text-1: #ffffff;
-  --calcite-color-inverse-press: #f3f3f3;
+  --calcite-color-inverse-press: #f2f2f2;
   --calcite-color-inverse-hover: #ffffff;
-  --calcite-color-inverse: #f8f8f8;
+  --calcite-color-inverse: #f7f7f7;
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
@@ -1300,11 +1300,11 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
   --calcite-color-transparent: rgba(255, 255, 255, 0);
-  --calcite-color-foreground-3: #151515;
-  --calcite-color-foreground-2: #202020;
+  --calcite-color-foreground-3: #141414;
+  --calcite-color-foreground-2: #212121;
   --calcite-color-foreground-1: #2b2b2b;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #353535;
+  --calcite-color-background: #363636;
 }
 "
 `;
@@ -1316,11 +1316,11 @@ exports[`generated tokens > CSS > light should match 1`] = `
  */
 
 :root {
-  --calcite-color-background: #f8f8f8;
+  --calcite-color-background: #f7f7f7;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
   --calcite-color-foreground-1: #ffffff;
-  --calcite-color-foreground-2: #f3f3f3;
-  --calcite-color-foreground-3: #eaeaea;
+  --calcite-color-foreground-2: #f2f2f2;
+  --calcite-color-foreground-3: #ebebeb;
   --calcite-color-foreground-current: #c7eaff;
   --calcite-color-transparent: rgba(0, 0, 0, 0);
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
@@ -1345,17 +1345,17 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-status-danger: #d83020;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger-press: #7c1d13;
-  --calcite-color-inverse: #353535;
+  --calcite-color-inverse: #363636;
   --calcite-color-inverse-hover: #2b2b2b;
-  --calcite-color-inverse-press: #202020;
-  --calcite-color-text-1: #151515;
+  --calcite-color-inverse-press: #212121;
+  --calcite-color-text-1: #141414;
   --calcite-color-text-2: #4a4a4a;
-  --calcite-color-text-3: #6a6a6a;
+  --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-inverse: #ffffff;
   --calcite-color-text-link: #00619b;
-  --calcite-color-border-1: #cacaca;
+  --calcite-color-border-1: #c9c9c9;
   --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-3: #dfdfdf;
+  --calcite-color-border-3: #dedede;
   --calcite-color-border-input: #949494;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-white: #ffffff;
@@ -1536,7 +1536,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-000}"
     },
     {
-      "value": "#f8f8f8",
+      "value": "#f7f7f7",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1563,7 +1563,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-005}"
     },
     {
-      "value": "#f3f3f3",
+      "value": "#f2f2f2",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1590,7 +1590,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-010}"
     },
     {
-      "value": "#eaeaea",
+      "value": "#ebebeb",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1617,7 +1617,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-020}"
     },
     {
-      "value": "#dfdfdf",
+      "value": "#dedede",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1671,7 +1671,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-040}"
     },
     {
-      "value": "#cacaca",
+      "value": "#c9c9c9",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1752,7 +1752,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-070}"
     },
     {
-      "value": "#aaaaaa",
+      "value": "#ababab",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1779,7 +1779,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-080}"
     },
     {
-      "value": "#9f9f9f",
+      "value": "#9e9e9e",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1914,7 +1914,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-130}"
     },
     {
-      "value": "#6a6a6a",
+      "value": "#6b6b6b",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1941,7 +1941,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-140}"
     },
     {
-      "value": "#606060",
+      "value": "#616161",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -1968,7 +1968,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-150}"
     },
     {
-      "value": "#555555",
+      "value": "#545454",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -2049,7 +2049,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-180}"
     },
     {
-      "value": "#353535",
+      "value": "#363636",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -2103,7 +2103,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-200}"
     },
     {
-      "value": "#202020",
+      "value": "#212121",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -2130,7 +2130,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-210}"
     },
     {
-      "value": "#151515",
+      "value": "#141414",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -2157,7 +2157,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-220}"
     },
     {
-      "value": "#0b0b0b",
+      "value": "#0a0a0a",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -2184,7 +2184,7 @@ exports[`generated tokens > DOCS > core should match 1`] = `
       "key": "{core.color.neutral.blk-230}"
     },
     {
-      "value": "#060606",
+      "value": "#050505",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -17700,7 +17700,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
   "timestamp": "TEST_TIMESTAMP",
   "tokens": [
     {
-      "value": "{\\"light\\":\\"#f8f8f8\\",\\"dark\\":\\"#353535\\"}",
+      "value": "{\\"light\\":\\"#f7f7f7\\",\\"dark\\":\\"#363636\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -17781,7 +17781,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.foreground.1}"
     },
     {
-      "value": "{\\"light\\":\\"#f3f3f3\\",\\"dark\\":\\"#202020\\"}",
+      "value": "{\\"light\\":\\"#f2f2f2\\",\\"dark\\":\\"#212121\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -17808,7 +17808,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.foreground.2}"
     },
     {
-      "value": "{\\"light\\":\\"#eaeaea\\",\\"dark\\":\\"#151515\\"}",
+      "value": "{\\"light\\":\\"#ebebeb\\",\\"dark\\":\\"#141414\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18503,7 +18503,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.danger.press}"
     },
     {
-      "value": "{\\"light\\":\\"#353535\\",\\"dark\\":\\"#f8f8f8\\"}",
+      "value": "{\\"light\\":\\"#363636\\",\\"dark\\":\\"#f7f7f7\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18557,7 +18557,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.inverse.hover}"
     },
     {
-      "value": "{\\"light\\":\\"#202020\\",\\"dark\\":\\"#f3f3f3\\"}",
+      "value": "{\\"light\\":\\"#212121\\",\\"dark\\":\\"#f2f2f2\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18584,7 +18584,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.inverse.press}"
     },
     {
-      "value": "{\\"light\\":\\"#151515\\",\\"dark\\":\\"#ffffff\\"}",
+      "value": "{\\"light\\":\\"#141414\\",\\"dark\\":\\"#ffffff\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18638,7 +18638,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.text.2}"
     },
     {
-      "value": "{\\"light\\":\\"#6a6a6a\\",\\"dark\\":\\"#9f9f9f\\"}",
+      "value": "{\\"light\\":\\"#6b6b6b\\",\\"dark\\":\\"#9e9e9e\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18665,7 +18665,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.text.3}"
     },
     {
-      "value": "{\\"light\\":\\"#ffffff\\",\\"dark\\":\\"#151515\\"}",
+      "value": "{\\"light\\":\\"#ffffff\\",\\"dark\\":\\"#141414\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18719,7 +18719,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.text.link}"
     },
     {
-      "value": "{\\"light\\":\\"#cacaca\\",\\"dark\\":\\"#555555\\"}",
+      "value": "{\\"light\\":\\"#c9c9c9\\",\\"dark\\":\\"#545454\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18773,7 +18773,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.border.2}"
     },
     {
-      "value": "{\\"light\\":\\"#dfdfdf\\",\\"dark\\":\\"#404040\\"}",
+      "value": "{\\"light\\":\\"#dedede\\",\\"dark\\":\\"#404040\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18854,7 +18854,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.border.ghost}"
     },
     {
-      "value": "{\\"light\\":\\"#ffffff\\",\\"dark\\":\\"#f8f8f8\\"}",
+      "value": "{\\"light\\":\\"#ffffff\\",\\"dark\\":\\"#f7f7f7\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -28806,31 +28806,31 @@ exports[`generated tokens > ES6 > core should match 1`] = `
  */
 
 export const calciteColorNeutralBlk000 = "#ffffff";
-export const calciteColorNeutralBlk005 = "#f8f8f8";
-export const calciteColorNeutralBlk010 = "#f3f3f3";
-export const calciteColorNeutralBlk020 = "#eaeaea";
-export const calciteColorNeutralBlk030 = "#dfdfdf";
+export const calciteColorNeutralBlk005 = "#f7f7f7";
+export const calciteColorNeutralBlk010 = "#f2f2f2";
+export const calciteColorNeutralBlk020 = "#ebebeb";
+export const calciteColorNeutralBlk030 = "#dedede";
 export const calciteColorNeutralBlk040 = "#d4d4d4";
-export const calciteColorNeutralBlk050 = "#cacaca";
+export const calciteColorNeutralBlk050 = "#c9c9c9";
 export const calciteColorNeutralBlk060 = "#bfbfbf";
 export const calciteColorNeutralBlk070 = "#b5b5b5";
-export const calciteColorNeutralBlk080 = "#aaaaaa";
-export const calciteColorNeutralBlk090 = "#9f9f9f";
+export const calciteColorNeutralBlk080 = "#ababab";
+export const calciteColorNeutralBlk090 = "#9e9e9e";
 export const calciteColorNeutralBlk100 = "#949494";
 export const calciteColorNeutralBlk110 = "#8a8a8a";
 export const calciteColorNeutralBlk120 = "#808080";
 export const calciteColorNeutralBlk130 = "#757575";
-export const calciteColorNeutralBlk140 = "#6a6a6a";
-export const calciteColorNeutralBlk150 = "#606060";
-export const calciteColorNeutralBlk160 = "#555555";
+export const calciteColorNeutralBlk140 = "#6b6b6b";
+export const calciteColorNeutralBlk150 = "#616161";
+export const calciteColorNeutralBlk160 = "#545454";
 export const calciteColorNeutralBlk170 = "#4a4a4a";
 export const calciteColorNeutralBlk180 = "#404040";
-export const calciteColorNeutralBlk190 = "#353535";
+export const calciteColorNeutralBlk190 = "#363636";
 export const calciteColorNeutralBlk200 = "#2b2b2b";
-export const calciteColorNeutralBlk210 = "#202020";
-export const calciteColorNeutralBlk220 = "#151515";
-export const calciteColorNeutralBlk230 = "#0b0b0b";
-export const calciteColorNeutralBlk235 = "#060606";
+export const calciteColorNeutralBlk210 = "#212121";
+export const calciteColorNeutralBlk220 = "#141414";
+export const calciteColorNeutralBlk230 = "#0a0a0a";
+export const calciteColorNeutralBlk235 = "#050505";
 export const calciteColorNeutralBlk240 = "#000000";
 export const calciteColorLowSaturationBlueLBb010 = "#edf3f7";
 export const calciteColorLowSaturationBlueLBb020 = "#d7e1e7";
@@ -30032,11 +30032,11 @@ exports[`generated tokens > ES6 > global should match 1`] = `
  * Do not edit directly, this file was auto-generated.
  */
 
-export const calciteColorBackground = { light: "#f8f8f8", dark: "#353535" };
+export const calciteColorBackground = { light: "#f7f7f7", dark: "#363636" };
 export const calciteColorBackgroundNone = "rgba(255, 255, 255, 0)";
 export const calciteColorForeground1 = { light: "#ffffff", dark: "#2b2b2b" };
-export const calciteColorForeground2 = { light: "#f3f3f3", dark: "#202020" };
-export const calciteColorForeground3 = { light: "#eaeaea", dark: "#151515" };
+export const calciteColorForeground2 = { light: "#f2f2f2", dark: "#212121" };
+export const calciteColorForeground3 = { light: "#ebebeb", dark: "#141414" };
 export const calciteColorForegroundCurrent = {
   light: "#c7eaff",
   dark: "#214155",
@@ -30112,23 +30112,23 @@ export const calciteColorStatusDangerPress = {
   light: "#7c1d13",
   dark: "#d90012",
 };
-export const calciteColorInverse = { light: "#353535", dark: "#f8f8f8" };
+export const calciteColorInverse = { light: "#363636", dark: "#f7f7f7" };
 export const calciteColorInverseHover = { light: "#2b2b2b", dark: "#ffffff" };
-export const calciteColorInversePress = { light: "#202020", dark: "#f3f3f3" };
-export const calciteColorText1 = { light: "#151515", dark: "#ffffff" };
+export const calciteColorInversePress = { light: "#212121", dark: "#f2f2f2" };
+export const calciteColorText1 = { light: "#141414", dark: "#ffffff" };
 export const calciteColorText2 = { light: "#4a4a4a", dark: "#bfbfbf" };
-export const calciteColorText3 = { light: "#6a6a6a", dark: "#9f9f9f" };
-export const calciteColorTextInverse = { light: "#ffffff", dark: "#151515" };
+export const calciteColorText3 = { light: "#6b6b6b", dark: "#9e9e9e" };
+export const calciteColorTextInverse = { light: "#ffffff", dark: "#141414" };
 export const calciteColorTextLink = { light: "#00619b", dark: "#00a0ff" };
-export const calciteColorBorder1 = { light: "#cacaca", dark: "#555555" };
+export const calciteColorBorder1 = { light: "#c9c9c9", dark: "#545454" };
 export const calciteColorBorder2 = { light: "#d4d4d4", dark: "#4a4a4a" };
-export const calciteColorBorder3 = { light: "#dfdfdf", dark: "#404040" };
+export const calciteColorBorder3 = { light: "#dedede", dark: "#404040" };
 export const calciteColorBorderInput = { light: "#949494", dark: "#757575" };
 export const calciteColorBorderGhost = {
   light: "rgba(0, 0, 0, 0.3)",
   dark: "rgba(117, 117, 117, 0.3)",
 };
-export const calciteColorBorderWhite = { light: "#ffffff", dark: "#f8f8f8" };
+export const calciteColorBorderWhite = { light: "#ffffff", dark: "#f7f7f7" };
 export const calciteBorderWidthNone = "0";
 export const calciteBorderWidthSm = "1px";
 export const calciteBorderWidthMd = "2px";
@@ -31402,7 +31402,7 @@ export default {
           key: "{core.color.neutral.blk-000}",
         },
         "blk-005": {
-          value: "#f8f8f8",
+          value: "#f7f7f7",
           type: "color",
           attributes: {
             category: "color",
@@ -31425,7 +31425,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#f8f8f8",
+            value: "#f7f7f7",
             type: "color",
             attributes: {
               category: "color",
@@ -31436,7 +31436,7 @@ export default {
           key: "{core.color.neutral.blk-005}",
         },
         "blk-010": {
-          value: "#f3f3f3",
+          value: "#f2f2f2",
           type: "color",
           attributes: {
             category: "color",
@@ -31459,7 +31459,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#f3f3f3",
+            value: "#f2f2f2",
             type: "color",
             attributes: {
               category: "color",
@@ -31470,7 +31470,7 @@ export default {
           key: "{core.color.neutral.blk-010}",
         },
         "blk-020": {
-          value: "#eaeaea",
+          value: "#ebebeb",
           type: "color",
           attributes: {
             category: "color",
@@ -31493,7 +31493,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#eaeaea",
+            value: "#ebebeb",
             type: "color",
             attributes: {
               category: "color",
@@ -31504,7 +31504,7 @@ export default {
           key: "{core.color.neutral.blk-020}",
         },
         "blk-030": {
-          value: "#dfdfdf",
+          value: "#dedede",
           type: "color",
           attributes: {
             category: "color",
@@ -31527,7 +31527,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#dfdfdf",
+            value: "#dedede",
             type: "color",
             attributes: {
               category: "color",
@@ -31572,7 +31572,7 @@ export default {
           key: "{core.color.neutral.blk-040}",
         },
         "blk-050": {
-          value: "#cacaca",
+          value: "#c9c9c9",
           type: "color",
           attributes: {
             category: "color",
@@ -31595,7 +31595,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#cacaca",
+            value: "#c9c9c9",
             type: "color",
             attributes: {
               category: "color",
@@ -31674,7 +31674,7 @@ export default {
           key: "{core.color.neutral.blk-070}",
         },
         "blk-080": {
-          value: "#aaaaaa",
+          value: "#ababab",
           type: "color",
           attributes: {
             category: "color",
@@ -31697,7 +31697,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#aaaaaa",
+            value: "#ababab",
             type: "color",
             attributes: {
               category: "color",
@@ -31708,7 +31708,7 @@ export default {
           key: "{core.color.neutral.blk-080}",
         },
         "blk-090": {
-          value: "#9f9f9f",
+          value: "#9e9e9e",
           type: "color",
           attributes: {
             category: "color",
@@ -31731,7 +31731,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#9f9f9f",
+            value: "#9e9e9e",
             type: "color",
             attributes: {
               category: "color",
@@ -31878,7 +31878,7 @@ export default {
           key: "{core.color.neutral.blk-130}",
         },
         "blk-140": {
-          value: "#6a6a6a",
+          value: "#6b6b6b",
           type: "color",
           attributes: {
             category: "color",
@@ -31901,7 +31901,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#6a6a6a",
+            value: "#6b6b6b",
             type: "color",
             attributes: {
               category: "color",
@@ -31912,7 +31912,7 @@ export default {
           key: "{core.color.neutral.blk-140}",
         },
         "blk-150": {
-          value: "#606060",
+          value: "#616161",
           type: "color",
           attributes: {
             category: "color",
@@ -31935,7 +31935,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#606060",
+            value: "#616161",
             type: "color",
             attributes: {
               category: "color",
@@ -31946,7 +31946,7 @@ export default {
           key: "{core.color.neutral.blk-150}",
         },
         "blk-160": {
-          value: "#555555",
+          value: "#545454",
           type: "color",
           attributes: {
             category: "color",
@@ -31969,7 +31969,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#555555",
+            value: "#545454",
             type: "color",
             attributes: {
               category: "color",
@@ -32048,7 +32048,7 @@ export default {
           key: "{core.color.neutral.blk-180}",
         },
         "blk-190": {
-          value: "#353535",
+          value: "#363636",
           type: "color",
           attributes: {
             category: "color",
@@ -32071,7 +32071,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#353535",
+            value: "#363636",
             type: "color",
             attributes: {
               category: "color",
@@ -32116,7 +32116,7 @@ export default {
           key: "{core.color.neutral.blk-200}",
         },
         "blk-210": {
-          value: "#202020",
+          value: "#212121",
           type: "color",
           attributes: {
             category: "color",
@@ -32139,7 +32139,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#202020",
+            value: "#212121",
             type: "color",
             attributes: {
               category: "color",
@@ -32150,7 +32150,7 @@ export default {
           key: "{core.color.neutral.blk-210}",
         },
         "blk-220": {
-          value: "#151515",
+          value: "#141414",
           type: "color",
           attributes: {
             category: "color",
@@ -32173,7 +32173,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#151515",
+            value: "#141414",
             type: "color",
             attributes: {
               category: "color",
@@ -32184,7 +32184,7 @@ export default {
           key: "{core.color.neutral.blk-220}",
         },
         "blk-230": {
-          value: "#0b0b0b",
+          value: "#0a0a0a",
           type: "color",
           attributes: {
             category: "color",
@@ -32207,7 +32207,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#0b0b0b",
+            value: "#0a0a0a",
             type: "color",
             attributes: {
               category: "color",
@@ -32218,7 +32218,7 @@ export default {
           key: "{core.color.neutral.blk-230}",
         },
         "blk-235": {
-          value: "#060606",
+          value: "#050505",
           type: "color",
           attributes: {
             category: "color",
@@ -32241,7 +32241,7 @@ export default {
           filePath: "src/tokens/core/color.json",
           isSource: false,
           original: {
-            value: "#060606",
+            value: "#050505",
             type: "color",
             attributes: {
               category: "color",
@@ -53072,8 +53072,8 @@ export default {
       background: {
         default: {
           value: {
-            light: "#f8f8f8",
-            dark: "#353535",
+            light: "#f7f7f7",
+            dark: "#363636",
           },
           type: "color",
           attributes: {
@@ -53182,8 +53182,8 @@ export default {
         },
         2: {
           value: {
-            light: "#f3f3f3",
-            dark: "#202020",
+            light: "#f2f2f2",
+            dark: "#212121",
           },
           type: "color",
           attributes: {
@@ -53219,8 +53219,8 @@ export default {
         },
         3: {
           value: {
-            light: "#eaeaea",
-            dark: "#151515",
+            light: "#ebebeb",
+            dark: "#141414",
           },
           type: "color",
           attributes: {
@@ -54187,8 +54187,8 @@ export default {
       inverse: {
         default: {
           value: {
-            light: "#353535",
-            dark: "#f8f8f8",
+            light: "#363636",
+            dark: "#f7f7f7",
           },
           type: "color",
           attributes: {
@@ -54261,8 +54261,8 @@ export default {
         },
         press: {
           value: {
-            light: "#202020",
-            dark: "#f3f3f3",
+            light: "#212121",
+            dark: "#f2f2f2",
           },
           type: "color",
           attributes: {
@@ -54300,7 +54300,7 @@ export default {
       text: {
         1: {
           value: {
-            light: "#151515",
+            light: "#141414",
             dark: "#ffffff",
           },
           type: "color",
@@ -54374,8 +54374,8 @@ export default {
         },
         3: {
           value: {
-            light: "#6a6a6a",
-            dark: "#9f9f9f",
+            light: "#6b6b6b",
+            dark: "#9e9e9e",
           },
           type: "color",
           attributes: {
@@ -54412,7 +54412,7 @@ export default {
         inverse: {
           value: {
             light: "#ffffff",
-            dark: "#151515",
+            dark: "#141414",
           },
           type: "color",
           attributes: {
@@ -54487,8 +54487,8 @@ export default {
       border: {
         1: {
           value: {
-            light: "#cacaca",
-            dark: "#555555",
+            light: "#c9c9c9",
+            dark: "#545454",
           },
           type: "color",
           attributes: {
@@ -54561,7 +54561,7 @@ export default {
         },
         3: {
           value: {
-            light: "#dfdfdf",
+            light: "#dedede",
             dark: "#404040",
           },
           type: "color",
@@ -54673,7 +54673,7 @@ export default {
         white: {
           value: {
             light: "#ffffff",
-            dark: "#f8f8f8",
+            dark: "#f7f7f7",
           },
           type: "color",
           attributes: {
@@ -68331,31 +68331,31 @@ exports[`generated tokens > SCSS > core should match 1`] = `
 // Do not edit directly, this file was auto-generated.
 
 $calcite-color-neutral-blk-000: #ffffff;
-$calcite-color-neutral-blk-005: #f8f8f8;
-$calcite-color-neutral-blk-010: #f3f3f3;
-$calcite-color-neutral-blk-020: #eaeaea;
-$calcite-color-neutral-blk-030: #dfdfdf;
+$calcite-color-neutral-blk-005: #f7f7f7;
+$calcite-color-neutral-blk-010: #f2f2f2;
+$calcite-color-neutral-blk-020: #ebebeb;
+$calcite-color-neutral-blk-030: #dedede;
 $calcite-color-neutral-blk-040: #d4d4d4;
-$calcite-color-neutral-blk-050: #cacaca;
+$calcite-color-neutral-blk-050: #c9c9c9;
 $calcite-color-neutral-blk-060: #bfbfbf;
 $calcite-color-neutral-blk-070: #b5b5b5;
-$calcite-color-neutral-blk-080: #aaaaaa;
-$calcite-color-neutral-blk-090: #9f9f9f;
+$calcite-color-neutral-blk-080: #ababab;
+$calcite-color-neutral-blk-090: #9e9e9e;
 $calcite-color-neutral-blk-100: #949494;
 $calcite-color-neutral-blk-110: #8a8a8a;
 $calcite-color-neutral-blk-120: #808080;
 $calcite-color-neutral-blk-130: #757575;
-$calcite-color-neutral-blk-140: #6a6a6a;
-$calcite-color-neutral-blk-150: #606060;
-$calcite-color-neutral-blk-160: #555555;
+$calcite-color-neutral-blk-140: #6b6b6b;
+$calcite-color-neutral-blk-150: #616161;
+$calcite-color-neutral-blk-160: #545454;
 $calcite-color-neutral-blk-170: #4a4a4a;
 $calcite-color-neutral-blk-180: #404040;
-$calcite-color-neutral-blk-190: #353535;
+$calcite-color-neutral-blk-190: #363636;
 $calcite-color-neutral-blk-200: #2b2b2b;
-$calcite-color-neutral-blk-210: #202020;
-$calcite-color-neutral-blk-220: #151515;
-$calcite-color-neutral-blk-230: #0b0b0b;
-$calcite-color-neutral-blk-235: #060606;
+$calcite-color-neutral-blk-210: #212121;
+$calcite-color-neutral-blk-220: #141414;
+$calcite-color-neutral-blk-230: #0a0a0a;
+$calcite-color-neutral-blk-235: #050505;
 $calcite-color-neutral-blk-240: #000000;
 $calcite-color-low-saturation-blue-l-bb-010: #edf3f7;
 $calcite-color-low-saturation-blue-l-bb-020: #d7e1e7;
@@ -68912,11 +68912,11 @@ exports[`generated tokens > SCSS > dark should match 1`] = `
 // Calcite Design System
 // Do not edit directly, this file was auto-generated.
 
-$calcite-color-background: #353535;
+$calcite-color-background: #363636;
 $calcite-color-background-none: rgba(255, 255, 255, 0);
 $calcite-color-foreground-1: #2b2b2b;
-$calcite-color-foreground-2: #202020;
-$calcite-color-foreground-3: #151515;
+$calcite-color-foreground-2: #212121;
+$calcite-color-foreground-3: #141414;
 $calcite-color-foreground-current: #214155;
 $calcite-color-transparent: rgba(255, 255, 255, 0);
 $calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
@@ -68941,20 +68941,20 @@ $calcite-color-status-warning-press: #f5d000;
 $calcite-color-status-danger: #fe583e;
 $calcite-color-status-danger-hover: #ff0015;
 $calcite-color-status-danger-press: #d90012;
-$calcite-color-inverse: #f8f8f8;
+$calcite-color-inverse: #f7f7f7;
 $calcite-color-inverse-hover: #ffffff;
-$calcite-color-inverse-press: #f3f3f3;
+$calcite-color-inverse-press: #f2f2f2;
 $calcite-color-text-1: #ffffff;
 $calcite-color-text-2: #bfbfbf;
-$calcite-color-text-3: #9f9f9f;
-$calcite-color-text-inverse: #151515;
+$calcite-color-text-3: #9e9e9e;
+$calcite-color-text-inverse: #141414;
 $calcite-color-text-link: #00a0ff;
-$calcite-color-border-1: #555555;
+$calcite-color-border-1: #545454;
 $calcite-color-border-2: #4a4a4a;
 $calcite-color-border-3: #404040;
 $calcite-color-border-input: #757575;
 $calcite-color-border-ghost: rgba(117, 117, 117, 0.3);
-$calcite-color-border-white: #f8f8f8;
+$calcite-color-border-white: #f7f7f7;
 "
 `;
 
@@ -69089,17 +69089,17 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-border-white: #ffffff;
   --calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
   --calcite-color-border-input: #949494;
-  --calcite-color-border-3: #dfdfdf;
+  --calcite-color-border-3: #dedede;
   --calcite-color-border-2: #d4d4d4;
-  --calcite-color-border-1: #cacaca;
+  --calcite-color-border-1: #c9c9c9;
   --calcite-color-text-link: #00619b;
   --calcite-color-text-inverse: #ffffff;
-  --calcite-color-text-3: #6a6a6a;
+  --calcite-color-text-3: #6b6b6b;
   --calcite-color-text-2: #4a4a4a;
-  --calcite-color-text-1: #151515;
-  --calcite-color-inverse-press: #202020;
+  --calcite-color-text-1: #141414;
+  --calcite-color-inverse-press: #212121;
   --calcite-color-inverse-hover: #2b2b2b;
-  --calcite-color-inverse: #353535;
+  --calcite-color-inverse: #363636;
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
@@ -69124,28 +69124,28 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
   --calcite-color-transparent: rgba(0, 0, 0, 0);
   --calcite-color-foreground-current: #c7eaff;
-  --calcite-color-foreground-3: #eaeaea;
-  --calcite-color-foreground-2: #f3f3f3;
+  --calcite-color-foreground-3: #ebebeb;
+  --calcite-color-foreground-2: #f2f2f2;
   --calcite-color-foreground-1: #ffffff;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #f8f8f8;
+  --calcite-color-background: #f7f7f7;
 }
 @mixin calcite-mode-dark {
   --calcite-color-foreground-current: #214155;
-  --calcite-color-border-white: #f8f8f8;
+  --calcite-color-border-white: #f7f7f7;
   --calcite-color-border-ghost: rgba(117, 117, 117, 0.3);
   --calcite-color-border-input: #757575;
   --calcite-color-border-3: #404040;
   --calcite-color-border-2: #4a4a4a;
-  --calcite-color-border-1: #555555;
+  --calcite-color-border-1: #545454;
   --calcite-color-text-link: #00a0ff;
-  --calcite-color-text-inverse: #151515;
-  --calcite-color-text-3: #9f9f9f;
+  --calcite-color-text-inverse: #141414;
+  --calcite-color-text-3: #9e9e9e;
   --calcite-color-text-2: #bfbfbf;
   --calcite-color-text-1: #ffffff;
-  --calcite-color-inverse-press: #f3f3f3;
+  --calcite-color-inverse-press: #f2f2f2;
   --calcite-color-inverse-hover: #ffffff;
-  --calcite-color-inverse: #f8f8f8;
+  --calcite-color-inverse: #f7f7f7;
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
@@ -69169,11 +69169,11 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-transparent-press: rgba(255, 255, 255, 0.16);
   --calcite-color-transparent-hover: rgba(255, 255, 255, 0.12);
   --calcite-color-transparent: rgba(255, 255, 255, 0);
-  --calcite-color-foreground-3: #151515;
-  --calcite-color-foreground-2: #202020;
+  --calcite-color-foreground-3: #141414;
+  --calcite-color-foreground-2: #212121;
   --calcite-color-foreground-1: #2b2b2b;
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-background: #353535;
+  --calcite-color-background: #363636;
 }
 "
 `;
@@ -69183,11 +69183,11 @@ exports[`generated tokens > SCSS > light should match 1`] = `
 // Calcite Design System
 // Do not edit directly, this file was auto-generated.
 
-$calcite-color-background: #f8f8f8;
+$calcite-color-background: #f7f7f7;
 $calcite-color-background-none: rgba(255, 255, 255, 0);
 $calcite-color-foreground-1: #ffffff;
-$calcite-color-foreground-2: #f3f3f3;
-$calcite-color-foreground-3: #eaeaea;
+$calcite-color-foreground-2: #f2f2f2;
+$calcite-color-foreground-3: #ebebeb;
 $calcite-color-foreground-current: #c7eaff;
 $calcite-color-transparent: rgba(0, 0, 0, 0);
 $calcite-color-transparent-hover: rgba(0, 0, 0, 0.04);
@@ -69212,17 +69212,17 @@ $calcite-color-status-warning-press: #bfa200;
 $calcite-color-status-danger: #d83020;
 $calcite-color-status-danger-hover: #a82b1e;
 $calcite-color-status-danger-press: #7c1d13;
-$calcite-color-inverse: #353535;
+$calcite-color-inverse: #363636;
 $calcite-color-inverse-hover: #2b2b2b;
-$calcite-color-inverse-press: #202020;
-$calcite-color-text-1: #151515;
+$calcite-color-inverse-press: #212121;
+$calcite-color-text-1: #141414;
 $calcite-color-text-2: #4a4a4a;
-$calcite-color-text-3: #6a6a6a;
+$calcite-color-text-3: #6b6b6b;
 $calcite-color-text-inverse: #ffffff;
 $calcite-color-text-link: #00619b;
-$calcite-color-border-1: #cacaca;
+$calcite-color-border-1: #c9c9c9;
 $calcite-color-border-2: #d4d4d4;
-$calcite-color-border-3: #dfdfdf;
+$calcite-color-border-3: #dedede;
 $calcite-color-border-input: #949494;
 $calcite-color-border-ghost: rgba(0, 0, 0, 0.3);
 $calcite-color-border-white: #ffffff;


### PR DESCRIPTION
**Related Issue:** #11725 
cc @trailtraveler

## Summary
This updates 15 of the `core.color.neutral` token values. Calcite does currently reference most of these tokens in the `semantic` colors, but the changes are so subtle that no changes to components are anticipated.

Before/after comparisons:
![image](https://github.com/user-attachments/assets/751efdce-8db5-4000-8fbc-8a81bad8bd72)

## Checklist:
- [x] update `--calcite-color-neutral-blk-005` to #F7F7F7
- [x] update `--calcite-color-neutral-blk-010` to #F2F2F2
- [x] update `--calcite-color-neutral-blk-020` to #EBEBEB
- [x] update `--calcite-color-neutral-blk-030` to #DEDEDE
- [x] update `--calcite-color-neutral-blk-050` to #C9C9C9
- [x] update `--calcite-color-neutral-blk-080` to #ABABAB
- [x] update `--calcite-color-neutral-blk-090` to #9E9E9E
- [x] update `--calcite-color-neutral-blk-140` to #6B6B6B
- [x] update `--calcite-color-neutral-blk-150` to #616161
- [x] update `--calcite-color-neutral-blk-160` to #545454
- [x] update `--calcite-color-neutral-blk-190` to #363636
- [x] update `--calcite-color-neutral-blk-210` to #212121
- [x] update `--calcite-color-neutral-blk-220` to #141414
- [x] update `--calcite-color-neutral-blk-230` to #0A0A0A
- [x] update `--calcite-color-neutral-blk-235` to #050505