### PR TITLE
feat(semantic-tokens): update and add to corner-radius tokens

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/corner.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/corner.json
@@ -16,6 +16,27 @@
             "category": "corner"
           }
         },
+        "none": {
+          "value": "{core.size.default.none}",
+          "type": "borderRadius",
+          "attributes": {
+            "category": "corner"
+          }
+        },
+        "xs": {
+          "value": "{core.size.default.2}",
+          "type": "borderRadius",
+          "attributes": {
+            "category": "corner"
+          }
+        },
+        "sm": {
+          "value": "{core.size.default.4}",
+          "type": "borderRadius",
+          "attributes": {
+            "category": "corner"
+          }
+        },
         "round": {
           "value": "{core.size.default.4}",
           "type": "borderRadius",

--- a/packages/calcite-design-tokens/src/tokens/semantic/corner.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/corner.json
@@ -15,7 +15,7 @@
           "attributes": {
             "category": "corner"
           },
-          "description": "deprecated"
+          "description": "deprecated, use --calcite-conder-radius-none instead"
         },
         "none": {
           "value": "{core.size.default.none}",
@@ -44,7 +44,7 @@
           "attributes": {
             "category": "corner"
           },
-          "description": "deprecated"
+          "description": "deprecated, use --calcite-corner-radius-sm instead"
         },
         "pill": {
           "value": "{core.size.relative.100}",

--- a/packages/calcite-design-tokens/src/tokens/semantic/corner.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/corner.json
@@ -14,7 +14,8 @@
           "type": "borderRadius",
           "attributes": {
             "category": "corner"
-          }
+          },
+          "description": "deprecated"
         },
         "none": {
           "value": "{core.size.default.none}",
@@ -42,7 +43,8 @@
           "type": "borderRadius",
           "attributes": {
             "category": "corner"
-          }
+          },
+          "description": "deprecated"
         },
         "pill": {
           "value": "{core.size.relative.100}",

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -965,11 +965,11 @@ exports[`generated tokens > CSS > global should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /* for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /* only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0; /* deprecated */
+  --calcite-corner-radius-sharp: 0; /* deprecated, use --calcite-conder-radius-none instead */
   --calcite-corner-radius-none: 0;
   --calcite-corner-radius-xs: 2px;
   --calcite-corner-radius-sm: 4px;
-  --calcite-corner-radius-round: 4px; /* deprecated */
+  --calcite-corner-radius-round: 4px; /* deprecated, use --calcite-corner-radius-sm instead */
   --calcite-corner-radius-pill: 100%;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /* Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /* Font family for code with fallbacks */
@@ -1403,11 +1403,11 @@ exports[`generated tokens > CSS > semantic should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /* for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /* only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0; /* deprecated */
+  --calcite-corner-radius-sharp: 0; /* deprecated, use --calcite-conder-radius-none instead */
   --calcite-corner-radius-none: 0;
   --calcite-corner-radius-xs: 2px;
   --calcite-corner-radius-sm: 4px;
-  --calcite-corner-radius-round: 4px; /* deprecated */
+  --calcite-corner-radius-round: 4px; /* deprecated, use --calcite-corner-radius-sm instead */
   --calcite-corner-radius-pill: 100%;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /* Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /* Font family for code with fallbacks */
@@ -19620,12 +19620,12 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
         "item": "radius",
         "subitem": "sharp",
         "value": "0",
-        "description": "deprecated",
+        "description": "deprecated, use --calcite-conder-radius-none instead",
         "filePath": "src/tokens/semantic/corner.json",
         "isSource": true,
         "name": "calcite-semantic-corner-radius-sharp",
         "path": ["semantic", "corner", "radius", "sharp"],
-        "comment": "deprecated",
+        "comment": "deprecated, use --calcite-conder-radius-none instead",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -19639,12 +19639,12 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
           "type": "dimension"
         }
       },
-      "description": "deprecated",
+      "description": "deprecated, use --calcite-conder-radius-none instead",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["semantic", "corner", "radius", "sharp"],
-      "comment": "deprecated",
+      "comment": "deprecated, use --calcite-conder-radius-none instead",
       "key": "{semantic.corner.radius.sharp}"
     },
     {
@@ -19737,12 +19737,12 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
         "item": "radius",
         "subitem": "round",
         "value": "4px",
-        "description": "deprecated",
+        "description": "deprecated, use --calcite-corner-radius-sm instead",
         "filePath": "src/tokens/semantic/corner.json",
         "isSource": true,
         "name": "calcite-semantic-corner-radius-round",
         "path": ["semantic", "corner", "radius", "round"],
-        "comment": "deprecated",
+        "comment": "deprecated, use --calcite-corner-radius-sm instead",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -19756,12 +19756,12 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
           "type": "dimension"
         }
       },
