### PR TITLE
feat(action-bar): add floating property and "grid" layout value

### DIFF
--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -36,6 +36,10 @@ describe("calcite-action-bar", () => {
         defaultValue: false,
       },
       {
+        propertyName: "floating",
+        defaultValue: false,
+      },
+      {
         propertyName: "expanded",
         defaultValue: false,
       },
@@ -62,6 +66,10 @@ describe("calcite-action-bar", () => {
       },
       {
         propertyName: "expanded",
+        value: true,
+      },
+      {
+        propertyName: "floating",
         value: true,
       },
       {
@@ -564,11 +572,41 @@ describe("calcite-action-bar", () => {
           </calcite-action-group>
         </calcite-action-bar>`,
         {
+          "--calcite-action-bar-background-color": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "backgroundColor",
+          },
           "--calcite-action-bar-expanded-max-width": {
+            shadowSelector: `.${CSS.container}`,
             targetProp: "maxInlineSize",
           },
           "--calcite-action-bar-items-space": {
+            shadowSelector: `.${CSS.container}`,
             targetProp: "gap",
+          },
+        },
+      );
+    });
+    describe("floating", () => {
+      themed(
+        html`<calcite-action-bar expanded layout="vertical" floating>
+          <calcite-action-group>
+            <calcite-action id="my-action" text="Add" label="Add Item" icon="plus"></calcite-action>
+          </calcite-action-group>
+          <calcite-action-group>
+            <calcite-action-menu label="Save and open">
+              <calcite-action id="menu-action" text-enabled text="Save" label="Save" icon="save"></calcite-action>
+            </calcite-action-menu>
+          </calcite-action-group>
+        </calcite-action-bar>`,
+        {
+          "--calcite-action-bar-corner-radius": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "borderRadius",
+          },
+          "--calcite-action-bar-shadow": {
+            shadowSelector: `.${CSS.container}`,
+            targetProp: "boxShadow",
           },
         },
       );

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -18,15 +18,9 @@
 }
 
 .container {
-  --tw-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
-  --tw-shadow-colored: 0 6px 20px -4px var(--tw-shadow-color), 0 4px 12px -2px var(--tw-shadow-color);
-  box-shadow: var(
-    --calcite-action-bar-shadow,
-    (var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow))
-  );
   @apply inline-flex
   flex-col
-  overflow-hidden;
+  flex-auto;
   gap: var(--calcite-action-bar-items-space, 0);
   background-color: var(--calcite-action-bar-background-color, var(--calcite-color-foreground-1));
 }
@@ -35,13 +29,19 @@
   .container {
     @apply animate-in;
     border-radius: var(--calcite-action-bar-corner-radius, var(--calcite-corner-radius-round));
+    --tw-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
+    --tw-shadow-colored: 0 6px 20px -4px var(--tw-shadow-color), 0 4px 12px -2px var(--tw-shadow-color);
+    box-shadow: var(
+      --calcite-action-bar-shadow,
+      (var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow))
+    );
   }
 }
 
 :host([layout="vertical"]) {
   @apply flex-col;
 
-  &:host([overflow-actions-disabled]) {
+  &:host([overflow-actions-disabled]) .container {
     overflow-y: auto;
   }
 
@@ -65,7 +65,7 @@
     @apply flex-row;
   }
 
-  &:host([overflow-actions-disabled]) {
+  &:host([overflow-actions-disabled]) .container {
     overflow-x: auto;
   }
 

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -27,7 +27,8 @@
 
 :host([floating]) {
   .container {
-    @apply animate-in;
+    @apply animate-in
+    overflow-hidden;
     border-radius: var(--calcite-action-bar-corner-radius, var(--calcite-corner-radius-round));
     --tw-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
     --tw-shadow-colored: 0 6px 20px -4px var(--tw-shadow-color), 0 4px 12px -2px var(--tw-shadow-color);

--- a/packages/calcite-components/src/components/action-bar/action-bar.scss
+++ b/packages/calcite-components/src/components/action-bar/action-bar.scss
@@ -3,17 +3,39 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
+ * @prop --calcite-action-bar-background-color: Specifies the component's background color.
+ * @prop --calcite-action-bar-corner-radius: Specifies the component's border radius when `floating` is `true`.
  * @prop --calcite-action-bar-expanded-max-width: When `layout` is `"vertical"`, specifies the component's maximum width.
  * @prop --calcite-action-bar-items-space: Specifies the space between slotted components in the component.
+ * @prop --calcite-action-bar-shadow: Specifies the component's shadow when `floating` is `true`.
  */
 
 :host {
   @extend %component-host;
-  @apply pointer-events-auto
-    inline-flex
+  @apply inline-flex
     self-stretch;
+  background: transparent;
+}
 
+.container {
+  --tw-shadow: 0 6px 20px -4px rgba(0, 0, 0, 0.1), 0 4px 12px -2px rgba(0, 0, 0, 0.08);
+  --tw-shadow-colored: 0 6px 20px -4px var(--tw-shadow-color), 0 4px 12px -2px var(--tw-shadow-color);
+  box-shadow: var(
+    --calcite-action-bar-shadow,
+    (var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow))
+  );
+  @apply inline-flex
+  flex-col
+  overflow-hidden;
   gap: var(--calcite-action-bar-items-space, 0);
+  background-color: var(--calcite-action-bar-background-color, var(--calcite-color-foreground-1));
+}
+
+:host([floating]) {
+  .container {
+    @apply animate-in;
+    border-radius: var(--calcite-action-bar-corner-radius, var(--calcite-corner-radius-round));
+  }
 }
 
 :host([layout="vertical"]) {
@@ -23,7 +45,7 @@
     overflow-y: auto;
   }
 
-  &:host([expanded]) {
+  &:host([expanded]) .container {
     max-inline-size: var(--calcite-action-bar-expanded-max-width, auto);
   }
 
@@ -38,6 +60,10 @@
 
 :host([layout="horizontal"]) {
   @apply flex-row;
+
+  .container {
+    @apply flex-row;
+  }
 
   &:host([overflow-actions-disabled]) {
     overflow-x: auto;

--- a/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
@@ -27,7 +27,7 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   <calcite-action-bar
     ${boolean("expand-disabled", args.expandDisabled)}
     ${boolean("expanded", args.expanded)}
-    floating="${args.floating}"
+    ${boolean("floating", args.floating)}
     position="${args.position}"
   >
     <calcite-action-group>
@@ -40,17 +40,18 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   </calcite-action-bar>
 `;
 
-export const floating = (args: ActionBarStoryArgs): string => html`
-  <calcite-action-bar position="${args.position}" floating>
-    <calcite-action-group>
-      <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
-      <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group>
-      <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
-    </calcite-action-group>
-  </calcite-action-bar>
-`;
+export const floating = (args: ActionBarStoryArgs): string =>
+  html`<div style="padding:20px;">
+    <calcite-action-bar position="${args.position}" floating>
+      <calcite-action-group>
+        <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+        <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  </div> `;
 
 export const floatingWithDefinedWidths = (): string => html`
   <style>
@@ -58,48 +59,54 @@ export const floatingWithDefinedWidths = (): string => html`
       --calcite-action-bar-expanded-max-width: 150px;
     }
   </style>
-  <calcite-action-bar floating expanded>
-    <calcite-action-group expanded>
-      <calcite-action text-enabled text="Add to my custom action bar application" icon="plus"></calcite-action>
-      <calcite-action text-enabled text="Save to my custom action bar application" icon="save"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group expanded>
-      <calcite-action text-enabled text="Layers in my custom action bar application" icon="layers"></calcite-action>
-    </calcite-action-group>
-  </calcite-action-bar>
+  <div style="padding:20px;">
+    <calcite-action-bar floating expanded>
+      <calcite-action-group expanded>
+        <calcite-action text-enabled text="Add to my custom action bar application" icon="plus"></calcite-action>
+        <calcite-action text-enabled text="Save to my custom action bar application" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group expanded>
+        <calcite-action text-enabled text="Layers in my custom action bar application" icon="layers"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  </div>
 `;
 
 export const floatingWithGroups = (): string =>
-  html`<calcite-action-bar floating layout="horizontal">
-    <calcite-action-group>
-      <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
-      <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group>
-      <calcite-action text="Layers" icon="layers" appearance="solid" scale="m"></calcite-action>
-      <calcite-action text="Basemaps" icon="layer-basemap" appearance="solid" scale="m"></calcite-action>
-    </calcite-action-group>
-    <calcite-tooltip
-      slot="expand-tooltip"
-      id="calcite-tooltip-c19274e3-ff3b-6168-ef1e-8a700b056e1c"
-      role="tooltip"
-      overlay-positioning="absolute"
-      placement="auto"
-      style="visibility: hidden; pointer-events: none; position: absolute;"
-      >Toggle Action bar</calcite-tooltip
-    >
-  </calcite-action-bar>`;
+  html`<div style="padding:20px;">
+    <calcite-action-bar floating layout="horizontal">
+      <calcite-action-group>
+        <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
+        <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Layers" icon="layers" appearance="solid" scale="m"></calcite-action>
+        <calcite-action text="Basemaps" icon="layer-basemap" appearance="solid" scale="m"></calcite-action>
+      </calcite-action-group>
+      <calcite-tooltip
+        slot="expand-tooltip"
+        id="calcite-tooltip-c19274e3-ff3b-6168-ef1e-8a700b056e1c"
+        role="tooltip"
+        overlay-positioning="absolute"
+        placement="auto"
+        style="visibility: hidden; pointer-events: none; position: absolute;"
+        >Toggle Action bar</calcite-tooltip
+      >
+    </calcite-action-bar>
+  </div>`;
 
 export const floatingDarkModeRTL = (): string =>
-  html` <calcite-action-bar floating position="start" dir="rtl" class="calcite-mode-dark">
-    <calcite-action-group>
-      <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
-      <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
-    </calcite-action-group>
-    <calcite-action-group>
-      <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
-    </calcite-action-group>
-  </calcite-action-bar>`;
+  html`<div style="padding:20px;">
+    <calcite-action-bar floating position="start" dir="rtl" class="calcite-mode-dark">
+      <calcite-action-group>
+        <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
+        <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
+      </calcite-action-group>
+      <calcite-action-group>
+        <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  </div>`;
 
 floatingDarkModeRTL.parameters = { themes: modesDarkDefault };
 
@@ -191,19 +198,21 @@ export const withDefinedWidths = (): string => html`
 `;
 
 export const gridLayout = (): string =>
-  html` <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled floating>
-    <calcite-action-group>
-      <calcite-action text="Northwest" icon="chevron-up-left"></calcite-action>
-      <calcite-action text="North" icon="chevron-up"></calcite-action>
-      <calcite-action text="Northeast" icon="chevron-up-right"></calcite-action>
-      <calcite-action text="West" icon="chevron-left"></calcite-action>
-      <calcite-action text="Center" icon="gps-on"></calcite-action>
-      <calcite-action text="East" icon="chevron-right"></calcite-action>
-      <calcite-action text="Southwest" icon="chevron-down-left"></calcite-action>
-      <calcite-action text="South" icon="chevron-down"></calcite-action>
-      <calcite-action text="Southeast" icon="chevron-down-right"></calcite-action>
-    </calcite-action-group>
-  </calcite-action-bar>`;
+  html`<div style="padding:20px;">
+    <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled floating>
+      <calcite-action-group>
+        <calcite-action text="Northwest" icon="chevron-up-left"></calcite-action>
+        <calcite-action text="North" icon="chevron-up"></calcite-action>
+        <calcite-action text="Northeast" icon="chevron-up-right"></calcite-action>
+        <calcite-action text="West" icon="chevron-left"></calcite-action>
+        <calcite-action text="Center" icon="gps-on"></calcite-action>
+        <calcite-action text="East" icon="chevron-right"></calcite-action>
+        <calcite-action text="Southwest" icon="chevron-down-left"></calcite-action>
+        <calcite-action text="South" icon="chevron-down"></calcite-action>
+        <calcite-action text="Southeast" icon="chevron-down-right"></calcite-action>
+      </calcite-action-group>
+    </calcite-action-bar>
+  </div>`;
 
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-action-bar position="start" dir="rtl" class="calcite-mode-dark">

--- a/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.stories.ts
@@ -5,7 +5,7 @@ import { ActionBar } from "./action-bar";
 
 const { position } = ATTRIBUTES;
 
-type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "position">;
+type ActionBarStoryArgs = Pick<ActionBar, "expandDisabled" | "expanded" | "floating" | "position">;
 
 export default {
   title: "Components/Action Bar",
@@ -13,6 +13,7 @@ export default {
     expandDisabled: false,
     expanded: false,
     position: position.defaultValue,
+    floating: false,
   },
   argTypes: {
     position: {
@@ -26,6 +27,7 @@ export const simple = (args: ActionBarStoryArgs): string => html`
   <calcite-action-bar
     ${boolean("expand-disabled", args.expandDisabled)}
     ${boolean("expanded", args.expanded)}
+    floating="${args.floating}"
     position="${args.position}"
   >
     <calcite-action-group>
@@ -37,6 +39,69 @@ export const simple = (args: ActionBarStoryArgs): string => html`
     </calcite-action-group>
   </calcite-action-bar>
 `;
+
+export const floating = (args: ActionBarStoryArgs): string => html`
+  <calcite-action-bar position="${args.position}" floating>
+    <calcite-action-group>
+      <calcite-action text="Undo" label="Undo Action" icon="undo"></calcite-action>
+      <calcite-action text="Redo" label="Redo Action" icon="redo"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Delete" label="Delete Item" icon="trash"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>
+`;
+
+export const floatingWithDefinedWidths = (): string => html`
+  <style>
+    calcite-action-bar {
+      --calcite-action-bar-expanded-max-width: 150px;
+    }
+  </style>
+  <calcite-action-bar floating expanded>
+    <calcite-action-group expanded>
+      <calcite-action text-enabled text="Add to my custom action bar application" icon="plus"></calcite-action>
+      <calcite-action text-enabled text="Save to my custom action bar application" icon="save"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group expanded>
+      <calcite-action text-enabled text="Layers in my custom action bar application" icon="layers"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>
+`;
+
+export const floatingWithGroups = (): string =>
+  html`<calcite-action-bar floating layout="horizontal">
+    <calcite-action-group>
+      <calcite-action text="Add" icon="plus" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Save" icon="save" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Layers" icon="layers" appearance="solid" scale="m"></calcite-action>
+      <calcite-action text="Basemaps" icon="layer-basemap" appearance="solid" scale="m"></calcite-action>
+    </calcite-action-group>
+    <calcite-tooltip
+      slot="expand-tooltip"
+      id="calcite-tooltip-c19274e3-ff3b-6168-ef1e-8a700b056e1c"
+      role="tooltip"
+      overlay-positioning="absolute"
+      placement="auto"
+      style="visibility: hidden; pointer-events: none; position: absolute;"
+      >Toggle Action bar</calcite-tooltip
+    >
+  </calcite-action-bar>`;
+
+export const floatingDarkModeRTL = (): string =>
+  html` <calcite-action-bar floating position="start" dir="rtl" class="calcite-mode-dark">
+    <calcite-action-group>
+      <calcite-action text="Add" label="Add Item" icon="plus"></calcite-action>
+      <calcite-action text="Save" label="Save Item" icon="save"></calcite-action>
+    </calcite-action-group>
+    <calcite-action-group>
+      <calcite-action text="Layers" label="View Layers" icon="layers"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>`;
+
+floatingDarkModeRTL.parameters = { themes: modesDarkDefault };
 
 export const horizontal = (): string => html`
   <div style="width: 500px;">
@@ -124,6 +189,21 @@ export const withDefinedWidths = (): string => html`
     </calcite-action-group>
   </calcite-action-bar>
 `;
+
+export const gridLayout = (): string =>
+  html` <calcite-action-bar layout="grid" expand-disabled overflow-actions-disabled floating>
+    <calcite-action-group>
+      <calcite-action text="Northwest" icon="chevron-up-left"></calcite-action>
+      <calcite-action text="North" icon="chevron-up"></calcite-action>
+      <calcite-action text="Northeast" icon="chevron-up-right"></calcite-action>
+      <calcite-action text="West" icon="chevron-left"></calcite-action>
+      <calcite-action text="Center" icon="gps-on"></calcite-action>
+      <calcite-action text="East" icon="chevron-right"></calcite-action>
+      <calcite-action text="Southwest" icon="chevron-down-left"></calcite-action>
+      <calcite-action text="South" icon="chevron-down"></calcite-action>
+      <calcite-action text="Southeast" icon="chevron-down-right"></calcite-action>
+    </calcite-action-group>
+  </calcite-action-bar>`;
 
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-action-bar position="start" dir="rtl" class="calcite-mode-dark">

--- a/packages/calcite-components/src/components/action-bar/action-bar.tsx
+++ b/packages/calcite-components/src/components/action-bar/action-bar.tsx
@@ -1,16 +1,7 @@
 // @ts-strict-ignore
 import { debounce } from "lodash-es";
 import { PropertyValues } from "lit";
-import {
-  LitElement,
-  property,
-  createEvent,
-  Fragment,
-  h,
-  method,
-  state,
-  JsxNode,
-} from "@arcgis/lumina";
+import { LitElement, property, createEvent, h, method, state, JsxNode } from "@arcgis/lumina";
 import {
   focusFirstTabbable,
   slotChangeGetAssignedElements,
@@ -132,6 +123,11 @@ export class ActionBar extends LitElement {
   /** Specifies the accessible label for the last `calcite-action-group`. */
   @property() actionsEndGroupLabel: string;
 
+  /**
+   * When `true`, the component is in a floating state.
+   */
+  @property({ reflect: true }) floating = false;
+
   /** When `true`, the expand-toggling behavior is disabled. */
   @property({ reflect: true }) expandDisabled = false;
 
@@ -139,7 +135,8 @@ export class ActionBar extends LitElement {
   @property({ reflect: true }) expanded = false;
 
   /** Specifies the layout direction of the actions. */
-  @property({ reflect: true }) layout: Extract<"horizontal" | "vertical", Layout> = "vertical";
+  @property({ reflect: true }) layout: Extract<"horizontal" | "vertical" | "grid", Layout> =
+    "vertical";
 
   /** Use this property to override individual strings used by the component. */
   @property() messageOverrides?: typeof this.messages._overrides;
@@ -284,11 +281,10 @@ export class ActionBar extends LitElement {
   private updateGroups(): void {
     const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
     this.actionGroups = groups;
-    this.setGroupLayout(groups);
-  }
-
-  private setGroupLayout(groups: ActionGroup["el"][]): void {
-    groups.forEach((group) => (group.layout = this.layout));
+    groups.forEach((group) => {
+      group.layout = this.layout;
+      group.scale = this.scale;
+    });
   }
 
   private handleDefaultSlotChange(): void {
@@ -363,10 +359,10 @@ export class ActionBar extends LitElement {
 
   override render(): JsxNode {
     return (
-      <>
+      <div class={CSS.container}>
         <slot onSlotChange={this.handleDefaultSlotChange} />
         {this.renderBottomActionGroup()}
-      </>
+      </div>
     );
   }
 

--- a/packages/calcite-components/src/components/action-bar/resources.ts
+++ b/packages/calcite-components/src/components/action-bar/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
+  container: "container",
   actionGroupEnd: "action-group--end",
 };
 

--- a/packages/calcite-components/src/components/action-bar/utils.ts
+++ b/packages/calcite-components/src/components/action-bar/utils.ts
@@ -25,7 +25,7 @@ const getMaxActionCount = ({
   actionHeight,
   groupCount,
 }: {
-  layout: Extract<"horizontal" | "vertical", Layout>;
+  layout: Extract<"horizontal" | "vertical" | "grid", Layout>;
   height: number;
   actionWidth: number;
   width: number;
@@ -46,7 +46,7 @@ export const getOverflowCount = ({
   height,
   groupCount,
 }: {
-  layout: Extract<"horizontal" | "vertical", Layout>;
+  layout: Extract<"horizontal" | "vertical" | "grid", Layout>;
   actionCount: number;
   actionWidth: number;
   width: number;

--- a/packages/calcite-components/src/components/action-pad/action-pad.tsx
+++ b/packages/calcite-components/src/components/action-pad/action-pad.tsx
@@ -10,6 +10,7 @@ import { OverlayPositioning } from "../../utils/floating-ui";
 import { useT9n } from "../../controllers/useT9n";
 import type { Tooltip } from "../tooltip/tooltip";
 import type { ActionGroup } from "../action-group/action-group";
+import { logger } from "../../utils/logger";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
 import { styles } from "./action-pad.scss";
@@ -21,6 +22,7 @@ declare global {
 }
 
 /**
+ * @deprecated Use the `calcite-dialog` component instead.
  * @slot - A slot for adding `calcite-action`s to the component.
  * @slot expand-tooltip - A slot to set the `calcite-tooltip` for the expand toggle.
  */
@@ -121,6 +123,14 @@ export class ActionPad extends LitElement {
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
+  }
+
+  async load(): Promise<void> {
+    logger.deprecated("component", {
+      name: "action-pad",
+      removalVersion: 4,
+      suggested: "action-bar",
+    });
   }
 
   override willUpdate(changes: PropertyValues<this>): void {

--- a/packages/calcite-components/src/components/shell-panel/resources.ts
+++ b/packages/calcite-components/src/components/shell-panel/resources.ts
@@ -1,5 +1,6 @@
 export const CSS = {
   container: "container",
+  actionBarContainer: "action-bar-container",
   contentContainer: "content-container",
   content: "content",
   contentHeader: "content__header",

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.e2e.ts
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.e2e.ts
@@ -112,15 +112,13 @@ describe("calcite-shell-panel", () => {
 
     const actionSlotIsFirst = await page.$eval(
       "calcite-shell-panel",
-      (panel: ShellPanel["el"], containerClass: string, slotName: string) => {
-        const container = panel.shadowRoot.querySelector(containerClass);
-        return (
-          container.firstElementChild.tagName == "SLOT" &&
-          (container.firstElementChild as HTMLSlotElement).name == slotName
-        );
+      (panel: ShellPanel["el"], containerSelector: string, actionBarContainerClass: string) => {
+        return panel.shadowRoot
+          .querySelector(containerSelector)
+          .firstElementChild.classList.contains(actionBarContainerClass);
       },
       `.${CSS.container}`,
-      SLOTS.actionBar,
+      CSS.actionBarContainer,
     );
 
     expect(actionSlotIsFirst).toBe(true);

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -281,9 +281,7 @@
   @apply pointer-events-auto
   flex
   flex-auto
-  box-border
-  w-full
-  h-full;
+  box-border;
 }
 
 .content-container {

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -277,6 +277,15 @@
   @apply flex flex-auto overflow-hidden;
 }
 
+.action-bar-container {
+  @apply pointer-events-auto
+  flex
+  flex-auto
+  box-border
+  w-full
+  h-full;
+}
+
 .content-container {
   @apply flex
   flex-auto
@@ -288,6 +297,7 @@
   h-full;
 }
 
+:host([layout="horizontal"]) .action-bar-container,
 :host([layout="horizontal"]) .content-container {
   flex-direction: column;
 }

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -458,12 +458,8 @@ export class ShellPanel extends LitElement {
     );
 
     const actionBarNode = (
-      <div class={CSS.actionBarContainer}>
-        <slot
-          key="action-bar"
-          name={SLOTS.actionBar}
-          onSlotChange={this.handleActionBarSlotChange}
-        />
+      <div class={CSS.actionBarContainer} key="action-bar-container">
+        <slot name={SLOTS.actionBar} onSlotChange={this.handleActionBarSlotChange} />
       </div>
     );
 

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -458,7 +458,13 @@ export class ShellPanel extends LitElement {
     );
 
     const actionBarNode = (
-      <slot key="action-bar" name={SLOTS.actionBar} onSlotChange={this.handleActionBarSlotChange} />
+      <div class={CSS.actionBarContainer}>
+        <slot
+          key="action-bar"
+          name={SLOTS.actionBar}
+          onSlotChange={this.handleActionBarSlotChange}
+        />
+      </div>
     );
 
     const mainNodes = [actionBarNode, contentNode];

--- a/packages/calcite-components/src/demos/action.html
+++ b/packages/calcite-components/src/demos/action.html
@@ -639,6 +639,143 @@
 
       <hr />
 
+      <!-- Action bar floating -->
+      <div class="parent-action-bar">
+        <div class="child right-aligned-text">action bar floating: basic</div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating scale="s">
+            <calcite-action-group label="test">
+              <calcite-action scale="s" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="s" text="Cool" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group label="test2" scale="s">
+              <calcite-action scale="s" text="Add" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating scale="m">
+            <calcite-action-group label="Revert">
+              <calcite-action scale="m" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="m" text="Cool" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group label="Add things" scale="m">
+              <calcite-action scale="m" text="Add" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating scale="l">
+            <calcite-action-group>
+              <calcite-action scale="l" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="l" text="Cool" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="l" text="Add" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+      </div>
+
+      <div class="parent-action-bar">
+        <div class="child right-aligned-text">tooltip on expand toogle</div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating id="action-bar-floating-test" scale="s">
+            <calcite-tooltip slot="expand-tooltip" label="Hello world!">Hello world!</calcite-tooltip>
+            <calcite-action scale="s" text="Add" icon="plus"></calcite-action>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating id="action-bar-floating-test" scale="m">
+            <calcite-tooltip slot="expand-tooltip" label="Hello world!">Hello world!</calcite-tooltip>
+            <calcite-action scale="m" text="Add" icon="plus"></calcite-action>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating id="action-bar-floating-test" scale="l">
+            <calcite-tooltip slot="expand-tooltip" label="Hello world!">Hello world!</calcite-tooltip>
+            <calcite-action scale="l" text="Add" icon="plus"></calcite-action>
+          </calcite-action-bar>
+        </div>
+      </div>
+
+      <div class="parent-action-bar">
+        <div class="child right-aligned-text">horizontal</div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating layout="horizontal" scale="s">
+            <calcite-action-group>
+              <calcite-action scale="s" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="s" text="Redo" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="s" text="Title" icon="title"></calcite-action>
+              <calcite-action scale="s" text="Text" icon="text"></calcite-action>
+              <calcite-action scale="s" text="Bold" icon="bold"></calcite-action>
+              <calcite-action scale="s" text="Italics" icon="italicize"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="s" text="Cut" icon="scissors"></calcite-action>
+              <calcite-action scale="s" text="Add" icon="plus-square"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="s" text="Remove" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating layout="horizontal" scale="m">
+            <calcite-action-group>
+              <calcite-action scale="m" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="m" text="Redo" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="m" text="Title" icon="title"></calcite-action>
+              <calcite-action scale="m" text="Text" icon="text"></calcite-action>
+              <calcite-action scale="m" text="Bold" icon="bold"></calcite-action>
+              <calcite-action scale="m" text="Italics" icon="italicize"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="m" text="Cut" icon="scissors"></calcite-action>
+              <calcite-action scale="m" text="Add" icon="plus-square"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="m" text="Remove" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="child-action-bar">
+          <calcite-action-bar floating layout="horizontal" scale="l">
+            <calcite-action-group>
+              <calcite-action scale="l" text="Undo" icon="undo"> </calcite-action>
+              <calcite-action scale="l" text="Redo" icon="redo"> </calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="l" text="Title" icon="title"></calcite-action>
+              <calcite-action scale="l" text="Text" icon="text"></calcite-action>
+              <calcite-action scale="l" text="Bold" icon="bold"></calcite-action>
+              <calcite-action scale="l" text="Italics" icon="italicize"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="l" text="Cut" icon="scissors"></calcite-action>
+              <calcite-action scale="l" text="Add" icon="plus-square"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group>
+              <calcite-action scale="l" text="Remove" icon="trash"> </calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+      </div>
+      <hr />
+
       <!--
       **************************************************
       * ACTION PAD


### PR DESCRIPTION
**Related Issue:** #7507

## Summary

- Adds `floating` property to `action-bar`
- Moves `pointer-events-auto` styling on action bar to `shell-panel` where it is needed.
- Deprecates `action-pad`
- Add tests
- Add stories