### PR TITLE
feat(dialog, panel, flow-item): add `icon` and `iconFlipRtl` properties

### DIFF
--- a/packages/calcite-components/src/components/dialog/dialog.e2e.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.e2e.ts
@@ -95,6 +95,14 @@ describe("calcite-dialog", () => {
         value: "brand",
       },
       {
+        propertyName: "icon",
+        value: "x",
+      },
+      {
+        propertyName: "iconFlipRtl",
+        value: true,
+      },
+      {
         propertyName: "loading",
         value: true,
       },
@@ -170,6 +178,14 @@ describe("calcite-dialog", () => {
       {
         propertyName: "headingLevel",
         defaultValue: undefined,
+      },
+      {
+        propertyName: "icon",
+        defaultValue: undefined,
+      },
+      {
+        propertyName: "iconFlipRtl",
+        defaultValue: false,
       },
       {
         propertyName: "kind",
@@ -269,6 +285,8 @@ describe("calcite-dialog", () => {
     dialog.setProperty("heading", "My Heading");
     dialog.setProperty("description", "My Description");
     dialog.setProperty("scale", "l");
+    dialog.setProperty("icon", "x");
+    dialog.setProperty("iconFlipRtl", true);
     dialog.setProperty("messageOverrides", messageOverrides);
     await page.waitForChanges();
 
@@ -280,6 +298,8 @@ describe("calcite-dialog", () => {
     expect(await panel.getProperty("heading")).toBe("My Heading");
     expect(await panel.getProperty("description")).toBe("My Description");
     expect(await panel.getProperty("scale")).toBe("l");
+    expect(await panel.getProperty("icon")).toBe("x");
+    expect(await panel.getProperty("iconFlipRtl")).toBe(true);
     expect((await panel.getProperty("messageOverrides")).close).toBe(messageOverrides.close);
     expect(await panel.getProperty("beforeClose")).toBeDefined();
   });
@@ -1110,7 +1130,9 @@ describe("calcite-dialog", () => {
     themed(
       async () => {
         const page = await newE2EPage();
-        await page.setContent(html`<calcite-dialog width-scale="s" modal open><p>Hello world!</p></calcite-dialog>`);
+        await page.setContent(
+          html`<calcite-dialog icon="banana" width-scale="s" modal open><p>Hello world!</p></calcite-dialog>`,
+        );
         // set large page to ensure test dialog isn't becoming fullscreen
         await page.setViewport({ width: 1440, height: 1440 });
         await skipAnimations(page);
@@ -1164,6 +1186,10 @@ describe("calcite-dialog", () => {
         "--calcite-dialog-background-color": {
           shadowSelector: `.${CSS.panel}`,
           targetProp: "--calcite-panel-background-color",
+        },
+        "--calcite-dialog-icon-color": {
+          shadowSelector: `.${CSS.panel}`,
+          targetProp: "--calcite-panel-icon-color",
         },
       },
     );

--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -124,7 +124,7 @@ calcite-panel {
 }
 
 :host([kind="brand"]) calcite-panel {
-  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-brand) ;);
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-brand));
 }
 
 :host([kind="danger"]) calcite-panel {

--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -16,6 +16,7 @@
  * @prop --calcite-dialog-offset-x: Specifies the horizontal offset of the component.
  * @prop --calcite-dialog-offset-y: Specifies the vertical offset of the component.
  * @prop --calcite-dialog-background-color: Specifies the background color of the component.
+ * @prop --calcite-dialog-icon-color: Specifies the color of the component's icon.
  */
 
 :host {
@@ -119,6 +120,7 @@ calcite-panel {
   --calcite-panel-footer-space: var(--calcite-dialog-footer-space);
   --calcite-panel-border-color: var(--calcite-dialog-border-color);
   --calcite-panel-background-color: var(--calcite-dialog-background-color, var(--calcite-color-foreground-1));
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color);
 }
 
 ::slotted(*) {

--- a/packages/calcite-components/src/components/dialog/dialog.scss
+++ b/packages/calcite-components/src/components/dialog/dialog.scss
@@ -123,6 +123,26 @@ calcite-panel {
   --calcite-panel-icon-color: var(--calcite-dialog-icon-color);
 }
 
+:host([kind="brand"]) calcite-panel {
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-brand) ;);
+}
+
+:host([kind="danger"]) calcite-panel {
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-status-danger));
+}
+
+:host([kind="info"]) calcite-panel {
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-status-info));
+}
+
+:host([kind="success"]) calcite-panel {
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-status-success));
+}
+
+:host([kind="warning"]) calcite-panel {
+  --calcite-panel-icon-color: var(--calcite-dialog-icon-color, var(--calcite-color-status-warning));
+}
+
 ::slotted(*) {
   --calcite-panel-background-color: initial;
 }

