### PR TITLE
fix(input-date-picker): ensure ar-fallback when the locale is ar-SA

### DIFF
--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -633,6 +633,21 @@ describe("calcite-input-date-picker", () => {
       expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
     });
 
+    it("parses/formats gregorian calendar locales when locale falls back to `ar`", async () => {
+      const page = await newE2EPage();
+      await page.setContent(`<calcite-input-date-picker lang="ar-SA" value="2023-05-31"></calcite-input-date-picker>`);
+      const inputDatePicker = await page.find("calcite-input-date-picker");
+      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
+
+      await inputDatePicker.click();
+      await calciteInputDatePickerOpenEvent;
+
+      await selectDayInMonthByIndex(page, 1);
+      await inputDatePicker.callMethod("blur");
+
+      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
+    });
+
     it("parses/formats bosnian calendar locales when date is selected", async () => {
       const page = await newE2EPage();
       await page.setContent(`<calcite-input-date-picker lang="bs" value="2023-05-31"></calcite-input-date-picker>`);

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.e2e.ts
@@ -618,70 +618,44 @@ describe("calcite-input-date-picker", () => {
       );
     });
 
-    it("parses/formats buddhist calendar locales when date is selected", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker lang="th" value="2023-05-31"></calcite-input-date-picker>`);
-      const inputDatePicker = await page.find("calcite-input-date-picker");
-      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
+    describe("regional date handling", () => {
+      const testLocaleDateSelection = async (locale: string, expectedFormattedValue?: string) => {
+        const page = await newE2EPage();
+        await page.setContent(
+          `<calcite-input-date-picker lang="${locale}" value="2023-05-31"></calcite-input-date-picker>`,
+        );
+        const inputDatePicker = await page.find("calcite-input-date-picker");
+        const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
 
-      await inputDatePicker.click();
-      await calciteInputDatePickerOpenEvent;
+        await inputDatePicker.click();
+        await calciteInputDatePickerOpenEvent;
 
-      await selectDayInMonthByIndex(page, 1);
-      await inputDatePicker.callMethod("blur");
+        await selectDayInMonthByIndex(page, 1);
+        await inputDatePicker.callMethod("blur");
 
-      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
-    });
+        expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
 
-    it("parses/formats gregorian calendar locales when locale falls back to `ar`", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker lang="ar-SA" value="2023-05-31"></calcite-input-date-picker>`);
-      const inputDatePicker = await page.find("calcite-input-date-picker");
-      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
+        if (expectedFormattedValue) {
+          const inputText = await page.find("calcite-input-date-picker >>> calcite-input-text");
+          expect(await inputText.getProperty("value")).toBe(expectedFormattedValue);
+        }
+      };
 
-      await inputDatePicker.click();
-      await calciteInputDatePickerOpenEvent;
+      it("handles Buddhist calendar (Thai) locale", async () => {
+        await testLocaleDateSelection("th");
+      });
 
-      await selectDayInMonthByIndex(page, 1);
-      await inputDatePicker.callMethod("blur");
+      it("handles Arabic with Saudi Arabia region fallback", async () => {
+        await testLocaleDateSelection("ar-SA");
+      });
 
-      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
-    });
+      it("handles Bosnian locale", async () => {
+        await testLocaleDateSelection("bs", "01.05.2023.");
+      });
 
-    it("parses/formats bosnian calendar locales when date is selected", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker lang="bs" value="2023-05-31"></calcite-input-date-picker>`);
-      const inputDatePicker = await page.find("calcite-input-date-picker");
-      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
-
-      await inputDatePicker.click();
-      await calciteInputDatePickerOpenEvent;
-
-      await selectDayInMonthByIndex(page, 1);
-      await inputDatePicker.callMethod("blur");
-
-      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
-
-      const inputText = await page.find("calcite-input-date-picker >>> calcite-input-text");
-      expect(await inputText.getProperty("value")).toBe("01.05.2023.");
-    });
-
-    it("parses/formats italian (Switzerland) calendar locales when date is selected", async () => {
-      const page = await newE2EPage();
-      await page.setContent(`<calcite-input-date-picker lang="it-CH" value="2023-05-31"></calcite-input-date-picker>`);
-      const inputDatePicker = await page.find("calcite-input-date-picker");
-      const calciteInputDatePickerOpenEvent = page.waitForEvent("calciteInputDatePickerOpen");
-
-      await inputDatePicker.click();
-      await calciteInputDatePickerOpenEvent;
-
-      await selectDayInMonthByIndex(page, 1);
-      await inputDatePicker.callMethod("blur");
-
-      expect(await inputDatePicker.getProperty("value")).toBe("2023-05-01");
-
-      const inputText = await page.find("calcite-input-date-picker >>> calcite-input-text");
-      expect(await inputText.getProperty("value")).toBe("1.5.2023");
+      it("handles Italian (Switzerland) locale", async () => {
+        await testLocaleDateSelection("it-CH", "1.5.2023");
+      });
     });
   });
 

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -52,7 +52,7 @@ import { connectLabel, disconnectLabel, LabelableComponent } from "../../utils/l
 import { componentFocusable, getIconScale } from "../../utils/component";
 import {
   getDateFormatSupportedLocale,
-  getDateTimeFormat,
+  getSupportedLocale,
   getSupportedNumberingSystem,
   NumberingSystem,
   numberStringFormatter,
@@ -627,8 +627,8 @@ export class InputDatePicker
       numberingSystem: getSupportedNumberingSystem(this.numberingSystem),
     };
 
-    this.dateTimeFormat = getDateTimeFormat(
-      getDateFormatSupportedLocale(this.messages._lang),
+    this.dateTimeFormat = new Intl.DateTimeFormat(
+      getDateFormatSupportedLocale(getSupportedLocale(this.messages._lang)),
       formattingOptions,
     );
   }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -52,6 +52,7 @@ import { connectLabel, disconnectLabel, LabelableComponent } from "../../utils/l
 import { componentFocusable, getIconScale } from "../../utils/component";
 import {
   getDateFormatSupportedLocale,
+  getDateTimeFormat,
   getSupportedNumberingSystem,
   NumberingSystem,
   numberStringFormatter,
@@ -626,7 +627,7 @@ export class InputDatePicker
       numberingSystem: getSupportedNumberingSystem(this.numberingSystem),
     };
 
-    this.dateTimeFormat = new Intl.DateTimeFormat(
+    this.dateTimeFormat = getDateTimeFormat(
       getDateFormatSupportedLocale(this.messages._lang),
       formattingOptions,
     );


### PR DESCRIPTION
**Related Issue:** #11399 

## Summary  

Updates `input-date-picker` to use `Intl.DateTimeFormat` utils that normalize locales.