-      "description": "deprecated",
+      "description": "deprecated, use --calcite-corner-radius-sm instead",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["semantic", "corner", "radius", "round"],
-      "comment": "deprecated",
+      "comment": "deprecated, use --calcite-corner-radius-sm instead",
       "key": "{semantic.corner.radius.round}"
     },
     {
@@ -25791,12 +25791,12 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
         "item": "radius",
         "subitem": "sharp",
         "value": "0",
-        "description": "deprecated",
+        "description": "deprecated, use --calcite-conder-radius-none instead",
         "filePath": "src/tokens/semantic/corner.json",
         "isSource": true,
         "name": "calcite-semantic-corner-radius-sharp",
         "path": ["semantic", "corner", "radius", "sharp"],
-        "comment": "deprecated",
+        "comment": "deprecated, use --calcite-conder-radius-none instead",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -25810,12 +25810,12 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
           "type": "dimension"
         }
       },
-      "description": "deprecated",
+      "description": "deprecated, use --calcite-conder-radius-none instead",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["semantic", "corner", "radius", "sharp"],
-      "comment": "deprecated",
+      "comment": "deprecated, use --calcite-conder-radius-none instead",
       "key": "{semantic.corner.radius.sharp}"
     },
     {
@@ -25908,12 +25908,12 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
         "item": "radius",
         "subitem": "round",
         "value": "4px",
-        "description": "deprecated",
+        "description": "deprecated, use --calcite-corner-radius-sm instead",
         "filePath": "src/tokens/semantic/corner.json",
         "isSource": true,
         "name": "calcite-semantic-corner-radius-round",
         "path": ["semantic", "corner", "radius", "round"],
-        "comment": "deprecated",
+        "comment": "deprecated, use --calcite-corner-radius-sm instead",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -25927,12 +25927,12 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
           "type": "dimension"
         }
       },
