### PR TITLE
refactor(action-bar): improve accuracy of overflow item count

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -26,9 +26,10 @@ import { useT9n } from "../../controllers/useT9n";
 import type { Tooltip } from "../tooltip/tooltip";
 import type { ActionGroup } from "../action-group/action-group";
 import { Action } from "../action/action";
+import { getOverflowCount } from "../../utils/overflow";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
-import { getOverflowCount, overflowActions, queryActions } from "./utils";
+import { overflowActions, queryActions } from "./utils";
 import { styles } from "./action-bar.scss";
 
 declare global {

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -53,8 +53,6 @@ export class ActionBar extends LitElement {
 
   // #region Private Properties
 
-  private actionSizes = new WeakMap<Action["el"], number>();
-
   private expandToggleEl: Action["el"];
 
   private actionGroups: ActionGroup["el"][];
@@ -255,18 +253,8 @@ export class ActionBar extends LitElement {
     }
 
     const clientSize = layout === "horizontal" ? "clientWidth" : "clientHeight";
-    const maxSize = Math.max(...actions.map((action) => action[clientSize] || 0));
-
-    return actions.map((action) => {
-      const actionSize = action[clientSize];
-
-      if (actionSize) {
-        this.actionSizes.set(action, actionSize);
-        return actionSize;
-      }
-
-      return this.actionSizes.get(action) ?? maxSize;
-    });
+    const fallbackSize = Math.max(...actions.map((action) => action[clientSize] || 0));
+    return actions.map((action) => action[clientSize] || fallbackSize);
   }
 
   private expandedHandler(): void {

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -81,9 +81,9 @@ export class ActionBar extends LitElement {
         : actionGroups.length;
 
     const overflowCount = getOverflowCount({
-      size: layout === "horizontal" ? width : height,
+      bufferSize: groupCount, // 1px border for each group
+      containerSize: layout === "horizontal" ? width : height,
       itemSizes,
-      bufferPx: groupCount, // 1px border for each group
     });
 
     overflowActions({

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -260,7 +260,7 @@ export class ActionBar extends LitElement {
         this.actionSizes.set(action, size);
         return size;
       }
-      return this.actionSizes.get(action); // todo: average fallback
+      return this.actionSizes.get(action) ?? 48; // todo: use better fallback size
     });
   }
 

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -254,13 +254,18 @@ export class ActionBar extends LitElement {
       actions.push(expandToggleEl);
     }
 
+    const clientSize = layout === "horizontal" ? "clientWidth" : "clientHeight";
+    const maxSize = Math.max(...actions.map((action) => action[clientSize] || 0));
+
     return actions.map((action) => {
-      const size = layout === "horizontal" ? action.clientWidth : action.clientHeight;
-      if (size) {
-        this.actionSizes.set(action, size);
-        return size;
+      const actionSize = action[clientSize];
+
+      if (actionSize) {
+        this.actionSizes.set(action, actionSize);
+        return actionSize;
       }
-      return this.actionSizes.get(action) ?? 48; // todo: use better fallback size
+
+      return this.actionSizes.get(action) ?? maxSize;
     });
   }
 

--- a/packages/calcite-components/src/components/action-bar/utils.ts
+++ b/packages/calcite-components/src/components/action-bar/utils.ts
@@ -4,15 +4,15 @@ import type { ActionGroup } from "../action-group/action-group";
 import type { Action } from "../action/action";
 
 const calculateMaxItems = ({
-  bufferPx,
+  bufferSize,
+  containerSize,
   itemSizes,
-  size,
 }: {
-  bufferPx: number;
+  bufferSize: number;
+  containerSize: number;
   itemSizes: number[];
-  size: number;
 }): number => {
-  const maxSize = size - bufferPx;
+  const maxSize = containerSize - bufferSize;
   let breakpoint = itemSizes.length; // assume all items will fit
   let sizeSum = 0;
   for (const [index, size] of itemSizes.entries()) {
@@ -30,15 +30,15 @@ const calculateMaxItems = ({
 };
 
 export const getOverflowCount = ({
-  bufferPx = 0,
+  bufferSize = 0,
+  containerSize,
   itemSizes,
-  size,
 }: {
-  bufferPx?: number;
+  bufferSize?: number;
+  containerSize: number;
   itemSizes: number[];
-  size: number;
 }): number => {
-  return Math.max(itemSizes.length - calculateMaxItems({ bufferPx, itemSizes, size }), 0);
+  return Math.max(itemSizes.length - calculateMaxItems({ bufferSize, itemSizes, containerSize }), 0);
 };
 
 export const queryActions = (el: HTMLElement): Action["el"][] => {

--- a/packages/calcite-components/src/components/action-bar/utils.ts
+++ b/packages/calcite-components/src/components/action-bar/utils.ts
@@ -3,44 +3,6 @@ import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import type { ActionGroup } from "../action-group/action-group";
 import type { Action } from "../action/action";
 
-const calculateMaxItems = ({
-  bufferSize,
-  containerSize,
-  itemSizes,
-}: {
-  bufferSize: number;
-  containerSize: number;
-  itemSizes: number[];
-}): number => {
-  const maxSize = containerSize - bufferSize;
-  let breakpoint = itemSizes.length; // assume all items will fit
-  let sizeSum = 0;
-  for (const [index, size] of itemSizes.entries()) {
-    sizeSum = sizeSum + size;
-
-    if (sizeSum > maxSize) {
-      breakpoint = index;
-      break;
-    } else {
-      continue;
-    }
-  }
-
-  return breakpoint;
-};
-
-export const getOverflowCount = ({
-  bufferSize = 0,
-  containerSize,
-  itemSizes,
-}: {
-  bufferSize?: number;
-  containerSize: number;
-  itemSizes: number[];
-}): number => {
-  return Math.max(itemSizes.length - calculateMaxItems({ bufferSize, itemSizes, containerSize }), 0);
-};
-
 export const queryActions = (el: HTMLElement): Action["el"][] => {
   return Array.from(el.querySelectorAll("calcite-action")).filter((action) =>
     action.closest("calcite-action-menu") ? action.slot === ACTION_MENU_SLOTS.trigger : true,

--- a/packages/calcite-components/src/utils/overflow.spec.ts
+++ b/packages/calcite-components/src/utils/overflow.spec.ts
@@ -17,7 +17,7 @@ describe("getOverflowCount", () => {
       containerSize: 100,
       itemSizes: [30, 40, 50, 20],
     });
-    expect(result).toBe(1); // Only the last item overflows
+    expect(result).toBe(2);
   });
 
   it("should return the total number of items when all overflow", () => {
@@ -44,7 +44,7 @@ describe("getOverflowCount", () => {
       containerSize: 100,
       itemSizes: [20, 30, 40],
     });
-    expect(result).toBe(3); // All items overflow
+    expect(result).toBe(3);
   });
 
   it("should handle edge case where containerSize is exactly the sum of itemSizes", () => {
@@ -53,7 +53,7 @@ describe("getOverflowCount", () => {
       containerSize: 90,
       itemSizes: [30, 30, 30],
     });
-    expect(result).toBe(0); // No items overflow
+    expect(result).toBe(0);
   });
 
   it("should handle edge case where containerSize is slightly less than the sum of itemSizes", () => {
@@ -62,6 +62,6 @@ describe("getOverflowCount", () => {
       containerSize: 89,
       itemSizes: [30, 30, 30],
     });
-    expect(result).toBe(1); // One item overflows
+    expect(result).toBe(1);
   });
 });

--- a/packages/calcite-components/src/utils/overflow.spec.ts
+++ b/packages/calcite-components/src/utils/overflow.spec.ts
@@ -1,5 +1,61 @@
 import { describe, expect, it } from "vitest";
-import { getOverflowCount } from "./overflow";
+import { calculateMaxItems, getOverflowCount } from "./overflow";
+
+describe("calculateMaxItems", () => {
+  it("should return the total number of items if all items fit within the container", () => {
+    const result = calculateMaxItems({
+      bufferSize: 0,
+      containerSize: 100,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(3);
+  });
+
+  it("should return the correct number of items that fit when some items overflow", () => {
+    const result = calculateMaxItems({
+      bufferSize: 0,
+      containerSize: 50,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(2);
+  });
+
+  it("should return 0 if no items fit within the container", () => {
+    const result = calculateMaxItems({
+      bufferSize: 0,
+      containerSize: 10,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(0);
+  });
+
+  it("should account for the buffer size when calculating the maximum items", () => {
+    const result = calculateMaxItems({
+      bufferSize: 10,
+      containerSize: 50,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(1);
+  });
+
+  it("should return 0 if the container size is less than or equal to the buffer size", () => {
+    const result = calculateMaxItems({
+      bufferSize: 50,
+      containerSize: 50,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(0);
+  });
+
+  it("should return the total number of items if the itemSizes array is empty", () => {
+    const result = calculateMaxItems({
+      bufferSize: 0,
+      containerSize: 100,
+      itemSizes: [],
+    });
+    expect(result).toBe(0);
+  });
+});
 
 describe("getOverflowCount", () => {
   it("should return 0 when no items overflow", () => {

--- a/packages/calcite-components/src/utils/overflow.spec.ts
+++ b/packages/calcite-components/src/utils/overflow.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { getOverflowCount } from "./overflow";
+
+describe("getOverflowCount", () => {
+  it("should return 0 when no items overflow", () => {
+    const result = getOverflowCount({
+      bufferSize: 0,
+      containerSize: 100,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(0);
+  });
+
+  it("should return the correct number of overflowing items", () => {
+    const result = getOverflowCount({
+      bufferSize: 10,
+      containerSize: 100,
+      itemSizes: [30, 40, 50, 20],
+    });
+    expect(result).toBe(1); // Only the last item overflows
+  });
+
+  it("should return the total number of items when all overflow", () => {
+    const result = getOverflowCount({
+      bufferSize: 0,
+      containerSize: 10,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(3);
+  });
+
+  it("should return 0 when itemSizes is empty", () => {
+    const result = getOverflowCount({
+      bufferSize: 0,
+      containerSize: 100,
+      itemSizes: [],
+    });
+    expect(result).toBe(0);
+  });
+
+  it("should handle edge case where bufferSize is larger than containerSize", () => {
+    const result = getOverflowCount({
+      bufferSize: 150,
+      containerSize: 100,
+      itemSizes: [20, 30, 40],
+    });
+    expect(result).toBe(3); // All items overflow
+  });
+
+  it("should handle edge case where containerSize is exactly the sum of itemSizes", () => {
+    const result = getOverflowCount({
+      bufferSize: 0,
+      containerSize: 90,
+      itemSizes: [30, 30, 30],
+    });
+    expect(result).toBe(0); // No items overflow
+  });
+
+  it("should handle edge case where containerSize is slightly less than the sum of itemSizes", () => {
+    const result = getOverflowCount({
+      bufferSize: 0,
+      containerSize: 89,
+      itemSizes: [30, 30, 30],
+    });
+    expect(result).toBe(1); // One item overflows
+  });
+});

--- a/packages/calcite-components/src/utils/overflow.ts
+++ b/packages/calcite-components/src/utils/overflow.ts
@@ -1,0 +1,46 @@
+const calculateMaxItems = ({
+  bufferSize,
+  containerSize,
+  itemSizes,
+}: {
+  bufferSize: number;
+  containerSize: number;
+  itemSizes: number[];
+}): number => {
+  const maxSize = containerSize - bufferSize;
+  let breakpoint = itemSizes.length; // assume all items will fit
+  let sizeSum = 0;
+  for (const [index, size] of itemSizes.entries()) {
+    sizeSum = sizeSum + size;
+
+    if (sizeSum > maxSize) {
+      breakpoint = index;
+      break;
+    } else {
+      continue;
+    }
+  }
+
+  return breakpoint;
+};
+
+/**
+ * Calculates the number of items that overflow a container.
+ *
+ * @param params - The parameters for the calculation.
+ * @param params.bufferSize - The buffer size to subtract from the container size (default is 0).
+ * @param params.containerSize - The total size of the container.
+ * @param params.itemSizes - An array of sizes for each item.
+ * @returns The number of items that overflow the container.
+ */
+export const getOverflowCount = ({
+  bufferSize = 0,
+  containerSize,
+  itemSizes,
+}: {
+  bufferSize?: number;
+  containerSize: number;
+  itemSizes: number[];
+}): number => {
+  return Math.max(itemSizes.length - calculateMaxItems({ bufferSize, itemSizes, containerSize }), 0);
+};

--- a/packages/calcite-components/src/utils/overflow.ts
+++ b/packages/calcite-components/src/utils/overflow.ts
@@ -1,9 +1,18 @@
-const calculateMaxItems = ({
-  bufferSize,
+/**
+ * Calculates the maximum number of items that can fit within a container.
+ *
+ * @param params - The parameters for the calculation.
+ * @param params.bufferSize - The buffer size to subtract from the container size (default is 0).
+ * @param params.containerSize - The total size of the container.
+ * @param params.itemSizes - An array of sizes for each item.
+ * @returns The maximum number of items that can fit within the container.
+ */
+export const calculateMaxItems = ({
+  bufferSize = 0,
   containerSize,
   itemSizes,
 }: {
-  bufferSize: number;
+  bufferSize?: number;
   containerSize: number;
   itemSizes: number[];
 }): number => {


### PR DESCRIPTION
**Related Issue:** #7507

## Summary

- Moves overflow logic to a utility for use by other components
- Adds spec tests for utility
- Updates utility to use the size of each item rather than an average size of all items. Falls back to largest item if item size is 0.