### PR TITLE
refactor: keep internal animation Tailwind utils scoped to components

### DIFF
--- a/packages/calcite-components/tailwind.config.ts
+++ b/packages/calcite-components/tailwind.config.ts
@@ -3,4 +3,14 @@ import calcitePreset from "@esri/calcite-tailwind-preset";
 export default {
   presets: [calcitePreset],
   content: ["./src/components/**/*.scss"],
+  theme: {
+    extend: {
+      animation: {
+        in: "in var(--calcite-internal-animation-timing-slow) ease-in-out",
+        "in-down": "in-down var(--calcite-internal-animation-timing-slow) ease-in-out",
+        "in-up": "in-up var(--calcite-internal-animation-timing-slow) ease-in-out",
+        "in-scale": "in-scale var(--calcite-internal-animation-timing-slow) linear",
+      },
+    },
+  },
 };

--- a/packages/calcite-tailwind-preset/src/index.ts
+++ b/packages/calcite-tailwind-preset/src/index.ts
@@ -147,12 +147,6 @@ export default {
       "danger-press": theme("colors.danger-press"),
     }),
     extend: {
-      animation: {
-        in: "in var(--calcite-internal-animation-timing-slow) ease-in-out",
-        "in-down": "in-down var(--calcite-internal-animation-timing-slow) ease-in-out",
-        "in-up": "in-up var(--calcite-internal-animation-timing-slow) ease-in-out",
-        "in-scale": "in-scale var(--calcite-internal-animation-timing-slow) linear",
-      },
       borderRadius: {
         half: "50%",
       },


### PR DESCRIPTION
**Related Issue:** N/A  

## Summary  

Moves custom animation utils that depend on `calcite-components` internals into the package.