### PR TITLE
feat: support  `nn` locale

### DIFF
--- a/packages/calcite-components/src/utils/locale.spec.ts
+++ b/packages/calcite-components/src/utils/locale.spec.ts
@@ -187,8 +187,7 @@ describe("getDateTimeFormat()", () => {
 
 describe("getSupportedLocale", () => {
   function assertAllContexts(locale: string, expectedLocale: string): void {
-    expect(getSupportedLocale(locale, "cldr")).toBe(expectedLocale);
-    expect(getSupportedLocale(locale, "t9n")).toBe(expectedLocale);
+    expect(getSupportedLocale(locale)).toBe(expectedLocale);
   }
 
   it("returns `en` if there is no locale", () => {
@@ -223,13 +222,12 @@ describe("getSupportedLocale", () => {
       assertAllContexts("nb", "no");
     });
 
-    it("maps `zh` to `zh-CN`", () => {
-      assertAllContexts("zh", "zh-CN");
+    it("maps `nn` to `no`", () => {
+      assertAllContexts("nn", "no");
     });
 
-    it("maps `pt` to `pt-BR` with t9n context", () => {
-      expect(getSupportedLocale("pt", "t9n")).toBe("pt-BR");
-      expect(getSupportedLocale("pt", "cldr")).toBe("pt");
+    it("maps `zh` to `zh-CN`", () => {
+      assertAllContexts("zh", "zh-CN");
     });
   });
 });

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -176,7 +176,7 @@ export function getSupportedLocale(locale: string, context: "cldr" | "t9n" = "cl
   locale = locale.toLowerCase();
 
   // we support both 'nb' and 'no' (BCP 47) for Norwegian but only `no` has corresponding bundle
-  if (locale === "nb") {
+  if (locale === "nb" || locale === "nn") {
     return "no";
   }
 

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -3,49 +3,6 @@ import { BigDecimal, isValidNumber, sanitizeExponentialNumberString } from "./nu
 
 export const defaultLocale = "en";
 
-export const t9nLocales = [
-  "ar",
-  "bg",
-  "bs",
-  "ca",
-  "cs",
-  "da",
-  "de",
-  "el",
-  defaultLocale,
-  "es",
-  "et",
-  "fi",
-  "fr",
-  "he",
-  "hr",
-  "hu",
-  "id",
-  "it",
-  "ja",
-  "ko",
-  "lt",
-  "lv",
-  "no",
-  "nl",
-  "pl",
-  "pt-BR",
-  "pt-PT",
-  "ro",
-  "ru",
-  "sk",
-  "sl",
-  "sr",
-  "sv",
-  "th",
-  "tr",
-  "uk",
-  "vi",
-  "zh-CN",
-  "zh-HK",
-  "zh-TW",
-];
-
 export const locales = [
   "ar",
   "bg",
@@ -134,8 +91,7 @@ export const localizedTwentyFourHourMeridiems = new Map(
 );
 
 export const numberingSystems = ["arab", "arabext", "latn"] as const;
-
-export const supportedLocales = [...new Set([...t9nLocales, ...locales])] as const;
+export const supportedLocales = [...locales] as const;
 
 export type NumberingSystem = (typeof numberingSystems)[number];
 
@@ -162,35 +118,27 @@ export const getSupportedNumberingSystem = (numberingSystem: string): NumberingS
  * @param locale – the BCP 47 locale code
  * @param context - specifies whether the locale code should match in the context of CLDR or T9N (translation)
  */
-export function getSupportedLocale(locale: string, context: "cldr" | "t9n" = "cldr"): SupportedLocale {
-  const contextualLocales = context === "cldr" ? locales : t9nLocales;
-
+export function getSupportedLocale(locale: string): SupportedLocale {
   if (!locale) {
     return defaultLocale;
   }
 
-  if (contextualLocales.includes(locale)) {
+  if (supportedLocales.includes(locale)) {
     return locale;
   }
 
   locale = locale.toLowerCase();
-
-  // we support both 'nb' and 'no' (BCP 47) for Norwegian but only `no` has corresponding bundle
-  if (locale === "nb" || locale === "nn") {
-    return "no";
-  }
-
-  // we use `pt-BR` as it will have the same translations as `pt`, which has no corresponding bundle
-  if (context === "t9n" && locale === "pt") {
-    return "pt-BR";
-  }
-
   if (locale.includes("-")) {
     locale = locale.replace(/(\w+)-(\w+)/, (_match, language, region) => `${language}-${region.toUpperCase()}`);
 
-    if (!contextualLocales.includes(locale)) {
+    if (!supportedLocales.includes(locale)) {
       locale = locale.split("-")[0];
     }
+  }
+
+  // we support 'nn', 'nb' and 'no' (BCP 47) for Norwegian but only `no` includes corresponding bundle
+  if (locale === "nb" || locale === "nn") {
+    return "no";
   }
 
   // we can `zh-CN` as base translation for chinese locales which has no corresponding bundle.
@@ -198,7 +146,7 @@ export function getSupportedLocale(locale: string, context: "cldr" | "t9n" = "cl
     return "zh-CN";
   }
 
-  if (!contextualLocales.includes(locale)) {
+  if (!supportedLocales.includes(locale)) {
     console.warn(
       `Translations for the "${locale}" locale are not available and will fall back to the default, English (en).`,
     );

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -116,7 +116,6 @@ export const getSupportedNumberingSystem = (numberingSystem: string): NumberingS
  * Gets the locale that best matches the context.
  *
  * @param locale – the BCP 47 locale code
- * @param context - specifies whether the locale code should match in the context of CLDR or T9N (translation)
  */
 export function getSupportedLocale(locale: string): SupportedLocale {
   if (!locale) {


### PR DESCRIPTION
**Related Issue:** #11978 

## Summary

- Add support for `nn` locale which maps to `no`
- removes `t9n` context from locale util since it is handled by lumina controller.