### PR TITLE
fix(action-menu): stop propagation of internal popover events

### DIFF
--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -287,6 +287,44 @@ describe("calcite-action-menu", () => {
     expect(await tooltipPositionContainer.isVisible()).toBe(false);
   });
 
+  it.only("should stop propagation of popover events", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(html`
+      <calcite-action-menu label="test">
+        <calcite-action id="trigger" slot="${SLOTS.trigger}" text="Add" icon="plus"></calcite-action>
+        <calcite-action text="Add" icon="plus"></calcite-action>
+      </calcite-action-menu>
+      <button id="outside">outside</button>
+    `);
+
+    await skipAnimations(page);
+
+    const actionMenu = await page.find("calcite-action-menu");
+    const trigger = await page.find("#trigger");
+    const outside = await page.find("#outside");
+
+    const popoverBeforeOpen = await actionMenu.spyOnEvent("calcitePopoverBeforeOpen");
+    const popoverOpen = await actionMenu.spyOnEvent("calcitePopoverOpen");
+    const popoverBeforeClose = await actionMenu.spyOnEvent("calcitePopoverBeforeClose");
+    const popoverClose = await actionMenu.spyOnEvent("calcitePopoverClose");
+
+    await trigger.click();
+    await page.waitForChanges();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+
+    await outside.click();
+    await page.waitForChanges();
+
+    expect(await actionMenu.getProperty("open")).toBe(false);
+
+    expect(popoverBeforeOpen).toHaveReceivedEventTimes(0);
+    expect(popoverOpen).toHaveReceivedEventTimes(0);
+    expect(popoverBeforeClose).toHaveReceivedEventTimes(0);
+    expect(popoverClose).toHaveReceivedEventTimes(0);
+  });
+
   describe("Keyboard navigation", () => {
     it("should handle ArrowDown navigation", async () => {
       const page = await newE2EPage({

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -304,9 +304,7 @@ describe("calcite-action-menu", () => {
     const trigger = await page.find("#trigger");
     const outside = await page.find("#outside");
 
-    const popoverBeforeOpen = await actionMenu.spyOnEvent("calcitePopoverBeforeOpen");
     const popoverOpen = await actionMenu.spyOnEvent("calcitePopoverOpen");
-    const popoverBeforeClose = await actionMenu.spyOnEvent("calcitePopoverBeforeClose");
     const popoverClose = await actionMenu.spyOnEvent("calcitePopoverClose");
 
     await trigger.click();
@@ -319,9 +317,7 @@ describe("calcite-action-menu", () => {
 
     expect(await actionMenu.getProperty("open")).toBe(false);
 
-    expect(popoverBeforeOpen).toHaveReceivedEventTimes(0);
     expect(popoverOpen).toHaveReceivedEventTimes(0);
-    expect(popoverBeforeClose).toHaveReceivedEventTimes(0);
     expect(popoverClose).toHaveReceivedEventTimes(0);
   });
 

--- a/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/calcite-components/src/components/action-menu/action-menu.e2e.ts
@@ -287,7 +287,7 @@ describe("calcite-action-menu", () => {
     expect(await tooltipPositionContainer.isVisible()).toBe(false);
   });
 
-  it.only("should stop propagation of popover events", async () => {
+  it("should stop propagation of popover events", async () => {
     const page = await newE2EPage();
 
     await page.setContent(html`

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -435,13 +435,23 @@ export class ActionMenu extends LitElement {
     this.open = value;
   }
 
-  private handlePopoverOpen(): void {
+  private handlePopoverOpen(event: CustomEvent<void>): void {
+    event.stopPropagation();
     this.open = true;
     this.setFocus();
   }
 
-  private handlePopoverClose(): void {
+  private handlePopoverClose(event: CustomEvent<void>): void {
+    event.stopPropagation();
     this.open = false;
+  }
+
+  private handlePopoverBeforeClose(event: CustomEvent<void>): void {
+    event.stopPropagation();
+  }
+
+  private handlePopoverBeforeOpen(event: CustomEvent<void>): void {
+    event.stopPropagation();
   }
 
   // #endregion
@@ -490,6 +500,8 @@ export class ActionMenu extends LitElement {
         focusTrapDisabled={true}
         label={label}
         offsetDistance={0}
+        oncalcitePopoverBeforeClose={this.handlePopoverBeforeClose}
+        oncalcitePopoverBeforeOpen={this.handlePopoverBeforeOpen}
         oncalcitePopoverClose={this.handlePopoverClose}
         oncalcitePopoverOpen={this.handlePopoverOpen}
         overlayPositioning={overlayPositioning}

--- a/packages/calcite-components/src/components/action-menu/action-menu.tsx
+++ b/packages/calcite-components/src/components/action-menu/action-menu.tsx
@@ -446,14 +446,6 @@ export class ActionMenu extends LitElement {
     this.open = false;
   }
 
-  private handlePopoverBeforeClose(event: CustomEvent<void>): void {
-    event.stopPropagation();
-  }
-
-  private handlePopoverBeforeOpen(event: CustomEvent<void>): void {
-    event.stopPropagation();
-  }
-
   // #endregion
 
   // #region Rendering
@@ -500,8 +492,6 @@ export class ActionMenu extends LitElement {
         focusTrapDisabled={true}
         label={label}
         offsetDistance={0}
-        oncalcitePopoverBeforeClose={this.handlePopoverBeforeClose}
-        oncalcitePopoverBeforeOpen={this.handlePopoverBeforeOpen}
         oncalcitePopoverClose={this.handlePopoverClose}
         oncalcitePopoverOpen={this.handlePopoverOpen}
         overlayPositioning={overlayPositioning}


### PR DESCRIPTION
**Related Issue:** #12048

## Summary

- stop propagation of internal popover events
- add tests
