### PR TITLE
docs(tabs): fix error in token description

### DIFF
--- a/packages/calcite-components/src/components/tabs/tabs.scss
+++ b/packages/calcite-components/src/components/tabs/tabs.scss
@@ -3,7 +3,7 @@
  *
  * These properties can be overridden using the component's tag as selector.
  *
- * @prop --calcite-tab-background-color: When `bordered`, specifies the component's background color when `bordered`.
+ * @prop --calcite-tab-background-color: When `bordered`, specifies the component's background color.
  * @prop --calcite-tab-border-color: Specifies the component's border color.
  */
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Fixing a grammar error on the `--calcite-tab-background-color` token for the `tabs` component 