### PR TITLE
chore(deps): use updated lumina controllers package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,16 +334,6 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/@arcgis/components-controllers": {
-      "version": "4.33.0-next.117",
-      "resolved": "https://registry.npmjs.org/@arcgis/components-controllers/-/components-controllers-4.33.0-next.117.tgz",
-      "integrity": "sha512-NNV1foISrM+A8GtFc74qXAnomokIkoX20OFWbdOH3Klb6T2v7oue0leKRbUbHyUCJMhsAWXa0vylohp1leaALg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@arcgis/lumina": "4.33.0-next.117",
-        "tslib": "^2.7.0"
-      }
-    },
     "node_modules/@arcgis/components-utils": {
       "version": "4.33.0-next.117",
       "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.33.0-next.117.tgz",
@@ -36056,7 +36046,6 @@
       "version": "3.2.0-next.59",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/components-controllers": "^4.33.0-next.110",
         "@arcgis/components-utils": "^4.33.0-next.110",
         "@arcgis/lumina": "^4.33.0-next.110",
         "@esri/calcite-ui-icons": "4.2.0-next.4",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -75,7 +75,6 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@arcgis/components-controllers": "^4.33.0-next.110",
     "@arcgis/components-utils": "^4.33.0-next.110",
     "@arcgis/lumina": "^4.33.0-next.110",
     "@esri/calcite-ui-icons": "4.2.0-next.4",

--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -11,7 +11,7 @@ import {
   stringOrBoolean,
   LuminaJsx,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import { debounce, escapeRegExp } from "lodash-es";
 import {
   FlipPlacement,

--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -12,7 +12,7 @@ import {
   LuminaJsx,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import { findAssociatedForm, FormOwner, resetForm, submitForm } from "../../utils/form";
 import {
   InteractiveComponent,

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -12,7 +12,7 @@ import {
   LuminaJsx,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import { getElementDir, isPrimaryPointerButton, setRequestedIcon } from "../../utils/dom";
 import { Alignment, Scale, Status } from "../interfaces";
 import {

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -12,7 +12,7 @@ import {
   LuminaJsx,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import { getElementDir, setRequestedIcon } from "../../utils/dom";
 import {
   connectForm,

--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -13,7 +13,7 @@ import {
   LuminaJsx,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import {
   focusFirstTabbable,
   getElementDir,

--- a/packages/calcite-components/src/components/menu/menu.tsx
+++ b/packages/calcite-components/src/components/menu/menu.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { LitElement, property, h, method, JsxNode, LuminaJsx } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import {
   focusElement,
   focusElementInGroup,

--- a/packages/calcite-components/src/components/text-area/text-area.tsx
+++ b/packages/calcite-components/src/components/text-area/text-area.tsx
@@ -11,7 +11,7 @@ import {
   JsxNode,
   stringOrBoolean,
 } from "@arcgis/lumina";
-import { useWatchAttributes } from "@arcgis/components-controllers";
+import { useWatchAttributes } from "@arcgis/lumina/controllers";
 import {
   connectForm,
   disconnectForm,

--- a/packages/calcite-components/src/controllers/time/time.ts
+++ b/packages/calcite-components/src/controllers/time/time.ts
@@ -1,5 +1,5 @@
 import { PropertyValues } from "lit";
-import { GenericController, T9nMeta } from "@arcgis/components-controllers";
+import { GenericController, T9nMeta } from "@arcgis/lumina/controllers";
 import { GenericT9nStrings } from "@arcgis/components-utils";
 import { createEvent, LitElement } from "@arcgis/lumina";
 import {

--- a/packages/calcite-components/src/controllers/useFocusTrap.ts
+++ b/packages/calcite-components/src/controllers/useFocusTrap.ts
@@ -1,4 +1,4 @@
-import { makeGenericController } from "@arcgis/components-controllers";
+import { makeGenericController } from "@arcgis/lumina/controllers";
 import { createFocusTrap, FocusTrap, Options as Options } from "focus-trap";
 import { LitElement } from "@arcgis/lumina";
 import { createFocusTrapOptions } from "../utils/focusTrapComponent";

--- a/packages/calcite-components/src/controllers/usePreventDocumentScroll.ts
+++ b/packages/calcite-components/src/controllers/usePreventDocumentScroll.ts
@@ -7,7 +7,7 @@
  * @module usePreventDocumentScroll
  */
 
-import { makeGenericController } from "@arcgis/components-controllers";
+import { makeGenericController } from "@arcgis/lumina/controllers";
 import { LitElement } from "@arcgis/lumina";
 
 let openedComponentCount: number = 0;

--- a/packages/calcite-components/src/controllers/useT9n.ts
+++ b/packages/calcite-components/src/controllers/useT9n.ts
@@ -1,4 +1,4 @@
-import { makeT9nController } from "@arcgis/components-controllers";
+import { makeT9nController } from "@arcgis/lumina/controllers";
 import { getAssetPath } from "../runtime";
 
 export const useT9n = makeT9nController(getAssetPath);

--- a/support/createThirdPartyLicenses.ts
+++ b/support/createThirdPartyLicenses.ts
@@ -15,7 +15,7 @@ import { getProjectLicenses } from "generate-license-file";
     await execAsync("npm install --no-workspaces");
 
     const coveredByEsriLicense = [
-      "@arcgis/components-controllers",
+      "@arcgis/lumina/controllers",
       "@arcgis/components-utils",
       "@arcgis/lumina",
       "@esri/calcite-components",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Addresses the following build warning:

```
Deprecation warning: the @arcgis/components-controllers package was merged into @arcgis/lumina. Please remove it from your package.json and rewrite code to import from @arcgis/lumina/controllers and @arcgis/lumina/controllers/accessor instead.
```