### PR TITLE
refactor(dropdown): tidy up `setFocus` calls

### DIFF
--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -72,14 +72,6 @@ export class Dropdown
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
 
-  private onOpenEnd = (): void => {
-    this.focusOnFirstActiveOrDefaultItem();
-    this.el.removeEventListener(
-      "calciteDropdownOpen",
-      this.onOpenEnd,
-    ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-  };
-
   transitionProp = "opacity" as const;
 
   referenceEl: HTMLDivElement;
@@ -506,7 +498,8 @@ export class Dropdown
     this.calciteDropdownBeforeOpen.emit();
   }
 
-  onOpen(): void {
+  async onOpen(): Promise<void> {
+    this.focusOnFirstActiveOrDefaultItem();
     this.calciteDropdownOpen.emit();
   }
 
@@ -562,10 +555,6 @@ export class Dropdown
       event.preventDefault();
       this.focusLastDropdownItem = key === "ArrowUp";
       this.open = true;
-      this.el.addEventListener(
-        "calciteDropdownOpen",
-        this.onOpenEnd,
-      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
     }
   }
 
@@ -612,12 +601,6 @@ export class Dropdown
 
   private toggleDropdown() {
     this.open = !this.open;
-    if (this.open) {
-      this.el.addEventListener(
-        "calciteDropdownOpen",
-        this.onOpenEnd,
-      ) /* TODO: [MIGRATION] If possible, refactor to use on* JSX prop or this.listen()/this.listenOn() utils - they clean up event listeners automatically, thus prevent memory leaks */;
-    }
   }
 
   private updateTabIndexOfItems(target: DropdownItem["el"]): void {


### PR DESCRIPTION
**Related Issue:** #11781

## Summary

Removes explicit open event listeners in favor of open/close hooks.

