### PR TITLE
build(deps): restore ^ range for @arcgis deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35890,7 +35890,7 @@
         "@arcgis/components-controllers": "^4.33.0-next.93",
         "@arcgis/components-utils": "^4.33.0-next.93",
         "@arcgis/lumina": "^4.33.0-next.93",
-        "@esri/calcite-ui-icons": "^4.2.0-next.2",
+        "@esri/calcite-ui-icons": "4.2.0-next.2",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35887,10 +35887,10 @@
       "version": "3.2.0-next.31",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/components-controllers": "4.33.0-next.93",
-        "@arcgis/components-utils": "4.33.0-next.93",
-        "@arcgis/lumina": "4.33.0-next.93",
-        "@esri/calcite-ui-icons": "4.2.0-next.2",
+        "@arcgis/components-controllers": "^4.33.0-next.93",
+        "@arcgis/components-utils": "^4.33.0-next.93",
+        "@arcgis/lumina": "^4.33.0-next.93",
+        "@esri/calcite-ui-icons": "^4.2.0-next.2",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
@@ -35905,7 +35905,7 @@
         "type-fest": "^4.30.1"
       },
       "devDependencies": {
-        "@arcgis/lumina-compiler": "4.33.0-next.93",
+        "@arcgis/lumina-compiler": "^4.33.0-next.93",
         "@esri/calcite-design-tokens": "3.1.0-next.4",
         "@esri/calcite-tailwind-preset": "0.2.0-next.5",
         "@esri/eslint-plugin-calcite-components": "2.0.2-next.4",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -75,10 +75,10 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@arcgis/components-controllers": "4.33.0-next.93",
-    "@arcgis/components-utils": "4.33.0-next.93",
-    "@arcgis/lumina": "4.33.0-next.93",
-    "@esri/calcite-ui-icons": "4.2.0-next.2",
+    "@arcgis/components-controllers": "^4.33.0-next.93",
+    "@arcgis/components-utils": "^4.33.0-next.93",
+    "@arcgis/lumina": "^4.33.0-next.93",
+    "@esri/calcite-ui-icons": "^4.2.0-next.2",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
@@ -93,7 +93,7 @@
     "type-fest": "^4.30.1"
   },
   "devDependencies": {
-    "@arcgis/lumina-compiler": "4.33.0-next.93",
+    "@arcgis/lumina-compiler": "^4.33.0-next.93",
     "@esri/calcite-design-tokens": "3.1.0-next.4",
     "@esri/calcite-tailwind-preset": "0.2.0-next.5",
     "@esri/eslint-plugin-calcite-components": "2.0.2-next.4",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -78,7 +78,7 @@
     "@arcgis/components-controllers": "^4.33.0-next.93",
     "@arcgis/components-utils": "^4.33.0-next.93",
     "@arcgis/lumina": "^4.33.0-next.93",
-    "@esri/calcite-ui-icons": "^4.2.0-next.2",
+    "@esri/calcite-ui-icons": "4.2.0-next.2",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",


### PR DESCRIPTION
**Related Issue:** #12044 

## Summary

Restores dependency ranges (^) that were unintentionally removed by https://github.com/Esri/calcite-design-system/pull/11925 (see https://github.com/Esri/calcite-design-system/pull/11190/ for previous approach).