-      "description": "deprecated",
+      "description": "deprecated, use --calcite-corner-radius-sm instead",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["semantic", "corner", "radius", "round"],
-      "comment": "deprecated",
+      "comment": "deprecated, use --calcite-corner-radius-sm instead",
       "key": "{semantic.corner.radius.round}"
     },
     {
@@ -30354,11 +30354,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0"; // deprecated
+export const calciteCornerRadiusSharp = "0"; // deprecated, use --calcite-conder-radius-none instead
 export const calciteCornerRadiusNone = "0";
 export const calciteCornerRadiusXs = "2px";
 export const calciteCornerRadiusSm = "4px";
-export const calciteCornerRadiusRound = "4px"; // deprecated
+export const calciteCornerRadiusRound = "4px"; // deprecated, use --calcite-corner-radius-sm instead
 export const calciteCornerRadiusPill = "100%";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -30851,11 +30851,11 @@ export const calciteContainerSizeMargin: string;
 export const calciteContainerSizeGutter: string; /** for fluid grid widths */
 export const calciteContainerSizeContentFluid: string; /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
-export const calciteCornerRadius: string; /** deprecated */
+export const calciteCornerRadius: string; /** deprecated, use --calcite-conder-radius-none instead */
 export const calciteCornerRadiusSharp: string;
 export const calciteCornerRadiusNone: string;
 export const calciteCornerRadiusXs: string;
-export const calciteCornerRadiusSm: string; /** deprecated */
+export const calciteCornerRadiusSm: string; /** deprecated, use --calcite-corner-radius-sm instead */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string; /** Primary font with fallbacks */
 export const calciteFontFamily: string[]; /** Font family for code with fallbacks */
@@ -31257,11 +31257,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0"; // deprecated
+export const calciteCornerRadiusSharp = "0"; // deprecated, use --calcite-conder-radius-none instead
 export const calciteCornerRadiusNone = "0";
 export const calciteCornerRadiusXs = "2px";
 export const calciteCornerRadiusSm = "4px";
-export const calciteCornerRadiusRound = "4px"; // deprecated
+export const calciteCornerRadiusRound = "4px"; // deprecated, use --calcite-corner-radius-sm instead
 export const calciteCornerRadiusPill = "100%";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -31449,11 +31449,11 @@ export const calciteContainerSizeMargin: string;
 export const calciteContainerSizeGutter: string; /** for fluid grid widths */
 export const calciteContainerSizeContentFluid: string; /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
-export const calciteCornerRadius: string; /** deprecated */
+export const calciteCornerRadius: string; /** deprecated, use --calcite-conder-radius-none instead */
 export const calciteCornerRadiusSharp: string;
 export const calciteCornerRadiusNone: string;
 export const calciteCornerRadiusXs: string;
-export const calciteCornerRadiusSm: string; /** deprecated */
+export const calciteCornerRadiusSm: string; /** deprecated, use --calcite-corner-radius-sm instead */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string; /** Primary font with fallbacks */
 export const calciteFontFamily: string[]; /** Font family for code with fallbacks */
@@ -55902,12 +55902,12 @@ export default {
             item: "radius",
             subitem: "sharp",
             value: "0",
-            description: "deprecated",
+            description: "deprecated, use --calcite-conder-radius-none instead",
             filePath: "src/tokens/semantic/corner.json",
             isSource: true,
             name: "calcite-semantic-corner-radius-sharp",
             path: ["semantic", "corner", "radius", "sharp"],
-            comment: "deprecated",
+            comment: "deprecated, use --calcite-conder-radius-none instead",
             names: {
               scss: "$calcite-corner-radius-sharp",
               css: "var(--calcite-corner-radius-sharp)",
@@ -55921,7 +55921,7 @@ export default {
               type: "dimension",
             },
           },
-          description: "deprecated",
+          description: "deprecated, use --calcite-conder-radius-none instead",
           filePath: "src/tokens/semantic/corner.json",
           isSource: true,
           original: {
@@ -55930,11 +55930,11 @@ export default {
             attributes: {
               category: "corner",
             },
-            description: "deprecated",
+            description: "deprecated, use --calcite-conder-radius-none instead",
           },
           name: "Corner Radius Sharp",
           path: ["semantic", "corner", "radius", "sharp"],
-          comment: "deprecated",
+          comment: "deprecated, use --calcite-conder-radius-none instead",
           key: "{semantic.corner.radius.sharp}",
         },
         none: {
@@ -56048,12 +56048,12 @@ export default {
             item: "radius",
             subitem: "round",
             value: "4px",
-            description: "deprecated",
+            description: "deprecated, use --calcite-corner-radius-sm instead",
             filePath: "src/tokens/semantic/corner.json",
             isSource: true,
             name: "calcite-semantic-corner-radius-round",
             path: ["semantic", "corner", "radius", "round"],
-            comment: "deprecated",
+            comment: "deprecated, use --calcite-corner-radius-sm instead",
             names: {
               scss: "$calcite-corner-radius-round",
               css: "var(--calcite-corner-radius-round)",
@@ -56067,7 +56067,7 @@ export default {
               type: "dimension",
             },
           },
-          description: "deprecated",
+          description: "deprecated, use --calcite-corner-radius-sm instead",
           filePath: "src/tokens/semantic/corner.json",
           isSource: true,
           original: {
@@ -56076,11 +56076,11 @@ export default {
             attributes: {
               category: "corner",
             },
-            description: "deprecated",
+            description: "deprecated, use --calcite-corner-radius-sm instead",
           },
           name: "Corner Radius Round",
           path: ["semantic", "corner", "radius", "round"],
-          comment: "deprecated",
+          comment: "deprecated, use --calcite-corner-radius-sm instead",
           key: "{semantic.corner.radius.round}",
         },
         pill: {
@@ -64547,12 +64547,12 @@ export default {
             item: "radius",
             subitem: "sharp",
             value: "0",
-            description: "deprecated",
+            description: "deprecated, use --calcite-conder-radius-none instead",
             filePath: "src/tokens/semantic/corner.json",
             isSource: true,
             name: "calcite-semantic-corner-radius-sharp",
             path: ["semantic", "corner", "radius", "sharp"],
-            comment: "deprecated",
+            comment: "deprecated, use --calcite-conder-radius-none instead",
             names: {
               scss: "$calcite-corner-radius-sharp",
               css: "var(--calcite-corner-radius-sharp)",
@@ -64566,7 +64566,7 @@ export default {
               type: "dimension",
             },
           },
-          description: "deprecated",
+          description: "deprecated, use --calcite-conder-radius-none instead",
           filePath: "src/tokens/semantic/corner.json",
           isSource: true,
           original: {
@@ -64575,11 +64575,11 @@ export default {
             attributes: {
               category: "corner",
             },
-            description: "deprecated",
+            description: "deprecated, use --calcite-conder-radius-none instead",
           },
           name: "Corner Radius Sharp",
           path: ["semantic", "corner", "radius", "sharp"],
-          comment: "deprecated",
+          comment: "deprecated, use --calcite-conder-radius-none instead",
           key: "{semantic.corner.radius.sharp}",
         },
         none: {
@@ -64693,12 +64693,12 @@ export default {
             item: "radius",
             subitem: "round",
             value: "4px",
-            description: "deprecated",
+            description: "deprecated, use --calcite-corner-radius-sm instead",
             filePath: "src/tokens/semantic/corner.json",
             isSource: true,
             name: "calcite-semantic-corner-radius-round",
             path: ["semantic", "corner", "radius", "round"],
-            comment: "deprecated",
+            comment: "deprecated, use --calcite-corner-radius-sm instead",
             names: {
               scss: "$calcite-corner-radius-round",
               css: "var(--calcite-corner-radius-round)",
@@ -64712,7 +64712,7 @@ export default {
               type: "dimension",
             },
           },
-          description: "deprecated",
+          description: "deprecated, use --calcite-corner-radius-sm instead",
           filePath: "src/tokens/semantic/corner.json",
           isSource: true,
           original: {
@@ -64721,11 +64721,11 @@ export default {
             attributes: {
               category: "corner",
             },
-            description: "deprecated",
+            description: "deprecated, use --calcite-corner-radius-sm instead",
           },
           name: "Corner Radius Round",
           path: ["semantic", "corner", "radius", "round"],
-          comment: "deprecated",
+          comment: "deprecated, use --calcite-corner-radius-sm instead",
           key: "{semantic.corner.radius.round}",
         },
         pill: {
@@ -69439,11 +69439,11 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0; // deprecated
+$calcite-corner-radius-sharp: 0; // deprecated, use --calcite-conder-radius-none instead
 $calcite-corner-radius-none: 0;
 $calcite-corner-radius-xs: 2px;
 $calcite-corner-radius-sm: 4px;
-$calcite-corner-radius-round: 4px; // deprecated
+$calcite-corner-radius-round: 4px; // deprecated, use --calcite-corner-radius-sm instead
 $calcite-corner-radius-pill: 100%;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
@@ -70063,11 +70063,11 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0; // deprecated
+$calcite-corner-radius-sharp: 0; // deprecated, use --calcite-conder-radius-none instead
 $calcite-corner-radius-none: 0;
 $calcite-corner-radius-xs: 2px;
 $calcite-corner-radius-sm: 4px;
-$calcite-corner-radius-round: 4px; // deprecated
+$calcite-corner-radius-round: 4px; // deprecated, use --calcite-corner-radius-sm instead
 $calcite-corner-radius-pill: 100%;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks

--- a/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
+++ b/packages/calcite-design-tokens/tests/spec/__snapshots__/index.spec.ts.snap
@@ -965,8 +965,11 @@ exports[`generated tokens > CSS > global should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /* for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /* only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0;
-  --calcite-corner-radius-round: 4px;
+  --calcite-corner-radius-sharp: 0; /* deprecated */
+  --calcite-corner-radius-none: 0;
+  --calcite-corner-radius-xs: 2px;
+  --calcite-corner-radius-sm: 4px;
+  --calcite-corner-radius-round: 4px; /* deprecated */
   --calcite-corner-radius-pill: 100%;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /* Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /* Font family for code with fallbacks */
@@ -1400,8 +1403,11 @@ exports[`generated tokens > CSS > semantic should match 1`] = `
   --calcite-container-size-gutter: 16px;
   --calcite-container-size-content-fluid: 100%; /* for fluid grid widths */
   --calcite-container-size-content-fixed: 1440px; /* only for lg breakpoint fixed grid width */
-  --calcite-corner-radius-sharp: 0;
-  --calcite-corner-radius-round: 4px;
+  --calcite-corner-radius-sharp: 0; /* deprecated */
+  --calcite-corner-radius-none: 0;
+  --calcite-corner-radius-xs: 2px;
+  --calcite-corner-radius-sm: 4px;
+  --calcite-corner-radius-round: 4px; /* deprecated */
   --calcite-corner-radius-pill: 100%;
   --calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; /* Primary font with fallbacks */
   --calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; /* Font family for code with fallbacks */
@@ -19610,9 +19616,16 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
       "type": "dimension",
       "attributes": {
         "category": "corner",
-        "type": "corner",
+        "type": "dimension",
         "item": "radius",
         "subitem": "sharp",
+        "value": "0",
+        "description": "deprecated",
+        "filePath": "src/tokens/semantic/corner.json",
+        "isSource": true,
+        "name": "calcite-semantic-corner-radius-sharp",
+        "path": ["semantic", "corner", "radius", "sharp"],
+        "comment": "deprecated",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -19626,11 +19639,67 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
           "type": "dimension"
         }
       },
+      "description": "deprecated",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["semantic", "corner", "radius", "sharp"],
+      "comment": "deprecated",
       "key": "{semantic.corner.radius.sharp}"
+    },
+    {
+      "value": "0",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "corner",
+        "item": "radius",
+        "subitem": "none",
+        "names": {
+          "scss": "$calcite-corner-radius-none",
+          "css": "var(--calcite-corner-radius-none)",
+          "js": "semantic.corner.radius.none",
+          "docs": "semantic.corner.radius.none",
+          "es6": "calciteCornerRadiusNone"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius None",
+      "path": ["semantic", "corner", "radius", "none"],
+      "key": "{semantic.corner.radius.none}"
+    },
+    {
+      "value": "2px",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "corner",
+        "item": "radius",
+        "subitem": "xs",
+        "names": {
+          "scss": "$calcite-corner-radius-xs",
+          "css": "var(--calcite-corner-radius-xs)",
+          "js": "semantic.corner.radius.xs",
+          "docs": "semantic.corner.radius.xs",
+          "es6": "calciteCornerRadiusXs"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius Xs",
+      "path": ["semantic", "corner", "radius", "xs"],
+      "key": "{semantic.corner.radius.xs}"
     },
     {
       "value": "4px",
@@ -19639,7 +19708,41 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
         "category": "corner",
         "type": "corner",
         "item": "radius",
+        "subitem": "sm",
+        "names": {
+          "scss": "$calcite-corner-radius-sm",
+          "css": "var(--calcite-corner-radius-sm)",
+          "js": "semantic.corner.radius.sm",
+          "docs": "semantic.corner.radius.sm",
+          "es6": "calciteCornerRadiusSm"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius Sm",
+      "path": ["semantic", "corner", "radius", "sm"],
+      "key": "{semantic.corner.radius.sm}"
+    },
+    {
+      "value": "4px",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "dimension",
+        "item": "radius",
         "subitem": "round",
+        "value": "4px",
+        "description": "deprecated",
+        "filePath": "src/tokens/semantic/corner.json",
+        "isSource": true,
+        "name": "calcite-semantic-corner-radius-round",
+        "path": ["semantic", "corner", "radius", "round"],
+        "comment": "deprecated",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -19653,10 +19756,12 @@ exports[`generated tokens > DOCS (internal) > global (internal) should match 1`]
           "type": "dimension"
         }
       },
+      "description": "deprecated",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["semantic", "corner", "radius", "round"],
+      "comment": "deprecated",
       "key": "{semantic.corner.radius.round}"
     },
     {
@@ -25682,9 +25787,16 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
       "type": "dimension",
       "attributes": {
         "category": "corner",
-        "type": "corner",
+        "type": "dimension",
         "item": "radius",
         "subitem": "sharp",
+        "value": "0",
+        "description": "deprecated",
+        "filePath": "src/tokens/semantic/corner.json",
+        "isSource": true,
+        "name": "calcite-semantic-corner-radius-sharp",
+        "path": ["semantic", "corner", "radius", "sharp"],
+        "comment": "deprecated",
         "names": {
           "scss": "$calcite-corner-radius-sharp",
           "css": "var(--calcite-corner-radius-sharp)",
@@ -25698,11 +25810,67 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
           "type": "dimension"
         }
       },
+      "description": "deprecated",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Sharp",
       "path": ["semantic", "corner", "radius", "sharp"],
+      "comment": "deprecated",
       "key": "{semantic.corner.radius.sharp}"
+    },
+    {
+      "value": "0",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "corner",
+        "item": "radius",
+        "subitem": "none",
+        "names": {
+          "scss": "$calcite-corner-radius-none",
+          "css": "var(--calcite-corner-radius-none)",
+          "js": "semantic.corner.radius.none",
+          "docs": "semantic.corner.radius.none",
+          "es6": "calciteCornerRadiusNone"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius None",
+      "path": ["semantic", "corner", "radius", "none"],
+      "key": "{semantic.corner.radius.none}"
+    },
+    {
+      "value": "2px",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "corner",
+        "item": "radius",
+        "subitem": "xs",
+        "names": {
+          "scss": "$calcite-corner-radius-xs",
+          "css": "var(--calcite-corner-radius-xs)",
+          "js": "semantic.corner.radius.xs",
+          "docs": "semantic.corner.radius.xs",
+          "es6": "calciteCornerRadiusXs"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius Xs",
+      "path": ["semantic", "corner", "radius", "xs"],
+      "key": "{semantic.corner.radius.xs}"
     },
     {
       "value": "4px",
@@ -25711,7 +25879,41 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
         "category": "corner",
         "type": "corner",
         "item": "radius",
+        "subitem": "sm",
+        "names": {
+          "scss": "$calcite-corner-radius-sm",
+          "css": "var(--calcite-corner-radius-sm)",
+          "js": "semantic.corner.radius.sm",
+          "docs": "semantic.corner.radius.sm",
+          "es6": "calciteCornerRadiusSm"
+        },
+        "calcite-schema": {
+          "system": "calcite",
+          "tier": "semantic",
+          "type": "dimension"
+        }
+      },
+      "filePath": "src/tokens/semantic/corner.json",
+      "isSource": true,
+      "name": "Corner Radius Sm",
+      "path": ["semantic", "corner", "radius", "sm"],
+      "key": "{semantic.corner.radius.sm}"
+    },
+    {
+      "value": "4px",
+      "type": "dimension",
+      "attributes": {
+        "category": "corner",
+        "type": "dimension",
+        "item": "radius",
         "subitem": "round",
+        "value": "4px",
+        "description": "deprecated",
+        "filePath": "src/tokens/semantic/corner.json",
+        "isSource": true,
+        "name": "calcite-semantic-corner-radius-round",
+        "path": ["semantic", "corner", "radius", "round"],
+        "comment": "deprecated",
         "names": {
           "scss": "$calcite-corner-radius-round",
           "css": "var(--calcite-corner-radius-round)",
@@ -25725,10 +25927,12 @@ exports[`generated tokens > DOCS (internal) > semantic (internal) should match 1
           "type": "dimension"
         }
       },
+      "description": "deprecated",
       "filePath": "src/tokens/semantic/corner.json",
       "isSource": true,
       "name": "Corner Radius Round",
       "path": ["semantic", "corner", "radius", "round"],
+      "comment": "deprecated",
       "key": "{semantic.corner.radius.round}"
     },
     {
@@ -30150,8 +30354,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0";
-export const calciteCornerRadiusRound = "4px";
+export const calciteCornerRadiusSharp = "0"; // deprecated
+export const calciteCornerRadiusNone = "0";
+export const calciteCornerRadiusXs = "2px";
+export const calciteCornerRadiusSm = "4px";
+export const calciteCornerRadiusRound = "4px"; // deprecated
 export const calciteCornerRadiusPill = "100%";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -30644,8 +30851,11 @@ export const calciteContainerSizeMargin: string;
 export const calciteContainerSizeGutter: string; /** for fluid grid widths */
 export const calciteContainerSizeContentFluid: string; /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
-export const calciteCornerRadius: string;
+export const calciteCornerRadius: string; /** deprecated */
 export const calciteCornerRadiusSharp: string;
+export const calciteCornerRadiusNone: string;
+export const calciteCornerRadiusXs: string;
+export const calciteCornerRadiusSm: string; /** deprecated */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string; /** Primary font with fallbacks */
 export const calciteFontFamily: string[]; /** Font family for code with fallbacks */
@@ -31047,8 +31257,11 @@ export const calciteContainerSizeGutter = "16px";
 export const calciteContainerSizeContentFluid = "100%"; // for fluid grid widths
 export const calciteContainerSizeContentFixed = "1440px"; // only for lg breakpoint fixed grid width
 export const calciteCornerRadius = "0";
-export const calciteCornerRadiusSharp = "0";
-export const calciteCornerRadiusRound = "4px";
+export const calciteCornerRadiusSharp = "0"; // deprecated
+export const calciteCornerRadiusNone = "0";
+export const calciteCornerRadiusXs = "2px";
+export const calciteCornerRadiusSm = "4px";
+export const calciteCornerRadiusRound = "4px"; // deprecated
 export const calciteCornerRadiusPill = "100%";
 export const calciteFontFamily = [
   "Avenir Next",
@@ -31236,8 +31449,11 @@ export const calciteContainerSizeMargin: string;
 export const calciteContainerSizeGutter: string; /** for fluid grid widths */
 export const calciteContainerSizeContentFluid: string; /** only for lg breakpoint fixed grid width */
 export const calciteContainerSizeContentFixed: string;
-export const calciteCornerRadius: string;
+export const calciteCornerRadius: string; /** deprecated */
 export const calciteCornerRadiusSharp: string;
+export const calciteCornerRadiusNone: string;
+export const calciteCornerRadiusXs: string;
+export const calciteCornerRadiusSm: string; /** deprecated */
 export const calciteCornerRadiusRound: string;
 export const calciteCornerRadiusPill: string; /** Primary font with fallbacks */
 export const calciteFontFamily: string[]; /** Font family for code with fallbacks */
@@ -55682,15 +55898,59 @@ export default {
           type: "dimension",
           attributes: {
             category: "corner",
-            type: "corner",
+            type: "dimension",
             item: "radius",
             subitem: "sharp",
+            value: "0",
+            description: "deprecated",
+            filePath: "src/tokens/semantic/corner.json",
+            isSource: true,
+            name: "calcite-semantic-corner-radius-sharp",
+            path: ["semantic", "corner", "radius", "sharp"],
+            comment: "deprecated",
             names: {
               scss: "$calcite-corner-radius-sharp",
               css: "var(--calcite-corner-radius-sharp)",
               js: "semantic.corner.radius.sharp",
               docs: "semantic.corner.radius.sharp",
               es6: "calciteCornerRadiusSharp",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          description: "deprecated",
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.none}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+            description: "deprecated",
+          },
+          name: "Corner Radius Sharp",
+          path: ["semantic", "corner", "radius", "sharp"],
+          comment: "deprecated",
+          key: "{semantic.corner.radius.sharp}",
+        },
+        none: {
+          value: "0",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "corner",
+            item: "radius",
+            subitem: "none",
+            names: {
+              scss: "$calcite-corner-radius-none",
+              css: "var(--calcite-corner-radius-none)",
+              js: "semantic.corner.radius.none",
+              docs: "semantic.corner.radius.none",
+              es6: "calciteCornerRadiusNone",
             },
             "calcite-schema": {
               system: "calcite",
@@ -55707,24 +55967,58 @@ export default {
               category: "corner",
             },
           },
-          name: "Corner Radius Sharp",
-          path: ["semantic", "corner", "radius", "sharp"],
-          key: "{semantic.corner.radius.sharp}",
+          name: "Corner Radius None",
+          path: ["semantic", "corner", "radius", "none"],
+          key: "{semantic.corner.radius.none}",
         },
-        round: {
+        xs: {
+          value: "2px",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "corner",
+            item: "radius",
+            subitem: "xs",
+            names: {
+              scss: "$calcite-corner-radius-xs",
+              css: "var(--calcite-corner-radius-xs)",
+              js: "semantic.corner.radius.xs",
+              docs: "semantic.corner.radius.xs",
+              es6: "calciteCornerRadiusXs",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.2}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+          },
+          name: "Corner Radius Xs",
+          path: ["semantic", "corner", "radius", "xs"],
+          key: "{semantic.corner.radius.xs}",
+        },
+        sm: {
           value: "4px",
           type: "dimension",
           attributes: {
             category: "corner",
             type: "corner",
             item: "radius",
-            subitem: "round",
+            subitem: "sm",
             names: {
-              scss: "$calcite-corner-radius-round",
-              css: "var(--calcite-corner-radius-round)",
-              js: "semantic.corner.radius.round",
-              docs: "semantic.corner.radius.round",
-              es6: "calciteCornerRadiusRound",
+              scss: "$calcite-corner-radius-sm",
+              css: "var(--calcite-corner-radius-sm)",
+              js: "semantic.corner.radius.sm",
+              docs: "semantic.corner.radius.sm",
+              es6: "calciteCornerRadiusSm",
             },
             "calcite-schema": {
               system: "calcite",
@@ -55741,8 +56035,52 @@ export default {
               category: "corner",
             },
           },
+          name: "Corner Radius Sm",
+          path: ["semantic", "corner", "radius", "sm"],
+          key: "{semantic.corner.radius.sm}",
+        },
+        round: {
+          value: "4px",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "dimension",
+            item: "radius",
+            subitem: "round",
+            value: "4px",
+            description: "deprecated",
+            filePath: "src/tokens/semantic/corner.json",
+            isSource: true,
+            name: "calcite-semantic-corner-radius-round",
+            path: ["semantic", "corner", "radius", "round"],
+            comment: "deprecated",
+            names: {
+              scss: "$calcite-corner-radius-round",
+              css: "var(--calcite-corner-radius-round)",
+              js: "semantic.corner.radius.round",
+              docs: "semantic.corner.radius.round",
+              es6: "calciteCornerRadiusRound",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          description: "deprecated",
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.4}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+            description: "deprecated",
+          },
           name: "Corner Radius Round",
           path: ["semantic", "corner", "radius", "round"],
+          comment: "deprecated",
           key: "{semantic.corner.radius.round}",
         },
         pill: {
@@ -62988,6 +63326,9 @@ declare const tokens: {
       radius: {
         default: DesignToken;
         sharp: DesignToken;
+        none: DesignToken;
+        xs: DesignToken;
+        sm: DesignToken;
         round: DesignToken;
         pill: DesignToken;
       };
@@ -64202,15 +64543,59 @@ export default {
           type: "dimension",
           attributes: {
             category: "corner",
-            type: "corner",
+            type: "dimension",
             item: "radius",
             subitem: "sharp",
+            value: "0",
+            description: "deprecated",
+            filePath: "src/tokens/semantic/corner.json",
+            isSource: true,
+            name: "calcite-semantic-corner-radius-sharp",
+            path: ["semantic", "corner", "radius", "sharp"],
+            comment: "deprecated",
             names: {
               scss: "$calcite-corner-radius-sharp",
               css: "var(--calcite-corner-radius-sharp)",
               js: "semantic.corner.radius.sharp",
               docs: "semantic.corner.radius.sharp",
               es6: "calciteCornerRadiusSharp",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          description: "deprecated",
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.none}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+            description: "deprecated",
+          },
+          name: "Corner Radius Sharp",
+          path: ["semantic", "corner", "radius", "sharp"],
+          comment: "deprecated",
+          key: "{semantic.corner.radius.sharp}",
+        },
+        none: {
+          value: "0",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "corner",
+            item: "radius",
+            subitem: "none",
+            names: {
+              scss: "$calcite-corner-radius-none",
+              css: "var(--calcite-corner-radius-none)",
+              js: "semantic.corner.radius.none",
+              docs: "semantic.corner.radius.none",
+              es6: "calciteCornerRadiusNone",
             },
             "calcite-schema": {
               system: "calcite",
@@ -64227,24 +64612,58 @@ export default {
               category: "corner",
             },
           },
-          name: "Corner Radius Sharp",
-          path: ["semantic", "corner", "radius", "sharp"],
-          key: "{semantic.corner.radius.sharp}",
+          name: "Corner Radius None",
+          path: ["semantic", "corner", "radius", "none"],
+          key: "{semantic.corner.radius.none}",
         },
-        round: {
+        xs: {
+          value: "2px",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "corner",
+            item: "radius",
+            subitem: "xs",
+            names: {
+              scss: "$calcite-corner-radius-xs",
+              css: "var(--calcite-corner-radius-xs)",
+              js: "semantic.corner.radius.xs",
+              docs: "semantic.corner.radius.xs",
+              es6: "calciteCornerRadiusXs",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.2}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+          },
+          name: "Corner Radius Xs",
+          path: ["semantic", "corner", "radius", "xs"],
+          key: "{semantic.corner.radius.xs}",
+        },
+        sm: {
           value: "4px",
           type: "dimension",
           attributes: {
             category: "corner",
             type: "corner",
             item: "radius",
-            subitem: "round",
+            subitem: "sm",
             names: {
-              scss: "$calcite-corner-radius-round",
-              css: "var(--calcite-corner-radius-round)",
-              js: "semantic.corner.radius.round",
-              docs: "semantic.corner.radius.round",
-              es6: "calciteCornerRadiusRound",
+              scss: "$calcite-corner-radius-sm",
+              css: "var(--calcite-corner-radius-sm)",
+              js: "semantic.corner.radius.sm",
+              docs: "semantic.corner.radius.sm",
+              es6: "calciteCornerRadiusSm",
             },
             "calcite-schema": {
               system: "calcite",
@@ -64261,8 +64680,52 @@ export default {
               category: "corner",
             },
           },
+          name: "Corner Radius Sm",
+          path: ["semantic", "corner", "radius", "sm"],
+          key: "{semantic.corner.radius.sm}",
+        },
+        round: {
+          value: "4px",
+          type: "dimension",
+          attributes: {
+            category: "corner",
+            type: "dimension",
+            item: "radius",
+            subitem: "round",
+            value: "4px",
+            description: "deprecated",
+            filePath: "src/tokens/semantic/corner.json",
+            isSource: true,
+            name: "calcite-semantic-corner-radius-round",
+            path: ["semantic", "corner", "radius", "round"],
+            comment: "deprecated",
+            names: {
+              scss: "$calcite-corner-radius-round",
+              css: "var(--calcite-corner-radius-round)",
+              js: "semantic.corner.radius.round",
+              docs: "semantic.corner.radius.round",
+              es6: "calciteCornerRadiusRound",
+            },
+            "calcite-schema": {
+              system: "calcite",
+              tier: "semantic",
+              type: "dimension",
+            },
+          },
+          description: "deprecated",
+          filePath: "src/tokens/semantic/corner.json",
+          isSource: true,
+          original: {
+            value: "{core.size.default.4}",
+            type: "dimension",
+            attributes: {
+              category: "corner",
+            },
+            description: "deprecated",
+          },
           name: "Corner Radius Round",
           path: ["semantic", "corner", "radius", "round"],
+          comment: "deprecated",
           key: "{semantic.corner.radius.round}",
         },
         pill: {
@@ -68148,6 +68611,9 @@ declare const tokens: {
       radius: {
         default: DesignToken;
         sharp: DesignToken;
+        none: DesignToken;
+        xs: DesignToken;
+        sm: DesignToken;
         round: DesignToken;
         pill: DesignToken;
       };
@@ -68973,8 +69439,11 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0;
-$calcite-corner-radius-round: 4px;
+$calcite-corner-radius-sharp: 0; // deprecated
+$calcite-corner-radius-none: 0;
+$calcite-corner-radius-xs: 2px;
+$calcite-corner-radius-sm: 4px;
+$calcite-corner-radius-round: 4px; // deprecated
 $calcite-corner-radius-pill: 100%;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks
@@ -69594,8 +70063,11 @@ $calcite-container-size-margin: 24px;
 $calcite-container-size-gutter: 16px;
 $calcite-container-size-content-fluid: 100%; // for fluid grid widths
 $calcite-container-size-content-fixed: 1440px; // only for lg breakpoint fixed grid width
-$calcite-corner-radius-sharp: 0;
-$calcite-corner-radius-round: 4px;
+$calcite-corner-radius-sharp: 0; // deprecated
+$calcite-corner-radius-none: 0;
+$calcite-corner-radius-xs: 2px;
+$calcite-corner-radius-sm: 4px;
+$calcite-corner-radius-round: 4px; // deprecated
 $calcite-corner-radius-pill: 100%;
 $calcite-font-family: 'Avenir Next', Avenir, 'Helvetica Neue', sans-serif; // Primary font with fallbacks
 $calcite-font-family-code: Monaco, Consolas, 'Andale Mono', 'Lucida Console', monospace; // Font family for code with fallbacks


### PR DESCRIPTION
**Related Issue:** #11906 

## Summary
- Deprecates 2 semantic corner-radius tokens
- Adds 3 new semantic corner-radius tokens - 2 replacements and 1 new with a new value of 2px

![image](https://github.com/user-attachments/assets/cac0a730-d704-4ae8-8ffd-f347043c94e4)


## Acceptance criteria
- [x] Mark `--calcite-corner-radius-sharp` (0px) as deprecated
- [x] Mark `--calcite-corner-radius-round` (4px) as deprecated
- [x] Add `--calcite-corner-radius-none` (0px)
- [x] Add `--calcite-corner-radius-xs` (2px)
- [x] Add `--calcite-corner-radius-sm` (4px)

deprecate(semantic-tokens): mark old corner-radius tokens as deprecated