### PR TITLE
build(preset): use valid TS module resolution

### DIFF
--- a/packages/calcite-tailwind-preset/tsconfig-base.json
+++ b/packages/calcite-tailwind-preset/tsconfig-base.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "lib": ["dom", "dom.iterable", "ES2023"],
     "module": "node18",
-    "moduleResolution": "node18",
+    "moduleResolution": "node16",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Uses `node16` instead of `node18` (invalid) as the module resolution.

Preset build was working since the default is `node16` when module is `node18` (see https://www.typescriptlang.org/tsconfig/#moduleResolution).