### PR TITLE
fix: ensure transition-duration is used in Tailwind utils

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -137,7 +137,6 @@
   .actions-end {
     @apply flex
       items-center
-      duration-150
       ease-in-out;
     @include word-break();
   }
@@ -192,8 +191,7 @@
 }
 
 .icon {
-  @apply duration-150
-    ease-in-out
+  @apply ease-in-out
     flex
     items-center;
   margin-inline-end: var(--calcite-internal-accordion-item-icon-spacing-start);

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -116,7 +116,6 @@
     leading-6
     opacity-0
     transition-opacity
-    duration-150
     ease-in-out;
 
   transition-property: margin;
@@ -173,7 +172,6 @@
   .button {
     @apply bg-transparent
       transition-shadow
-      duration-150
       ease-in-out;
 
     &:hover {

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -22,7 +22,6 @@
   @apply transition-margin ease-cubic flex flex-shrink-0 flex-grow-0
     flex-col border-0 border-b border-solid p-0;
   flex-basis: auto;
-  transition-duration: var(--calcite-animation-timing);
   border-color: var(--calcite-block-border-color, var(--calcite-color-border-3));
 }
 

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -121,7 +121,6 @@ calcite-handle {
     transition-color
     font-medium
     leading-tight
-    duration-150
     ease-in-out
     p-0;
 
@@ -171,7 +170,6 @@ calcite-handle {
   @apply transition-color
   self-center
   justify-self-end
-  duration-150
   ease-in-out;
 
   margin-inline-end: var(--calcite-spacing-md);

--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -415,7 +415,7 @@
 }
 
 .chip-icon {
-  @apply relative my-0 inline-flex duration-150 ease-in-out;
+  @apply relative my-0 inline-flex ease-in-out;
   color: var(--calcite-chip-icon-color, var(--calcite-chip-text-color, var(--calcite-icon-color, currentColor)));
   padding-inline: var(--calcite-internal-chip-icon-space, var(--calcite-spacing-xs, 0.375rem) /* 6px */);
 }

--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.scss
@@ -24,7 +24,7 @@ $size-l: 28px;
   inline-size: inherit;
 
   rect {
-    @apply transition-all duration-150 ease-in-out;
+    @apply transition-all ease-in-out;
   }
 }
 

--- a/packages/calcite-components/src/components/combobox-item/combobox-item.scss
+++ b/packages/calcite-components/src/components/combobox-item/combobox-item.scss
@@ -115,7 +115,6 @@ ul:focus {
 
 .icon {
   @apply inline-flex
-    duration-150
     ease-in-out;
 
   color: var(--calcite-color-border-input);

--- a/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
+++ b/packages/calcite-components/src/components/date-picker-month-header/date-picker-month-header.scss
@@ -57,8 +57,8 @@
     items-center
     justify-center
     border-none
-    transition-default 
-    w-full 
+    transition-default
+    w-full
     h-full;
   --calcite-internal-action-padding-block: 0;
   --calcite-action-background-color: var(--calcite-date-picker-header-action-background-color);
@@ -117,7 +117,7 @@
   text-center;
   inline-size: #{$calcite-size-44};
   &:hover {
-    @apply duration-100 ease-in-out;
+    @apply ease-in-out;
     transition-property: outline-color;
     outline: 2px solid var(--calcite-color-border-2);
     outline-offset: -2px;

--- a/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/calcite-components/src/components/dropdown-item/dropdown-item.scss
@@ -5,7 +5,7 @@
  *
  * @prop --calcite-dropdown-item-background-color-hover: Specifies the item's background color when hovered.
  * @prop --calcite-dropdown-item-background-color-press: Specifies the item's background color when selected or active.
- * @prop --calcite-dropdown-item-icon-color-hover: [Deprecated] Specifies the item's icon selection color when hovered. 
+ * @prop --calcite-dropdown-item-icon-color-hover: [Deprecated] Specifies the item's icon selection color when hovered.
  * @prop --calcite-dropdown-item-icon-color-press: Specifies the item's icon selection color when selected or active.
  * @prop --calcite-dropdown-item-text-color-press: Specifies the item's text when selected or active.
  * @prop --calcite-dropdown-item-text-color: Specifies the item's text color.
@@ -48,7 +48,6 @@
 .dropdown-item-icon {
   @apply relative
     opacity-0
-    duration-150
     ease-in-out;
   transform: scale(0.9);
 }

--- a/packages/calcite-components/src/components/meter/meter.scss
+++ b/packages/calcite-components/src/components/meter/meter.scss
@@ -132,7 +132,7 @@
 }
 
 .fill {
-  @apply block absolute duration-150 ease-in-out z-default;
+  @apply block absolute ease-in-out z-default;
   inset-inline-start: var(--calcite-internal-meter-space);
   inset-block: var(--calcite-internal-meter-space);
   border-radius: var(--calcite-internal-meter-corner-radius);

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.scss
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.scss
@@ -294,12 +294,12 @@
     border-color: var(--calcite-stepper-bar-fill-color, var(--calcite-color-border-3));
 
     &:focus {
-      @apply focus-outset duration-0;
+      @apply focus-outset;
     }
   }
 
   .stepper-item-content {
-    @apply cursor-auto duration-150 ease-in-out;
+    @apply cursor-auto ease-in-out;
     padding-block: 0;
     padding-inline-end: var(--calcite-internal-stepper-item-spacing-unit-m);
     text-align: start;

--- a/packages/calcite-components/src/components/switch/switch.scss
+++ b/packages/calcite-components/src/components/switch/switch.scss
@@ -91,7 +91,6 @@
     absolute
     block
     transition-all
-    duration-150
     ease-in-out;
   inset-block-start: var(--calcite-spacing-base);
   inset-inline: var(--calcite-spacing-base) auto;

--- a/packages/calcite-components/src/components/tile-select/tile-select.scss
+++ b/packages/calcite-components/src/components/tile-select/tile-select.scss
@@ -125,7 +125,6 @@ $spacing: $baseline * 0.5;
 .tile {
   @apply bg-foreground-1
     box-border
-    duration-150
     ease-in-out
     flex
     flex-col
@@ -155,7 +154,6 @@ $spacing: $baseline * 0.5;
 
 .tile-heading {
   @apply break-words
-    duration-150
     ease-in-out
     font-medium
     pointer-events-none
@@ -165,7 +163,6 @@ $spacing: $baseline * 0.5;
 
 .tile-description {
   @apply break-words
-    duration-150
     ease-in-out
     pointer-events-none
     text-color-3

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -181,7 +181,7 @@ type State = "press" | "hover" | "focus";
 
 /** Describes a test target for themed components. */
 type TestTarget = {
-  /** An object with target element and selector info. */
+  /** An object with the target element and selector info. */
   target: TargetInfo;
 
   /** The selector for the interaction's target element. */

--- a/packages/calcite-components/src/tests/commonTests/themed.ts
+++ b/packages/calcite-components/src/tests/commonTests/themed.ts
@@ -330,8 +330,6 @@ async function assertThemedProps(page: E2EPage, options: TestTarget): Promise<vo
     }
   }
 
-  await page.waitForChanges();
-
   if (targetProp.startsWith("--calcite-")) {
     const customPropValue = await getComputedStylePropertyValue(targetEl, targetProp, pseudoElement);
     expect(getStyleString(token, targetProp, customPropValue)).toBe(getStyleString(token, targetProp, expectedValue));

--- a/packages/calcite-components/tailwind.config.ts
+++ b/packages/calcite-components/tailwind.config.ts
@@ -1,6 +1,7 @@
+import type { Config } from "tailwindcss";
 import calcitePreset from "@esri/calcite-tailwind-preset";
 
-export default {
+const config: Config = {
   presets: [calcitePreset],
   content: ["./src/components/**/*.scss"],
   theme: {
@@ -11,6 +12,11 @@ export default {
         "in-up": "in-up var(--calcite-internal-animation-timing-slow) ease-in-out",
         "in-scale": "in-scale var(--calcite-internal-animation-timing-slow) linear",
       },
+      transitionDuration: {
+        DEFAULT: "var(--calcite-animation-timing)",
+      },
     },
   },
 };
+
+export default config;

--- a/packages/calcite-tailwind-preset/src/index.ts
+++ b/packages/calcite-tailwind-preset/src/index.ts
@@ -1,3 +1,4 @@
+import type { Config } from "tailwindcss";
 import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import plugin from "tailwindcss/plugin";
 
@@ -23,9 +24,10 @@ function invert(value: string, flagPropName: string): string {
           )`;
 }
 
-export default {
+// we omit content to work around https://github.com/tailwindlabs/tailwindcss/issues/11725 (fixed in v4, but not v3)
+const config: Omit<Config, "content"> = {
   theme: {
-    borderColor: ({ theme }): object => ({
+    borderColor: ({ theme }) => ({
       color: {
         1: "var(--calcite-color-border-1)",
         2: "var(--calcite-color-border-2)",
@@ -133,7 +135,7 @@ export default {
       l: "1024px",
       xl: "1440px",
     },
-    backgroundColor: ({ theme }): object => ({
+    backgroundColor: ({ theme }) => ({
       ...theme("colors.background"),
       transparent: theme("colors.transparent"),
       brand: theme("colors.brand"),
@@ -168,39 +170,39 @@ export default {
       keyframes: {
         in: {
           "0%": {
-            opacity: 0,
+            opacity: "0",
           },
           "100%": {
-            opacity: 1,
+            opacity: "1",
           },
         },
         "in-down": {
           "0%": {
-            opacity: 0,
+            opacity: "0",
             transform: "translate3D(0, -5px, 0)",
           },
           "100%": {
-            opacity: 1,
+            opacity: "1",
             transform: "translate3D(0, 0, 0)",
           },
         },
         "in-up": {
           "0%": {
-            opacity: 0,
+            opacity: "0",
             transform: "translate3D(0, 5px, 0)",
           },
           "100%": {
-            opacity: 1,
+            opacity: "1",
             transform: "translate3D(0, 0, 0)",
           },
         },
         "in-scale": {
           "0%": {
-            opacity: 0,
+            opacity: "0",
             transform: "scale3D(0.95, 0.95, 1)",
           },
           "100%": {
-            opacity: 1,
+            opacity: "1",
             transform: "scale3D(1, 1, 1)",
           },
         },
@@ -296,3 +298,5 @@ export default {
     }),
   ],
 };
+
+export default config;


### PR DESCRIPTION
**Related Issue:** #12170

## Summary

This ensures `--calcite-duration-factor` is honored in Tailwind transition utilities (e.g., `transition-color`).

Also, this improves test consistency in cases like the `themed` test helper, where animations are expected to be disabled via `--calcite-duration-factor` (required by https://github.com/Esri/calcite-design-system/issues/10433).