### PR TITLE
feat(sheet): add component tokens

### DIFF
--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, focusable, hidden, openClose, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, openClose, reflects, renders, themed } from "../../tests/commonTests";
 import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils";
 import { resizeStep, resizeShiftStep } from "../../utils/resources";
 import { CSS } from "./resources";
@@ -759,6 +759,60 @@ describe("calcite-sheet properties", () => {
 
       computedStyle = await container.getComputedStyle();
       expect(computedStyle.blockSize).toBe(`${minSize}px`);
+    });
+  });
+
+  describe.only("themed", () => {
+    describe("default", () => {
+      themed(
+        html`<calcite-sheet open resizable display-mode="float" position="inline-start" width="l" height="m">
+          <calcite-panel heading="hello world">test!</calcite-panel>
+        </calcite-sheet>`,
+        {
+          "--calcite-sheet-background-color": {
+            shadowSelector: `#sheet-content.${CSS.content}`,
+            targetProp: "backgroundColor",
+          },
+          "--calcite-sheet-border-color": {
+            shadowSelector: `.${CSS.resizeHandleBar}`,
+            targetProp: "borderInlineStartColor",
+          },
+          "--calcite-sheet-corner-radius": [
+            {
+              shadowSelector: `#sheet-content.${CSS.content}`,
+              targetProp: "borderRadius",
+            },
+            {
+              shadowSelector: `.${CSS.contentContainer}`,
+              targetProp: "borderRadius",
+            },
+            {
+              shadowSelector: `.${CSS.container}`,
+              targetProp: "borderRadius",
+            },
+            {
+              shadowSelector: `.${CSS.resizeHandleBar}`,
+              targetProp: "borderStartEndRadius",
+            },
+          ],
+          "--calcite-sheet-text-color": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "color",
+          },
+          "--calcite-sheet-shadow": {
+            shadowSelector: `#sheet-content.${CSS.content}`,
+            targetProp: "boxShadow",
+          },
+          "--calcite-sheet-resize-background-color": {
+            shadowSelector: `.${CSS.resizeHandleBar}`,
+            targetProp: "backgroundColor",
+          },
+          "--calcite-sheet-resize-text-color": {
+            shadowSelector: `.${CSS.resizeHandleBar}`,
+            targetProp: "color",
+          },
+        },
+      );
     });
   });
 });

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -2,7 +2,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { html } from "../../../support/formatting";
-import { accessible, defaults, focusable, hidden, openClose, reflects, renders } from "../../tests/commonTests";
+import { accessible, defaults, focusable, hidden, openClose, reflects, renders, themed } from "../../tests/commonTests";
 import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils/puppeteer";
 import { resizeStep, resizeShiftStep } from "../../utils/resources";
 import { CSS } from "./resources";

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -762,7 +762,7 @@ describe("calcite-sheet properties", () => {
     });
   });
 
