### PR TITLE
feat: make version console message easier to disable

### DIFF
--- a/packages/calcite-components/src/runtime.ts
+++ b/packages/calcite-components/src/runtime.ts
@@ -1,7 +1,5 @@
 import { makeRuntime } from "@arcgis/lumina";
-import globalScript from "./utils/globalScript";
-
-globalScript();
+import "./utils/globalScript";
 
 export const runtime = makeRuntime();
 

--- a/packages/calcite-components/src/utils/globalScript.ts
+++ b/packages/calcite-components/src/utils/globalScript.ts
@@ -1,20 +1,18 @@
+/**
+ * This file is imported in src/runtime.ts
+ */
 import { isServer } from "lit";
 import { initModeChangeEvent } from "./mode";
 import { stampVersion } from "./config";
 
-/**
- * This file is imported in Stencil's `globalScript` config option.
- *
- * @see [Stencil's globalScript](https://stenciljs.com/docs/config#globalscript).
- */
-export default function (): void {
-  if (!isServer) {
-    if (document.readyState === "interactive") {
-      initModeChangeEvent();
-    } else {
-      document.addEventListener("DOMContentLoaded", () => initModeChangeEvent(), { once: true });
-    }
+if (!isServer) {
+  if (document.readyState === "interactive") {
+    initModeChangeEvent();
+  } else {
+    document.addEventListener("DOMContentLoaded", initModeChangeEvent, { once: true });
   }
+}
 
-  stampVersion();
+if (process.env.NODE_ENV !== "test") {
+  queueMicrotask(stampVersion);
 }


### PR DESCRIPTION
**Related Issue:** #10038

## Summary

1. Don't log calcite version message in tests as it adds noise in tests and can even cause tests to fail (see #10038 for details)
2. Delay emission of a console message until a microtask to give users more time to disable the console message. This is the exact same change I implemented in Lit: https://github.com/lit/lit/pull/4901 - see that pr and associated issue for reasoning
   - In case of calcite, the console message can be disabled by running `(globalThis as { calciteConfig?: { version?: string } }).calciteConfig ??= { version: " " };` before the microtask fires