### PR TITLE
fix(navigation): add missing css display

### DIFF
--- a/packages/calcite-components/src/components/navigation/navigation.e2e.ts
+++ b/packages/calcite-components/src/components/navigation/navigation.e2e.ts
@@ -7,7 +7,7 @@ import { CSS } from "./resources";
 
 describe("calcite-navigation", () => {
   describe("renders", () => {
-    renders("calcite-navigation", { display: "inline" });
+    renders("calcite-navigation", { display: "block" });
   });
 
   describe("honors hidden attribute", () => {

--- a/packages/calcite-components/src/components/navigation/navigation.scss
+++ b/packages/calcite-components/src/components/navigation/navigation.scss
@@ -11,6 +11,10 @@
 
 @include base-component();
 
+:host {
+  @apply block;
+}
+
 .container {
   @apply flex
   flex-col


### PR DESCRIPTION
**Related Issue:** #11022

## Summary

- Add missing CSS `display: block;` to host
- ~~could be considered a breaking change~~ considered a fix, not a breaking change. 
- add test