-  describe.only("themed", () => {
+  describe("themed", () => {
     describe("default", () => {
       themed(
         html`<calcite-sheet open resizable display-mode="float" position="inline-start" width="l" height="m">
@@ -807,7 +807,7 @@ describe("calcite-sheet properties", () => {
             shadowSelector: `.${CSS.resizeHandleBar}`,
             targetProp: "backgroundColor",
           },
-          "--calcite-sheet-resize-text-color": {
+          "--calcite-sheet-resize-icon-color": {
             shadowSelector: `.${CSS.resizeHandleBar}`,
             targetProp: "color",
           },

--- a/packages/calcite-components/src/components/sheet/sheet.scss
+++ b/packages/calcite-components/src/components/sheet/sheet.scss
@@ -2,6 +2,13 @@
  * CSS Custom Properties
  *
  * These properties can be overridden using the component's tag as selector.
+ * @prop --calcite-sheet-background-color: Specifies the background color of the sheet.
+ * @prop --calcite-sheet-corner-radius: Specifies the corner radius of the component.
+ * @prop --calcite-sheet-shadow: Specifies the shadow of the component.
+ * @prop --calcite-sheet-text-color: Specifies the text color of the component.
+ *
+ * @prop --calcite-sheet-resize-background-color: Specifies the background color of the resize handle.
+ * @prop --calcite-sheet-resize-text-color: Specifies the text color of the resize handle.
  *
  * @prop --calcite-sheet-scrim-background: Specifies the background color of the sheet scrim.
  * @prop --calcite-sheet-width: When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component.
@@ -25,7 +32,8 @@
 }
 
 .calcite--rtl {
-  --calcite-scrim-shadow-inline-start-internal: -4px 0 8px -1px rgba(0, 0, 0, 0.08), -2px 0 4px -1px rgba(0, 0, 0, 0.04);
+  --calcite-scrim-shadow-inline-start-internal:
+    -4px 0 8px -1px rgba(0, 0, 0, 0.08), -2px 0 4px -1px rgba(0, 0, 0, 0.04);
   --calcite-scrim-shadow-inline-end-internal: 4px 0 8px -1px rgba(0, 0, 0, 0.08), 2px 0 4px -1px rgba(0, 0, 0, 0.04);
 }
 
@@ -34,13 +42,13 @@
 }
 
 .container {
-  @apply text-color-2
-    box-border
+  @apply box-border
     fixed
     flex
     opacity-0
     z-overlay
     invisible;
+  color: var(--calcite-sheet-text-color, var(--calcite-color-text-2));
   transition:
     visibility 0ms linear var(--calcite-internal-animation-timing-medium),
     opacity var(--calcite-internal-animation-timing-medium) $easing-function;
@@ -75,7 +83,14 @@
 }
 
 :host([display-mode="float"]) .content {
-  @apply shadow-2-sm;
+  --tw-shadow: 0 2px 12px -4px rgba(0, 0, 0, 0.2), 0 2px 4px -2px rgba(0, 0, 0, 0.16);
+  --tw-shadow-colored: 0 2px 12px -4px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(
+    --calcite-sheet-shadow,
+    var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow)
+  );
 }
 
 :host([display-mode="overlay"][position="inline-start"]) .container {
@@ -153,7 +168,7 @@
 
 .content {
   @apply flex relative box-border p-0 z-modal max-h-full max-w-full;
-  background-color: theme("colors.background.foreground.1");
+  background-color: var(--calcite-sheet-background-color, var(--calcite-color-foreground-1));
   max-block-size: 100%;
   visibility: hidden;
   transition:
@@ -174,11 +189,11 @@
 :host([display-mode="float"]) .content,
 :host([display-mode="float"]) .container,
 :host([display-mode="float"]) .content-container {
-  @apply rounded;
+  border-radius: var(--calcite-sheet-corner-radius, var(--calcite-corner-radius-round));
 }
 
 :host([display-mode="float"]) .container {
-  @apply p-3;
+  padding: var(--calcite-spacing-md);
 }
 
 .container--open {
@@ -257,13 +272,15 @@
 .resize-handle:active,
 .resize-handle:hover {
   .resize-handle-bar {
-    @apply text-color-1 bg-foreground-3;
+    color: var(--calcite-sheet-resize-text-color, var(--calcite-color-text-1));
+    background-color: var(--calcite-sheet-resize-background-color, var(--calcite-color-foreground-3));
   }
 }
 
 .resize-handle-bar {
-  @apply flex bg-background justify-center items-center pointer-events-none;
-  color: var(--calcite-color-border-input);
+  @apply flex justify-center items-center pointer-events-none;
+  color: var(--calcite-sheet-resize-text-color, var(--calcite-color-border-input));
+  background-color: var(--calcite-sheet-resize-background-color, var(--calcite-color-background));
 }
 
 .resize-handle:focus .resize-handle-bar {
@@ -281,11 +298,13 @@
   .resize-handle-bar {
     block-size: 100%;
     inline-size: var(--calcite-size-fixed-sm-plus);
-    border-inline-start: 1px solid var(--calcite-color-border-3);
+    border-inline-start: var(--calcite-border-width-sm) solid
+      var(--calcite-sheet-border-color, var(--calcite-color-border-3));
   }
 
   &:host([display-mode="float"]) .resize-handle-bar {
-    @apply rounded-e;
+    border-start-end-radius: var(--calcite-sheet-corner-radius, var(--calcite-corner-radius-round));
+    border-end-end-radius: var(--calcite-sheet-corner-radius, var(--calcite-corner-radius-round));
   }
 }
 
@@ -300,7 +319,8 @@
   .resize-handle-bar {
     block-size: 100%;
     inline-size: var(--calcite-size-fixed-sm-plus);
-    border-inline-end: 1px solid var(--calcite-color-border-3);
+    border-inline-end: var(--calcite-border-width-sm) solid
+      var(--calcite-sheet-border-color, var(--calcite-color-border-3));
   }
 
   &:host([display-mode="float"]) .resize-handle-bar {
@@ -318,7 +338,8 @@
   .resize-handle-bar {
     inline-size: 100%;
     block-size: var(--calcite-size-fixed-sm-plus);
-    border-block-start: 1px solid var(--calcite-color-border-3);
+    border-block-start: var(--calcite-border-width-sm) solid
+      var(--calcite-sheet-border-color, var(--calcite-color-border-3));
   }
 
   &:host([display-mode="float"]) .resize-handle-bar {
@@ -336,11 +357,13 @@
   .resize-handle-bar {
     inline-size: 100%;
     block-size: var(--calcite-size-fixed-sm-plus);
-    border-block-end: 1px solid var(--calcite-color-border-3);
+    border-block-end: var(--calcite-border-width-sm) solid
+      var(--calcite-sheet-border-color, var(--calcite-color-border-3));
   }
 
   &:host([display-mode="float"]) .resize-handle-bar {
-    @apply rounded-t;
+    border-top-left-radius: var(--calcite-sheet-corner-radius, var(--calcite-corner-radius-round));
+    border-top-right-radius: var(--calcite-sheet-corner-radius, var(--calcite-corner-radius-round));
   }
 }
 

--- a/packages/calcite-components/src/components/sheet/sheet.scss
+++ b/packages/calcite-components/src/components/sheet/sheet.scss
@@ -8,7 +8,7 @@
  * @prop --calcite-sheet-text-color: Specifies the text color of the component.
  *
  * @prop --calcite-sheet-resize-background-color: Specifies the background color of the resize handle.
- * @prop --calcite-sheet-resize-text-color: Specifies the text color of the resize handle.
+ * @prop --calcite-sheet-resize-icon-color: Specifies the text color of the resize handle.
  *
  * @prop --calcite-sheet-scrim-background: Specifies the background color of the sheet scrim.
  * @prop --calcite-sheet-width: When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component.
@@ -272,14 +272,14 @@
 .resize-handle:active,
 .resize-handle:hover {
   .resize-handle-bar {
-    color: var(--calcite-sheet-resize-text-color, var(--calcite-color-text-1));
+    color: var(--calcite-sheet-resize-icon-color, var(--calcite-color-text-1));
     background-color: var(--calcite-sheet-resize-background-color, var(--calcite-color-foreground-3));
   }
 }
 
 .resize-handle-bar {
   @apply flex justify-center items-center pointer-events-none;
-  color: var(--calcite-sheet-resize-text-color, var(--calcite-color-border-input));
+  color: var(--calcite-sheet-resize-icon-color, var(--calcite-color-border-input));
   background-color: var(--calcite-sheet-resize-background-color, var(--calcite-color-background));
 }
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -627,7 +627,7 @@ export class Sheet extends LitElement implements OpenCloseComponent {
         ref={this.setTransitionEl}
       >
         <calcite-scrim class={CSS.scrim} onClick={this.handleOutsideClose} />
-        <div class={CSS.content} ref={this.setContentEl}>
+        <div class={CSS.content} id="sheet-content" ref={this.setContentEl}>
           <div class={CSS.contentContainer}>
             <slot />
           </div>


### PR DESCRIPTION
**Related Issue:** #7180

## Summary

Adds the following tokens:

- --calcite-sheet-background-color: Specifies the background color of the sheet.
- --calcite-sheet-corner-radius: Specifies the corner radius of the component.
- --calcite-sheet-shadow: Specifies the shadow of the component.
- --calcite-sheet-text-color: Specifies the text color of the component.
- --calcite-sheet-resize-background-color: Specifies the background color of the resize handle.
- --calcite-sheet-resize-icon-color: Specifies the text color of the resize handle.
