### PR TITLE
refactor(input-time-picker): use private computed property for step precision

### DIFF
--- a/packages/calcite-components/src/components/time-picker/time-picker.tsx
+++ b/packages/calcite-components/src/components/time-picker/time-picker.tsx
@@ -67,6 +67,8 @@ export class TimePicker extends LitElement {
 
   private secondEl: HTMLSpanElement;
 
+  private stepPrecision: number;
+
   /**
    * Made into a prop for testing purposes only
    *
@@ -335,7 +337,7 @@ export class TimePicker extends LitElement {
   private fractionalSecondKeyDownHandler(event: KeyboardEvent): void {
     const { key } = event;
     if (numberKeys.includes(key)) {
-      const stepPrecision = decimalPlaces(this.step);
+      const { stepPrecision } = this;
       const fractionalSecondAsInteger = parseInt(this.fractionalSecond);
       const fractionalSecondAsIntegerLength = fractionalSecondAsInteger.toString().length;
 
@@ -567,7 +569,7 @@ export class TimePicker extends LitElement {
 
   private nudgeFractionalSecond(direction: "up" | "down"): void {
     const stepDecimal = getDecimals(this.step);
-    const stepPrecision = decimalPlaces(this.step);
+    const { stepPrecision } = this;
     const fractionalSecondAsInteger = parseInt(this.fractionalSecond);
     const fractionalSecondAsFloat = parseFloat(`0.${this.fractionalSecond}`);
     let nudgedValue;
@@ -610,8 +612,9 @@ export class TimePicker extends LitElement {
   }
 
   private sanitizeFractionalSecond(fractionalSecond: string): string {
-    return fractionalSecond && decimalPlaces(this.step) !== fractionalSecond.length
-      ? parseFloat(`0.${fractionalSecond}`).toFixed(decimalPlaces(this.step)).replace("0.", "")
+    const { stepPrecision } = this;
+    return fractionalSecond && stepPrecision !== fractionalSecond.length
+      ? parseFloat(`0.${fractionalSecond}`).toFixed(stepPrecision).replace("0.", "")
       : fractionalSecond;
   }
 
@@ -795,7 +798,7 @@ export class TimePicker extends LitElement {
         });
       }
     } else if (key === "fractionalSecond") {
-      const stepPrecision = decimalPlaces(this.step);
+      const { stepPrecision } = this;
       if (typeof value === "number") {
         this.fractionalSecond =
           value === 0 ? "".padStart(stepPrecision, "0") : formatTimePart(value, stepPrecision);
@@ -858,7 +861,8 @@ export class TimePicker extends LitElement {
 
   private toggleSecond(): void {
     this.showSecond = this.step < 60;
-    this.showFractionalSecond = decimalPlaces(this.step) > 0;
+    this.stepPrecision = decimalPlaces(this.step);
+    this.showFractionalSecond = this.stepPrecision > 0;
   }
 
   private updateLocale() {
@@ -1074,7 +1078,7 @@ export class TimePicker extends LitElement {
               role="spinbutton"
               tabIndex={0}
             >
-              {this.localizedFractionalSecond || "".padStart(decimalPlaces(this.step), "-")}
+              {this.localizedFractionalSecond || "".padStart(this.stepPrecision, "-")}
             </span>
             <span
               ariaLabel={this.messages.fractionalSecondDown}


### PR DESCRIPTION
**Related Issue:** #12090

## Summary

This PR addresses refactor review comments from #11712.