### PR TITLE
chore(linting): set up additional ESLint rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "patch-package": "8.0.0"
       },
       "devDependencies": {
+        "@arcgis/eslint-config": "4.32.14",
         "@cspell/dict-gis": "1.0.1",
         "@cspell/dict-pokemon": "1.0.1",
         "@cspell/dict-scientific-terms-us": "3.0.6",
@@ -350,6 +351,52 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@arcgis/eslint-config": {
+      "version": "4.32.14",
+      "resolved": "https://registry.npmjs.org/@arcgis/eslint-config/-/eslint-config-4.32.14.tgz",
+      "integrity": "sha512-AgGaSsJPdy49DaInn7NlADWl4d0TlUyPvmwJHOvagJnoYGXnjm0uZKRz6ZQ/AadD7VQ6CCzJEjsVv8d2/yF7gQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/components-utils": "4.32.14",
+        "@eslint/js": "^9.17.0",
+        "@types/confusing-browser-globals": "^1.0.3",
+        "confusing-browser-globals": "^1.0.11",
+        "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-storybook": "^0.11.1",
+        "globals": "^15.12.0",
+        "prettier": "^3.3.3",
+        "tslib": "^2.7.0",
+        "typescript": "~5.6.3",
+        "typescript-eslint": "^8.18.1"
+      },
+      "peerDependencies": {
+        "eslint": "^9.17.0"
+      }
+    },
+    "node_modules/@arcgis/eslint-config/node_modules/@arcgis/components-utils": {
+      "version": "4.32.14",
+      "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.32.14.tgz",
+      "integrity": "sha512-7uvJRrS4GMiBVJsqr4SOpmYWLOB++Wf+DkgHi1j/d379vdF72p725vy+u5US9JrG9haolE92ZO3gfQ5gLBqSpw==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@arcgis/eslint-config/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@arcgis/lumina": {
@@ -7836,6 +7883,16 @@
         }
       }
     },
