### PR TITLE
feat(button): enhance component's interactivity states

### DIFF
--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -676,9 +676,16 @@
 
 :host([appearance="transparent"][kind="inverse"]) {
   button,
-  a,
-  calcite-loader {
-    --calcite-internal-button-text-color: var(--calcite-color-text-inverse);
+  a {
+    &:hover {
+      background-color: var(--calcite-color-transparent-inverse-hover);
+    }
+    &:active {
+      background-color: var(--calcite-color-transparent-inverse-press);
+    }
+    calcite-loader {
+      --calcite-internal-button-text-color: var(--calcite-color-text-inverse);
+    }
   }
 }
 


### PR DESCRIPTION
**Related Issue:** [#11576](https://github.com/Esri/calcite-design-system/issues/11576)

## Summary

For `appearance="transparent"` `kind="inverse"`:

- Update `:hover` to `--calcite-color-transparent-inverse-hover` background change instead of a stroke width change.
- Update `:press` to a `--calcite-color-transparent-inverse-press` background change instead of a stroke width change.
