### PR TITLE
fix(autocomplete): fix setFocus method in Safari

### DIFF
--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -53,6 +53,7 @@ import type { AutocompleteItemGroup } from "../autocomplete-item-group/autocompl
 import type { Label } from "../label/label";
 import { Validation } from "../functional/Validation";
 import { createObserver } from "../../utils/observers";
+import { componentFocusable } from "../../utils/component";
 import { styles } from "./autocomplete.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, SLOTS } from "./resources";
@@ -377,6 +378,8 @@ export class Autocomplete
    */
   @method()
   async setFocus(): Promise<void> {
+    await componentFocusable(this);
+
     return this.referenceEl.setFocus();
   }
 


### PR DESCRIPTION
**Related Issue:** #12078

## Summary

- fixes setFocus method in safari by waiting for component to be focusable before proceeding to focus internal component