### PR TITLE
fix(semantic-tokens): provide sufficient warning color contrast across components

### DIFF
--- a/packages/calcite-design-tokens/src/build/preprocessors/store-same-value-theme-tokens.ts
+++ b/packages/calcite-design-tokens/src/build/preprocessors/store-same-value-theme-tokens.ts
@@ -4,6 +4,11 @@ import { dark, light } from "../dictionaries/index.js";
 import { isThemed } from "../utils/token-types.js";
 import { state } from "../shared/state.js";
 
+const mergeInclusions = [
+  // excluded to match test output – we can remove for a breaking change release
+  "{semantic.color.background.none}",
+];
+
 export function registerPreprocessorStoreSameValueThemeTokens(): void {
   StyleDictionary.registerPreprocessor({
     name: PreprocessorStoreSameValueThemeTokens,
@@ -11,7 +16,12 @@ export function registerPreprocessorStoreSameValueThemeTokens(): void {
       const keyToToken = new Map<string, DesignToken>();
 
       light.allTokens.forEach((token, index) => {
-        if (isThemed(token) && token.value === dark.allTokens[index].value && token.key) {
+        if (
+          isThemed(token) &&
+          token.value === dark.allTokens[index].value &&
+          token.key &&
+          mergeInclusions.includes(token.key)
+        ) {
           keyToToken.set(token.key, token);
         }
       });

--- a/packages/calcite-design-tokens/src/build/transforms/value/merge-value.ts
+++ b/packages/calcite-design-tokens/src/build/transforms/value/merge-value.ts
@@ -4,6 +4,7 @@ import { PlatformConfig } from "../../../types/extensions.js";
 import { RegisterFn } from "../../../types/interfaces.js";
 import { dark, light } from "../../dictionaries/index.js";
 import { isLightOrDarkColorToken } from "../../filter/light-or-dark.js";
+import { state } from "../../shared/state.js";
 
 let dictionaries: {
   light: Dictionary;
@@ -31,16 +32,14 @@ const transformValueMergeValues: ValueTransform["transform"] = async (token, con
     (t: TransformedToken) => t.path.join("/") === token.path.join("/"),
   );
 
-  if (tokenIndex > -1) {
-    const lightValue = dictionaries.light.allTokens[tokenIndex].value;
-    const darkValue = dictionaries.dark.allTokens[tokenIndex].value;
+  const lightToken = dictionaries.light.allTokens[tokenIndex];
+  const darkToken = dictionaries.dark.allTokens[tokenIndex];
 
-    if (lightValue !== darkValue) {
-      return {
-        light: lightValue,
-        dark: darkValue,
-      };
-    }
+  if (tokenIndex > -1 && lightToken.key && !state.sameValueThemeTokens.has(lightToken.key)) {
+    return {
+      light: lightToken.value,
+      dark: darkToken.value,
+    };
   }
 
   return token.value;

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
@@ -181,21 +181,21 @@
         },
         "warning": {
           "default": {
-            "value": "{core.color.dark.yellow.d-yy-420}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "hover": {
-            "value": "{core.color.vibrant.yellow.v-yy-140}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-120}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "press": {
-            "value": "{core.color.vibrant.yellow.v-yy-160}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-140}",
             "type": "color",
             "category": "color"
           }

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
@@ -183,21 +183,21 @@
         },
         "warning": {
           "default": {
-            "value": "{core.color.high-saturation.yellow.h-yy-060}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "hover": {
-            "value": "{core.color.high-saturation.yellow.h-yy-070}",
+            "value": "{core.color.vibrant.orange-yellow.v-oy-180}",
             "type": "color",
             "attributes": {
               "category": "color"
             }
           },
           "press": {
-            "value": "{core.color.high-saturation.yellow.h-yy-080}",
+            "value": "{core.color.high-saturation.orange-yellow.h-oy-080}",
             "type": "color",
             "attributes": {
               "category": "color"

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -924,9 +924,9 @@ exports[`generated tokens > CSS > dark should match 1`] = `
   --calcite-color-status-success: #36da43;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success-press: #00b81b;
-  --calcite-color-status-warning: #ffc900;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning-press: #f5d000;
+  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning-press: #ff9500;
   --calcite-color-status-danger: #fe583e;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger-press: #d90012;
@@ -957,6 +957,7 @@ exports[`generated tokens > CSS > global should match 1`] = `
 
 :root {
   --calcite-color-background-none: rgba(255, 255, 255, 0);
+  --calcite-color-status-warning: #f89927;
   --calcite-border-width-none: 0;
   --calcite-border-width-sm: 1px;
   --calcite-border-width-md: 2px;
@@ -1095,9 +1096,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1141,9 +1142,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #7c1d13;
     --calcite-color-status-danger-hover: #a82b1e;
     --calcite-color-status-danger: #d83020;
-    --calcite-color-status-warning-press: #bfa200;
-    --calcite-color-status-warning-hover: #d9bc00;
-    --calcite-color-status-warning: #edd317;
+    --calcite-color-status-warning-press: #9a5b10;
+    --calcite-color-status-warning-hover: #d17300;
+    --calcite-color-status-warning: #f89927;
     --calcite-color-status-success-press: #1a6324;
     --calcite-color-status-success-hover: #288835;
     --calcite-color-status-success: #35ac46;
@@ -1189,9 +1190,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
     --calcite-color-status-danger-press: #d90012;
     --calcite-color-status-danger-hover: #ff0015;
     --calcite-color-status-danger: #fe583e;
-    --calcite-color-status-warning-press: #f5d000;
-    --calcite-color-status-warning-hover: #ffee33;
-    --calcite-color-status-warning: #ffc900;
+    --calcite-color-status-warning-press: #ff9500;
+    --calcite-color-status-warning-hover: #ffb54d;
+    --calcite-color-status-warning: #f89927;
     --calcite-color-status-success-press: #00b81b;
     --calcite-color-status-success-hover: #3bed52;
     --calcite-color-status-success: #36da43;
@@ -1234,9 +1235,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -1280,9 +1281,9 @@ exports[`generated tokens > CSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #f5d000;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning: #ffc900;
+  --calcite-color-status-warning-press: #ff9500;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -1339,9 +1340,9 @@ exports[`generated tokens > CSS > light should match 1`] = `
   --calcite-color-status-success: #35ac46;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success-press: #1a6324;
-  --calcite-color-status-warning: #edd317;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning-press: #bfa200;
+  --calcite-color-status-warning: #f89927;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning-press: #9a5b10;
   --calcite-color-status-danger: #d83020;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger-press: #7c1d13;
@@ -18335,7 +18336,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.success.press}"
     },
     {
-      "value": "{\\"light\\":\\"#edd317\\",\\"dark\\":\\"#ffc900\\"}",
+      "value": "#f89927",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18363,7 +18364,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.default}"
     },
     {
-      "value": "{\\"light\\":\\"#d9bc00\\",\\"dark\\":\\"#ffee33\\"}",
+      "value": "{\\"light\\":\\"#d17300\\",\\"dark\\":\\"#ffb54d\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -18391,7 +18392,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.warning.hover}"
     },
     {
-      "value": "{\\"light\\":\\"#bfa200\\",\\"dark\\":\\"#f5d000\\"}",
+      "value": "{\\"light\\":\\"#9a5b10\\",\\"dark\\":\\"#ff9500\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -30094,14 +30095,14 @@ export const calciteColorStatusSuccessPress = {
   light: "#1a6324",
   dark: "#00b81b",
 };
-export const calciteColorStatusWarning = { light: "#edd317", dark: "#ffc900" };
+export const calciteColorStatusWarning = "#f89927";
 export const calciteColorStatusWarningHover = {
-  light: "#d9bc00",
-  dark: "#ffee33",
+  light: "#d17300",
+  dark: "#ffb54d",
 };
 export const calciteColorStatusWarningPress = {
-  light: "#bfa200",
-  dark: "#f5d000",
+  light: "#9a5b10",
+  dark: "#ff9500",
 };
 export const calciteColorStatusDanger = { light: "#d83020", dark: "#fe583e" };
 export const calciteColorStatusDangerHover = {
@@ -30572,7 +30573,7 @@ export const calciteColorStatusInfoPress: { light: string; dark: string };
 export const calciteColorStatusSuccess: { light: string; dark: string };
 export const calciteColorStatusSuccessHover: { light: string; dark: string };
 export const calciteColorStatusSuccessPress: { light: string; dark: string };
-export const calciteColorStatusWarning: { light: string; dark: string };
+export const calciteColorStatusWarning: string;
 export const calciteColorStatusWarningHover: { light: string; dark: string };
 export const calciteColorStatusWarningPress: { light: string; dark: string };
 export const calciteColorStatusDanger: { light: string; dark: string };
@@ -53953,10 +53954,7 @@ export default {
         },
         warning: {
           default: {
-            value: {
-              light: "#edd317",
-              dark: "#ffc900",
-            },
+            value: "#f89927",
             type: "color",
             attributes: {
               category: "color",
@@ -53980,7 +53978,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-060}",
+              value: "{core.color.high-saturation.orange-yellow.h-oy-060}",
               type: "color",
               attributes: {
                 category: "color",
@@ -53992,8 +53990,8 @@ export default {
           },
           hover: {
             value: {
-              light: "#d9bc00",
-              dark: "#ffee33",
+              light: "#d17300",
+              dark: "#ffb54d",
             },
             type: "color",
             attributes: {
@@ -54018,7 +54016,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-070}",
+              value: "{core.color.vibrant.orange-yellow.v-oy-180}",
               type: "color",
               attributes: {
                 category: "color",
@@ -54030,8 +54028,8 @@ export default {
           },
           press: {
             value: {
-              light: "#bfa200",
-              dark: "#f5d000",
+              light: "#9a5b10",
+              dark: "#ff9500",
             },
             type: "color",
             attributes: {
@@ -54056,7 +54054,7 @@ export default {
             filePath: "src/tokens/semantic/color/light.json",
             isSource: false,
             original: {
-              value: "{core.color.high-saturation.yellow.h-yy-080}",
+              value: "{core.color.high-saturation.orange-yellow.h-oy-080}",
               type: "color",
               attributes: {
                 category: "color",
@@ -68935,9 +68933,9 @@ $calcite-color-status-info-press: #009af2;
 $calcite-color-status-success: #36da43;
 $calcite-color-status-success-hover: #3bed52;
 $calcite-color-status-success-press: #00b81b;
-$calcite-color-status-warning: #ffc900;
-$calcite-color-status-warning-hover: #ffee33;
-$calcite-color-status-warning-press: #f5d000;
+$calcite-color-status-warning: #f89927;
+$calcite-color-status-warning-hover: #ffb54d;
+$calcite-color-status-warning-press: #ff9500;
 $calcite-color-status-danger: #fe583e;
 $calcite-color-status-danger-hover: #ff0015;
 $calcite-color-status-danger-press: #d90012;
@@ -68965,6 +68963,7 @@ exports[`generated tokens > SCSS > global should match 1`] = `
 // Do not edit directly, this file was auto-generated.
 
 $calcite-color-background-none: rgba(255, 255, 255, 0);
+$calcite-color-status-warning: #f89927;
 $calcite-border-width-none: 0;
 $calcite-border-width-sm: 1px;
 $calcite-border-width-md: 2px;
@@ -69103,9 +69102,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #7c1d13;
   --calcite-color-status-danger-hover: #a82b1e;
   --calcite-color-status-danger: #d83020;
-  --calcite-color-status-warning-press: #bfa200;
-  --calcite-color-status-warning-hover: #d9bc00;
-  --calcite-color-status-warning: #edd317;
+  --calcite-color-status-warning-press: #9a5b10;
+  --calcite-color-status-warning-hover: #d17300;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #1a6324;
   --calcite-color-status-success-hover: #288835;
   --calcite-color-status-success: #35ac46;
@@ -69149,9 +69148,9 @@ exports[`generated tokens > SCSS > index should match 1`] = `
   --calcite-color-status-danger-press: #d90012;
   --calcite-color-status-danger-hover: #ff0015;
   --calcite-color-status-danger: #fe583e;
-  --calcite-color-status-warning-press: #f5d000;
-  --calcite-color-status-warning-hover: #ffee33;
-  --calcite-color-status-warning: #ffc900;
+  --calcite-color-status-warning-press: #ff9500;
+  --calcite-color-status-warning-hover: #ffb54d;
+  --calcite-color-status-warning: #f89927;
   --calcite-color-status-success-press: #00b81b;
   --calcite-color-status-success-hover: #3bed52;
   --calcite-color-status-success: #36da43;
@@ -69206,9 +69205,9 @@ $calcite-color-status-info-press: #00304d;
 $calcite-color-status-success: #35ac46;
 $calcite-color-status-success-hover: #288835;
 $calcite-color-status-success-press: #1a6324;
-$calcite-color-status-warning: #edd317;
-$calcite-color-status-warning-hover: #d9bc00;
-$calcite-color-status-warning-press: #bfa200;
+$calcite-color-status-warning: #f89927;
+$calcite-color-status-warning-hover: #d17300;
+$calcite-color-status-warning-press: #9a5b10;
 $calcite-color-status-danger: #d83020;
 $calcite-color-status-danger-hover: #a82b1e;
 $calcite-color-status-danger-press: #7c1d13;

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -957,7 +957,6 @@ exports[`generated tokens > CSS > global should match 1`] = `
 
 :root {
   --calcite-color-background-none: rgba(255, 255, 255, 0);
-  --calcite-color-status-warning: #f89927;
   --calcite-border-width-none: 0;
   --calcite-border-width-sm: 1px;
   --calcite-border-width-md: 2px;
@@ -18336,7 +18335,7 @@ exports[`generated tokens > DOCS > global should match 1`] = `
       "key": "{semantic.color.status.success.press}"
     },
     {
-      "value": "#f89927",
+      "value": "{\\"light\\":\\"#f89927\\",\\"dark\\":\\"#f89927\\"}",
       "type": "color",
       "attributes": {
         "category": "color",
@@ -30095,7 +30094,7 @@ export const calciteColorStatusSuccessPress = {
   light: "#1a6324",
   dark: "#00b81b",
 };
-export const calciteColorStatusWarning = "#f89927";
+export const calciteColorStatusWarning = { light: "#f89927", dark: "#f89927" };
 export const calciteColorStatusWarningHover = {
   light: "#d17300",
   dark: "#ffb54d",
@@ -30573,7 +30572,7 @@ export const calciteColorStatusInfoPress: { light: string; dark: string };
 export const calciteColorStatusSuccess: { light: string; dark: string };
 export const calciteColorStatusSuccessHover: { light: string; dark: string };
 export const calciteColorStatusSuccessPress: { light: string; dark: string };
-export const calciteColorStatusWarning: string;
+export const calciteColorStatusWarning: { light: string; dark: string };
 export const calciteColorStatusWarningHover: { light: string; dark: string };
 export const calciteColorStatusWarningPress: { light: string; dark: string };
 export const calciteColorStatusDanger: { light: string; dark: string };
@@ -53954,7 +53953,10 @@ export default {
         },
         warning: {
           default: {
-            value: "#f89927",
+            value: {
+              light: "#f89927",
+              dark: "#f89927",
+            },
             type: "color",
             attributes: {
               category: "color",
@@ -68963,7 +68965,6 @@ exports[`generated tokens > SCSS > global should match 1`] = `
 // Do not edit directly, this file was auto-generated.
 
 $calcite-color-background-none: rgba(255, 255, 255, 0);
-$calcite-color-status-warning: #f89927;
 $calcite-border-width-none: 0;
 $calcite-border-width-sm: 1px;
 $calcite-border-width-md: 2px;


### PR DESCRIPTION
**Related Issue:** [#7798](https://github.com/Esri/calcite-design-system/issues/7798)

## Summary

Update the following semantic tokens to resolve contrast issues:

LIGHT MODE
status/warning/default → `color/high-saturation/orange-yellow/h-oy-060`
status/warning/hover → `color/vibrant/orange-yellow/v-oy-180`
status/warning/press → `color/high-saturation/orange-yellow/h-oy-080`

DARK MODE
status/warning/default → `color/high-saturation/orange-yellow/h-oy-060`
status/warning/hover → `color/vibrant/orange-yellow/v-oy-120`
status/warning/press → `color/vibrant/orange-yellow/v-oy-140`