### PR TITLE
fix(list): reorder options not shown in nested list drag menus

### DIFF
--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -540,7 +540,7 @@ describe("calcite-list", () => {
     it("navigating items after filtering", async () => {
       const page = await newE2EPage();
       await page.setContent(html`
-        <calcite-list filter-enabled>
+        <calcite-list drag-enabled filter-enabled>
           <calcite-list-item value="one" label="One" description="hello world"></calcite-list-item>
           <calcite-list-item value="two" label="Two" description="hello world"></calcite-list-item>
         </calcite-list>

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -228,6 +228,55 @@ describe("calcite-list", () => {
     }
   });
 
+  it("should set the setSize and setPosition properties on nested items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list display-mode="nested" label="Park features" drag-enabled group="nested-lists">
+        <calcite-list-item open label="Trails" value="trails">
+          <calcite-list id="nested" label="Trails" display-mode="nested" drag-enabled group="nested-lists">
+            <calcite-list-item label="Hiking trails" value="hiking-trails">
+              <calcite-action slot="actions-end" icon="layer" text="Hiking trails layer"></calcite-action>
+            </calcite-list-item>
+            <calcite-list-item label="Multi-use trails" value="multi-use-trails">
+              <calcite-action slot="actions-end" icon="layer" text="Multi-use trails layer"></calcite-action>
+            </calcite-list-item>
+            <calcite-list-item label="Boardwalks" value="boardwalks">
+              <calcite-action slot="actions-end" icon="layer" text="Boardwalks layer"></calcite-action>
+            </calcite-list-item>
+            <calcite-list-item label="Interpretive trails" value="interpretive-trails">
+              <calcite-action slot="actions-end" icon="layer" text="Interpretive trails layer"></calcite-action>
+            </calcite-list-item>
+          </calcite-list>
+        </calcite-list-item>
+        <calcite-list-item label="Waterfalls" value="waterfalls">
+          <calcite-action slot="actions-end" icon="layer" text="Waterfalls layer"></calcite-action>
+        </calcite-list-item>
+        <calcite-list-item label="Rivers" value="rivers">
+          <calcite-action slot="actions-end" icon="layer" text="Rivers layer"></calcite-action>
+        </calcite-list-item>
+        <calcite-list-item label="Estuaries" value="estuaries">
+          <calcite-action slot="actions-end" icon="layer" text="Estuaries layer"></calcite-action>
+        </calcite-list-item>
+      </calcite-list>`,
+    );
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.filter);
+
+    const items = await findAll(page, "#nested calcite-list-item");
+
+    expect(await items[0].getProperty("setPosition")).toBe(1);
+    expect(await items[0].getProperty("setSize")).toBe(4);
+
+    expect(await items[1].getProperty("setPosition")).toBe(2);
+    expect(await items[1].getProperty("setSize")).toBe(4);
+
+    expect(await items[2].getProperty("setPosition")).toBe(3);
+    expect(await items[2].getProperty("setSize")).toBe(4);
+
+    expect(await items[3].getProperty("setPosition")).toBe(4);
+    expect(await items[3].getProperty("setSize")).toBe(4);
+  });
+
   it("should set the dragHandle property on items", async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -104,7 +104,6 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
       moveToItems,
       displayMode,
       scale,
-      defaultSlotEl,
     } = this;
 
     const items = Array.from(this.el.querySelectorAll(listItemSelector));
@@ -145,9 +144,6 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     this.setActiveListItem();
     this.updateSelectedItems();
     this.setUpSorting();
-    if (defaultSlotEl) {
-      updateListItemChildren(defaultSlotEl);
-    }
   }, DEBOUNCE.nextTick);
 
   private visibleItems: ListItem["el"][] = [];
@@ -617,10 +613,14 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   }
 
   private setUpSorting(): void {
-    const { dragEnabled } = this;
+    const { dragEnabled, defaultSlotEl } = this;
 
     if (!dragEnabled) {
       return;
+    }
+
+    if (defaultSlotEl) {
+      updateListItemChildren(defaultSlotEl);
     }
 
     connectSortableComponent(this);


### PR DESCRIPTION
**Related Issue:** #12185

## Summary

- fixes setting `setPosition` and `setSize` correctly on sort handle with nested lists
- adds test for list