### PR TITLE
fix: fix memory leak caused when disconnecting floating-ui

### DIFF
--- a/packages/calcite-components/src/utils/floating-ui.ts
+++ b/packages/calcite-components/src/utils/floating-ui.ts
@@ -581,12 +581,6 @@ export async function connectFloatingUI(component: FloatingUIComponent): Promise
  * @param component - A floating-ui component.
  */
 export function disconnectFloatingUI(component: FloatingUIComponent): void {
-  const { floatingEl, referenceEl } = component;
-
-  if (!floatingEl || !referenceEl) {
-    return;
-  }
-
   const trackedState = autoUpdatingComponentMap.get(component);
 
   if (trackedState?.state === "active") {


### PR DESCRIPTION
**Related Issue:** #10648 

## Summary

Addresses a memory leak where floating-ui cleanup was not invoked when the component had missing elements. Tear down should always occur if it was previously registered, regardless of component state.

Our test environment doesn't cover memory profiling, so no tests were added.