--- a/packages/calcite-components/src/components/dialog/dialog.stories.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.stories.ts
@@ -198,7 +198,84 @@ export const customContentSlot = (): string => html`
 `;
 
 export const withIcon = (): string => html`
-  <calcite-dialog icon="banana" heading="Banana" open scale="m" width-scale="s" modal> Hello world! </calcite-dialog>
+  <calcite-dialog icon="banana" heading="Banana" description="This is bananas" open scale="m" width-scale="s" modal>
+    Hello world!
+  </calcite-dialog>
+`;
+
+export const withKindBrandIcon = (): string => html`
+  <calcite-dialog
+    kind="brand"
+    icon="banana"
+    heading="Banana"
+    description="This is bananas"
+    open
+    scale="m"
+    width-scale="s"
+    modal
+  >
+    Hello world!
+  </calcite-dialog>
+`;
+
+export const withKindDangerIcon = (): string => html`
+  <calcite-dialog
+    kind="danger"
+    icon="banana"
+    heading="Banana"
+    description="This is bananas"
+    open
+    scale="m"
+    width-scale="s"
+    modal
+  >
+    Hello world!
+  </calcite-dialog>
+`;
+
+export const withKindInfoIcon = (): string => html`
+  <calcite-dialog
+    kind="info"
+    icon="banana"
+    heading="Banana"
+    description="This is bananas"
+    open
+    scale="m"
+    width-scale="s"
+    modal
+  >
+    Hello world!
+  </calcite-dialog>
+`;
+
+export const withKindSuccessIcon = (): string => html`
+  <calcite-dialog
+    kind="info"
+    icon="banana"
+    heading="Banana"
+    description="This is bananas"
+    open
+    scale="m"
+    width-scale="s"
+    modal
+  >
+    Hello world!
+  </calcite-dialog>
+`;
+
+export const withKindWarningIcon = (): string => html`
+  <calcite-dialog
+    kind="warning"
+    icon="banana"
+    description="This is bananas"
+    heading="Banana"
+    open
+    scale="m"
+    width-scale="s"
+    modal
+  >
+    Hello world!
+  </calcite-dialog>
 `;
 
 export const darkModeRTLCustomSizeCSSVars = (): string => html`

--- a/packages/calcite-components/src/components/dialog/dialog.stories.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.stories.ts
@@ -198,7 +198,7 @@ export const customContentSlot = (): string => html`
 `;
 
 export const withIcon = (): string => html`
-  <calcite-dialog icon="banana" heading="Banana" open> Hello world! </calcite-dialog>
+  <calcite-dialog icon="banana" heading="Banana" open scale="m" width-scale="s" modal> Hello world! </calcite-dialog>
 `;
 
 export const darkModeRTLCustomSizeCSSVars = (): string => html`

--- a/packages/calcite-components/src/components/dialog/dialog.stories.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.stories.ts
@@ -17,6 +17,8 @@ type DialogStoryArgs = Pick<
   | "closeDisabled"
   | "placement"
   | "loading"
+  | "icon"
+  | "iconFlipRtl"
   | "menuOpen"
   | "modal"
   | "overlayPositioning"
