### PR TITLE
feat(block): add specific component css tokens

### DIFF
--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -499,7 +499,10 @@ describe("calcite-block", () => {
             targetProp: "backgroundColor",
             state: { press: `calcite-block >>> .${CSS.toggle}` },
           },
-          "--calcite-block-text-color": [{ shadowSelector: `.${CSS.contentStart}`, targetProp: "color" }],
+          "--calcite-block-text-color": {
+            shadowSelector: `.${CSS.contentStart}`,
+            targetProp: "color",
+          },
           "--calcite-block-heading-text-color-press": {
             shadowSelector: `.${CSS.heading}`,
             targetProp: "color",
@@ -511,11 +514,11 @@ describe("calcite-block", () => {
           },
           "--calcite-block-icon-color": [
             {
-              shadowSelector: `.${CSS.iconEnd}`,
+              shadowSelector: `.${CSS.iconStart}`,
               targetProp: "color",
             },
             {
-              shadowSelector: `.${CSS.iconStart}`,
+              shadowSelector: `.${CSS.iconEnd}`,
               targetProp: "color",
             },
             {

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -499,25 +499,35 @@ describe("calcite-block", () => {
             targetProp: "backgroundColor",
             state: { press: `calcite-block >>> .${CSS.toggle}` },
           },
-          "--calcite-block-text-color": [
-            { shadowSelector: `.${CSS.description}`, targetProp: "color" },
-            { shadowSelector: `.${CSS.contentStart}`, targetProp: "color" },
-            { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
-            { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
-            { shadowSelector: `.${CSS.toggleIcon}`, targetProp: "color" },
-          ],
-          "--calcite-block-heading-text-color-press": [
+          "--calcite-block-text-color": [{ shadowSelector: `.${CSS.contentStart}`, targetProp: "color" }],
+          "--calcite-block-heading-text-color-press": {
+            shadowSelector: `.${CSS.heading}`,
+            targetProp: "color",
+            state: { press: { attribute: "class", value: CSS.heading } },
+          },
+          "--calcite-block-description-text-color": {
+            shadowSelector: `.${CSS.description}`,
+            targetProp: "color",
+          },
+          "--calcite-block-icon-color": [
+            {
+              shadowSelector: `.${CSS.iconEnd}`,
+              targetProp: "color",
+            },
+            {
+              shadowSelector: `.${CSS.iconStart}`,
+              targetProp: "color",
+            },
             {
               shadowSelector: `.${CSS.toggleIcon}`,
               targetProp: "color",
-              state: "hover",
-            },
-            {
-              shadowSelector: `.${CSS.heading}`,
-              targetProp: "color",
-              state: { press: { attribute: "class", value: CSS.heading } },
             },
           ],
+          "--calcite-block-icon-color-hover": {
+            shadowSelector: `.${CSS.toggleIcon}`,
+            targetProp: "color",
+            state: "hover",
+          },
         },
       );
     });

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -11,6 +11,9 @@
  * @prop --calcite-block-heading-text-color-press: When the component is `expanded`, specifies the `heading` text color.
  * @prop --calcite-block-padding: [Deprecated] Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color: Specifies the component's text color.
+ * @prop --calcite-block-description-text-color: Specifies the component's description text color.
+ * @prop --calcite-block-icon-color: Specifies the component's icon color.
+ * @prop --calcite-block-icon-color-hover: Specifies the component's icon color when hovered.
  */
 
 :host {
@@ -66,7 +69,7 @@
 
 .icon--start,
 .icon--end {
-  color: var(--calcite-block-text-color, var(--calcite-color-text-3));
+  color: var(--calcite-block-icon-color, var(--calcite-color-text-3));
 }
 
 .actions-end {
@@ -131,7 +134,7 @@ calcite-handle {
     mt-0.5
     p-0;
 
-  color: var(--calcite-block-text-color, var(--calcite-color-text-3));
+  color: var(--calcite-block-description-text-color, var(--calcite-color-text-3));
 }
 
 .icon {
@@ -172,11 +175,11 @@ calcite-handle {
   ease-in-out;
 
   margin-inline-end: var(--calcite-spacing-md);
-  color: var(--calcite-block-text-color, var(--calcite-color-text-3));
+  color: var(--calcite-block-icon-color, var(--calcite-color-text-3));
 }
 
 .toggle:hover .toggle-icon {
-  color: var(--calcite-block-heading-text-color-press, var(--calcite-color-text-1));
+  color: var(--calcite-block-icon-color-hover, var(--calcite-color-text-1));
 }
 
 .container {
@@ -216,12 +219,12 @@ calcite-action-menu {
   }
 
   .description {
-    color: var(--calcite-block-text-color, var(--calcite-color-text-2));
+    color: var(--calcite-block-description-text-color, var(--calcite-color-text-2));
   }
 
   .icon--start,
   .icon--end {
-    color: var(--calcite-block-text-color, var(--calcite-color-text-1));
+    color: var(--calcite-block-icon-color, var(--calcite-color-text-1));
   }
 }
 

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -11,9 +11,9 @@
  * @prop --calcite-block-heading-text-color-press: When the component is `expanded`, specifies the `heading` text color.
  * @prop --calcite-block-padding: [Deprecated] Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color: Specifies the component's text color.
- * @prop --calcite-block-description-text-color: Specifies the component's description text color.
- * @prop --calcite-block-icon-color: Specifies the component's icon color.
- * @prop --calcite-block-icon-color-hover: Specifies the component's icon color when hovered.
+ * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
+ * @prop --calcite-block-icon-color: Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
  */
 
 :host {

--- a/packages/calcite-components/src/custom-theme/block.ts
+++ b/packages/calcite-components/src/custom-theme/block.ts
@@ -7,6 +7,9 @@ export const blockTokens = {
   calciteBlockTextColor: "",
   calciteBlockHeadingTextColor: "",
   calciteBlockHeadingTextColorPress: "",
+  calciteBlockDescriptionTextColor: "",
+  calciteBlockIconColor: "",
+  calciteBlockIconColorHover: "",
 };
 
 export const block = html` <calcite-block


### PR DESCRIPTION
**Related Issue:** [#11888](https://github.com/Esri/calcite-design-system/issues/11888)

## Summary

Add specific css tokens:

`--calcite-block-description-text-color`: Specifies the component's `description` text color.
`--calcite-block-icon-color`: Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
`--calcite-block-icon-color-hover`: Specifies the component's `collapsible` icon color when hovered.
