### PR TITLE
fix(input-date-picker): add label property for screen readers and AT

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -68,6 +68,7 @@ describe("calcite-input-date-picker", () => {
 
   describe("labelable", () => {
     labelable("calcite-input-date-picker");
+    labelable("<calcite-input-date-picker range></calcite-input-date-picker>");
   });
 
   describe("disabled", () => {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -198,6 +198,9 @@ export class InputDatePicker
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
 
+  /** Accessible name for the component. */
+  @property() label: string;
+
   /** Defines the layout of the component. */
   @property({ reflect: true }) layout: "horizontal" | "vertical" = "horizontal";
 
@@ -1100,6 +1103,7 @@ export class InputDatePicker
                   }}
                   disabled={disabled}
                   icon="calendar"
+                  label={this.label}
                   oncalciteInputTextInput={this.calciteInternalInputInputHandler}
                   oncalciteInternalInputTextBlur={this.calciteInternalInputBlurHandler}
                   oncalciteInternalInputTextFocus={this.startInputFocus}
@@ -1184,6 +1188,7 @@ export class InputDatePicker
                     }}
                     disabled={disabled}
                     icon="calendar"
+                    label={this.label}
                     oncalciteInputTextInput={this.calciteInternalInputInputHandler}
                     oncalciteInternalInputTextBlur={this.calciteInternalInputBlurHandler}
                     oncalciteInternalInputTextFocus={this.endInputFocus}


### PR DESCRIPTION
**Related Issue:** #8480

## Summary

This PR adds a `label` property to `calcite-input-date-picker` to support an accessible screen reading experience.