@@ -38,6 +40,8 @@ export default {
     description: "My description!",
     closeDisabled: false,
     loading: false,
+    icon: "",
+    iconFlipRtl: false,
     menuOpen: false,
     modal: false,
     dragEnabled: false,
@@ -107,6 +111,8 @@ export const simple = (args: DialogStoryArgs): string => html`
     width-scale="${args.widthScale}"
     placement="${args.placement}"
     heading="${args.heading}"
+    icon="${args.icon}"
+    icon-flip-rtl="${args.iconFlipRtl}"
     description="${args.description}"
     overlay-positioning="${args.overlayPositioning}"
   >
@@ -189,6 +195,10 @@ export const slotsWithModal = (): string => html`
 
 export const customContentSlot = (): string => html`
   <calcite-dialog heading="Custom content slot dialog" open placement="cover"> ${customContent} </calcite-dialog>
+`;
+
+export const withIcon = (): string => html`
+  <calcite-dialog icon="banana" heading="Banana" open> Hello world! </calcite-dialog>
 `;
 
 export const darkModeRTLCustomSizeCSSVars = (): string => html`

--- a/packages/calcite-components/src/components/dialog/dialog.stories.ts
+++ b/packages/calcite-components/src/components/dialog/dialog.stories.ts
@@ -250,7 +250,7 @@ export const withKindInfoIcon = (): string => html`
 
 export const withKindSuccessIcon = (): string => html`
   <calcite-dialog
-    kind="info"
+    kind="success"
     icon="banana"
     heading="Banana"
     description="This is bananas"

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -18,6 +18,7 @@ import type { Panel } from "../panel/panel";
 import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import { usePreventDocumentScroll } from "../../controllers/usePreventDocumentScroll";
 import { resizeShiftStep } from "../../utils/resources";
+import { IconNameOrString } from "../icon/interfaces";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, initialDragPosition, initialResizePosition, SLOTS } from "./resources";
 import { DialogDragPosition, DialogPlacement, DialogResizePosition } from "./interfaces";
@@ -174,6 +175,12 @@ export class Dialog extends LitElement implements OpenCloseComponent {
     "brand" | "danger" | "info" | "success" | "warning",
     Kind
   >;
+
+  /** Specifies an icon to display. */
+  @property({ reflect: true }) icon: IconNameOrString;
+
+  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
@@ -740,7 +747,7 @@ export class Dialog extends LitElement implements OpenCloseComponent {
   //#region Rendering
 
   override render(): JsxNode {
-    const { assistiveText, description, heading, opened } = this;
+    const { assistiveText, description, heading, opened, icon, iconFlipRtl } = this;
     return (
       <div
         class={{
@@ -779,6 +786,8 @@ export class Dialog extends LitElement implements OpenCloseComponent {
                 description={description}
                 heading={heading}
                 headingLevel={this.headingLevel}
+                icon={icon}
+                iconFlipRtl={iconFlipRtl}
                 loading={this.loading}
                 menuOpen={this.menuOpen}
                 messageOverrides={this.messageOverrides}

--- a/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.e2e.ts
@@ -66,6 +66,14 @@ describe("calcite-flow-item", () => {
         defaultValue: false,
       },
       {
+        propertyName: "icon",
+        defaultValue: undefined,
+      },
+      {
+        propertyName: "iconFlipRtl",
+        defaultValue: false,
+      },
+      {
         propertyName: "loading",
         defaultValue: false,
       },
@@ -116,6 +124,14 @@ describe("calcite-flow-item", () => {
       },
       {
         propertyName: "loading",
+        value: true,
+      },
+      {
+        propertyName: "icon",
+        value: "x",
+      },
+      {
+        propertyName: "iconFlipRtl",
         value: true,
       },
       {
@@ -276,6 +292,17 @@ describe("calcite-flow-item", () => {
     expect(await flowItem.getProperty("collapsed")).toBe(false);
   });
 
+  it("sets icon on internal panel", async () => {
+    const page = await newE2EPage();
+    await page.setContent(html`<calcite-flow-item icon="x" icon-flip-rtl></calcite-flow-item>`);
+    await page.waitForChanges();
+
+    const panel = await page.find(`calcite-flow-item >>> calcite-panel`);
+
+    expect(await panel.getProperty("icon")).toBe("x");
+    expect(await panel.getProperty("iconFlipRtl")).toBe(true);
+  });
+
   it("allows scrolling content", async () => {
     const page = await newE2EPage();
     await page.setContent(html`
@@ -394,7 +421,7 @@ describe("calcite-flow-item", () => {
   });
 
   describe("theme", () => {
-    themed(html`<calcite-flow-item show-back-button></calcite-flow-item>`, {
+    themed(html`<calcite-flow-item show-back-button icon="banana"></calcite-flow-item>`, {
       "--calcite-flow-corner-radius": {
         shadowSelector: "calcite-panel",
         targetProp: "--calcite-panel-corner-radius",
@@ -402,6 +429,10 @@ describe("calcite-flow-item", () => {
       "--calcite-flow-heading-text-color": {
         shadowSelector: "calcite-panel",
         targetProp: "--calcite-panel-heading-text-color",
+      },
+      "--calcite-flow-icon-color": {
+        shadowSelector: "calcite-panel",
+        targetProp: "--calcite-panel-icon-color",
       },
       "--calcite-flow-description-text-color": {
         shadowSelector: "calcite-panel",

--- a/packages/calcite-components/src/components/flow-item/flow-item.scss
+++ b/packages/calcite-components/src/components/flow-item/flow-item.scss
@@ -7,6 +7,7 @@
  * @prop --calcite-flow-item-header-border-block-end: [Deprecated] Use `--calcite-flow-border-color` instead. Specifies the component header's block end border.
  * @prop --calcite-flow-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-flow-heading-text-color: Specifies the text color of the component's `heading`.
+ * @prop --calcite-flow-icon-color: Specifies the color of the component's icon.
  * @prop --calcite-flow-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-flow-border-color: Specifies the component's border color.
  * @prop --calcite-flow-background-color: Specifies the component's background color.
@@ -63,6 +64,7 @@ calcite-panel {
   --calcite-panel-header-background-color: var(--calcite-flow-header-background-color);
   --calcite-panel-header-content-space: var(--calcite-flow-header-content-space);
   --calcite-panel-heading-text-color: var(--calcite-flow-heading-text-color);
+  --calcite-panel-icon-color: var(--calcite-flow-icon-color);
   --calcite-panel-space: var(--calcite-flow-space);
 }
 

--- a/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
@@ -16,6 +16,8 @@ interface FlowItemStoryArgs
     | "collapsed"
     | "collapseDirection"
     | "loading"
+    | "icon"
+    | "iconFlipRtl"
     | "scale"
     | "selected"
   > {
@@ -32,6 +34,8 @@ export default {
     collapsed: false,
     collapseDirection: collapseDirection.defaultValue,
     heightScale: scale.defaultValue,
+    icon: "",
+    iconFlipRtl: false,
     scale: scale.defaultValue,
     loading: false,
     selected: true,
@@ -105,6 +109,8 @@ export const simple = (args: FlowItemStoryArgs): string => html`
     ${boolean("loading", args.loading)}
     ${boolean("selected", args.selected)}
     heading="Heading"
+    icon="${args.icon}"
+    icon-flip-rtl="${args.iconFlipRtl}"
     description="A wonderful flow item description"
   >
     <calcite-action text="Action" label="Action" slot="${SLOTS.headerActionsStart}" icon="bluetooth"></calcite-action>
@@ -126,6 +132,10 @@ export const onlyProps = (): string => html`
       heading="flowItem title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum Tile title lorem ipsum"
     />
   </div>
+`;
+
+export const withIcon = (): string => html`
+  <calcite-flow-item icon="banana" heading="Banana"> Hello World! </calcite-flow-item>
 `;
 
 export const collapsed_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
+++ b/packages/calcite-components/src/components/flow-item/flow-item.stories.ts
@@ -135,7 +135,7 @@ export const onlyProps = (): string => html`
 `;
 
 export const withIcon = (): string => html`
-  <calcite-flow-item icon="banana" heading="Banana"> Hello World! </calcite-flow-item>
+  <calcite-flow-item icon="banana" selected heading="Banana"> Hello World! </calcite-flow-item>
 `;
 
 export const collapsed_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -15,6 +15,7 @@ import { CollapseDirection, Scale } from "../interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import type { Panel } from "../panel/panel";
 import type { Action } from "../action/action";
+import { IconNameOrString } from "../icon/interfaces";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, ICONS, SLOTS } from "./resources";
 import { styles } from "./flow-item.scss";
@@ -101,6 +102,12 @@ export class FlowItem extends LitElement implements InteractiveComponent {
 
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
+
+  /** Specifies an icon to display. */
+  @property({ reflect: true }) icon: IconNameOrString;
+
+  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
@@ -298,6 +305,8 @@ export class FlowItem extends LitElement implements InteractiveComponent {
       messages,
       overlayPositioning,
       beforeClose,
+      icon,
+      iconFlipRtl,
     } = this;
     return (
       <InteractiveContainer disabled={disabled}>
@@ -312,6 +321,8 @@ export class FlowItem extends LitElement implements InteractiveComponent {
           disabled={disabled}
           heading={heading}
           headingLevel={headingLevel}
+          icon={icon}
+          iconFlipRtl={iconFlipRtl}
           loading={loading}
           menuOpen={menuOpen}
           messageOverrides={messages}

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -143,6 +143,14 @@ describe("calcite-panel", () => {
         propertyName: "menuFlipPlacements",
         defaultValue: undefined,
       },
+      {
+        propertyName: "icon",
+        defaultValue: undefined,
+      },
+      {
+        propertyName: "iconFlipRtl",
+        defaultValue: false,
+      },
     ]);
   });
 
@@ -167,6 +175,14 @@ describe("calcite-panel", () => {
       {
         propertyName: "menuPlacement",
         value: "bottom",
+      },
+      {
+        propertyName: "icon",
+        value: "x",
+      },
+      {
+        propertyName: "iconFlipRtl",
+        value: "true",
       },
     ]);
   });
@@ -684,7 +700,13 @@ describe("calcite-panel", () => {
 
   describe("theme", () => {
     themed(
-      html`<calcite-panel heading="Terms and conditions" description="Something great about this" closable collapsible>
+      html`<calcite-panel
+        icon="banana"
+        heading="Terms and conditions"
+        description="Something great about this"
+        closable
+        collapsible
+      >
         <calcite-action text="banana" text-enabled icon="banana" slot="header-menu-actions"></calcite-action>
         <calcite-action text="measure" text-enabled icon="measure" slot="header-menu-actions"></calcite-action>
         <calcite-action text="Layers" icon="question" slot="header-actions-end"></calcite-action>
@@ -730,6 +752,10 @@ describe("calcite-panel", () => {
         "--calcite-panel-description-text-color": {
           shadowSelector: `.${CSS.description}`,
           targetProp: "color",
+        },
+        "--calcite-panel-icon-color": {
+          shadowSelector: `.${CSS.icon}`,
+          targetProp: "--calcite-icon-color",
         },
         "--calcite-panel-background-color": {
           shadowSelector: `.${CSS.contentWrapper}`,

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -293,7 +293,7 @@ calcite-action-menu {
 }
 
 calcite-icon {
-  --calcite-icon-color: var(--calcite-panel-icon-color);
+  --calcite-icon-color: var(--calcite-panel-icon-color, var(--calcite-color-text-1));
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -155,9 +155,8 @@
   margin-inline-end: auto;
   justify-content: center;
 
-  .heading-container {
-    display: flex;
-    align-items: center;
+  .heading-text-content {
+    flex: 1 1 auto;
   }
 
   .heading,
@@ -237,13 +236,19 @@ calcite-action-menu {
   padding-block: var(--calcite-internal-panel-header-vertical-padding);
   padding-inline: var(--calcite-internal-panel-default-space);
 
-  &.header-slotted-content {
+  &.header--slotted-content {
     padding: var(
       --calcite-panel-header-content-space,
       var(--calcite-internal-panel-header-vertical-padding) var(--calcite-internal-panel-default-space)
     );
   }
+
+  &.header--non-slotted-content {
+    align-items: center;
+    flex-direction: row;
+  }
 }
+
 .footer {
   @apply flex mt-auto flex-row content-between justify-center items-center text-n2-wrap;
   border-block-start: 1px solid var(--calcite-panel-border-color, var(--calcite-color-border-3));

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -5,6 +5,7 @@
 
  * @prop --calcite-panel-corner-radius: Specifies the component's corner radius.
  * @prop --calcite-panel-heading-text-color: Specifies the text color of the component's `heading`.
+ * @prop --calcite-panel-icon-color: Specifies the color of the component's icon.
  * @prop --calcite-panel-description-text-color: Specifies the text color of the component's `description`.
  * @prop --calcite-panel-border-color: Specifies the component's border color.
  * @prop --calcite-panel-background-color: Specifies the component's background color.
@@ -267,6 +268,10 @@ calcite-action-menu {
   z-sticky;
   inset-inline: 0;
   inline-size: fit-content;
+}
+
+calcite-icon {
+  --calcite-icon-color: var(--calcite-panel-icon-color);
 }
 
 @include base-component();

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -48,6 +48,10 @@
     .description {
       font-size: var(--calcite-font-size--2);
     }
+
+    .icon {
+      margin-inline-end: var(--calcite-spacing-sm);
+    }
   }
 }
 
@@ -63,6 +67,10 @@
     .description {
       font-size: var(--calcite-font-size--1);
     }
+
+    .icon {
+      margin-inline-end: var(--calcite-spacing-md);
+    }
   }
 }
 
@@ -77,6 +85,10 @@
 
     .description {
       font-size: var(--calcite-font-size-0);
+    }
+
+    .icon {
+      margin-inline-end: var(--calcite-spacing-lg);
     }
   }
 }
@@ -142,6 +154,11 @@
 
   margin-inline-end: auto;
   justify-content: center;
+
+  .heading-container {
+    display: flex;
+    align-items: center;
+  }
 
   .heading,
   .description {

--- a/packages/calcite-components/src/components/panel/panel.stories.ts
+++ b/packages/calcite-components/src/components/panel/panel.stories.ts
@@ -141,7 +141,9 @@ export const disabledWithStyledSlot_TestOnly = (): string => html`
 `;
 
 export const withIcon = (): string => html`
-  <calcite-panel icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
+  <calcite-panel scale="s" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
+  <calcite-panel scale="m" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
+  <calcite-panel scale="l" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
 `;
 
 export const darkModeRTL_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/panel/panel.stories.ts
+++ b/packages/calcite-components/src/components/panel/panel.stories.ts
@@ -141,9 +141,9 @@ export const disabledWithStyledSlot_TestOnly = (): string => html`
 `;
 
 export const withIcon = (): string => html`
-  <calcite-panel scale="s" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
-  <calcite-panel scale="m" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
-  <calcite-panel scale="l" icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
+  <calcite-panel scale="s" icon="banana" heading="Banana"> Hello world! </calcite-panel>
+  <calcite-panel scale="m" icon="banana" heading="Banana"> Hello world! </calcite-panel>
+  <calcite-panel scale="l" icon="banana" heading="Banana"> Hello world! </calcite-panel>
 `;
 
 export const darkModeRTL_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/panel/panel.stories.ts
+++ b/packages/calcite-components/src/components/panel/panel.stories.ts
@@ -146,6 +146,12 @@ export const withIcon = (): string => html`
   <calcite-panel scale="l" icon="banana" heading="Banana"> Hello world! </calcite-panel>
 `;
 
+export const withDescriptionAndIcon = (): string => html`
+  <calcite-panel scale="s" icon="banana" heading="Banana" description="This is bananas!"> Hello world! </calcite-panel>
+  <calcite-panel scale="m" icon="banana" heading="Banana" description="This is bananas!"> Hello world! </calcite-panel>
+  <calcite-panel scale="l" icon="banana" heading="Banana" description="This is bananas!"> Hello world! </calcite-panel>
+`;
+
 export const darkModeRTL_TestOnly = (): string => html`
   <calcite-panel collapse-direction="down" height-scale="m" dir="rtl" class="calcite-mode-dark">
     ${panelContent}

--- a/packages/calcite-components/src/components/panel/panel.stories.ts
+++ b/packages/calcite-components/src/components/panel/panel.stories.ts
@@ -14,6 +14,8 @@ interface PanelStoryArgs
     | "disabled"
     | "closable"
     | "collapsed"
+    | "icon"
+    | "iconFlipRtl"
     | "collapsible"
     | "collapseDirection"
     | "loading"
@@ -34,6 +36,8 @@ export default {
     collapsible: false,
     collapseDirection: collapseDirection.defaultValue,
     heightScale: scale.defaultValue,
+    icon: "",
+    iconFlipRtl: false,
     scale: scale.defaultValue,
     loading: false,
   },
@@ -105,6 +109,7 @@ export const simple = (args: PanelStoryArgs): string => html`
     collapseDirection="${args.collapseDirection}"
     heightScale="${args.heightScale}"
     scale="${args.scale}"
+    icon="${args.icon}"
     ${boolean("loading", args.loading)}
     menu-placement="${args.menuPlacement}"
     heading="Heading"
@@ -133,6 +138,10 @@ export const disabledWithStyledSlot_TestOnly = (): string => html`
   <calcite-panel style="height: 100%;" heading="Heading" disabled>
     <div id="content" style="height: 100%;">${contentHTML}</div>
   </calcite-panel>
+`;
+
+export const withIcon = (): string => html`
+  <calcite-panel icon="banana" heading="Banana"> ${contentHTML} </calcite-panel>
 `;
 
 export const darkModeRTL_TestOnly = (): string => html`

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -408,19 +408,22 @@ export class Panel extends LitElement implements InteractiveComponent {
 
     const headingNode = heading ? (
       <Heading class={CSS.heading} level={headingLevel}>
-        <div class={CSS.headingContainer}>
-          {iconNode}
-          {heading}
-        </div>
+        {heading}
       </Heading>
     ) : null;
 
     const descriptionNode = description ? <span class={CSS.description}>{description}</span> : null;
 
     return !hasHeaderContent && (headingNode || descriptionNode) ? (
-      <div class={CSS.headerContent} key="header-content">
-        {headingNode}
-        {descriptionNode}
+      <div
+        class={{ [CSS.headerContent]: true, [CSS.headerNonSlottedContent]: true }}
+        key="header-content"
+      >
+        {iconNode}
+        <div class={CSS.headingTextContent}>
+          {headingNode}
+          {descriptionNode}
+        </div>
       </div>
     ) : null;
   }

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -11,7 +11,7 @@ import {
   InteractiveContainer,
   updateHostInteraction,
 } from "../../utils/interactive";
-import { componentFocusable } from "../../utils/component";
+import { componentFocusable, getIconScale } from "../../utils/component";
 import { createObserver } from "../../utils/observers";
 import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { Heading, HeadingLevel } from "../functional/Heading";
@@ -25,6 +25,7 @@ import { CollapseDirection, Scale } from "../interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import type { Alert } from "../alert/alert";
 import type { ActionBar } from "../action-bar/action-bar";
+import { IconNameOrString } from "../icon/interfaces";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, ICONS, IDS, SLOTS } from "./resources";
 import { styles } from "./panel.scss";
@@ -142,6 +143,12 @@ export class Panel extends LitElement implements InteractiveComponent {
 
   /** Specifies the heading level of the component's `heading` for proper document structure, without affecting visual styling. */
   @property({ type: Number, reflect: true }) headingLevel: HeadingLevel;
+
+  /** Specifies an icon to display. */
+  @property({ reflect: true }) icon: IconNameOrString;
+
+  /** When `true`, the icon will be flipped when the element direction is right-to-left (`"rtl"`). */
+  @property({ reflect: true }) iconFlipRtl = false;
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
@@ -393,9 +400,15 @@ export class Panel extends LitElement implements InteractiveComponent {
   //#region Rendering
 
   private renderHeaderContent(): JsxNode {
-    const { heading, headingLevel, description, hasHeaderContent } = this;
+    const { heading, headingLevel, description, hasHeaderContent, icon, scale } = this;
+
+    const iconNode = icon ? (
+      <calcite-icon class={CSS.icon} icon={icon} scale={getIconScale(scale)} />
+    ) : null;
+
     const headingNode = heading ? (
       <Heading class={CSS.heading} level={headingLevel}>
+        {iconNode}
         {heading}
       </Heading>
     ) : null;

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -408,8 +408,10 @@ export class Panel extends LitElement implements InteractiveComponent {
 
     const headingNode = heading ? (
       <Heading class={CSS.heading} level={headingLevel}>
-        {iconNode}
-        {heading}
+        <div class={CSS.headingContainer}>
+          {iconNode}
+          {heading}
+        </div>
       </Heading>
     ) : null;
 

--- a/packages/calcite-components/src/components/panel/resources.ts
+++ b/packages/calcite-components/src/components/panel/resources.ts
@@ -7,6 +7,7 @@ export const CSS = {
   header: "header",
   headerContainer: "header-container",
   headerContainerBorderEnd: "header-container--border-end",
+  headingContainer: "heading-container",
   heading: "heading",
   summary: "summary",
   description: "description",

--- a/packages/calcite-components/src/components/panel/resources.ts
+++ b/packages/calcite-components/src/components/panel/resources.ts
@@ -14,6 +14,7 @@ export const CSS = {
   headerActions: "header-actions",
   headerActionsEnd: "header-actions--end",
   headerActionsStart: "header-actions--start",
+  icon: "icon",
   contentWrapper: "content-wrapper",
   fabContainer: "fab-container",
   footer: "footer",

--- a/packages/calcite-components/src/components/panel/resources.ts
+++ b/packages/calcite-components/src/components/panel/resources.ts
@@ -7,7 +7,7 @@ export const CSS = {
   header: "header",
   headerContainer: "header-container",
   headerContainerBorderEnd: "header-container--border-end",
-  headingContainer: "heading-container",
+  headingTextContent: "heading-text-content",
   heading: "heading",
   summary: "summary",
   description: "description",
@@ -23,7 +23,8 @@ export const CSS = {
   footerActions: "footer-actions",
   footerStart: "footer-start",
   footerEnd: "footer-end",
-  headerSlottedContent: "header-slotted-content",
+  headerSlottedContent: "header--slotted-content",
+  headerNonSlottedContent: "header--non-slotted-content",
   menuAction: "menu-action",
 };
 

--- a/packages/calcite-components/src/demos/panel.html
+++ b/packages/calcite-components/src/demos/panel.html
@@ -98,6 +98,16 @@
         </div>
       </div>
 
+      <!-- with icon -->
+      <div class="parent">
+        <div class="child right-aligned-text">with icon</div>
+        <div class="child">
+          <calcite-panel scale="s" icon="banana" heading="Small Bananas!"> Hello world! </calcite-panel>
+          <calcite-panel scale="m" icon="banana" heading="Medium Bananas!"> Hello world! </calcite-panel>
+          <calcite-panel scale="l" icon="banana" heading="Large Bananas!"> Hello world! </calcite-panel>
+        </div>
+      </div>
+
       <!-- with action bar and content top-->
       <div class="parent">
         <div class="child right-aligned-text">Slotted Action Bar + Slotted Content Top</div>


### PR DESCRIPTION
**Related Issue:** #10265

## Summary

- adds `icon` property to `panel`, `flow-item` and `dialog` components
- adds `iconFlipRtl` property to `panel`, `flow-item` and `dialog` components
- adds `--calcite-dialog-icon-color` css var to `dialog`
- adds `--calcite-flow-icon-color` css var to `flow-item`
- adds `--calcite-panel-icon-color` css var to `panel`
- adds tests
- adds stories
- add demo html