+    "node_modules/@storybook/csf": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
+      "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
     "node_modules/@storybook/csf-plugin": {
       "version": "8.6.12",
       "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.12.tgz",
@@ -7851,6 +7908,19 @@
       },
       "peerDependencies": {
         "storybook": "^8.6.12"
+      }
+    },
+    "node_modules/@storybook/csf/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/global": {
@@ -8264,6 +8334,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/confusing-browser-globals": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/confusing-browser-globals/-/confusing-browser-globals-1.0.3.tgz",
+      "integrity": "sha512-q+6axdE3RyjrSsy2ONE4UpF89rwOfpoMBP3lqJ+OzLuOeYHwP+o2GITzuleKb1UT3FSYybO8QmeACgyHleu2CA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11995,6 +12072,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
@@ -14949,6 +15033,37 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.6.tgz",
+      "integrity": "sha512-mUcf7QG2Tjk7H055Jk0lGBjbgDnfrvqjhXh9t2xLMSCjZVcw9Rb1V6sVNXO0th3jgeO7zllWPTNRil3JW94TnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -15008,6 +15123,24 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-storybook": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.11.6.tgz",
+      "integrity": "sha512-3WodYD6Bs9ACqnB+TP2TuLh774c/nacAjxSKOP9bHJ2c8rf+nrhocxjjeAWNmO9IPkFIzTKlcl0vNXI2yYpVOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf": "^0.1.11",
+        "@typescript-eslint/utils": "^8.8.1",
+        "ts-dedent": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -15541,6 +15674,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-equals": {
       "version": "5.2.2",
@@ -27183,6 +27323,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-jsdoc": "50.6.9",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-unicorn": "58.0.0",
+        "eslint-plugin-unused-imports": "4.1.4",
         "generate-license-file": "4.0.0",
         "globals": "16.0.0",
         "globby": "14.1.0",
@@ -15042,6 +15043,22 @@
       },
       "peerDependencies": {
         "eslint": ">=9.22.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "util:update-3rd-party-licenses": "turbo run util:update-3rd-party-licenses --log-order=stream"
   },
   "devDependencies": {
+    "@arcgis/eslint-config": "4.32.14",
     "@cspell/dict-gis": "1.0.1",
     "@cspell/dict-pokemon": "1.0.1",
     "@cspell/dict-scientific-terms-us": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-jsdoc": "50.6.9",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-unicorn": "58.0.0",
+    "eslint-plugin-unused-imports": "4.1.4",
     "generate-license-file": "4.0.0",
     "globals": "16.0.0",
     "globby": "14.1.0",

--- a/packages/calcite-components/eslint.config.mjs
+++ b/packages/calcite-components/eslint.config.mjs
@@ -5,6 +5,7 @@ import vitestPlugin from "@vitest/eslint-plugin";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import unusedImports from "eslint-plugin-unused-imports";
+import luminaPlugin from "@arcgis/eslint-config/plugins/lumina";
 
 export default tseslint.config(
   {
@@ -16,6 +17,7 @@ export default tseslint.config(
     plugins: {
       "@esri/calcite-components": calcitePlugin,
       "unused-imports": unusedImports,
+      lumina: luminaPlugin,
     },
 
     languageOptions: {
@@ -26,6 +28,8 @@ export default tseslint.config(
     },
 
     rules: {
+      "lumina/member-ordering": "warn",
+
       "no-restricted-imports": [
         "error",
         {

--- a/packages/calcite-components/eslint.config.mjs
+++ b/packages/calcite-components/eslint.config.mjs
@@ -4,6 +4,7 @@ import calcitePlugin from "@esri/eslint-plugin-calcite-components";
 import vitestPlugin from "@vitest/eslint-plugin";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import unusedImports from "eslint-plugin-unused-imports";
 
 export default tseslint.config(
   {
@@ -14,6 +15,7 @@ export default tseslint.config(
     extends: [calciteCoreConfig, calciteJsxConfig],
     plugins: {
       "@esri/calcite-components": calcitePlugin,
+      "unused-imports": unusedImports,
     },
 
     languageOptions: {
@@ -43,6 +45,8 @@ export default tseslint.config(
           message: "Use custom findAll test util for more predictable (non-empty) result usage.",
         },
       ],
+
+      "unused-imports/no-unused-imports": "error",
 
       "@esri/calcite-components/no-dynamic-createelement": "warn",
       "@esri/calcite-components/strict-boolean-attributes": "error",

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -43,13 +43,13 @@ declare global {
  * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
 export class ActionBar extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionGroups: ActionGroup["el"][];
 
@@ -108,9 +108,16 @@ export class ActionBar extends LitElement {
     this.calciteActionBarToggle.emit();
   };
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() expandTooltip: Tooltip["el"];
 
@@ -118,9 +125,9 @@ export class ActionBar extends LitElement {
 
   @state() hasBottomActions = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the accessible label for the last `calcite-action-group`. */
   @property() actionsEndGroupLabel: string;
@@ -136,13 +143,6 @@ export class ActionBar extends LitElement {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /** Disables automatically overflowing `calcite-action`s that won't fit into menus. */
   @property({ reflect: true }) overflowActionsDisabled = false;
@@ -162,9 +162,9 @@ export class ActionBar extends LitElement {
   /** Specifies the size of the expand `calcite-action`. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Overflows actions that won't fit into menus.
@@ -184,16 +184,16 @@ export class ActionBar extends LitElement {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the `expanded` property is toggled. */
   calciteActionBarToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -241,9 +241,10 @@ export class ActionBar extends LitElement {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private expandedHandler(): void {
     const { el, expanded } = this;
     toggleChildActionText({ el, expanded });
@@ -310,9 +311,9 @@ export class ActionBar extends LitElement {
     this.expandTooltip = tooltips[0];
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderBottomActionGroup(): JsxNode {
     const {
@@ -369,5 +370,5 @@ export class ActionBar extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/action-group/action-group.tsx
+++ b/packages/calcite-components/src/components/action-group/action-group.tsx
@@ -25,21 +25,32 @@ declare global {
  * @slot menu-tooltip - A slot for adding a `calcite-tooltip` for the menu.
  */
 export class ActionGroup extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region State Properties
+  //#region Private Properties
+
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
+
+  //#endregion
+
+  //#region State Properties
 
   @state() hasMenuActions = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Indicates number of columns. */
   @property({ type: Number, reflect: true }) columns: Columns;
@@ -71,13 +82,6 @@ export class ActionGroup extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Determines the type of positioning to use for the overlaid content.
    *
    * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
@@ -88,9 +92,9 @@ export class ActionGroup extends LitElement {
   /** Specifies the size of the `calcite-action-menu`. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first focusable element. */
   @method()
@@ -99,9 +103,9 @@ export class ActionGroup extends LitElement {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
@@ -112,9 +116,11 @@ export class ActionGroup extends LitElement {
       this.menuOpen = false;
     }
   }
-  // #endregion
 
-  // #region Private Methods
+  //#endregion
+
+  //#region Private Methods
+
   private setMenuOpen(event: ToEvents<ActionMenu>["calciteActionMenuOpen"]): void {
     this.menuOpen = !!event.currentTarget.open;
   }
@@ -123,9 +129,9 @@ export class ActionGroup extends LitElement {
     this.hasMenuActions = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderMenu(): JsxNode {
     const {
@@ -176,5 +182,5 @@ export class ActionGroup extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -25,15 +25,15 @@ declare global {
  * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
 export class ActionPad extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionGroups: ActionGroup["el"][];
 
@@ -44,15 +44,22 @@ export class ActionPad extends LitElement {
     this.calciteActionPadToggle.emit();
   };
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() expandTooltip: Tooltip["el"];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the accessible label for the last `calcite-action-group`. */
   @property() actionsEndGroupLabel: string;
@@ -71,13 +78,6 @@ export class ActionPad extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Determines the type of positioning to use for the overlaid content.
    *
    * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
@@ -92,9 +92,9 @@ export class ActionPad extends LitElement {
   /** Specifies the size of the expand `calcite-action`. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first focusable element. */
   @method()
@@ -103,16 +103,16 @@ export class ActionPad extends LitElement {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the `expanded` property is toggled. */
   calciteActionPadToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -141,9 +141,10 @@ export class ActionPad extends LitElement {
     this.mutationObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private actionMenuOpenHandler(event: CustomEvent<void>): void {
     if ((event.target as ActionGroup["el"]).menuOpen) {
       const composedPath = event.composedPath();
@@ -177,9 +178,9 @@ export class ActionPad extends LitElement {
     this.expandTooltip = tooltips[0];
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderBottomActionGroup(): JsxNode {
     const {
@@ -233,5 +234,5 @@ export class ActionPad extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -29,13 +29,13 @@ declare global {
  * @slot tooltip - [Deprecated] Use the `calcite-tooltip` component instead.
  */
 export class Action extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private guid = `calcite-action-${guid()}`;
 
@@ -47,9 +47,16 @@ export class Action extends LitElement implements InteractiveComponent {
 
   private mutationObserver = createObserver("mutation", () => this.requestUpdate());
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, the component is highlighted. */
   @property({ reflect: true }) active = false;
@@ -95,13 +102,6 @@ export class Action extends LitElement implements InteractiveComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
-
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
@@ -115,9 +115,9 @@ export class Action extends LitElement implements InteractiveComponent {
   /** Indicates whether the text is displayed. */
   @property({ reflect: true }) textEnabled = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -126,9 +126,9 @@ export class Action extends LitElement implements InteractiveComponent {
     this.buttonEl.value?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
@@ -142,9 +142,9 @@ export class Action extends LitElement implements InteractiveComponent {
     this.mutationObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleTooltipSlotChange(event: Event): void {
     const tooltips = (event.target as HTMLSlotElement)
@@ -160,9 +160,9 @@ export class Action extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderTextContainer(): JsxNode {
     const { text, textEnabled } = this;
@@ -313,5 +313,5 @@ export class Action extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/alert/alert.tsx
+++ b/packages/calcite-components/src/components/alert/alert.tsx
@@ -48,13 +48,13 @@ const manager = new AlertManager();
  * @slot actions-end - A slot for adding `calcite-action`s to the end of the component. It is recommended to use two or fewer actions.
  */
 export class Alert extends LitElement implements OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private autoCloseTimeoutId: number = null;
 
@@ -72,9 +72,16 @@ export class Alert extends LitElement implements OpenCloseComponent {
 
   transitionEl: HTMLDivElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasEndActions = false;
 
@@ -82,9 +89,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
 
   @state() numberStringFormatter = new NumberStringFormat();
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * This internal property, managed by the AlertManager, is used
@@ -133,13 +140,6 @@ export class Alert extends LitElement implements OpenCloseComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property({ reflect: true }) numberingSystem: NumberingSystem;
 
@@ -163,9 +163,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Sets focus on the component's "close" button, the first focusable item.
@@ -178,9 +178,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteAlertBeforeClose = createEvent({ cancelable: false });
@@ -194,9 +194,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
   /** Fires when the component is open and animation is complete. */
   calciteAlertOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     const open = this.open;
@@ -251,9 +251,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
     this.embedded = false;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleActiveChange(): void {
     onToggleOpenCloseComponent(this);
@@ -385,9 +385,9 @@ export class Alert extends LitElement implements OpenCloseComponent {
     this.autoCloseTimeoutId = window.setTimeout(() => this.closeAlert(), timeRemaining);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { open, autoClose, label, placement, active, openAlertCount } = this;
@@ -486,5 +486,5 @@ export class Alert extends LitElement implements OpenCloseComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -12,17 +12,13 @@ declare global {
 
 /** @slot - A slot for adding `calcite-autocomplete-item`s. */
 export class AutocompleteItemGroup extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
-
-  // #endregion
-
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * When `true`, signifies that the group should not have extra spacing. Used for styling.
@@ -48,13 +44,9 @@ export class AutocompleteItemGroup extends LitElement {
    */
   @property() scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
-
-  // #endregion
-
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { scale } = this;
@@ -76,5 +68,5 @@ export class AutocompleteItemGroup extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -81,13 +81,13 @@ export class Autocomplete
     OpenCloseComponent,
     TextualInputComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private guid = guid();
 
@@ -127,9 +127,17 @@ export class Autocomplete
 
   private inputValueMatchPattern: RegExp;
 
-  // #endregion
+  private mutationObserver = createObserver("mutation", () => this.getAllItemsDebounced());
 
-  // #region State Properties
+  private resizeObserver = createObserver("resize", () => {
+    this.setFloatingElSize();
+  });
+
+  private getAllItemsDebounced = debounce(this.getAllItems, 0);
+
+  //#endregion
+
+  //#region State Properties
 
   @state() activeDescendant = "";
 
@@ -153,9 +161,9 @@ export class Autocomplete
     return this.items.filter((item) => !item.disabled);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the text alignment of the component's value. */
   @property({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
@@ -315,9 +323,9 @@ export class Autocomplete
   /** The component's value. */
   @property() value = "";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Updates the position of the component.
@@ -380,9 +388,9 @@ export class Autocomplete
     return this.referenceEl.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteAutocompleteBeforeClose = createEvent({ cancelable: false });
@@ -405,9 +413,9 @@ export class Autocomplete
   /** Fires each time a new `inputValue` is typed. */
   calciteAutocompleteTextInput = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -495,9 +503,9 @@ export class Autocomplete
     disconnectFloatingUI(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private setFloatingElSize(): void {
     const { referenceEl, floatingEl } = this;
@@ -550,12 +558,6 @@ export class Autocomplete
     await this.setFocus();
     this.open = false;
   }
-
-  private mutationObserver = createObserver("mutation", () => this.getAllItemsDebounced());
-
-  private resizeObserver = createObserver("resize", () => {
-    this.setFloatingElSize();
-  });
 
   onLabelClick(): void {
     this.setFocus();
@@ -633,8 +635,6 @@ export class Autocomplete
   private handleContentBottomSlotChange(event: Event): void {
     this.hasContentBottom = slotChangeHasAssignedElement(event);
   }
-
-  private getAllItemsDebounced = debounce(this.getAllItems, 0);
 
   private getAllItems(): void {
     const { el } = this;
@@ -763,9 +763,9 @@ export class Autocomplete
     this.transitionEl = el;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { disabled, listId, inputId, isOpen } = this;
@@ -893,5 +893,5 @@ export class Autocomplete
       ));
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -20,13 +20,24 @@ declare global {
 
 /** @slot - A slot for adding custom content. */
 export class BlockSection extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Private Properties
+
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
+
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, the component is expanded to show child components. */
   @property({ reflect: true }) expanded = false;
@@ -44,13 +55,6 @@ export class BlockSection extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * When `true`, expands the component and its contents.
    *
    * @deprecated Use `expanded` prop instead.
@@ -59,7 +63,6 @@ export class BlockSection extends LitElement {
   get open(): boolean {
     return this.expanded;
   }
-
   set open(value: boolean) {
     logger.deprecated("property", {
       name: "open",
@@ -88,9 +91,9 @@ export class BlockSection extends LitElement {
    */
   @property({ reflect: true }) toggleDisplay: BlockSectionToggleDisplay = "button";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first tabbable element. */
   @method()
@@ -99,16 +102,16 @@ export class BlockSection extends LitElement {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the header has been clicked. */
   calciteBlockSectionToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleHeaderKeyDown(event: KeyboardEvent): void {
     if (isActivationKey(event.key)) {
@@ -123,9 +126,9 @@ export class BlockSection extends LitElement {
     this.calciteBlockSectionToggle.emit();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderStatusIcon(): JsxNode {
     const { status } = this;
@@ -248,5 +251,5 @@ export class BlockSection extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -41,13 +41,13 @@ declare global {
  * @slot header-menu-actions - A slot for adding an overflow menu with `calcite-action`s inside a dropdown menu.
  */
 export class Block extends LitElement implements InteractiveComponent, OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   transitionProp = "margin-top" as const;
 
@@ -55,9 +55,16 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
 
   private sortHandleEl: SortHandle["el"];
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasContentStart = false;
 
@@ -69,9 +76,9 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
 
   @state() hasMenuActions = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, the component is collapsible. */
   @property({ reflect: true }) collapsible = false;
@@ -131,13 +138,6 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Sets the item to display a border.
    *
    * @private
@@ -153,7 +153,6 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
   get open(): boolean {
     return this.expanded;
   }
-
   set open(value: boolean) {
     logger.deprecated("property", {
       name: "open",
@@ -162,6 +161,7 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
     });
     this.expanded = value;
   }
+
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
@@ -195,9 +195,9 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
    */
   @property({ reflect: true }) status: Status;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first tabbable element. */
   @method()
@@ -206,9 +206,9 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteBlockBeforeClose = createEvent({ cancelable: false });
@@ -241,9 +241,9 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
    */
   calciteBlockToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.transitionEl = this.el;
@@ -275,9 +275,10 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   onBeforeOpen(): void {
     this.calciteBlockBeforeOpen.emit();
   }
@@ -355,9 +356,9 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
     this.hasContentStart = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderScrim(): JsxNode {
     const { loading } = this;
@@ -560,5 +561,5 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -50,13 +50,13 @@ export class Button
   extends LitElement
   implements LabelableComponent, InteractiveComponent, FormOwner
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   attributeWatch = useWatchAttributes(["aria-expanded"], this.handleGlobalAttributesChanged);
 
@@ -75,9 +75,16 @@ export class Button
 
   private resizeObserver = createObserver("resize", () => this.setTooltipText());
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   /** determine if there is slotted content for styling purposes */
   @state() private hasContent = false;
@@ -85,9 +92,9 @@ export class Button
   /** keeps track of the tooltipText */
   @state() tooltipText: string;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the alignment of the component's elements. */
   @property({ reflect: true }) alignment: ButtonAlignment = "center";
@@ -141,13 +148,6 @@ export class Button
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies the name of the component on form submission. */
   @property({ reflect: true }) name?: string;
 
@@ -184,9 +184,9 @@ export class Button
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -196,9 +196,9 @@ export class Button
     this.childEl?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.setupTextContentObserver();
@@ -227,9 +227,9 @@ export class Button
     this.formEl = null;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -281,9 +281,9 @@ export class Button
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const childElType = this.href ? "a" : "button";
@@ -375,5 +375,5 @@ export class Button
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/card/card.tsx
+++ b/packages/calcite-components/src/components/card/card.tsx
@@ -43,19 +43,26 @@ declare global {
  * @slot footer-end - A slot for adding a trailing footer.
  */
 export class Card extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private containerEl = createRef<HTMLDivElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() private hasContent = false;
 
@@ -73,9 +80,9 @@ export class Card extends LitElement implements InteractiveComponent {
 
   @state() hasTitle = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
@@ -88,13 +95,6 @@ export class Card extends LitElement implements InteractiveComponent {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * When `true`, the component is selectable.
@@ -120,9 +120,9 @@ export class Card extends LitElement implements InteractiveComponent {
   /** Sets the placement of the thumbnail defined in the `thumbnail` slot. */
   @property({ reflect: true }) thumbnailPosition: LogicalFlowPosition = "block-start";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -133,9 +133,9 @@ export class Card extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the deprecated `selectable` is true, or `selectionMode` set on parent `calcite-card-group` is not `none` and the component is selected. */
   calciteCardSelect = createEvent({ cancelable: false });
@@ -143,17 +143,17 @@ export class Card extends LitElement implements InteractiveComponent {
   /** @private */
   calciteInternalCardKeyEvent = createEvent<KeyboardEvent>({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override updated(): void {
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleThumbnailSlotChange(event: Event): void {
     this.hasThumbnail = slotChangeHasAssignedElement(event);
@@ -226,9 +226,9 @@ export class Card extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderCheckboxDeprecated(): JsxNode {
     return (
@@ -341,5 +341,5 @@ export class Card extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/carousel/carousel.tsx
+++ b/packages/calcite-components/src/components/carousel/carousel.tsx
@@ -33,13 +33,13 @@ declare global {
 
 /** @slot - A slot for adding `calcite-carousel-item`s. */
 export class Carousel extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private autoplayHandler = (): void => {
     this.clearIntervals();
@@ -84,9 +84,16 @@ export class Carousel extends LitElement implements InteractiveComponent {
     }
   };
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() direction: "forward" | "backward" | "standby" = "standby";
 
@@ -108,9 +115,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
 
   @state() userPreventsSuspend = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies how and if the "previous" and "next" arrows are displayed. */
   @property({ reflect: true }) arrowType: ArrowType = "inline";
@@ -142,13 +149,6 @@ export class Carousel extends LitElement implements InteractiveComponent {
    *
    * @private
    */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
   @property() paused: boolean;
 
   /**
@@ -158,9 +158,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
    */
   @property() selectedItem: CarouselItem["el"];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Play the carousel. If `autoplay` is not enabled (initialized either to `true` or `"paused"`), these methods will have no effect. */
   @method()
@@ -188,9 +188,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
     this.handlePause(true);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the selected `calcite-carousel-item` changes. */
   calciteCarouselChange = createEvent({ cancelable: false });
@@ -207,9 +207,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
   /** Fires when the carousel autoplay state is stopped by a user. */
   calciteCarouselStop = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.resizeObserver?.observe(this.el);
@@ -260,9 +260,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private autoplayWatcher(autoplay: AutoplayType): void {
     if (!autoplay) {
@@ -562,9 +562,9 @@ export class Carousel extends LitElement implements InteractiveComponent {
     this.itemContainer = el;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderRotationControl(): JsxNode {
     const text = this.playing ? this.messages.pause : this.messages.play;
@@ -718,5 +718,5 @@ export class Carousel extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/chip/chip.tsx
+++ b/packages/calcite-components/src/components/chip/chip.tsx
@@ -30,29 +30,36 @@ declare global {
  * @slot image - A slot for adding an image.
  */
 export class Chip extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private closeButtonEl = createRef<HTMLButtonElement>();
 
   private containerEl = createRef<HTMLDivElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() private hasImage = false;
 
   @state() private hasText = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the appearance style of the component. */
   @property({ reflect: true }) appearance: Extract<
@@ -99,13 +106,6 @@ export class Chip extends LitElement implements InteractiveComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** @private */
   @property() parentChipGroup: ChipGroup["el"];
 
@@ -129,9 +129,9 @@ export class Chip extends LitElement implements InteractiveComponent {
   /** The component's value. */
   @property() value: any;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -144,9 +144,9 @@ export class Chip extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component's close button is selected. */
   calciteChipClose = createEvent({ cancelable: false });
@@ -163,9 +163,9 @@ export class Chip extends LitElement implements InteractiveComponent {
   /** @private */
   calciteInternalSyncSelectedChips = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -199,9 +199,9 @@ export class Chip extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private watchSelected(selected: boolean): void {
     if (this.selectionMode === "none") {
@@ -287,9 +287,9 @@ export class Chip extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderChipImage(): JsxNode {
     return (
@@ -400,5 +400,5 @@ export class Chip extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -66,13 +66,13 @@ declare global {
 const throttleFor60FpsInMs = 16;
 
 export class ColorPicker extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private activeCanvasInfo: {
     context: CanvasRenderingContext2D;
@@ -86,10 +86,6 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
       }
     | undefined;
 
-  private get baseColorFieldColor(): ColorInstance {
-    return this.color || this.previousColor || DEFAULT_COLOR;
-  }
-
   private checkerPattern: HTMLCanvasElement;
 
   private _color: InternalColor | null = DEFAULT_COLOR;
@@ -97,10 +93,6 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
   private colorFieldRenderingContext: CanvasRenderingContext2D;
 
   private colorFieldScopeNode: HTMLDivElement;
-
-  private get effectiveSliderWidth(): number {
-    return this.dynamicDimensions.slider.width;
-  }
 
   private hueScopeNode: HTMLDivElement;
 
@@ -130,262 +122,12 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
 
   private _valueWasSet = false;
 
-  // #endregion
-
-  // #region State Properties
-
-  @state() channelMode: ColorMode = "rgb";
-
-  @state() channels: Channels = this.toChannels(DEFAULT_COLOR);
-
-  @state() colorFieldScopeLeft: number;
-
-  @state() colorFieldScopeTop: number;
-
-  @state() staticDimensions = STATIC_DIMENSIONS.m;
-
-  @state() hueScopeLeft: number;
-
-  @state() opacityScopeLeft: number;
-
-  @state() savedColors: string[] = [];
-
-  @state() scopeOrientation: "vertical" | "horizontal";
-
-  // #endregion
-
-  // #region Public Properties
-
-  /**
-   * When `true`, an empty color (`null`) will be allowed as a `value`.
-   *
-   * When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
-   *
-   * @deprecated Use `clearable` instead
-   */
-  @property({ reflect: true }) allowEmpty = false;
-
-  /** When `true`, the component will allow updates to the color's alpha value. */
-  @property() alphaChannel = false;
-
-  /** When `true`, hides the RGB/HSV channel inputs. */
-  @property() channelsDisabled = false;
-
-  /**
-   * When `true`, an empty color (`null`) will be allowed as a `value`.
-   *
-   * When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
-   */
-  @property({ reflect: true }) clearable = false;
-
-  /**
-   * Internal prop for advanced use-cases.
-   *
-   * @private
-   */
-  @property()
-  get color(): InternalColor | null {
-    return this._color;
-  }
-
-  set color(color: InternalColor | null) {
-    const oldColor = this._color;
-    this._color = color;
-    this.handleColorChange(color, oldColor);
-  }
-
-  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
-  @property({ reflect: true }) disabled = false;
-
-  /**
-   * The format of `value`.
-   *
-   * When `"auto"`, the format will be inferred from `value` when set.
-   *
-   * @default "auto"
-   */
-  @property({ reflect: true }) format: Format = "auto";
-
-  /** When `true`, hides the hex input. */
-  @property() hexDisabled = false;
-
-  /** Use this property to override individual strings used by the component. */
-  @property() messageOverrides?: typeof this.messages._overrides;
-
   /**
    * Made into a prop for testing purposes only
    *
    * @private
    */
   messages = useT9n<typeof T9nStrings>({ blocking: true });
-
-  /** Specifies the Unicode numeral system used by the component for localization. */
-  @property({ reflect: true }) numberingSystem: NumberingSystem;
-
-  /** When `true`, hides the saved colors section. */
-  @property({ reflect: true }) savedDisabled = false;
-
-  /** Specifies the size of the component. */
-  @property({ reflect: true }) scale: Scale = "m";
-
-  /** Specifies the storage ID for colors. */
-  @property({ reflect: true }) storageId: string;
-
-  /**
-   * The component's value, where the value can be a CSS color string, or a RGB, HSL or HSV object.
-   *
-   * The type will be preserved as the color is updated.
-   *
-   * @default
-   *
-   * @see [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color),
-   * @see [ColorValue](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/components/color-picker/interfaces.ts#L10).
-   */
-  @property()
-  get value(): ColorValue | null {
-    return this._value;
-  }
-
-  set value(value: ColorValue | null) {
-    const oldValue = this._value;
-    this._value = value;
-    this.handleValueChange(value, oldValue);
-    this._valueWasSet = true;
-  }
-
-  // #endregion
-
-  // #region Public Methods
-
-  /** Sets focus on the component's first focusable element. */
-  @method()
-  async setFocus(): Promise<void> {
-    await componentFocusable(this);
-
-    focusFirstTabbable(this.el);
-  }
-
-  // #endregion
-
-  // #region Events
-
-  /** Fires when the color value has changed. */
-  calciteColorPickerChange = createEvent({ cancelable: false });
-
-  /**
-   * Fires as the color value changes.
-   *
-   * Similar to the `calciteColorPickerChange` event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
-   */
-  calciteColorPickerInput = createEvent({ cancelable: false });
-
-  // #endregion
-
-  // #region Lifecycle
-
-  constructor() {
-    super();
-    this.listen("keydown", this.handleChannelKeyUpOrDown, { capture: true });
-    this.listen("keyup", this.handleChannelKeyUpOrDown, { capture: true });
-  }
-
-  connectedCallback(): void {
-    this.observeResize();
-  }
-
-  async load(): Promise<void> {
-    if (!this._valueWasSet) {
-      this._value ??= normalizeHex(hexify(DEFAULT_COLOR, this.alphaChannel));
-    }
-
-    this.handleAllowEmptyOrClearableChange();
-
-    const { isClearable, color, format, value } = this;
-    const willSetNoColor = isClearable && !value;
-    const parsedMode = parseMode(value);
-    const valueIsCompatible =
-      willSetNoColor || (format === "auto" && parsedMode) || format === parsedMode;
-    const initialColor = willSetNoColor ? null : valueIsCompatible ? Color(value) : color;
-
-    if (!valueIsCompatible) {
-      this.showIncompatibleColorWarning(value, format);
-    }
-    this.setMode(format, false);
-    this.internalColorSet(initialColor, false, "initial");
-
-    this.updateStaticDimensions(this.scale);
-    this.updateDynamicDimensions(STATIC_DIMENSIONS[this.scale].minWidth);
-
-    const storageKey = `${DEFAULT_STORAGE_KEY_PREFIX}${this.storageId}`;
-
-    if (this.storageId && localStorage.getItem(storageKey)) {
-      this.savedColors = JSON.parse(localStorage.getItem(storageKey));
-    }
-  }
-
-  override willUpdate(changes: PropertyValues<this>): void {
-    /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
-    To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
-    Please refactor your code to reduce the need for this check.
-    Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
-    if (
-      (changes.has("allowEmpty") && (this.hasUpdated || this.allowEmpty !== false)) ||
-      (changes.has("clearable") && (this.hasUpdated || this.clearable !== false))
-    ) {
-      this.handleAllowEmptyOrClearableChange();
-    }
-
-    if (changes.has("alphaChannel") && (this.hasUpdated || this.alphaChannel !== false)) {
-      this.handleAlphaChannelChange(this.alphaChannel);
-    }
-
-    if (
-      this.hasUpdated &&
-      ((changes.has("alphaChannel") && this.alphaChannel !== false) ||
-        (changes.has("staticDimensions") && this.staticDimensions !== STATIC_DIMENSIONS.m))
-    ) {
-      this.handleAlphaChannelDimensionsChange();
-    }
-
-    if (
-      (changes.has("alphaChannel") && (this.hasUpdated || this.alphaChannel !== false)) ||
-      (changes.has("format") && (this.hasUpdated || this.format !== "auto"))
-    ) {
-      this.handleFormatOrAlphaChannelChange();
-    }
-
-    if (changes.has("scale") && (this.hasUpdated || this.scale !== "m")) {
-      this.handleScaleChange(this.scale);
-    }
-  }
-
-  override updated(): void {
-    updateHostInteraction(this);
-  }
-
-  loaded(): void {
-    this.handleAlphaChannelDimensionsChange();
-  }
-
-  override disconnectedCallback(): void {
-    window.removeEventListener(
-      "pointermove",
-      this.globalPointerMoveHandler,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-    window.removeEventListener(
-      "pointerup",
-      this.globalPointerUpHandler,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-    this.resizeObserver?.disconnect();
-  }
-
-  // #endregion
-
-  // #region Private Methods
-
-  private observeResize(): void {
-    this.resizeObserver?.observe(this.el);
-  }
 
   private captureColorFieldColor = (x: number, y: number, skipEqual = true): void => {
     const { width, height } = this.dynamicDimensions.colorField;
@@ -495,6 +237,274 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     this.updateCanvasSize();
     this.drawColorControls();
   }, throttleFor60FpsInMs);
+
+  private updateDynamicDimensions = (width: number): void => {
+    const sliderDims = {
+      width: getSliderWidth(width, this.staticDimensions, this.alphaChannel),
+      height: this.staticDimensions.slider.height,
+    };
+
+    this.dynamicDimensions = {
+      colorField: getColorFieldDimensions(width),
+      slider: sliderDims,
+    };
+  };
+
+  //#endregion
+
+  //#region State Properties
+
+  @state() channelMode: ColorMode = "rgb";
+
+  @state() channels: Channels = this.toChannels(DEFAULT_COLOR);
+
+  @state() colorFieldScopeLeft: number;
+
+  @state() colorFieldScopeTop: number;
+
+  @state() staticDimensions = STATIC_DIMENSIONS.m;
+
+  @state() hueScopeLeft: number;
+
+  @state() opacityScopeLeft: number;
+
+  @state() savedColors: string[] = [];
+
+  @state() scopeOrientation: "vertical" | "horizontal";
+
+  //#endregion
+
+  //#region Public Properties
+
+  /**
+   * When `true`, an empty color (`null`) will be allowed as a `value`.
+   *
+   * When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+   *
+   * @deprecated Use `clearable` instead
+   */
+  @property({ reflect: true }) allowEmpty = false;
+
+  /** When `true`, the component will allow updates to the color's alpha value. */
+  @property() alphaChannel = false;
+
+  /** When `true`, hides the RGB/HSV channel inputs. */
+  @property() channelsDisabled = false;
+
+  /**
+   * When `true`, an empty color (`null`) will be allowed as a `value`.
+   *
+   * When `false`, a color value is enforced, and clearing the input or blurring will restore the last valid `value`.
+   */
+  @property({ reflect: true }) clearable = false;
+
+  /**
+   * Internal prop for advanced use-cases.
+   *
+   * @private
+   */
+  @property()
+  get color(): InternalColor | null {
+    return this._color;
+  }
+  set color(color: InternalColor | null) {
+    const oldColor = this._color;
+    this._color = color;
+    this.handleColorChange(color, oldColor);
+  }
+
+  /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
+  @property({ reflect: true }) disabled = false;
+
+  /**
+   * The format of `value`.
+   *
+   * When `"auto"`, the format will be inferred from `value` when set.
+   *
+   * @default "auto"
+   */
+  @property({ reflect: true }) format: Format = "auto";
+
+  /** When `true`, hides the hex input. */
+  @property() hexDisabled = false;
+
+  /** Use this property to override individual strings used by the component. */
+  @property() messageOverrides?: typeof this.messages._overrides;
+
+  /** Specifies the Unicode numeral system used by the component for localization. */
+  @property({ reflect: true }) numberingSystem: NumberingSystem;
+
+  /** When `true`, hides the saved colors section. */
+  @property({ reflect: true }) savedDisabled = false;
+
+  /** Specifies the size of the component. */
+  @property({ reflect: true }) scale: Scale = "m";
+
+  /** Specifies the storage ID for colors. */
+  @property({ reflect: true }) storageId: string;
+
+  /**
+   * The component's value, where the value can be a CSS color string, or a RGB, HSL or HSV object.
+   *
+   * The type will be preserved as the color is updated.
+   *
+   * @default
+   *
+   * @see [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color),
+   * @see [ColorValue](https://github.com/Esri/calcite-design-system/blob/dev/packages/calcite-components/src/components/color-picker/interfaces.ts#L10).
+   */
+  @property()
+  get value(): ColorValue | null {
+    return this._value;
+  }
+  set value(value: ColorValue | null) {
+    const oldValue = this._value;
+    this._value = value;
+    this.handleValueChange(value, oldValue);
+    this._valueWasSet = true;
+  }
+
+  //#endregion
+
+  //#region Public Methods
+
+  /** Sets focus on the component's first focusable element. */
+  @method()
+  async setFocus(): Promise<void> {
+    await componentFocusable(this);
+
+    focusFirstTabbable(this.el);
+  }
+
+  //#endregion
+
+  //#region Events
+
+  /** Fires when the color value has changed. */
+  calciteColorPickerChange = createEvent({ cancelable: false });
+
+  /**
+   * Fires as the color value changes.
+   *
+   * Similar to the `calciteColorPickerChange` event with the exception of dragging. When dragging the color field or hue slider thumb, this event fires as the thumb is moved.
+   */
+  calciteColorPickerInput = createEvent({ cancelable: false });
+
+  //#endregion
+
+  //#region Lifecycle
+
+  constructor() {
+    super();
+    this.listen("keydown", this.handleChannelKeyUpOrDown, { capture: true });
+    this.listen("keyup", this.handleChannelKeyUpOrDown, { capture: true });
+  }
+
+  connectedCallback(): void {
+    this.observeResize();
+  }
+
+  async load(): Promise<void> {
+    if (!this._valueWasSet) {
+      this._value ??= normalizeHex(hexify(DEFAULT_COLOR, this.alphaChannel));
+    }
+
+    this.handleAllowEmptyOrClearableChange();
+
+    const { isClearable, color, format, value } = this;
+    const willSetNoColor = isClearable && !value;
+    const parsedMode = parseMode(value);
+    const valueIsCompatible =
+      willSetNoColor || (format === "auto" && parsedMode) || format === parsedMode;
+    const initialColor = willSetNoColor ? null : valueIsCompatible ? Color(value) : color;
+
+    if (!valueIsCompatible) {
+      this.showIncompatibleColorWarning(value, format);
+    }
+    this.setMode(format, false);
+    this.internalColorSet(initialColor, false, "initial");
+
+    this.updateStaticDimensions(this.scale);
+    this.updateDynamicDimensions(STATIC_DIMENSIONS[this.scale].minWidth);
+
+    const storageKey = `${DEFAULT_STORAGE_KEY_PREFIX}${this.storageId}`;
+
+    if (this.storageId && localStorage.getItem(storageKey)) {
+      this.savedColors = JSON.parse(localStorage.getItem(storageKey));
+    }
+  }
+
+  override willUpdate(changes: PropertyValues<this>): void {
+    /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
+    To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
+    Please refactor your code to reduce the need for this check.
+    Docs: https://qawebgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
+    if (
+      (changes.has("allowEmpty") && (this.hasUpdated || this.allowEmpty !== false)) ||
+      (changes.has("clearable") && (this.hasUpdated || this.clearable !== false))
+    ) {
+      this.handleAllowEmptyOrClearableChange();
+    }
+
+    if (changes.has("alphaChannel") && (this.hasUpdated || this.alphaChannel !== false)) {
+      this.handleAlphaChannelChange(this.alphaChannel);
+    }
+
+    if (
+      this.hasUpdated &&
+      ((changes.has("alphaChannel") && this.alphaChannel !== false) ||
+        (changes.has("staticDimensions") && this.staticDimensions !== STATIC_DIMENSIONS.m))
+    ) {
+      this.handleAlphaChannelDimensionsChange();
+    }
+
+    if (
+      (changes.has("alphaChannel") && (this.hasUpdated || this.alphaChannel !== false)) ||
+      (changes.has("format") && (this.hasUpdated || this.format !== "auto"))
+    ) {
+      this.handleFormatOrAlphaChannelChange();
+    }
+
+    if (changes.has("scale") && (this.hasUpdated || this.scale !== "m")) {
+      this.handleScaleChange(this.scale);
+    }
+  }
+
+  override updated(): void {
+    updateHostInteraction(this);
+  }
+
+  loaded(): void {
+    this.handleAlphaChannelDimensionsChange();
+  }
+
+  override disconnectedCallback(): void {
+    window.removeEventListener(
+      "pointermove",
+      this.globalPointerMoveHandler,
+    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
+    window.removeEventListener(
+      "pointerup",
+      this.globalPointerUpHandler,
+    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
+    this.resizeObserver?.disconnect();
+  }
+
+  //#endregion
+
+  //#region Private Methods
+
+  private get baseColorFieldColor(): ColorInstance {
+    return this.color || this.previousColor || DEFAULT_COLOR;
+  }
+
+  private get effectiveSliderWidth(): number {
+    return this.dynamicDimensions.slider.width;
+  }
+
+  private observeResize(): void {
+    this.resizeObserver?.observe(this.el);
+  }
 
   private handleAllowEmptyOrClearableChange(): void {
     this.isClearable = this.clearable || this.allowEmpty;
@@ -1102,18 +1112,6 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     this.drawOpacitySlider();
   }
 
-  private updateDynamicDimensions = (width: number): void => {
-    const sliderDims = {
-      width: getSliderWidth(width, this.staticDimensions, this.alphaChannel),
-      height: this.staticDimensions.slider.height,
-    };
-
-    this.dynamicDimensions = {
-      colorField: getColorFieldDimensions(width),
-      slider: sliderDims,
-    };
-  };
-
   private updateCanvasSize(
     context: "all" | "color-field" | "hue-slider" | "opacity-slider" = "all",
   ): void {
@@ -1459,9 +1457,9 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     return [left - SCOPE_SIZE / 2, top - SCOPE_SIZE / 2];
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const {
@@ -1768,5 +1766,5 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.tsx
@@ -29,25 +29,25 @@ declare global {
  * @slot content-start - A slot for adding non-actionable elements before the component's content.
  */
 export class ComboboxItem extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region State Properties
-
-  @state() hasContent = false;
-
-  // #endregion
-
-  // #region Private Properties
+  //#region Private Properties
 
   private _selected = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region State Properties
+
+  @state() hasContent = false;
+
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, the component is active. */
   @property({ reflect: true }) active = false;
@@ -158,9 +158,9 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
    *  */
   @property({ reflect: true }) itemHidden = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires whenever the component is selected or unselected. */
   calciteComboboxItemChange = createEvent({ cancelable: false });
@@ -172,9 +172,9 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
    */
   calciteInternalComboboxItemChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.ancestors = getAncestors(this.el);
@@ -200,9 +200,9 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private emitItemChange(): void {
     this.calciteInternalComboboxItemChange.emit();
@@ -227,9 +227,9 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
     this.toggleSelected();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderIcon(iconPath: IconNameOrString): JsxNode {
     return this.icon ? (
@@ -347,5 +347,5 @@ export class ComboboxItem extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -92,13 +92,13 @@ export class Combobox
     OpenCloseComponent,
     FloatingUIComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private closeButtonEl = createRef<HTMLButtonElement>();
 
@@ -109,18 +109,6 @@ export class Combobox
   private data: ItemData[];
 
   defaultValue: Combobox["value"];
-
-  private emitComboboxChange(): void {
-    this.calciteComboboxChange.emit();
-  }
-
-  private get effectiveFilterProps(): string[] {
-    if (!this.filterProps) {
-      return ["description", "label", "metadata", "shortHeading", "textLabel"];
-    }
-
-    return this.filterProps.filter((prop) => prop !== "el");
-  }
 
   private filterItems = (() => {
     const find = (item: ComboboxChildElement, filteredData: ItemData[]) =>
@@ -248,26 +236,22 @@ export class Combobox
 
   private _selectedItems: HTMLCalciteComboboxItemElement["el"][] = [];
 
-  private get showingInlineIcon(): boolean {
-    const { placeholderIcon, selectionMode, selectedItems, open } = this;
-    const selectedItem = selectedItems[0];
-    const selectedIcon = selectedItem?.icon;
-    const singleSelectionMode = isSingleLike(selectionMode);
-
-    return !open && selectedItem
-      ? !!selectedIcon && singleSelectionMode
-      : !!placeholderIcon && (!selectedItem || singleSelectionMode);
-  }
-
   private textInput = createRef<HTMLInputElement>();
 
   transitionEl: HTMLDivElement;
 
   private _value: string | string[] = null;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() activeChipIndex = -1;
 
@@ -281,9 +265,9 @@ export class Combobox
 
   @state() selectedVisibleChipsCount = 0;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, allows entry of custom values, which are not in the original set of items. */
   @property({ reflect: true }) allowCustomValues: boolean;
@@ -299,7 +283,6 @@ export class Combobox
   get filterText(): string {
     return this._filterText;
   }
-
   set filterText(filterText: string) {
     const oldFilterText = this._filterText;
     if (filterText !== oldFilterText) {
@@ -340,13 +323,6 @@ export class Combobox
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * Specifies the name of the component.
@@ -396,7 +372,6 @@ export class Combobox
   @property() get selectedItems(): HTMLCalciteComboboxItemElement["el"][] {
     return this._selectedItems;
   }
-
   set selectedItems(selectedItems: HTMLCalciteComboboxItemElement["el"][]) {
     const oldSelectedItems = this._selectedItems;
     if (selectedItems !== oldSelectedItems) {
@@ -468,7 +443,6 @@ export class Combobox
   get value(): string | string[] {
     return this._value;
   }
-
   set value(value: string | string[]) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -477,9 +451,9 @@ export class Combobox
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Updates the position of the component.
@@ -515,9 +489,9 @@ export class Combobox
     this.activeItemIndex = -1;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed, and before the closing transition begins. */
   calciteComboboxBeforeClose = createEvent({ cancelable: false });
@@ -540,9 +514,9 @@ export class Combobox
   /** Fires when the component is open and animation is complete. */
   calciteComboboxOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -623,9 +597,32 @@ export class Combobox
     disconnectFloatingUI(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  private emitComboboxChange(): void {
+    this.calciteComboboxChange.emit();
+  }
+
+  private get effectiveFilterProps(): string[] {
+    if (!this.filterProps) {
+      return ["description", "label", "metadata", "shortHeading", "textLabel"];
+    }
+
+    return this.filterProps.filter((prop) => prop !== "el");
+  }
+
+  private get showingInlineIcon(): boolean {
+    const { placeholderIcon, selectionMode, selectedItems, open } = this;
+    const selectedItem = selectedItems[0];
+    const selectedIcon = selectedItem?.icon;
+    const singleSelectionMode = isSingleLike(selectionMode);
+
+    return !open && selectedItem
+      ? !!selectedIcon && singleSelectionMode
+      : !!placeholderIcon && (!selectedItem || singleSelectionMode);
+  }
 
   private filterTextChange(value: string): void {
     this.updateActiveItemIndex(-1);
@@ -1412,9 +1409,9 @@ export class Combobox
     this.textInput.value?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderChips(): JsxNode {
     const { activeChipIndex, readOnly, scale, selectionMode, messages } = this;
@@ -1811,5 +1808,5 @@ export class Combobox
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -39,21 +39,28 @@ declare global {
 }
 
 export class DatePicker extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private rangeValueChangedByUser = false;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   /** Active end date. */
   @state() activeEndDate: Date;
@@ -76,9 +83,9 @@ export class DatePicker extends LitElement {
 
   @state() startAsDate: Date;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the component's active date. */
   @property() activeDate: Date;
@@ -103,13 +110,6 @@ export class DatePicker extends LitElement {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
    * When the component resides in a form,
@@ -141,9 +141,9 @@ export class DatePicker extends LitElement {
   /** Specifies the selected date as a full date object (`new Date("yyyy-mm-dd")`), or an array containing full date objects (`[new Date("yyyy-mm-dd"), new Date("yyyy-mm-dd")]`). */
   @property() valueAsDate: Date | Date[];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Resets active date state.
@@ -163,9 +163,9 @@ export class DatePicker extends LitElement {
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when a user changes the component's date. For `range` events, use `calciteDatePickerRangeChange`. */
   calciteDatePickerChange = createEvent({ cancelable: false });
@@ -173,9 +173,9 @@ export class DatePicker extends LitElement {
   /** Fires when a user changes the component's date `range`. For components without `range` use `calciteDatePickerChange`. */
   calciteDatePickerRangeChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -231,9 +231,9 @@ export class DatePicker extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private activeDateWatcher(newValue: Date): void {
     if (!this.range) {
@@ -600,9 +600,9 @@ export class DatePicker extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const date = dateFromRange(
@@ -672,5 +672,5 @@ export class DatePicker extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -47,13 +47,13 @@ declare global {
  * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
  */
 export class Dialog extends LitElement implements OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private dragPosition: DialogDragPosition = { ...initialDragPosition };
 
@@ -103,9 +103,16 @@ export class Dialog extends LitElement implements OpenCloseComponent {
 
   transitionEl: HTMLDivElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() assistiveText: string | null = null;
 
@@ -121,9 +128,9 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     return !this.embedded && this.modal;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Passes a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;
@@ -185,13 +192,6 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** When `true`, displays a scrim blocking interaction underneath the component. */
   @property({ reflect: true }) modal = false;
 
@@ -203,7 +203,6 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   get open(): boolean {
     return this._open;
   }
-
   set open(open: boolean) {
     const oldOpen = this._open;
     if (open !== oldOpen) {
@@ -243,9 +242,9 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   /** Specifies the width of the component. */
   @property({ reflect: true }) width: Extract<Width, Scale>;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Scrolls the component's content to a specified set of coordinates.
@@ -288,14 +287,9 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     this.focusTrap.updateContainerElements();
   }
 
-  /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */
-  focusTrapDisabledOverride(): boolean {
-    return !this.modal && this.focusTrapDisabled;
-  }
+  //#endregion
 
-  // #endregion
-
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteDialogBeforeClose = createEvent({ cancelable: false });
@@ -312,9 +306,9 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   /** Fires when the content is scrolled. */
   calciteDialogScroll = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
@@ -355,9 +349,14 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     this.cleanupInteractions();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */
+  focusTrapDisabledOverride(): boolean {
+    return !this.modal && this.focusTrapDisabled;
+  }
 
   private updateAssistiveText(): void {
     const { messages } = this;
@@ -745,9 +744,9 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     this.focusTrap.updateContainerElements();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { assistiveText, description, heading, opened } = this;
@@ -820,5 +819,5 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/filter/filter.tsx
+++ b/packages/calcite-components/src/components/filter/filter.tsx
@@ -25,15 +25,15 @@ declare global {
 }
 
 export class Filter extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private filterDebounced = debounce(
     (value: string, emit = false, onFilter?: () => void): void =>
@@ -45,9 +45,16 @@ export class Filter extends LitElement implements InteractiveComponent {
 
   private _value = "";
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
@@ -79,13 +86,6 @@ export class Filter extends LitElement implements InteractiveComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies placeholder text for the input element. */
   @property() placeholder: string;
 
@@ -97,7 +97,6 @@ export class Filter extends LitElement implements InteractiveComponent {
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -106,9 +105,9 @@ export class Filter extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Performs a filter on the component.
@@ -135,16 +134,16 @@ export class Filter extends LitElement implements InteractiveComponent {
     return this.textInput.value?.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the filter text changes. */
   calciteFilterChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   async load(): Promise<void> {
     this.updateFiltered(filter(this.items ?? [], this.value, this.filterProps));
@@ -171,9 +170,10 @@ export class Filter extends LitElement implements InteractiveComponent {
     this.filterDebounced.cancel();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private valueHandler(value: string): void {
     this.filterDebounced(value);
   }
@@ -213,9 +213,9 @@ export class Filter extends LitElement implements InteractiveComponent {
     callback?.();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { disabled, scale } = this;
@@ -244,5 +244,5 @@ export class Filter extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -42,21 +42,28 @@ declare global {
  * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
  */
 export class FlowItem extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private backButtonEl: Action["el"];
 
   private containerEl: Panel["el"];
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** When provided, the method will be called before it is removed from its parent `calcite-flow`. */
   @property() beforeBack: () => Promise<void>;
@@ -105,13 +112,6 @@ export class FlowItem extends LitElement implements InteractiveComponent {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Determines the type of positioning to use for the overlaid content.
    *
    * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
@@ -133,9 +133,9 @@ export class FlowItem extends LitElement implements InteractiveComponent {
    */
   @property() showBackButton = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Scrolls the component's content to a specified set of coordinates.
@@ -172,9 +172,9 @@ export class FlowItem extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the back button is clicked. */
   calciteFlowItemBack = createEvent();
@@ -191,9 +191,9 @@ export class FlowItem extends LitElement implements InteractiveComponent {
   /** @private */
   calciteInternalFlowItemChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
@@ -209,9 +209,10 @@ export class FlowItem extends LitElement implements InteractiveComponent {
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private handleInternalPanelScroll(event: CustomEvent<void>): void {
     if (event.target !== this.containerEl) {
       return;
@@ -253,9 +254,9 @@ export class FlowItem extends LitElement implements InteractiveComponent {
     this.containerEl = node;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderBackButton(): JsxNode {
     const { el } = this;
@@ -341,5 +342,5 @@ export class FlowItem extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/handle/handle.tsx
+++ b/packages/calcite-components/src/components/handle/handle.tsx
@@ -25,19 +25,26 @@ declare global {
  * @deprecated Use the `calcite-sort-handle` component instead.
  */
 export class Handle extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private handleButton = createRef<HTMLSpanElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only.
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /**
    * When `true`, disables unselecting the component when blurred.
@@ -61,13 +68,6 @@ export class Handle extends LitElement implements InteractiveComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only.
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
-
   /** When `true`, the component is selected. */
   @property({ reflect: true }) selected = false;
 
@@ -83,9 +83,9 @@ export class Handle extends LitElement implements InteractiveComponent {
    */
   @property() setSize: number;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -95,9 +95,9 @@ export class Handle extends LitElement implements InteractiveComponent {
     this.handleButton.value?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires whenever the component is selected or unselected. */
   calciteHandleChange = createEvent({ cancelable: false });
@@ -112,9 +112,9 @@ export class Handle extends LitElement implements InteractiveComponent {
    */
   calciteInternalAssistiveTextChange = createEvent<HandleChange>({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
@@ -144,9 +144,9 @@ export class Handle extends LitElement implements InteractiveComponent {
     });
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleAriaTextChange(): void {
     const message = this.getAriaText("live");
@@ -232,9 +232,9 @@ export class Handle extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     return (
@@ -259,5 +259,5 @@ export class Handle extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -27,15 +27,15 @@ declare global {
 
 /** @slot - A slot for adding a `calcite-input`. */
 export class InlineEditable extends LitElement implements InteractiveComponent, LabelableComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private cancelEditingButton = createRef<Button["el"]>();
 
@@ -51,15 +51,18 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
 
   private shouldEmitCancel: boolean;
 
-  private get shouldShowControls(): boolean {
-    return this.editingEnabled && this.controls;
-  }
-
   private valuePriorToEditing: string;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** Specifies a callback to be executed prior to disabling editing via the controls. When provided, the component's loading state will be handled automatically. */
   @property() afterConfirm: () => Promise<void>;
@@ -75,7 +78,6 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
   get editingEnabled(): boolean {
     return this._editingEnabled;
   }
-
   set editingEnabled(editingEnabled: boolean) {
     const oldEditingEnabled = this._editingEnabled;
     if (editingEnabled !== oldEditingEnabled) {
@@ -90,19 +92,12 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies the size of the component. Defaults to the scale of the wrapped `calcite-input` or the scale of the closest wrapping component with a set scale. */
   @property({ reflect: true }) scale: Scale;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -112,9 +107,9 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
     this.inputElement?.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Emits when the component's "cancel editing" button is pressed. */
   calciteInlineEditableEditCancel = createEvent({ cancelable: false });
@@ -125,9 +120,9 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
   /** @private */
   calciteInternalInlineEditableEnableEditingChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -156,9 +151,13 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
     disconnectLabel(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  private get shouldShowControls(): boolean {
+    return this.editingEnabled && this.controls;
+  }
 
   private disabledWatcher(disabled: boolean): void {
     if (this.inputElement) {
@@ -283,9 +282,9 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     return (
@@ -353,5 +352,5 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -90,15 +90,15 @@ export class InputDatePicker
     LabelableComponent,
     OpenCloseComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private commonDateSeparators = [".", "-", "/"];
 
@@ -166,9 +166,16 @@ export class InputDatePicker
 
   private valueAsDateChangedExternally = false;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() datePickerActiveDate: Date;
 
@@ -176,9 +183,9 @@ export class InputDatePicker
 
   @state() private localeData: DateLocaleData;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
@@ -216,13 +223,6 @@ export class InputDatePicker
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides & DatePicker["messageOverrides"];
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
    * When the component resides in a form,
@@ -326,7 +326,6 @@ export class InputDatePicker
   get value(): string | string[] {
     return this._value;
   }
-
   set value(value: string | string[]) {
     const valueChanged = value !== this._value;
     const invalidValueCleared =
@@ -341,9 +340,9 @@ export class InputDatePicker
   /** The component's value as a full date object. */
   @property() valueAsDate: Date | Date[];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Updates the position of the component.
@@ -376,9 +375,9 @@ export class InputDatePicker
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteInputDatePickerBeforeClose = createEvent({ cancelable: false });
@@ -395,9 +394,9 @@ export class InputDatePicker
   /** Fires when the component is open and animation is complete. */
   calciteInputDatePickerOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -528,9 +527,9 @@ export class InputDatePicker
     disconnectFloatingUI(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleDisabledAndReadOnlyChange(value: boolean): void {
     if (!value) {
@@ -1059,9 +1058,9 @@ export class InputDatePicker
     focusedInput.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const {
@@ -1243,5 +1242,5 @@ export class InputDatePicker
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-message/input-message.tsx
+++ b/packages/calcite-components/src/components/input-message/input-message.tsx
@@ -23,20 +23,20 @@ declare global {
 
 /** @slot - A slot for adding text. */
 export class InputMessage extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   /** the computed icon to render */
   private requestedIcon?: IconNameOrString;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies an icon to display. */
   @property({ reflect: true, converter: stringOrBoolean }) icon: IconNameOrString | boolean;
@@ -50,9 +50,9 @@ export class InputMessage extends LitElement {
   /** Specifies the status of the input field, which determines message and icons. */
   @property({ reflect: true }) status: Status = "idle";
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.requestedIcon = setRequestedIcon(StatusIconDefaults, this.icon, this.status);
@@ -71,11 +71,9 @@ export class InputMessage extends LitElement {
     }
   }
 
-  // #endregion
-  // #region Private Methods
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const hidden = this.el.hidden;
@@ -102,5 +100,5 @@ export class InputMessage extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -73,13 +73,13 @@ export class InputNumber
     NumericInputComponent,
     TextualInputComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionWrapperEl = createRef<HTMLDivElement>();
 
@@ -98,10 +98,6 @@ export class InputNumber
   private inlineEditableEl: InlineEditable["el"];
 
   private inputWrapperEl = createRef<HTMLDivElement>();
-
-  get isClearable(): boolean {
-    return this.clearable && this.value.length > 0;
-  }
 
   labelEl: Label["el"];
 
@@ -135,17 +131,24 @@ export class InputNumber
 
   private _value = "";
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() displayedValue: string;
 
   @state() slottedActionElDisabledInternally = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the text alignment of the component's value. */
   @property({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
@@ -226,13 +229,6 @@ export class InputNumber
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * When the component resides in a form,
@@ -338,7 +334,6 @@ export class InputNumber
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -353,9 +348,9 @@ export class InputNumber
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Selects the text of the component's `value`. */
   @method()
@@ -371,9 +366,9 @@ export class InputNumber
     this.childNumberEl?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires each time a new value is typed and committed. */
   calciteInputNumberChange = createEvent({ cancelable: false });
@@ -387,9 +382,9 @@ export class InputNumber
   /** @private */
   calciteInternalInputNumberFocus = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -465,9 +460,13 @@ export class InputNumber
     ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  get isClearable(): boolean {
+    return this.clearable && this.value.length > 0;
+  }
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -898,9 +897,9 @@ export class InputNumber
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const dir = getElementDir(this.el);
@@ -1052,5 +1051,5 @@ export class InputNumber
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -55,13 +55,13 @@ export class InputText
   extends LitElement
   implements LabelableComponent, FormComponent, InteractiveComponent, TextualInputComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionWrapperEl = createRef<HTMLDivElement>();
 
@@ -80,10 +80,6 @@ export class InputText
   private inlineEditableEl: InlineEditable["el"];
 
   private inputWrapperEl = createRef<HTMLDivElement>();
-
-  get isClearable(): boolean {
-    return this.clearable && this.value.length > 0;
-  }
 
   labelEl: Label["el"];
 
@@ -111,15 +107,22 @@ export class InputText
 
   private _value = "";
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() slottedActionElDisabledInternally = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the text alignment of the component's value. */
   @property({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
@@ -178,13 +181,6 @@ export class InputText
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * When the component resides in a form,
@@ -277,7 +273,6 @@ export class InputText
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -286,9 +281,9 @@ export class InputText
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Selects the text of the component's `value`. */
   @method()
@@ -304,9 +299,9 @@ export class InputText
     this.childEl?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires each time a new value is typed and committed. */
   calciteInputTextChange = createEvent();
@@ -323,9 +318,9 @@ export class InputText
     value: string;
   }>();
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -372,9 +367,13 @@ export class InputText
     ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  get isClearable(): boolean {
+    return this.clearable && this.value.length > 0;
+  }
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -537,9 +536,9 @@ export class InputText
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const dir = getElementDir(this.el);
@@ -638,5 +637,5 @@ export class InputText
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -155,15 +155,15 @@ export class InputTimePicker
   extends LitElement
   implements FormComponent, InteractiveComponent, LabelableComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private calciteTimePickerEl: TimePicker["el"];
 
@@ -186,17 +186,28 @@ export class InputTimePicker
 
   private _value = null;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  private setLocalizedInputValue = (params?: GetLocalizedTimeStringParameters): void => {
+    this.setInputValue(this.getLocalizedTimeString(params));
+  };
+
+  //#endregion
+
+  //#region State Properties
 
   @state() calciteInputEl: InputText["el"];
 
   @state() effectiveHourFormat: EffectiveHourFormat;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({ reflect: true }) disabled = false;
@@ -232,13 +243,6 @@ export class InputTimePicker
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides & TimePicker["messageOverrides"];
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * When the component resides in a form,
@@ -324,7 +328,6 @@ export class InputTimePicker
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -333,9 +336,9 @@ export class InputTimePicker
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Updates the position of the component.
@@ -354,9 +357,9 @@ export class InputTimePicker
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteInputTimePickerBeforeClose = createEvent({ cancelable: false });
@@ -373,9 +376,9 @@ export class InputTimePicker
   /** Fires when the component is open and animation is complete. */
   calciteInputTimePickerOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -452,9 +455,9 @@ export class InputTimePicker
     disconnectForm(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private async langWatcher(): Promise<void> {
     await this.loadLocaleData();
@@ -983,10 +986,6 @@ export class InputTimePicker
     );
   }
 
-  private setLocalizedInputValue = (params?: GetLocalizedTimeStringParameters): void => {
-    this.setInputValue(this.getLocalizedTimeString(params));
-  };
-
   private setInputValue(newInputValue: string): void {
     if (!this.calciteInputEl) {
       return;
@@ -1040,9 +1039,9 @@ export class InputTimePicker
     this.open = false;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { disabled, messages, readOnly } = this;
@@ -1123,5 +1122,5 @@ export class InputTimePicker
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -53,15 +53,15 @@ export class InputTimeZone
   extends LitElement
   implements FormComponent, InteractiveComponent, LabelableComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private comboboxEl: Combobox["el"];
 
@@ -79,9 +79,16 @@ export class InputTimeZone
 
   private _value: string;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /**
    * When `true`, an empty value (`null`) will be allowed as a `value`.
@@ -105,13 +112,6 @@ export class InputTimeZone
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
    * This specifies the type of `value` and the associated options presented to the user:
@@ -221,14 +221,13 @@ export class InputTimeZone
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     this._value = value;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -237,9 +236,9 @@ export class InputTimeZone
     await this.comboboxEl.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteInputTimeZoneBeforeClose = createEvent({ cancelable: false });
@@ -256,9 +255,9 @@ export class InputTimeZone
   /** Fires after the component is opened and animation is complete. */
   calciteInputTimeZoneOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     connectForm(this);
@@ -314,9 +313,9 @@ export class InputTimeZone
     disconnectLabel(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private async handleTimeZoneItemPropsChange(): Promise<void> {
     if (!this.timeZoneItems || !this.hasUpdated) {
@@ -487,9 +486,9 @@ export class InputTimeZone
     return value ? this.normalizer(value) : value;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     return (
@@ -578,5 +577,5 @@ export class InputTimeZone
     ));
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -75,13 +75,13 @@ export class Input
     NumericInputComponent,
     TextualInputComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionWrapperEl = createRef<HTMLDivElement>();
 
@@ -106,14 +106,6 @@ export class Input
   private inlineEditableEl: InlineEditable["el"];
 
   private inputWrapperEl = createRef<HTMLDivElement>();
-
-  get isClearable(): boolean {
-    return !this.isTextarea && (this.clearable || this.type === "search") && this.value?.length > 0;
-  }
-
-  get isTextarea(): boolean {
-    return this.childElType === "textarea";
-  }
 
   labelEl: Label["el"];
 
@@ -147,17 +139,24 @@ export class Input
 
   private _value = "";
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() displayedValue: string;
 
   @state() slottedActionElDisabledInternally = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * Specifies a comma separated list of unique file type specifiers for limiting accepted file types.
@@ -246,13 +245,6 @@ export class Input
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * When the component resides in a form,
@@ -400,7 +392,6 @@ export class Input
   get value(): string {
     return this._value;
   }
-
   set value(value: string) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -415,9 +406,9 @@ export class Input
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Selects the text of the component's `value`. */
   @method()
@@ -437,9 +428,9 @@ export class Input
     focusFirstTabbable(this.type === "number" ? this.childNumberEl : this.childEl);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires each time a new `value` is typed and committed. */
   calciteInputChange = createEvent({ cancelable: false });
@@ -453,9 +444,9 @@ export class Input
   /** @private */
   calciteInternalInputFocus = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -529,9 +520,17 @@ export class Input
     ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  get isClearable(): boolean {
+    return !this.isTextarea && (this.clearable || this.type === "search") && this.value?.length > 0;
+  }
+
+  get isTextarea(): boolean {
+    return this.childElType === "textarea";
+  }
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -969,9 +968,9 @@ export class Input
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const dir = getElementDir(this.el);
@@ -1182,5 +1181,5 @@ export class Input
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -42,13 +42,13 @@ const focusMap = new Map<List["el"], number>();
  * @slot content-bottom - A slot for adding content below the component's `label` and `description`.
  */
 export class ListItem extends LitElement implements InteractiveComponent, SortableComponentItem {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private actionsEndEl = createRef<HTMLDivElement>();
 
@@ -64,9 +64,16 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
 
   private sortHandleEl: SortHandle["el"];
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasActionsEnd = false;
 
@@ -86,9 +93,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
 
   @state() parentListEl: List["el"];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * Sets the item as focusable. Only one item should be focusable within a list.
@@ -149,13 +156,6 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Provides additional metadata to the component. Primary use is for a filter on the parent `calcite-list`. */
   @property() metadata: Record<string, unknown>;
 
@@ -182,7 +182,6 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   get open(): boolean {
     return this.expanded;
   }
-
   set open(value: boolean) {
     logger.deprecated("property", {
       name: "open",
@@ -251,9 +250,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   /** Displays the `iconStart` and/or `iconEnd` as flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) iconFlipRtl: FlipContext;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -278,9 +277,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
     containerEl?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /**
    *
@@ -341,9 +340,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   /** Fires when the open button is clicked. */
   calciteListItemToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -407,9 +406,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private activeHandler(active: boolean): void {
     if (!active) {
@@ -699,9 +698,9 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
     focusedEl?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderSelected(): JsxNode {
     const { selected, selectionMode, selectionAppearance } = this;
@@ -1048,5 +1047,5 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -58,13 +58,13 @@ const parentSelector = `${listItemGroupSelector}, ${listItemSelector}`;
  * @slot filter-no-results - When `filterEnabled` is `true`, a slot for adding content to display when no results are found.
  */
 export class List extends LitElement implements InteractiveComponent, SortableComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   dragSelector = listItemSelector;
 
@@ -152,9 +152,16 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   /** TODO: [MIGRATION] this flag was used to work around an issue with debounce using the last args passed when invoking the debounced fn, causing events to not emit */
   private willPerformFilter: boolean = false;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() assistiveText: string;
 
@@ -186,9 +193,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     );
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When provided, the method will be called to determine whether the element can move from the list. */
   @property() canPull: (detail: ListDragDetail) => boolean;
@@ -276,13 +283,6 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
-
-  /**
    * Specifies the nesting behavior of `calcite-list-item`s, where
    *
    * `"flat"` displays `calcite-list-item`s in a uniform list, and
@@ -326,9 +326,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     SelectionMode
   > = "none";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Emits a `calciteListMoveHalt` event.
@@ -357,9 +357,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     return this.focusableItems.find((listItem) => listItem.active)?.setFocus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /**
    * Fires when the default slot has changes in order to notify parent lists.
@@ -380,15 +380,15 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   /** Fires when the component's filter has changed. */
   calciteListFilter = createEvent({ cancelable: false });
 
-  /** Fires when the component's item order changes. */
-  calciteListOrderChange = createEvent<ListDragDetail>({ cancelable: false });
-
   /** Fires when a user attempts to move an element using the sort menu and 'canPut' or 'canPull' returns falsy. */
   calciteListMoveHalt = createEvent<ListDragDetail>({ cancelable: false });
 
-  // #endregion
+  /** Fires when the component's item order changes. */
+  calciteListOrderChange = createEvent<ListDragDetail>({ cancelable: false });
 
-  // #region Lifecycle
+  //#endregion
+
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -465,9 +465,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     disconnectSortableComponent(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleListItemChange(): void {
     this.willPerformFilter = true;
@@ -1057,9 +1057,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     });
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const {
@@ -1179,5 +1179,5 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     ) : null;
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/menu-item/menu-item.tsx
+++ b/packages/calcite-components/src/components/menu-item/menu-item.tsx
@@ -30,13 +30,13 @@ declare global {
 
 /** @slot submenu-item - A slot for adding `calcite-menu-item`s in a submenu. */
 export class MenuItem extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private anchorEl = createRef<HTMLAnchorElement>();
 
@@ -44,17 +44,24 @@ export class MenuItem extends LitElement {
 
   private isFocused: boolean;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only.
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasSubmenu = false;
 
   @state() submenuItems: MenuItem["el"][];
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, the component is highlighted. */
   @property({ reflect: true }) active: boolean;
@@ -90,13 +97,6 @@ export class MenuItem extends LitElement {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only.
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** When `true`, the component will display any slotted `calcite-menu-item` in an open overflow menu. */
   @property({ reflect: true }) open = false;
 
@@ -120,9 +120,9 @@ export class MenuItem extends LitElement {
   /** @private */
   @property() topLevelMenuLayout: Layout;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -131,9 +131,9 @@ export class MenuItem extends LitElement {
     this.anchorEl.value.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalMenuItemKeyEvent = createEvent<MenuItemCustomEvent>();
@@ -141,9 +141,9 @@ export class MenuItem extends LitElement {
   /** Emits when the component is selected. */
   calciteMenuItemSelect = createEvent();
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -153,9 +153,9 @@ export class MenuItem extends LitElement {
     this.listen("focus", this.focusHandler);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleClickOut(event: Event): void {
     if (
@@ -273,9 +273,9 @@ export class MenuItem extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderIconStart(): JsxNode {
     return (
@@ -432,5 +432,5 @@ export class MenuItem extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -23,23 +23,30 @@ declare global {
 type Layout = "horizontal" | "vertical";
 
 export class Menu extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   attributeWatch = useWatchAttributes(["role"], this.handleGlobalAttributesChanged);
 
   private menuItems: MenuItem["el"][] = [];
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only.
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /**
    * Accessible name for the component.
@@ -54,16 +61,9 @@ export class Menu extends LitElement {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only.
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
+  //#endregion
 
-  // #endregion
-
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first focusable element. */
   @method()
@@ -72,9 +72,9 @@ export class Menu extends LitElement {
     focusFirstTabbable(this.menuItems[0]);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -91,9 +91,9 @@ export class Menu extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -171,9 +171,9 @@ export class Menu extends LitElement {
     return (this.el.role || "menubar") as LuminaJsx.AriaAttributes["role"];
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     return (
@@ -183,5 +183,5 @@ export class Menu extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -47,13 +47,13 @@ declare global {
  * @slot back - A slot for adding a back button.
  */
 export class Modal extends LitElement implements OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private closeButtonEl = createRef<HTMLButtonElement>();
 
@@ -107,9 +107,31 @@ export class Modal extends LitElement implements OpenCloseComponent {
 
   transitionEl: HTMLDivElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  private keyDownHandler = (event: KeyboardEvent): void => {
+    const { defaultPrevented, key } = event;
+
+    if (
+      !defaultPrevented &&
+      this.focusTrapDisabled &&
+      this.open &&
+      !this.escapeDisabled &&
+      key === "Escape"
+    ) {
+      event.preventDefault();
+      this.open = false;
+    }
+  };
+
+  //#endregion
+
+  //#region State Properties
 
   @state() contentEl: HTMLElement;
 
@@ -135,9 +157,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
     return !this.embedded;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Passes a function to run before the component closes. */
   @property() beforeClose: (el: Modal["el"]) => Promise<void>;
@@ -184,19 +206,11 @@ export class Modal extends LitElement implements OpenCloseComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** When `true`, displays and positions the component. */
   @property({ reflect: true })
   get open(): boolean {
     return this._open;
   }
-
   set open(open: boolean) {
     const oldOpen = this._open;
     if (open !== oldOpen) {
@@ -221,9 +235,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
   /** Specifies the width of the component. */
   @property({ reflect: true }) widthScale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Sets the scroll top of the component's content.
@@ -263,9 +277,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
     this.focusTrap.updateContainerElements();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteModalBeforeClose = createEvent({ cancelable: false });
@@ -279,9 +293,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
   /** Fires when the component is open and animation is complete. */
   calciteModalOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -330,24 +344,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
     this.embedded = false;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
-
-  private keyDownHandler = (event: KeyboardEvent): void => {
-    const { defaultPrevented, key } = event;
-
-    if (
-      !defaultPrevented &&
-      this.focusTrapDisabled &&
-      this.open &&
-      !this.escapeDisabled &&
-      key === "Escape"
-    ) {
-      event.preventDefault();
-      this.open = false;
-    }
-  };
+  //#region Private Methods
 
   private handleHeaderSlotChange(event: Event): void {
     this.titleEl = slotChangeGetAssignedElements<HTMLElement>(event)[0];
@@ -478,9 +477,9 @@ export class Modal extends LitElement implements OpenCloseComponent {
     this.hasContentBottom = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, add a check for this.el.hasAttribute() before calling setAttribute() here */
@@ -614,5 +613,5 @@ export class Modal extends LitElement implements OpenCloseComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/notice/notice.tsx
+++ b/packages/calcite-components/src/components/notice/notice.tsx
@@ -41,13 +41,13 @@ declare global {
  * @slot actions-end - A slot for adding `calcite-action`s to the end of the component. It is recommended to use two or less actions.
  */
 export class Notice extends LitElement implements OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   /** The close button element. */
   private closeButton = createRef<HTMLButtonElement>();
@@ -59,15 +59,22 @@ export class Notice extends LitElement implements OpenCloseComponent {
 
   transitionEl: HTMLElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasActionEnd = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, a close button is added to the component. */
   @property({ reflect: true }) closable = false;
@@ -87,13 +94,6 @@ export class Notice extends LitElement implements OpenCloseComponent {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** When `true`, the component is visible. */
   @property({ reflect: true }) open = false;
 
@@ -103,9 +103,9 @@ export class Notice extends LitElement implements OpenCloseComponent {
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first focusable element. */
   @method()
@@ -124,9 +124,9 @@ export class Notice extends LitElement implements OpenCloseComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteNoticeBeforeClose = createEvent({ cancelable: false });
@@ -140,9 +140,9 @@ export class Notice extends LitElement implements OpenCloseComponent {
   /** Fires when the component is open and animation is complete. */
   calciteNoticeOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   async load(): Promise<void> {
     this.requestedIcon = setRequestedIcon(KindIcons, this.icon, this.kind);
@@ -165,9 +165,10 @@ export class Notice extends LitElement implements OpenCloseComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   onBeforeClose(): void {
     this.calciteNoticeBeforeClose.emit();
   }
@@ -200,9 +201,9 @@ export class Notice extends LitElement implements OpenCloseComponent {
     this.hasActionEnd = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const closeButton = (
@@ -240,5 +241,5 @@ export class Notice extends LitElement implements OpenCloseComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/option-group/option-group.tsx
+++ b/packages/calcite-components/src/components/option-group/option-group.tsx
@@ -10,13 +10,13 @@ declare global {
 }
 /** @slot - A slot for adding `calcite-option`s. */
 export class OptionGroup extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, interaction is prevented and the component is displayed with lower opacity. */
   @property({
@@ -31,17 +31,16 @@ export class OptionGroup extends LitElement {
    */
   @property() label: string;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
-
   private calciteInternalOptionGroupChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
@@ -56,11 +55,9 @@ export class OptionGroup extends LitElement {
     }
   }
 
-  // #endregion
-  // #region Private Methods
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     return (
@@ -71,5 +68,5 @@ export class OptionGroup extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/pagination/pagination.tsx
+++ b/packages/calcite-components/src/components/pagination/pagination.tsx
@@ -36,15 +36,15 @@ const maxItemBreakpoints = {
 };
 
 export class Pagination extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private resizeHandler = ({ contentRect: { width } }: ResizeObserverEntry): void =>
     this.setMaxItemsToBreakpoint(width);
@@ -53,9 +53,16 @@ export class Pagination extends LitElement {
     entries.forEach(this.resizeHandler),
   );
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() isXXSmall: boolean;
 
@@ -65,22 +72,15 @@ export class Pagination extends LitElement {
 
   @state() totalPages: number;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, number values are displayed with a group separator corresponding to the language and country format. */
   @property({ reflect: true }) groupSeparator = false;
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property() numberingSystem: NumberingSystem;
@@ -97,9 +97,9 @@ export class Pagination extends LitElement {
   /** Specifies the total number of items. */
   @property({ reflect: true }) totalItems = 0;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Set a specified page as active.
@@ -146,16 +146,16 @@ export class Pagination extends LitElement {
     this.el.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Emits when the selected page changes. */
   calcitePaginationChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.resizeObserver?.observe(this.el);
@@ -207,9 +207,9 @@ export class Pagination extends LitElement {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleTotalPages(): void {
     if (this.pageSize < 1) {
@@ -311,9 +311,9 @@ export class Pagination extends LitElement {
     this.emitUpdate();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderEllipsis(type: "start" | "end"): JsxNode {
     return (
@@ -537,5 +537,5 @@ export class Pagination extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -52,13 +52,13 @@ declare global {
  * @slot footer-start - A slot for adding a leading footer custom content. Should not be used with the `"footer"` slot.
  */
 export class Panel extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private containerEl: HTMLElement;
 
@@ -66,9 +66,16 @@ export class Panel extends LitElement implements InteractiveComponent {
 
   private resizeObserver = createObserver("resize", () => this.resizeHandler());
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hasActionBar = false;
 
@@ -98,9 +105,9 @@ export class Panel extends LitElement implements InteractiveComponent {
 
   @state() showHeaderContent = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Passes a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;
@@ -152,13 +159,6 @@ export class Panel extends LitElement implements InteractiveComponent {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Determines the type of positioning to use for the overlaid content.
    *
    * Using `"absolute"` will work for most cases. The component will be positioned inside of overflowing parent containers and will affect the container's layout.
@@ -170,9 +170,9 @@ export class Panel extends LitElement implements InteractiveComponent {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Scrolls the component's content to a specified set of coordinates.
@@ -198,9 +198,9 @@ export class Panel extends LitElement implements InteractiveComponent {
     focusFirstTabbable(this.containerEl);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the close button is clicked. */
   calcitePanelClose = createEvent({ cancelable: false });
@@ -211,9 +211,9 @@ export class Panel extends LitElement implements InteractiveComponent {
   /** Fires when the collapse button is clicked. */
   calcitePanelToggle = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -246,9 +246,10 @@ export class Panel extends LitElement implements InteractiveComponent {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private resizeHandler(): void {
     const { panelScrollEl } = this;
 
@@ -387,9 +388,9 @@ export class Panel extends LitElement implements InteractiveComponent {
     });
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderHeaderContent(): JsxNode {
     const { heading, headingLevel, description, hasHeaderContent } = this;
@@ -669,5 +670,5 @@ export class Panel extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -53,13 +53,13 @@ const manager = new PopoverManager();
 
 /** @slot - A slot for adding custom content. */
 export class Popover extends LitElement implements FloatingUIComponent, OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private arrowEl: SVGSVGElement;
 
@@ -96,17 +96,24 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
 
   transitionEl: HTMLDivElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() floatingLayout: FloatingLayout = "vertical";
 
   @state() referenceEl: ReferenceElement;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, clicking outside of the component automatically closes open `calcite-popover`s. */
   @property({ reflect: true }) autoClose = false;
@@ -148,13 +155,6 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * Offsets the position of the popover away from the `referenceElement`.
@@ -201,9 +201,9 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
    */
   @property({ reflect: true }) triggerDisabled = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * Updates the position of the component.
@@ -255,9 +255,9 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
     this.focusTrap.updateContainerElements();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calcitePopoverBeforeClose = createEvent({ cancelable: false });
@@ -271,9 +271,9 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
   /** Fires when the component is open and animation is complete. */
   calcitePopoverOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
@@ -327,9 +327,9 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
     disconnectFloatingUI(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private flipPlacementsHandler(): void {
     this.setFilteredPlacements();
@@ -472,9 +472,9 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
     this.reposition(true);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderCloseButton(): JsxNode {
     const { messages, closable } = this;
@@ -556,5 +556,5 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/rating/rating.tsx
+++ b/packages/calcite-components/src/components/rating/rating.tsx
@@ -46,13 +46,13 @@ export class Rating
   extends LitElement
   implements LabelableComponent, FormComponent, InteractiveComponent
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   defaultValue: Rating["value"];
 
@@ -74,15 +74,22 @@ export class Rating
 
   private _value = 0;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() hoverValue: number;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies a cumulative average from previous ratings to display. */
   @property({ reflect: true }) average: number;
@@ -102,13 +109,6 @@ export class Rating
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
    * Specifies the name of the component.
@@ -170,7 +170,6 @@ export class Rating
   get value(): number {
     return this._value;
   }
-
   set value(value: number) {
     const oldValue = this._value;
     if (value !== oldValue) {
@@ -181,9 +180,9 @@ export class Rating
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -192,16 +191,16 @@ export class Rating
     focusFirstTabbable(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component's value changes. */
   calciteRatingChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -257,9 +256,9 @@ export class Rating
     disconnectForm(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleValueUpdate(newValue: number): void {
     this.hoverValue = newValue;
@@ -379,9 +378,9 @@ export class Rating
     return currentValue === 1 ? 5 : currentValue - 1;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const countString = this.count?.toString();
@@ -460,5 +459,5 @@ export class Rating
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/scrim/scrim.tsx
+++ b/packages/calcite-components/src/components/scrim/scrim.tsx
@@ -17,35 +17,17 @@ declare global {
 
 /** @slot - A slot for adding custom content, primarily loading information. */
 export class Scrim extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private loaderEl: Loader["el"];
 
   private resizeObserver = createObserver("resize", () => this.handleResize());
-
-  // #endregion
-
-  // #region State Properties
-
-  @state() hasContent = false;
-
-  @state() loaderScale: Scale;
-
-  // #endregion
-
-  // #region Public Properties
-
-  /** When `true`, a busy indicator is displayed. */
-  @property({ reflect: true }) loading = false;
-
-  /** Use this property to override individual strings used by the component. */
-  @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
    * Made into a prop for testing purposes only
@@ -54,9 +36,27 @@ export class Scrim extends LitElement {
    */
   messages = useT9n<typeof T9nStrings>();
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region State Properties
+
+  @state() hasContent = false;
+
+  @state() loaderScale: Scale;
+
+  //#endregion
+
+  //#region Public Properties
+
+  /** When `true`, a busy indicator is displayed. */
+  @property({ reflect: true }) loading = false;
+
+  /** Use this property to override individual strings used by the component. */
+  @property() messageOverrides?: typeof this.messages._overrides;
+
+  //#endregion
+
+  //#region Lifecycle
 
   override connectedCallback(): void {
     this.resizeObserver?.observe(this.el);
@@ -66,9 +66,9 @@ export class Scrim extends LitElement {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleDefaultSlotChange(event: Event): void {
     this.hasContent = slotChangeHasContent(event);
@@ -99,9 +99,9 @@ export class Scrim extends LitElement {
     this.loaderScale = this.getScale(Math.min(el.clientHeight, el.clientWidth) ?? 0);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { hasContent, loading, messages } = this;
@@ -122,5 +122,5 @@ export class Scrim extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -37,13 +37,13 @@ declare global {
 
 /** @slot - A slot for adding custom content. */
 export class Sheet extends LitElement implements OpenCloseComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private contentEl: HTMLDivElement;
 
@@ -95,9 +95,24 @@ export class Sheet extends LitElement implements OpenCloseComponent {
 
   transitionEl: HTMLDivElement;
 
-  // #endregion
+  private keyDownHandler = (event: KeyboardEvent): void => {
+    const { defaultPrevented, key } = event;
 
-  // #region State Properties
+    if (
+      !defaultPrevented &&
+      !this.escapeDisabled &&
+      this.focusTrapDisabled &&
+      this.open &&
+      key === "Escape"
+    ) {
+      event.preventDefault();
+      this.open = false;
+    }
+  };
+
+  //#endregion
+
+  //#region State Properties
 
   @state() resizeValues: ResizeValues = {
     inlineSize: null,
@@ -112,9 +127,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     return !this.embedded;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * Passes a function to run before the component closes.
@@ -178,7 +193,6 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   get open(): boolean {
     return this._open;
   }
-
   set open(open: boolean) {
     const oldOpen = this._open;
     if (open !== oldOpen) {
@@ -204,7 +218,6 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   @property({ reflect: true }) resizable = false;
 
   /** When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component. */
-
   /**
    * When `position` is `"inline-start"` or `"inline-end"`, specifies the width of the component.
    *
@@ -215,9 +228,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   /** Specifies the width of the component. */
   @property({ reflect: true }) width: Extract<Width, Scale>;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's "close" button - the first focusable item. */
   @method()
@@ -239,9 +252,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     this.focusTrap.updateContainerElements();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteSheetBeforeClose = createEvent({ cancelable: false });
@@ -255,9 +268,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   /** Fires when the component is open and animation is complete. */
   calciteSheetOpen = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -300,24 +313,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     this.cleanupInteractions();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
-
-  private keyDownHandler = (event: KeyboardEvent): void => {
-    const { defaultPrevented, key } = event;
-
-    if (
-      !defaultPrevented &&
-      !this.escapeDisabled &&
-      this.focusTrapDisabled &&
-      this.open &&
-      key === "Escape"
-    ) {
-      event.preventDefault();
-      this.open = false;
-    }
-  };
+  //#region Private Methods
 
   private toggleSheet(value: boolean): void {
     if (this.ignoreOpenChange) {
@@ -587,9 +585,9 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     this.focusTrap.updateContainerElements();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { resizable, position, resizeValues } = this;
@@ -654,5 +652,5 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -32,13 +32,13 @@ declare global {
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  */
 export class ShellPanel extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private resizeHandleEl: HTMLDivElement;
 
@@ -48,9 +48,16 @@ export class ShellPanel extends LitElement {
 
   private contentEl: HTMLDivElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() resizeValues: ResizeValues = {
     inlineSize: null,
@@ -63,9 +70,9 @@ export class ShellPanel extends LitElement {
 
   @state() hasHeader = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, hides the component's content area. */
   @property({ reflect: true }) collapsed = false;
@@ -98,13 +105,6 @@ export class ShellPanel extends LitElement {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies the component's position. Will be flipped when the element direction is right-to-left (`"rtl"`). */
   @property({ reflect: true }) position: Extract<"start" | "end", Position> = "start";
 
@@ -124,9 +124,9 @@ export class ShellPanel extends LitElement {
   /** Specifies the width of the component. */
   @property({ reflect: true }) width: Extract<Width, Scale>;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalShellPanelResizeEnd = createEvent({ cancelable: false });
@@ -134,9 +134,9 @@ export class ShellPanel extends LitElement {
   /** @private */
   calciteInternalShellPanelResizeStart = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override willUpdate(changes: PropertyValues<this>): void {
     /* TODO: [MIGRATION] First time Lit calls willUpdate(), changes will include not just properties provided by the user, but also any default values your component set.
@@ -152,9 +152,9 @@ export class ShellPanel extends LitElement {
     this.cleanupInteractions();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private getContentElDOMRect(): DOMRect {
     return this.contentEl.getBoundingClientRect();
@@ -366,15 +366,15 @@ export class ShellPanel extends LitElement {
     this.hasHeader = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
-
-  // #region Rendering
-
   private getResizeIcon(): string {
     const { layout } = this;
 
     return layout === "horizontal" ? "drag-resize-vertical" : "drag-resize-horizontal";
   }
+
+  //#endregion
+
+  //#region Rendering
 
   private renderHeader(): JsxNode {
     return (
@@ -474,5 +474,5 @@ export class ShellPanel extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -40,13 +40,13 @@ declare global {
 
 /** @slot - A slot for adding custom content. */
 export class StepperItem extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private headerEl = createRef<HTMLDivElement>();
 
@@ -59,9 +59,16 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   /** the latest requested item position */
   private selectedPosition: number;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, the step has been completed. */
   @property({ reflect: true }) complete = false;
@@ -106,13 +113,6 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * When `true`, displays the step number in the `calcite-stepper-item` heading inherited from parent `calcite-stepper`.
    *
    * @private
@@ -132,9 +132,9 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   /** When `true`, the component is selected. */
   @property({ reflect: true }) selected = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -144,9 +144,9 @@ export class StepperItem extends LitElement implements InteractiveComponent {
     (this.layout === "vertical" ? this.el : this.headerEl.value)?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalStepperItemKeyEvent = createEvent<StepperItemKeyEventDetail>({
@@ -162,9 +162,9 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   /** Fires when the active `calcite-stepper-item` changes. */
   calciteStepperItemSelect = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -210,9 +210,9 @@ export class StepperItem extends LitElement implements InteractiveComponent {
     setAttribute(this.el, "tabindex", this.disabled || this.layout === "horizontal" ? null : 0);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private selectedHandler(): void {
     if (this.selected) {
@@ -310,9 +310,9 @@ export class StepperItem extends LitElement implements InteractiveComponent {
     ).indexOf(this.el);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
@@ -379,5 +379,5 @@ export class StepperItem extends LitElement implements InteractiveComponent {
     return numberStringFormatter.numberFormatter.format(this.itemPosition + 1);
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/stepper/stepper.tsx
+++ b/packages/calcite-components/src/components/stepper/stepper.tsx
@@ -28,13 +28,13 @@ declare global {
 
 /** @slot - A slot for adding `calcite-stepper-item` elements. */
 export class Stepper extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private containerEl: HTMLDivElement;
 
@@ -51,15 +51,22 @@ export class Stepper extends LitElement {
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() currentActivePosition: number;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, displays a status icon in the `calcite-stepper-item` heading. */
   @property({ reflect: true }) icon = false;
@@ -69,13 +76,6 @@ export class Stepper extends LitElement {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /** When `true`, displays the step number in the `calcite-stepper-item` heading. */
   @property({ reflect: true }) numbered = false;
@@ -93,9 +93,9 @@ export class Stepper extends LitElement {
    */
   @property() selectedItem: StepperItem["el"] = null;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Set the last `calcite-stepper-item` as active. */
   @method()
@@ -159,9 +159,9 @@ export class Stepper extends LitElement {
     this.updateStep(enabledStepIndex);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /**
    * Fires when the active `calcite-stepper-item` changes.
@@ -182,9 +182,9 @@ export class Stepper extends LitElement {
    */
   calciteStepperItemChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -244,9 +244,10 @@ export class Stepper extends LitElement {
     this.mutationObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private calciteInternalStepperItemKeyEvent(event: CustomEvent<StepperItemKeyEventDetail>): void {
     const item = event.detail.item;
     const itemToFocus = event.target as StepperItem["el"];
@@ -401,9 +402,9 @@ export class Stepper extends LitElement {
     this.setStepperItemNumberingSystem();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
@@ -468,5 +469,5 @@ export class Stepper extends LitElement {
     ) : null;
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/calcite-components/src/components/tab-nav/tab-nav.tsx
@@ -33,22 +33,15 @@ declare global {
 
 /** @slot - A slot for adding `calcite-tab-title`s. */
 export class TabNav extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private effectiveDir: Direction = "ltr";
-
-  get enabledTabTitles(): TabTitle["el"][] {
-    return filterDirectChildren<TabTitle["el"]>(
-      this.el,
-      "calcite-tab-title:not([disabled])",
-    ).filter((tabTitle) => !tabTitle.closed);
-  }
 
   private intersectionObserver: IntersectionObserver;
 
@@ -60,22 +53,20 @@ export class TabNav extends LitElement {
     this.updateScrollingState();
   });
 
-  private get scrollerButtonWidth(): number {
-    const { scale } = this;
-    return parseInt(scale === "s" ? calciteSize24 : scale === "m" ? calciteSize32 : calciteSize44);
-  }
-
   private tabTitleContainerEl: HTMLDivElement;
-
-  get tabTitles(): TabTitle["el"][] {
-    return filterDirectChildren<TabTitle["el"]>(this.el, "calcite-tab-title");
-  }
 
   private makeFirstVisibleTabClosable = false;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only.
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() private hasOverflowingEndTabTitle = false;
 
@@ -83,9 +74,9 @@ export class TabNav extends LitElement {
 
   @state() selectedTabId: TabID;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** @private */
   @property({ reflect: true }) bordered = false;
@@ -95,13 +86,6 @@ export class TabNav extends LitElement {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only.
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /**
    * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`, defaults to `top`.
@@ -130,9 +114,9 @@ export class TabNav extends LitElement {
   /** Specifies text to update multiple components to keep in sync if one changes. */
   @property({ reflect: true }) syncId: string;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalTabChange = createEvent<TabChangeEventDetail>({ cancelable: false });
@@ -143,9 +127,9 @@ export class TabNav extends LitElement {
   /** Emits when the selected `calcite-tab` changes. */
   calciteTabChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -219,9 +203,26 @@ export class TabNav extends LitElement {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
+  get enabledTabTitles(): TabTitle["el"][] {
+    return filterDirectChildren<TabTitle["el"]>(
+      this.el,
+      "calcite-tab-title:not([disabled])",
+    ).filter((tabTitle) => !tabTitle.closed);
+  }
+
+  private get scrollerButtonWidth(): number {
+    const { scale } = this;
+    return parseInt(scale === "s" ? calciteSize24 : scale === "m" ? calciteSize32 : calciteSize44);
+  }
+
+  get tabTitles(): TabTitle["el"][] {
+    return filterDirectChildren<TabTitle["el"]>(this.el, "calcite-tab-title");
+  }
+
   private focusPreviousTabHandler(event: CustomEvent): void {
     this.handleTabFocus(event, event.target as TabTitle["el"], "previous");
   }
@@ -306,7 +307,6 @@ export class TabNav extends LitElement {
    *
    * @param event
    */
-
   private async updateTabTitles(event: CustomEvent<TabID>): Promise<void> {
     if ((event.target as TabTitle["el"]).selected) {
       this.selectedTabId = event.detail;
@@ -564,9 +564,9 @@ export class TabNav extends LitElement {
     });
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
@@ -630,5 +630,5 @@ export class TabNav extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/tab-title/tab-title.tsx
+++ b/packages/calcite-components/src/components/tab-title/tab-title.tsx
@@ -43,13 +43,13 @@ declare global {
  * @slot - A slot for adding text.
  */
 export class TabTitle extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private closeButtonEl = createRef<HTMLButtonElement>();
 
@@ -66,18 +66,25 @@ export class TabTitle extends LitElement implements InteractiveComponent {
     this.calciteInternalTabIconChanged.emit();
   });
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() controls: string;
 
   /** determine if there is slotted text for styling purposes */
   @state() hasText = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** @private */
   @property({ reflect: true }) bordered = false;
@@ -107,13 +114,6 @@ export class TabTitle extends LitElement implements InteractiveComponent {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`, defaults to `top`.
    *
    *  `@internal`
@@ -141,9 +141,9 @@ export class TabTitle extends LitElement implements InteractiveComponent {
    */
   @property({ reflect: true }) tab: string;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /**
    * This activates a tab in order for it and its associated tab-title be selected.
@@ -192,9 +192,9 @@ export class TabTitle extends LitElement implements InteractiveComponent {
     this.controls = tabIds[titleIds.indexOf(this.el.id)] || null;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalTabIconChanged = createEvent({ cancelable: false });
@@ -236,9 +236,9 @@ export class TabTitle extends LitElement implements InteractiveComponent {
   /** Fires when a `calcite-tab` is closed. */
   calciteTabsClose = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -300,9 +300,9 @@ export class TabTitle extends LitElement implements InteractiveComponent {
     this.resizeObserver?.disconnect();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private selectedHandler(): void {
     if (this.selected) {
@@ -388,9 +388,9 @@ export class TabTitle extends LitElement implements InteractiveComponent {
     this.calciteTabsClose.emit();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const { el, closed } = this;
@@ -466,5 +466,5 @@ export class TabTitle extends LitElement implements InteractiveComponent {
     ) : null;
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/table-cell/table-cell.tsx
+++ b/packages/calcite-components/src/components/table-cell/table-cell.tsx
@@ -25,19 +25,26 @@ declare global {
 
 /** @slot - A slot for adding content, usually text content. */
 export class TableCell extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private containerEl = createRef<HTMLTableCellElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() contentsText = "";
 
@@ -45,9 +52,9 @@ export class TableCell extends LitElement implements InteractiveComponent {
 
   @state() selectionText = "";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the alignment of the component. */
   @property({ reflect: true }) alignment: Alignment = "start";
@@ -66,13 +73,6 @@ export class TableCell extends LitElement implements InteractiveComponent {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
 
   /** @private */
   @property() numberCell: boolean;
@@ -104,9 +104,9 @@ export class TableCell extends LitElement implements InteractiveComponent {
   /** @private */
   @property() selectionCell: boolean;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -115,9 +115,9 @@ export class TableCell extends LitElement implements InteractiveComponent {
     this.containerEl.value.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   async load(): Promise<void> {
     this.updateScreenReaderContentsText();
@@ -134,9 +134,10 @@ export class TableCell extends LitElement implements InteractiveComponent {
     updateHostInteraction(this);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private updateScreenReaderSelectionText(): void {
     const selectedText = `${this.messages?.row} ${this.parentRowPositionLocalized} ${this.messages?.selected} ${this.messages?.keyboardDeselect}`;
     const unselectedText = `${this.messages?.row} ${this.parentRowPositionLocalized} ${this.messages?.unselected} ${this.messages?.keyboardSelect}`;
@@ -155,9 +156,9 @@ export class TableCell extends LitElement implements InteractiveComponent {
     this.focused = true;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const dir = getElementDir(this.el);
@@ -201,5 +202,5 @@ export class TableCell extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/table-header/table-header.tsx
+++ b/packages/calcite-components/src/components/table-header/table-header.tsx
@@ -18,27 +18,34 @@ declare global {
 }
 
 export class TableHeader extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private containerEl = createRef<HTMLTableCellElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() focused = false;
 
   @state() screenReaderText = "";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** Specifies the alignment of the component. */
   @property({ reflect: true }) alignment: Alignment = "start";
@@ -63,13 +70,6 @@ export class TableHeader extends LitElement {
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /** @private */
   @property() numberCell = false;
@@ -104,9 +104,9 @@ export class TableHeader extends LitElement {
   /** @private */
   @property() selectionMode: SelectionMode;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component. */
   @method()
@@ -115,9 +115,9 @@ export class TableHeader extends LitElement {
     this.containerEl.value.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   async load(): Promise<void> {
     this.updateScreenReaderText();
@@ -129,9 +129,10 @@ export class TableHeader extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private updateScreenReaderText(): void {
     let text = "";
     const sharedText = `${this.selectedRowCountLocalized} ${this.messages?.selected}`;
@@ -155,9 +156,9 @@ export class TableHeader extends LitElement {
     this.focused = true;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const scope = this.rowSpan
@@ -220,5 +221,5 @@ export class TableHeader extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/table-row/table-row.tsx
+++ b/packages/calcite-components/src/components/table-row/table-row.tsx
@@ -26,13 +26,13 @@ declare global {
 
 /** @slot - A slot for adding `calcite-table-cell` or `calcite-table-header` elements. */
 export class TableRow extends LitElement implements InteractiveComponent {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   messages;
 
@@ -46,9 +46,22 @@ export class TableRow extends LitElement implements InteractiveComponent {
 
   private _selected = false;
 
-  // #endregion
+  private clickHandler = (): void => {
+    this.handleRowSelection();
+  };
 
-  // #region Public Properties
+  private handleKeyboardSelection = (event: KeyboardEvent): void => {
+    if (isActivationKey(event.key)) {
+      if (event.key === " ") {
+        event.preventDefault();
+      }
+      this.handleRowSelection();
+    }
+  };
+
+  //#endregion
+
+  //#region Public Properties
 
   /** Specifies the alignment of the component. */
   @property({ reflect: true }) alignment: Alignment;
@@ -101,7 +114,6 @@ export class TableRow extends LitElement implements InteractiveComponent {
   get selected(): boolean {
     return this._selected;
   }
-
   set selected(value: boolean) {
     const oldValue = this._selected;
     if (value !== oldValue) {
@@ -119,9 +131,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
   /** @private */
   @property() selectionMode: Extract<"multiple" | "single" | "none", SelectionMode> = "none";
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalTableRowFocusRequest = createEvent<TableRowFocusEvent>({ cancelable: false });
@@ -132,9 +144,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
   /** Fires when the selected state of the component changes. */
   calciteTableRowSelect = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -190,9 +202,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleSlotChange(): void {
     this.updateCells();
@@ -345,10 +357,6 @@ export class TableRow extends LitElement implements InteractiveComponent {
     this.cellCount = cells?.length;
   }
 
-  private clickHandler = (): void => {
-    this.handleRowSelection();
-  };
-
   private async handleRowSelection(): Promise<void> {
     if (this.rowType === "body" || (this.rowType === "head" && this.selectionMode === "multiple")) {
       this.userTriggered = true;
@@ -358,18 +366,9 @@ export class TableRow extends LitElement implements InteractiveComponent {
     }
   }
 
-  private handleKeyboardSelection = (event: KeyboardEvent): void => {
-    if (isActivationKey(event.key)) {
-      if (event.key === " ") {
-        event.preventDefault();
-      }
-      this.handleRowSelection();
-    }
-  };
+  //#endregion
 
-  // #endregion
-
-  // #region Rendering
+  //#region Rendering
 
   renderSelectionIcon(): JsxNode {
     const icon =
@@ -478,5 +477,5 @@ export class TableRow extends LitElement implements InteractiveComponent {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/table/table.tsx
+++ b/packages/calcite-components/src/components/table/table.tsx
@@ -33,13 +33,13 @@ declare global {
  * @slot selection-actions - A slot for adding `calcite-actions` or other elements to display when `selectionMode` is not `"none"` and `selectionDisplay` is not `"none"`.
  */
 export class Table extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private allRows: TableRow["el"][];
 
@@ -57,9 +57,16 @@ export class Table extends LitElement {
 
   private tableHeadSlotEl = createRef<HTMLSlotElement>();
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() colCount = 0;
 
@@ -69,9 +76,11 @@ export class Table extends LitElement {
 
   @state() selectedCount = 0;
 
-  // #endregion
+  @state() _selectedItems: TableRow["el"][] = [];
 
-  // #region Public Properties
+  //#endregion
+
+  //#region Public Properties
 
   /** When `true`, displays borders in the component. */
   @property({ reflect: true }) bordered = false;
@@ -95,13 +104,6 @@ export class Table extends LitElement {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
-
   /** When `true`, displays the position of the row in numeric form. */
   @property({ reflect: true }) numbered = false;
 
@@ -123,8 +125,6 @@ export class Table extends LitElement {
     return this._selectedItems;
   }
 
-  @state() _selectedItems: TableRow["el"][] = [];
-
   /** Specifies the display of the selection interface when `selection-mode` is not `"none"`. When `"none"`, content slotted the `selection-actions` slot will not be displayed. */
   @property({ reflect: true }) selectionDisplay: TableSelectionDisplay = "top";
 
@@ -145,9 +145,9 @@ export class Table extends LitElement {
   /** When `true`, displays striped styling in the component. */
   @property({ reflect: true }) striped = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** @private */
   calciteInternalTableRowFocusChange = createEvent<TableRowFocusEvent>({ cancelable: false });
@@ -158,9 +158,9 @@ export class Table extends LitElement {
   /** Emits when the component's selected rows change. */
   calciteTableSelect = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -196,9 +196,9 @@ export class Table extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleSlotChange(): void {
     this.updateRows();
@@ -387,9 +387,9 @@ export class Table extends LitElement {
     return numberStringFormatter.localize(value.toString());
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderSelectionArea(): JsxNode {
     const outOfViewCount = this._selectedItems?.filter((el) => isHidden(el))?.length;
@@ -524,5 +524,5 @@ export class Table extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -60,13 +60,13 @@ export class TextArea
     InteractiveComponent,
     Omit<TextualInputComponent, "pattern">
 {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   attributeWatch = useWatchAttributes(
     ["autofocus", "spellcheck"],
@@ -121,7 +121,6 @@ export class TextArea
   });
 
   // height and width are set to auto here to avoid overlapping on to neighboring elements in the layout when user starts resizing.
-
   // throttle is used to avoid flashing of textarea when user resizes.
   private updateSizeToAuto = throttle(
     (dimension: "height" | "width"): void => {
@@ -131,17 +130,24 @@ export class TextArea
     { leading: false },
   );
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() endSlotHasElements: boolean;
 
   @state() startSlotHasElements: boolean;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * Specifies the component's number of columns.
@@ -185,13 +191,6 @@ export class TextArea
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
-
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   /**
    * When the component resides in a form,
@@ -287,9 +286,9 @@ export class TextArea
    */
   @property({ reflect: true }) wrap: "soft" | "hard" = "soft";
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Selects the text of the component's `value`. */
   @method()
@@ -305,9 +304,9 @@ export class TextArea
     this.textAreaEl.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires each time a new `value` is typed and committed. */
   calciteTextAreaChange = createEvent();
@@ -315,9 +314,9 @@ export class TextArea
   /** Fires each time a new `value` is typed. */
   calciteTextAreaInput = createEvent();
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   override connectedCallback(): void {
     connectLabel(this);
@@ -336,9 +335,9 @@ export class TextArea
     this.updateSizeToAuto?.cancel();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private handleGlobalAttributesChanged(): void {
     this.requestUpdate();
@@ -461,9 +460,9 @@ export class TextArea
     this.validationMessageEl = el;
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   override render(): JsxNode {
     const hasFooter = this.startSlotHasElements || this.endSlotHasElements || !!this.maxLength;
@@ -565,5 +564,5 @@ export class TextArea
     return null;
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/time-picker/time-picker.tsx
+++ b/packages/calcite-components/src/components/time-picker/time-picker.tsx
@@ -43,14 +43,15 @@ function capitalize(str: string): string {
 }
 
 export class TimePicker extends LitElement {
-  // #region Static Members
+  //#region Static Members
+
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region Private Properties
+  //#region Private Properties
 
   private fractionalSecondEl: HTMLSpanElement;
 
@@ -66,9 +67,16 @@ export class TimePicker extends LitElement {
 
   private secondEl: HTMLSpanElement;
 
-  // #endregion
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
 
-  // #region State Properties
+  //#endregion
+
+  //#region State Properties
 
   @state() activeEl: HTMLSpanElement;
 
@@ -106,9 +114,9 @@ export class TimePicker extends LitElement {
 
   @state() showSecond: boolean;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /**
    * Specifies the component's hour format, where:
@@ -124,13 +132,6 @@ export class TimePicker extends LitElement {
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
 
-  /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
   /** Specifies the Unicode numeral system used by the component for localization. */
   @property() numberingSystem: NumberingSystem;
 
@@ -143,9 +144,9 @@ export class TimePicker extends LitElement {
   /** The component's value in UTC (always 24-hour format). */
   @property() value: string = null;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Methods
+  //#region Public Methods
 
   /** Sets focus on the component's first focusable element. */
   @method()
@@ -155,16 +156,16 @@ export class TimePicker extends LitElement {
     this.el?.focus();
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Fires when a user changes the component's time */
   calciteTimePickerChange = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   constructor() {
     super();
@@ -196,9 +197,10 @@ export class TimePicker extends LitElement {
     }
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
+
   private blurHandler(): void {
     this.activeEl = undefined;
     this.pointerActivated = false;
@@ -860,7 +862,9 @@ export class TimePicker extends LitElement {
     this.setValue(this.sanitizeValue(this.value));
   }
 
-  // #endregion
+  //#endregion
+
+  //#region Rendering
 
   override render(): JsxNode {
     const hourIsNumber = isValidNumber(this.hour);
@@ -1138,5 +1142,5 @@ export class TimePicker extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }

--- a/packages/calcite-components/src/components/tip/tip.tsx
+++ b/packages/calcite-components/src/components/tip/tip.tsx
@@ -20,19 +20,30 @@ declare global {
  * @slot thumbnail - A slot for adding an HTML image element.
  */
 export class Tip extends LitElement {
-  // #region Static Members
+  //#region Static Members
 
   static override styles = styles;
 
-  // #endregion
+  //#endregion
 
-  // #region State Properties
+  //#region Private Properties
+
+  /**
+   * Made into a prop for testing purposes only
+   *
+   * @private
+   */
+  messages = useT9n<typeof T9nStrings>();
+
+  //#endregion
+
+  //#region State Properties
 
   @state() hasThumbnail = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Public Properties
+  //#region Public Properties
 
   /** When `true`, the close button is not present on the component. */
   @property({ reflect: true }) closeDisabled = false;
@@ -50,29 +61,22 @@ export class Tip extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Made into a prop for testing purposes only
-   *
-   * @private
-   */
-  messages = useT9n<typeof T9nStrings>();
-
-  /**
    * When `true`, the component is selected if it has a parent `calcite-tip-manager`.
    *
    * Only one tip can be selected within the `calcite-tip-manager` parent.
    */
   @property({ reflect: true }) selected = false;
 
-  // #endregion
+  //#endregion
 
-  // #region Events
+  //#region Events
 
   /** Emits when the component has been closed. */
   calciteTipDismiss = createEvent({ cancelable: false });
 
-  // #endregion
+  //#endregion
 
-  // #region Lifecycle
+  //#region Lifecycle
 
   async load(): Promise<void> {
     logger.deprecated("component", {
@@ -82,9 +86,9 @@ export class Tip extends LitElement {
     });
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Private Methods
+  //#region Private Methods
 
   private hideTip(): void {
     this.closed = true;
@@ -96,9 +100,9 @@ export class Tip extends LitElement {
     this.hasThumbnail = slotChangeHasAssignedElement(event);
   }
 
-  // #endregion
+  //#endregion
 
-  // #region Rendering
+  //#region Rendering
 
   private renderHeader(): JsxNode {
     const { heading, headingLevel, el } = this;
@@ -165,5 +169,5 @@ export class Tip extends LitElement {
     );
   }
 
-  // #endregion
+  //#endregion
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Sets up [`eslint-plugin-unused-imports`](https://www.npmjs.com/package/eslint-plugin-unused-imports) and [`@arcgis/eslint-config`](https://www.npmjs.com/package/@arcgis/eslint-config) (enables `lumina/member-ordering` rule for now, we'll incrementally enable more)

**Note**: this also includes linting fixes.