### PR TITLE
feat(action-bar): add floating property and "grid" layout value

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -36,8 +36,8 @@ describe("calcite-action-bar", () => {
         defaultValue: false,
       },
       {
-        propertyName: "displayMode",
-        defaultValue: "dock",
+        propertyName: "floating",
+        defaultValue: false,
       },
       {
         propertyName: "expanded",
@@ -69,8 +69,8 @@ describe("calcite-action-bar", () => {
         value: true,
       },
       {
-        propertyName: "displayMode",
-        value: "float",
+        propertyName: "floating",
+        value: true,
       },
       {
         propertyName: "overlayPositioning",
@@ -587,9 +587,9 @@ describe("calcite-action-bar", () => {
         },
       );
     });
-    describe(`displayMode="float"`, () => {
+    describe("floating", () => {
       themed(
-        html`<calcite-action-bar expanded layout="vertical" display-mode="float">
+        html`<calcite-action-bar expanded layout="vertical" floating>
           <calcite-action-group>
             <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
           </calcite-action-group>

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -36,6 +36,10 @@ describe("calcite-action-bar", () => {
         defaultValue: false,
       },
       {
+        propertyName: "displayMode",
+        defaultValue: "dock",
+      },
+      {
         propertyName: "expanded",
         defaultValue: false,
       },
@@ -63,6 +67,10 @@ describe("calcite-action-bar", () => {
       {
         propertyName: "expanded",
         value: true,
+      },
+      {
+        propertyName: "displayMode",
+        value: "float",
       },
       {
         propertyName: "overlayPositioning",
@@ -564,11 +572,41 @@ describe("calcite-action-bar", () => {
           </calcite-action-group>
         </calcite-action-bar>`,
         {
+          "--calcite-action-bar-background-color": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "backgroundColor",
+          },
           "--calcite-action-bar-expanded-max-width": {
+            shadowSelector: `.${CSS.container}`,
             targetProp: "maxInlineSize",
           },
           "--calcite-action-bar-items-space": {
+            shadowSelector: `.${CSS.container}`,
             targetProp: "gap",
+          },
+        },
+      );
+    });
+    describe(`displayMode="float"`, () => {
+      themed(
+        html`<calcite-action-bar expanded layout="vertical">
+          <calcite-action-group>
+            <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action-menu label="Save and open">
+              <calcite-action id="menu-action" text-enabled text="Save" label="Save" icon="save"></calcite-action>
+            </calcite-action-menu>
+          </calcite-action-group>
+        </calcite-action-bar>`,
+        {
+          "--calcite-action-bar-corner-radius": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "borderRadius",
+          },
+          "--calcite-action-bar-shadow": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "boxShadow",
           },
         },
       );

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -589,7 +589,7 @@ describe("calcite-action-bar", () => {
     });
     describe(`displayMode="float"`, () => {
       themed(
-        html`<calcite-action-bar expanded layout="vertical">
+        html`<calcite-action-bar expanded layout="vertical" display-mode="float">
           <calcite-action-group>
             <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
           </calcite-action-group>

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -3,17 +3,39 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-action-bar-background-color: Specifies the component's background color.
+ * @prop --calcite-action-bar-corner-radius: Specifies the component's border radius when `displayMode` is `"float"`.
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the component's maximum width.
  * @prop --calcite-action-bar-items-space: Specifies the space between slotted components in the component.
+ * @prop --calcite-action-bar-shadow: Specifies the component's shadow when `displayMode` is `"float"`.
  */
 
 :host {
   @extend %component-host;
-  @apply pointer-events-auto
-    inline-flex
+  @apply inline-flex
     self-stretch;
+  background: transparent;
+}
 
+.container {
+  --tw-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
+  --tw-shadow-colored: 0 6px 20px -4px var(--tw-shadow-color), 0 4px 12px -2px var(--tw-shadow-color);
+  box-shadow: var(
+    --calcite-action-bar-shadow,
+    (var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow))
+  );
+  @apply inline-flex
+  flex-col
+  overflow-hidden;
   gap: var(--calcite-action-bar-items-space, 0);
+  background-color: var(--calcite-action-bar-background-color, var(--calcite-color-foreground-1));
+}
+
+:host([display-mode="float"]) {
+  .container {
+    @apply animate-in;
+    border-radius: var(--calcite-action-bar-corner-radius, var(--calcite-corner-radius-round));
+  }
 }
 
 :host([layout="vertical"]) {
@@ -23,7 +45,7 @@
     overflow-y: auto;
   }
 
-  &:host([expanded]) {
+  &:host([expanded]) .container {
     max-inline-size: var(--calcite-action-bar-expanded-max-width, auto);
   }
 
@@ -38,6 +60,10 @@
 
 :host([layout="horizontal"]) {
   @apply flex-row;
+
+  .container {
+    @apply flex-row;
+  }
 
   &:host([overflow-actions-disabled]) {
     overflow-x: auto;

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -4,10 +4,10 @@
  * These properties can be overridden using the component's tag as selector.
  *
  * @prop --calcite-action-bar-background-color: Specifies the component's background color.
- * @prop --calcite-action-bar-corner-radius: Specifies the component's border radius when `displayMode` is `"float"`.
+ * @prop --calcite-action-bar-corner-radius: Specifies the component's border radius when `floating` is `true`.
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the component's maximum width.
  * @prop --calcite-action-bar-items-space: Specifies the space between slotted components in the component.
- * @prop --calcite-action-bar-shadow: Specifies the component's shadow when `displayMode` is `"float"`.
+ * @prop --calcite-action-bar-shadow: Specifies the component's shadow when `floating` is `true`.
  */
 
 :host {
@@ -31,7 +31,7 @@
   background-color: var(--calcite-action-bar-background-color, var(--calcite-color-foreground-1));
 }
 
-:host([display-mode="float"]) {
+:host([floating]) {
   .container {
     @apply animate-in;
     border-radius: var(--calcite-action-bar-corner-radius, var(--calcite-corner-radius-round));

--- a/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
@@ -196,6 +196,21 @@ export const withDefinedWidths = (): string => html`
   </calcite-action-bar>
 `;
 
+export const gridLayout = (): string =>
+  html` <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled display-mode="float">
+    <calcite-action-group>
+      <calcite-action text="Northwest" icon="chevron-up-left"></calcite-action>
+      <calcite-action text="North" icon="chevron-up"></calcite-action>
+      <calcite-action text="Northeast" icon="chevron-up-right"></calcite-action>
+      <calcite-action text="West" icon="chevron-left"></calcite-action>
+      <calcite-action text="Center" icon="gps-on"></calcite-action>
+      <calcite-action text="East" icon="chevron-right"></calcite-action>
+      <calcite-action text="Southwest" icon="chevron-down-left"></calcite-action>
+      <calcite-action text="South" icon="chevron-down"></calcite-action>
+      <calcite-action text="Southeast" icon="chevron-down-right"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>`;
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-action-bar position="start" dir="rtl" class="calcite-mode-dark">
     <calcite-action-group>

--- a/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
@@ -5,9 +5,7 @@ import { ActionBar } from "./action-bar";
 
 const { position } = ATTRIBUTES;
 
-type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "displayMode" | "position">;
-
-const displayModeValues = ["dock", "float"];
+type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "floating" | "position">;
 
 export default {
   title: "Components/Action Bar",
@@ -15,15 +13,11 @@ export default {
     expandDisabled: false,
     expanded: false,
     position: position.defaultValue,
-    displayMode: displayModeValues[0],
+    floating: false,
   },
   argTypes: {
     position: {
       options: position.values.filter((option) => option !== "top" && option !== "bottom"),
-      control: { type: "select" },
-    },
-    displayMode: {
-      options: displayModeValues,
       control: { type: "select" },
     },
   },
@@ -33,7 +27,7 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   <calcite-action-bar
     ${boolean("expand-disabled", args.expandDisabled)}
     ${boolean("expanded", args.expanded)}
-    display-mode="${args.displayMode}"
+    floating="${args.floating}"
     position="${args.position}"
   >
     <calcite-action-group>
@@ -46,8 +40,8 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   </calcite-action-bar>
 `;
 
-export const float = (args: ActionBarStoryArgs): string => html`
-  <calcite-action-bar position="${args.position}" display-mode="float">
+export const floating = (args: ActionBarStoryArgs): string => html`
+  <calcite-action-bar position="${args.position}" floating>
     <calcite-action-group>
       <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
       <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
@@ -58,13 +52,13 @@ export const float = (args: ActionBarStoryArgs): string => html`
   </calcite-action-bar>
 `;
 
-export const floatWithDefinedWidths = (): string => html`
+export const floatingWithDefinedWidths = (): string => html`
   <style>
     calcite-action-bar {
       --calcite-action-bar-expanded-max-width: 150px;
     }
   </style>
-  <calcite-action-bar display-mode="float" expanded>
+  <calcite-action-bar floating expanded>
     <calcite-action-group expanded>
       <calcite-action text-enabled text="Add to my custom action bar application" icon="plus"></calcite-action>
       <calcite-action text-enabled text="Save to my custom action bar application" icon="save"></calcite-action>
@@ -75,8 +69,8 @@ export const floatWithDefinedWidths = (): string => html`
   </calcite-action-bar>
 `;
 
-export const floatWithGroups = (): string =>
-  html`<calcite-action-bar display-mode="float" layout="horizontal">
+export const floatingWithGroups = (): string =>
+  html`<calcite-action-bar floating layout="horizontal">
     <calcite-action-group>
       <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
       <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
@@ -96,8 +90,8 @@ export const floatWithGroups = (): string =>
     >
   </calcite-action-bar>`;
 
-export const floatDarkModeRTL = (): string =>
-  html` <calcite-action-bar display-mode="float" position="start" dir="rtl" class="calcite-mode-dark">
+export const floatingDarkModeRTL = (): string =>
+  html` <calcite-action-bar floating position="start" dir="rtl" class="calcite-mode-dark">
     <calcite-action-group>
       <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
       <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
@@ -107,7 +101,7 @@ export const floatDarkModeRTL = (): string =>
     </calcite-action-group>
   </calcite-action-bar>`;
 
-floatDarkModeRTL.parameters = { themes: modesDarkDefault };
+floatingDarkModeRTL.parameters = { themes: modesDarkDefault };
 
 export const horizontal = (): string => html`
   <div style="width: 500px;">
@@ -197,7 +191,7 @@ export const withDefinedWidths = (): string => html`
 `;
 
 export const gridLayout = (): string =>
-  html` <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled display-mode="float">
+  html` <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled floating>
     <calcite-action-group>
       <calcite-action text="Northwest" icon="chevron-up-left"></calcite-action>
       <calcite-action text="North" icon="chevron-up"></calcite-action>

--- a/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
@@ -5,7 +5,9 @@ import { ActionBar } from "./action-bar";
 
 const { position } = ATTRIBUTES;
 
-type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "position">;
+type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "displayMode" | "position">;
+
+const displayModeValues = ["dock", "float"];
 
 export default {
   title: "Components/Action Bar",
@@ -13,10 +15,15 @@ export default {
     expandDisabled: false,
     expanded: false,
     position: position.defaultValue,
+    displayMode: displayModeValues[0],
   },
   argTypes: {
     position: {
       options: position.values.filter((option) => option !== "top" && option !== "bottom"),
+      control: { type: "select" },
+    },
+    displayMode: {
+      options: displayModeValues,
       control: { type: "select" },
     },
   },
@@ -26,6 +33,7 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   <calcite-action-bar
     ${boolean("expand-disabled", args.expandDisabled)}
     ${boolean("expanded", args.expanded)}
+    display-mode="${args.displayMode}"
     position="${args.position}"
   >
     <calcite-action-group>
@@ -37,6 +45,69 @@ export const simple = (args: ActionBarStoryArgs): string => html`
     </calcite-action-group>
   </calcite-action-bar>
 `;
+
+export const float = (args: ActionBarStoryArgs): string => html`
+  <calcite-action-bar position="${args.position}" display-mode="float">
+    <calcite-action-group>
+      <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+      <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>
+`;
+
+export const floatWithDefinedWidths = (): string => html`
+  <style>
+    calcite-action-bar {
+      --calcite-action-bar-expanded-max-width: 150px;
+    }
+  </style>
+  <calcite-action-bar display-mode="float" expanded>
+    <calcite-action-group expanded>
+      <calcite-action text-enabled text="Add to my custom action bar application" icon="plus"></calcite-action>
+      <calcite-action text-enabled text="Save to my custom action bar application" icon="save"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group expanded>
+      <calcite-action text-enabled text="Layers in my custom action bar application" icon="layers"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>
+`;
+
+export const floatWithGroups = (): string =>
+  html`<calcite-action-bar display-mode="float" layout="horizontal">
+    <calcite-action-group>
+      <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Layers" icon="layers" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Basemaps" icon="layer-basemap" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-tooltip
+      slot="expand-tooltip"
+      id="calcite-tooltip-c19274e3-ff3b-6168-ef1e-8a700b056e1c"
+      role="tooltip"
+      overlay-positioning="absolute"
+      placement="auto"
+      style="visibility: hidden; pointer-events: none; position: absolute;"
+      >Toggle Action bar</calcite-tooltip
+    >
+  </calcite-action-bar>`;
+
+export const floatDarkModeRTL = (): string =>
+  html` <calcite-action-bar display-mode="float" position="start" dir="rtl" class="calcite-mode-dark">
+    <calcite-action-group>
+      <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
+      <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>`;
+
+floatDarkModeRTL.parameters = { themes: modesDarkDefault };
 
 export const horizontal = (): string => html`
   <div style="width: 500px;">

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -138,7 +138,8 @@ export class ActionBar extends LitElement {
   @property({ reflect: true }) expanded = false;
 
   /** Specifies the layout direction of the actions. */
-  @property({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
+  @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
+    "vertical";
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -22,7 +22,6 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
 import { overflowActions, queryActions } from "./utils";
 import { styles } from "./action-bar.scss";
-import { DisplayMode } from "./interfaces";
 
 declare global {
   interface DeclareElements {
@@ -123,13 +122,9 @@ export class ActionBar extends LitElement {
   @property() actionsEndGroupLabel: string;
 
   /**
-   * Specifies the display mode of the component, where:
-   *
-   * `"dock"` displays at full height.
-   *
-   * `"float"` does not display at full height.
+   * When `true`, the component is in a floating state.
    */
-  @property({ reflect: true }) displayMode: DisplayMode = "dock";
+  @property({ reflect: true }) floating = false;
 
   /** When `true`, the expand-toggling behavior is disabled. */
   @property({ reflect: true }) expandDisabled = false;

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -1,16 +1,7 @@
 // @ts-strict-ignore
 import { debounce } from "lodash-es";
 import { PropertyValues } from "lit";
-import {
-  LitElement,
-  property,
-  createEvent,
-  Fragment,
-  h,
-  method,
-  state,
-  JsxNode,
-} from "@arcgis/lumina";
+import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {
   focusFirstTabbable,
   slotChangeGetAssignedElements,
@@ -31,6 +22,7 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
 import { overflowActions, queryActions } from "./utils";
 import { styles } from "./action-bar.scss";
+import { DisplayMode } from "./interfaces";
 
 declare global {
   interface DeclareElements {
@@ -129,6 +121,15 @@ export class ActionBar extends LitElement {
 
   /** Specifies the accessible label for the last `calcite-action-group`. */
   @property() actionsEndGroupLabel: string;
+
+  /**
+   * Specifies the display mode of the component, where:
+   *
+   * `"dock"` displays at full height.
+   *
+   * `"float"` does not display at full height.
+   */
+  @property({ reflect: true }) displayMode: DisplayMode = "dock";
 
   /** When `true`, the expand-toggling behavior is disabled. */
   @property({ reflect: true }) expandDisabled = false;
@@ -296,11 +297,10 @@ export class ActionBar extends LitElement {
   private updateGroups(): void {
     const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
     this.actionGroups = groups;
-    this.setGroupLayout(groups);
-  }
-
-  private setGroupLayout(groups: ActionGroup["el"][]): void {
-    groups.forEach((group) => (group.layout = this.layout));
+    groups.forEach((group) => {
+      group.layout = this.layout;
+      group.scale = this.scale;
+    });
   }
 
   private handleDefaultSlotChange(): void {
@@ -376,10 +376,10 @@ export class ActionBar extends LitElement {
 
   override render(): JsxNode {
     return (
-      <>
+      <div class={CSS.container}>
         <slot onSlotChange={this.handleDefaultSlotChange} />
         {this.renderBottomActionGroup()}
-      </>
+      </div>
     );
   }
 

--- a/packages/calcite-components/src/components/action-bar/interfaces.ts
+++ b/packages/calcite-components/src/components/action-bar/interfaces.ts
@@ -1,1 +1,0 @@
-export type DisplayMode = "dock" | "float";

--- a/packages/calcite-components/src/components/action-bar/interfaces.ts
+++ b/packages/calcite-components/src/components/action-bar/interfaces.ts
@@ -1,0 +1,1 @@
+export type DisplayMode = "dock" | "float";

--- a/packages/calcite-components/src/components/action-bar/resources.ts
+++ b/packages/calcite-components/src/components/action-bar/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
+  container: "container",
   actionGroupEnd: "action-group--end",
 };
 

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -10,6 +10,7 @@ import { OverlayPositioning } from "../../utils/floating-ui";
 import { useT9n } from "../../controllers/useT9n";
 import type { Tooltip } from "../tooltip/tooltip";
 import type { ActionGroup } from "../action-group/action-group";
+import { logger } from "../../utils/logger";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
 import { styles } from "./action-pad.scss";
@@ -21,6 +22,7 @@ declare global {
 }
 
 /**
+ * @deprecated Use the `calcite-dialog` component instead.
  * @slot - A slot for adding `calcite-action`s to the component.
  * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
@@ -121,6 +123,14 @@ export class ActionPad extends LitElement {
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
+  }
+
+  async load(): Promise<void> {
+    logger.deprecated("component", {
+      name: "action-pad",
+      removalVersion: 4,
+      suggested: "action-bar",
+    });
   }
 
   override willUpdate(changes: PropertyValues<this>): void {


### PR DESCRIPTION
**Related Issue:** #7507

## Summary

- Adds `floating` property to `action-bar`
- Deprecates `action-pad`
- Add tests
- Add stories