### PR TITLE
fix(dialog, modal, sheet): honor `initialFocus` when opening components

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.e2e.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.e2e.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
+import { newE2EPage, E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   accessible,
@@ -17,6 +17,7 @@ import { html } from "../../../support/formatting";
 import { GlobalTestProps, isElementFocused, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils/puppeteer";
 import { IDS as PanelIDS } from "../panel/resources";
 import { resizeShiftStep } from "../../utils/resources";
+import { focusTrap } from "../../tests/commonTests/focusTrap";
 import { CSS, SLOTS } from "./resources";
 import type { Dialog } from "./dialog";
 
@@ -219,16 +220,33 @@ describe("calcite-dialog", () => {
 
   describe("accessible", () => {
     accessible(async () => {
-      const page = await newE2EPage();
-
-      await page.setContent(
-        `<calcite-dialog heading="My Dialog" description="My Description" open>Hello world!</calcite-dialog>`,
-      );
-      const openEvent = page.waitForEvent("calciteDialogOpen");
+      const page = await newProgrammaticE2EPage();
       await skipAnimations(page);
+      const openEvent = page.waitForEvent("calciteDialogOpen");
+      await page.evaluate(() => {
+        const dialog = document.createElement("calcite-dialog");
+        dialog.open = true;
+        dialog.heading = "My Dialog";
+        dialog.description = "My Description";
+        document.body.append(dialog);
+      });
       await openEvent;
 
       return { page, tag: "calcite-dialog" };
+    });
+  });
+
+  describe("focus-trap", () => {
+    describe("default", () => {
+      focusTrap("calcite-dialog", {
+        toggleProp: "open",
+      });
+    });
+
+    describe("modal", () => {
+      focusTrap(html`<calcite-dialog modal></calcite-dialog>`, {
+        toggleProp: "open",
+      });
     });
   });
 
@@ -624,12 +642,14 @@ describe("calcite-dialog", () => {
     it("subsequently opening a dialog dynamically gets focus trapped", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-dialog open id="dialog1" heading="Dialog 1">
+        <calcite-dialog id="dialog1" heading="Dialog 1">
           <calcite-button id="openButton">open second dialog</calcite-button>
         </calcite-dialog>
       `);
       let openEvent = page.waitForEvent("calciteDialogOpen");
       await skipAnimations(page);
+      const dialog = await page.find("calcite-dialog");
+      dialog.setProperty("open", true);
       await page.waitForChanges();
 
       await page.evaluate(() => {
@@ -724,14 +744,18 @@ describe("calcite-dialog", () => {
   });
 
   it("closes when Escape key is pressed and dialog is open on page load", async () => {
-    const page = await newE2EPage();
-    await page.setContent(`<calcite-dialog open></calcite-dialog>`);
-    const openedEvent = page.waitForEvent("calciteDialogOpen");
+    const page = await newProgrammaticE2EPage();
+    const openEvent = page.waitForEvent("calciteDialogOpen");
+    await page.evaluate(() => {
+      const dialog = document.createElement("calcite-dialog");
+      dialog.open = true;
+      document.body.append(dialog);
+    });
 
     const dialog = await page.find("calcite-dialog");
     await page.waitForChanges();
     expect(dialog).toHaveAttribute("open");
-    await openedEvent;
+    await openEvent;
 
     await page.keyboard.press("Escape");
     await page.waitForChanges();
@@ -1162,125 +1186,65 @@ describe("calcite-dialog", () => {
     });
   });
 
-  describe("focusTrap behavior for modal dialogs", () => {
+  describe.each([{ modal: true }, { modal: false }])("focusTrap behavior", ({ modal }) => {
     let page: E2EPage;
+    let dialog: E2EElement;
 
     beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-dialog modal width-scale="s" open closable><button id="insideEl">inside</button></calcite-dialog>
-        <button id="outsideEl">outside</button>
-      `);
-
+      page = await newProgrammaticE2EPage();
       await skipAnimations(page);
+      const openEvent = page.waitForEvent("calciteDialogOpen");
+      await page.evaluate((modal) => {
+        const innerButton = document.createElement("button");
+        innerButton.id = "insideEl";
+        innerButton.innerText = "inside";
+
+        const outsideButton = document.createElement("button");
+        outsideButton.id = "outsideEl";
+        outsideButton.innerText = "outside";
+
+        const dialog = document.createElement("calcite-dialog");
+        dialog.modal = modal;
+        dialog.open = true;
+
+        dialog.append(innerButton);
+        document.body.append(dialog);
+        document.body.append(outsideButton);
+      }, modal);
       await page.waitForChanges();
+      await openEvent;
+      await page.waitForChanges();
+
+      dialog = await page.find("calcite-dialog");
     });
 
-    it("cannot tab out of dialog when modal=true and focusTrapDisabled=true", async () => {
-      const dialog = await page.find("calcite-dialog");
-      const insideEl = await page.find("#insideEl");
-
+    it(`can tab out of dialog when modal=${modal} and focusTrapDisabled=true`, async () => {
       dialog.setProperty("focusTrapDisabled", true);
-
       await page.waitForChanges();
 
-      expect(await dialog.isVisible()).toBe(true);
+      expect(await isElementFocused(page, "calcite-dialog")).toBe(true);
 
+      // focus starts on close button
+      await page.keyboard.press("Tab");
       await page.keyboard.press("Tab");
       await page.waitForChanges();
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
 
-      const activeElementId = await page.evaluate(() => document.activeElement.id);
-      expect(activeElementId).toBe(await insideEl.getProperty("id"));
+      expect(await isElementFocused(page, "#outsideEl")).toBe(true);
     });
 
-    it("cannot tab out of dialog when modal=true and focusTrapDisabled=false", async () => {
-      const dialog = await page.find("calcite-dialog");
-      const action = await page.find("calcite-dialog >>> calcite-action");
-      const insideEl = await page.find("#insideEl");
-
+    it(`cannot tab out of dialog when modal=${modal} and focusTrapDisabled=false`, async () => {
       dialog.setProperty("focusTrapDisabled", false);
-
       await page.waitForChanges();
 
-      expect(await dialog.isVisible()).toBe(true);
+      expect(await isElementFocused(page, "calcite-dialog")).toBe(true);
 
-      await action.callMethod("setFocus");
-      await page.waitForChanges();
-
+      // focus starts on close button
       await page.keyboard.press("Tab");
-      await page.waitForChanges();
       await page.keyboard.press("Tab");
-      await page.waitForChanges();
       await page.keyboard.press("Tab");
       await page.waitForChanges();
 
-      const activeElementId = await page.evaluate(() => document.activeElement.id);
-      expect(activeElementId).toBe(await insideEl.getProperty("id"));
-    });
-  });
-
-  describe("focusTrap behavior for non-modal dialogs", () => {
-    let page: E2EPage;
-
-    beforeEach(async () => {
-      page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-dialog width-scale="s" open closable><button id="insideEl">inside</button></calcite-dialog>
-        <button id="outsideEl">outside</button>
-      `);
-
-      await skipAnimations(page);
-      await page.waitForChanges();
-    });
-
-    it("can tab out of non-modal dialog when focusTrapDisabled=true", async () => {
-      const dialog = await page.find("calcite-dialog");
-      const action = await page.find("calcite-dialog >>> calcite-action");
-      const outsideEl = await page.find("#outsideEl");
-
-      dialog.setProperty("focusTrapDisabled", true);
-
-      await page.waitForChanges();
-
-      expect(await dialog.isVisible()).toBe(true);
-
-      await action.callMethod("setFocus");
-      await page.waitForChanges();
-
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
-
-      const activeElementId = await page.evaluate(() => document.activeElement.id);
-      expect(activeElementId).toBe(await outsideEl.getProperty("id"));
-    });
-
-    it("cannot tab out of non-modal dialog when focusTrapDisabled=false", async () => {
-      const dialog = await page.find("calcite-dialog");
-      const action = await page.find("calcite-dialog >>> calcite-action");
-      const insideEl = await page.find("#insideEl");
-
-      dialog.setProperty("focusTrapDisabled", false);
-
-      await page.waitForChanges();
-
-      expect(await dialog.isVisible()).toBe(true);
-
-      await action.callMethod("setFocus");
-      await page.waitForChanges();
-
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
-      await page.keyboard.press("Tab");
-      await page.waitForChanges();
-
-      const activeElementId = await page.evaluate(() => document.activeElement.id);
-      expect(activeElementId).toBe(await insideEl.getProperty("id"));
+      expect(await isElementFocused(page, "#insideEl")).toBe(true);
     });
   });
 });

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -85,14 +85,6 @@ export class Dialog extends LitElement implements OpenCloseComponent {
 
   private _open = false;
 
-  private openEnd = (): void => {
-    this.setFocus();
-    this.el.removeEventListener(
-      "calciteDialogOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-  };
-
   openProp = "opened";
 
   transitionProp = "opacity" as const;
@@ -372,8 +364,11 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   }
 
   onOpen(): void {
-    this.calciteDialogOpen.emit();
+    if (this.focusTrapDisabled) {
+      this.setFocus();
+    }
     this.focusTrap.activate();
+    this.calciteDialogOpen.emit();
   }
 
   onBeforeClose(): void {
@@ -381,8 +376,8 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   }
 
   onClose(): void {
-    this.calciteDialogClose.emit();
     this.focusTrap.deactivate();
+    this.calciteDialogClose.emit();
   }
 
   private toggleDialog(value: boolean): void {
@@ -708,10 +703,6 @@ export class Dialog extends LitElement implements OpenCloseComponent {
 
   private async openDialog(): Promise<void> {
     await this.componentOnReady();
-    this.el.addEventListener(
-      "calciteDialogOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     this.opened = true;
   }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -72,14 +72,6 @@ export class Dropdown
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
 
-  private onOpenEnd = (): void => {
-    this.focusOnFirstActiveOrDefaultItem();
-    this.el.removeEventListener(
-      "calciteDropdownOpen",
-      this.onOpenEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-  };
-
   transitionProp = "opacity" as const;
 
   referenceEl: HTMLDivElement;
@@ -506,7 +498,8 @@ export class Dropdown
     this.calciteDropdownBeforeOpen.emit();
   }
 
-  onOpen(): void {
+  async onOpen(): Promise<void> {
+    this.focusOnFirstActiveOrDefaultItem();
     this.calciteDropdownOpen.emit();
   }
 
@@ -562,10 +555,6 @@ export class Dropdown
       event.preventDefault();
       this.focusLastDropdownItem = key === "ArrowUp";
       this.open = true;
-      this.el.addEventListener(
-        "calciteDropdownOpen",
-        this.onOpenEnd,
-      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     }
   }
 
@@ -612,12 +601,6 @@ export class Dropdown
 
   private toggleDropdown() {
     this.open = !this.open;
-    if (this.open) {
-      this.el.addEventListener(
-        "calciteDropdownOpen",
-        this.onOpenEnd,
-      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-    }
   }
 
   private updateTabIndexOfItems(target: DropdownItem["el"]): void {

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -72,6 +72,14 @@ export class Dropdown
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
 
+  private onOpenEnd = (): void => {
+    this.focusOnFirstActiveOrDefaultItem();
+    this.el.removeEventListener(
+      "calciteDropdownOpen",
+      this.onOpenEnd,
+    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
+  };
+
   transitionProp = "opacity" as const;
 
   referenceEl: HTMLDivElement;
@@ -498,8 +506,7 @@ export class Dropdown
     this.calciteDropdownBeforeOpen.emit();
   }
 
-  async onOpen(): Promise<void> {
-    this.focusOnFirstActiveOrDefaultItem();
+  onOpen(): void {
     this.calciteDropdownOpen.emit();
   }
 
@@ -555,6 +562,10 @@ export class Dropdown
       event.preventDefault();
       this.focusLastDropdownItem = key === "ArrowUp";
       this.open = true;
+      this.el.addEventListener(
+        "calciteDropdownOpen",
+        this.onOpenEnd,
+      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     }
   }
 
@@ -601,6 +612,12 @@ export class Dropdown
 
   private toggleDropdown() {
     this.open = !this.open;
+    if (this.open) {
+      this.el.addEventListener(
+        "calciteDropdownOpen",
+        this.onOpenEnd,
+      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
+    }
   }
 
   private updateTabIndexOfItems(target: DropdownItem["el"]): void {

--- a/packages/calcite-components/src/components/modal/modal.e2e.ts
+++ b/packages/calcite-components/src/components/modal/modal.e2e.ts
@@ -1,9 +1,16 @@
 // @ts-strict-ignore
-import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
+import { E2EPage, newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it, vi } from "vitest";
 import { defaults, focusable, hidden, openClose, renders, slots, t9n } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
-import { GlobalTestProps, isElementFocused, skipAnimations, waitForAnimationFrame } from "../../tests/utils/puppeteer";
+import {
+  GlobalTestProps,
+  isElementFocused,
+  newProgrammaticE2EPage,
+  skipAnimations,
+  waitForAnimationFrame,
+} from "../../tests/utils/puppeteer";
+import { focusTrap } from "../../tests/commonTests/focusTrap";
 import { CSS, SLOTS } from "./resources";
 import type { Modal } from "./modal";
 
@@ -40,6 +47,12 @@ describe("calcite-modal", () => {
         defaultValue: false,
       },
     ]);
+  });
+
+  describe("focus-trap", () => {
+    focusTrap("calcite-modal", {
+      toggleProp: "open",
+    });
   });
 
   it("should hide closeButton when disabled", async () => {
@@ -334,22 +347,29 @@ describe("calcite-modal", () => {
     });
 
     it("subsequently opening a modal dynamically gets focus trapped", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-modal open id="modal1">
-          <div slot="header">Modal 1</div>
-          <div slot="content">
-            <calcite-button id="openButton">open second modal</calcite-button>
-          </div>
-        </calcite-modal>
-      `);
-      let openEvent = page.waitForEvent("calciteModalOpen");
+      const page = await newProgrammaticE2EPage();
       await skipAnimations(page);
-      await page.waitForChanges();
-
+      let openEvent = page.waitForEvent("calciteModalOpen");
       await page.evaluate(() => {
-        const btn = document.getElementById("openButton");
-        btn.addEventListener("click", () => {
+        const modal = document.createElement("calcite-modal");
+        modal.open = true;
+        modal.id = "modal1";
+        document.body.append(modal);
+
+        const header = document.createElement("div");
+        header.slot = "header";
+        header.innerHTML = "Modal 1";
+        modal.append(header);
+        const content = document.createElement("div");
+        content.slot = "content";
+        const button = document.createElement("calcite-button");
+        button.id = "openButton";
+        button.innerHTML = "Open Modal 2";
+        content.append(button);
+
+        modal.append(content);
+
+        button.addEventListener("click", () => {
           const button = document.createElement("calcite-button");
           button.innerHTML = "focusable";
           button.slot = "content";
@@ -366,6 +386,7 @@ describe("calcite-modal", () => {
 
       openEvent = page.waitForEvent("calciteModalOpen");
       await page.click("#openButton");
+      await page.waitForChanges();
       await openEvent;
 
       expect(await isElementFocused(page, "#modal2")).toBe(true);

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -91,14 +91,6 @@ export class Modal extends LitElement implements OpenCloseComponent {
 
   private _open = false;
 
-  private openEnd = (): void => {
-    this.setFocus();
-    this.el.removeEventListener(
-      "calciteModalOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-  };
-
   openProp = "opened";
 
   transitionProp = "opacity" as const;
@@ -384,8 +376,11 @@ export class Modal extends LitElement implements OpenCloseComponent {
 
   onOpen(): void {
     this.transitionEl?.classList.remove(CSS.openingIdle, CSS.openingActive);
-    this.calciteModalOpen.emit();
+    if (this.focusTrapDisabled) {
+      this.setFocus();
+    }
     this.focusTrap.activate();
+    this.calciteModalOpen.emit();
   }
 
   onBeforeClose(): void {
@@ -429,10 +424,6 @@ export class Modal extends LitElement implements OpenCloseComponent {
 
   private async openModal(): Promise<void> {
     await this.componentOnReady();
-    this.el.addEventListener(
-      "calciteModalOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     this.opened = true;
 
     this.titleId = ensureId(this.titleEl);

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -5,6 +5,7 @@ import { html } from "../../../support/formatting";
 import { accessible, defaults, focusable, hidden, openClose, reflects, renders, themed } from "../../tests/commonTests";
 import { GlobalTestProps, newProgrammaticE2EPage, skipAnimations } from "../../tests/utils/puppeteer";
 import { resizeStep, resizeShiftStep } from "../../utils/resources";
+import { focusTrap } from "../../tests/commonTests/focusTrap";
 import { CSS } from "./resources";
 import type { Sheet } from "./sheet";
 
@@ -128,6 +129,12 @@ describe("calcite-sheet properties", () => {
   describe("openClose", () => {
     openClose("calcite-sheet");
     openClose.initial("calcite-sheet");
+  });
+
+  describe("focus-trap", () => {
+    focusTrap("calcite-sheet", {
+      toggleProp: "open",
+    });
   });
 
   it("sets custom width correctly", async () => {

--- a/packages/calcite-components/src/components/sheet/sheet.e2e.ts
+++ b/packages/calcite-components/src/components/sheet/sheet.e2e.ts
@@ -132,9 +132,16 @@ describe("calcite-sheet properties", () => {
   });
 
   describe("focus-trap", () => {
-    focusTrap("calcite-sheet", {
-      toggleProp: "open",
-    });
+    focusTrap(
+      html` <calcite-sheet>
+        <!-- sheet has no default focusable parts -->
+        <input id="focusable-content" />
+      </calcite-sheet>`,
+      {
+        toggleProp: "open",
+        focusTargetSelector: "#focusable-content",
+      },
+    );
   });
 
   it("sets custom width correctly", async () => {

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -79,14 +79,6 @@ export class Sheet extends LitElement implements OpenCloseComponent {
 
   private _open = false;
 
-  private openEnd = (): void => {
-    this.setFocus();
-    this.el.removeEventListener(
-      "calciteSheetOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-  };
-
   openProp = "opened";
 
   transitionProp = "opacity" as const;
@@ -550,10 +542,6 @@ export class Sheet extends LitElement implements OpenCloseComponent {
 
   private async openSheet(): Promise<void> {
     await this.componentOnReady();
-    this.el.addEventListener(
-      "calciteSheetOpen",
-      this.openEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     this.opened = true;
   }
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -509,8 +509,11 @@ export class Sheet extends LitElement implements OpenCloseComponent {
   }
 
   onOpen(): void {
-    this.calciteSheetOpen.emit();
+    if (this.focusTrapDisabled) {
+      this.setFocus();
+    }
     this.focusTrap.activate();
+    this.calciteSheetOpen.emit();
   }
 
   onBeforeClose(): void {

--- a/packages/calcite-components/src/tests/commonTests/focusTrap.ts
+++ b/packages/calcite-components/src/tests/commonTests/focusTrap.ts
@@ -7,6 +7,12 @@ import { ComponentTestSetup } from "./interfaces";
 
 interface FocusTrapOptions {
   /**
+   * The selector for the element to focus when the component is opened.
+   * If not provided, the component itself will be used as the target.
+   */
+  focusTargetSelector?: string;
+
+  /**
    * The property that toggles the opening of the component.
    */
   toggleProp: string;
@@ -32,6 +38,7 @@ export function focusTrap(componentTestSetup: ComponentTestSetup, options: Focus
     let page: E2EPage;
     let tag: string;
     let element: E2EElement;
+    let focusTargetSelector: string;
 
     let openEvent: ReturnType<typeof page.waitForEvent>;
 
@@ -48,34 +55,35 @@ export function focusTrap(componentTestSetup: ComponentTestSetup, options: Focus
       element = await page.find(tag);
       const openEventName = `${camelCase(`${tag}${pascalCase(options.toggleProp)}`)}`;
       openEvent = page.waitForEvent(openEventName);
+      focusTargetSelector = options.focusTargetSelector || tag;
     });
 
     it("does not focus when false", async () => {
-      expect(await isElementFocused(page, tag)).toBe(false);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
       element.setProperty("focusTrapOptions", { initialFocus: false });
       await page.waitForChanges();
       await toggleComponent(page, element, options);
 
-      expect(await isElementFocused(page, tag)).toBe(false);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
     });
 
     it("focuses by default", async () => {
-      expect(await isElementFocused(page, tag)).toBe(false);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
       await toggleComponent(page, element, options);
 
-      expect(await isElementFocused(page, tag)).toBe(true);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(true);
     });
 
     it("focuses when true", async () => {
-      expect(await isElementFocused(page, tag)).toBe(false);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
       element.setProperty("focusTrapOptions", { initialFocus: true });
       await page.waitForChanges();
       await toggleComponent(page, element, options);
 
-      expect(await isElementFocused(page, tag)).toBe(true);
+      expect(await isElementFocused(page, focusTargetSelector)).toBe(true);
     });
 
     describe("when focusTrapDisabled = true", () => {
@@ -85,31 +93,31 @@ export function focusTrap(componentTestSetup: ComponentTestSetup, options: Focus
       });
 
       it("focuses when false", async () => {
-        expect(await isElementFocused(page, tag)).toBe(false);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
         element.setProperty("focusTrapOptions", { initialFocus: false });
         await page.waitForChanges();
         await toggleComponent(page, element, options);
 
-        expect(await isElementFocused(page, tag)).toBe(true);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(true);
       });
 
       it("focuses by default", async () => {
-        expect(await isElementFocused(page, tag)).toBe(false);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
         await toggleComponent(page, element, options);
 
-        expect(await isElementFocused(page, tag)).toBe(true);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(true);
       });
 
       it("focuses when true", async () => {
-        expect(await isElementFocused(page, tag)).toBe(false);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(false);
 
         element.setProperty("focusTrapOptions", { initialFocus: true });
         await page.waitForChanges();
         await toggleComponent(page, element, options);
 
-        expect(await isElementFocused(page, tag)).toBe(true);
+        expect(await isElementFocused(page, focusTargetSelector)).toBe(true);
       });
     });
   });

--- a/packages/calcite-components/src/tests/commonTests/focusTrap.ts
+++ b/packages/calcite-components/src/tests/commonTests/focusTrap.ts
@@ -1,0 +1,116 @@
+import { E2EPage, E2EElement } from "@arcgis/lumina-compiler/puppeteerTesting";
+import { beforeEach, describe, expect, it } from "vitest";
+import { camelCase, pascalCase } from "change-case";
+import { isElementFocused, skipAnimations } from "../utils/puppeteer";
+import { getTagAndPage } from "./utils";
+import { ComponentTestSetup } from "./interfaces";
+
+interface FocusTrapOptions {
+  /**
+   * The property that toggles the opening of the component.
+   */
+  toggleProp: string;
+}
+
+/**
+ * Helper for testing focus-trapping behavior in components.
+ *
+ * Note: this assumes the component under test is closed and will be opened before running assertions.
+ *
+ * @example
+ * describe("focus-trap", () => {
+ *   focusTrap("calcite-modal", {
+ *    toggleProp: "open"
+ *   });
+ * });
+ *
+ * @param {string} componentTestSetup
+ * @param options
+ */
+export function focusTrap(componentTestSetup: ComponentTestSetup, options: FocusTrapOptions): void {
+  describe(`initialFocus`, () => {
+    let page: E2EPage;
+    let tag: string;
+    let element: E2EElement;
+
+    let openEvent: ReturnType<typeof page.waitForEvent>;
+
+    async function toggleComponent(page: E2EPage, element: E2EElement, options: FocusTrapOptions): Promise<void> {
+      element.setProperty(options.toggleProp, true);
+      await page.waitForChanges();
+      await openEvent;
+      await page.waitForChanges();
+    }
+
+    beforeEach(async () => {
+      ({ tag, page } = await getTagAndPage(componentTestSetup));
+      await skipAnimations(page);
+      element = await page.find(tag);
+      const openEventName = `${camelCase(`${tag}${pascalCase(options.toggleProp)}`)}`;
+      openEvent = page.waitForEvent(openEventName);
+    });
+
+    it("does not focus when false", async () => {
+      expect(await isElementFocused(page, tag)).toBe(false);
+
+      element.setProperty("focusTrapOptions", { initialFocus: false });
+      await page.waitForChanges();
+      await toggleComponent(page, element, options);
+
+      expect(await isElementFocused(page, tag)).toBe(false);
+    });
+
+    it("focuses by default", async () => {
+      expect(await isElementFocused(page, tag)).toBe(false);
+
+      await toggleComponent(page, element, options);
+
+      expect(await isElementFocused(page, tag)).toBe(true);
+    });
+
+    it("focuses when true", async () => {
+      expect(await isElementFocused(page, tag)).toBe(false);
+
+      element.setProperty("focusTrapOptions", { initialFocus: true });
+      await page.waitForChanges();
+      await toggleComponent(page, element, options);
+
+      expect(await isElementFocused(page, tag)).toBe(true);
+    });
+
+    describe("when focusTrapDisabled = true", () => {
+      beforeEach(async () => {
+        element.setProperty("focusTrapDisabled", true);
+        await page.waitForChanges();
+      });
+
+      it("focuses when false", async () => {
+        expect(await isElementFocused(page, tag)).toBe(false);
+
+        element.setProperty("focusTrapOptions", { initialFocus: false });
+        await page.waitForChanges();
+        await toggleComponent(page, element, options);
+
+        expect(await isElementFocused(page, tag)).toBe(true);
+      });
+
+      it("focuses by default", async () => {
+        expect(await isElementFocused(page, tag)).toBe(false);
+
+        await toggleComponent(page, element, options);
+
+        expect(await isElementFocused(page, tag)).toBe(true);
+      });
+
+      it("focuses when true", async () => {
+        expect(await isElementFocused(page, tag)).toBe(false);
+
+        element.setProperty("focusTrapOptions", { initialFocus: true });
+        await page.waitForChanges();
+        await toggleComponent(page, element, options);
+
+        expect(await isElementFocused(page, tag)).toBe(true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
**Related Issue:** #11781

## Summary

Fixes an issue that caused focus-trapping components with `initialFocus` disabled to be ignored.

### Notes

* to avoid a breaking change, components with `focusTrapDisabled` will still focus on opening
  * this will likely change in a future version and require developers to call `setFocus` after opening
* adds starter `focusTrap` common test util to cover this behavior
* improves test coverage for `dialog`'s focus-trapping test group

