### PR TITLE
docs(popover, tooltip): add note to not place components in their refernce elements

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.tsx
+++ b/packages/calcite-components/src/components/popover/popover.tsx
@@ -185,7 +185,13 @@ export class Popover extends LitElement implements FloatingUIComponent, OpenClos
   @property({ reflect: true }) pointerDisabled = false;
 
   /**
-   * The `referenceElement` used to position the component according to its `placement` value. Setting to an `HTMLElement` is preferred so the component does not need to query the DOM. However, a string `id` of the reference element can also be used.
+   * The `referenceElement` used to position the component according to its `placement` value.
+   *
+   * Setting to an `HTMLElement` is preferred so the component does not need to query the DOM.
+   *
+   * However, a string `id` of the reference element can also be used.
+   *
+   * The component should not be placed within its own `referenceElement` to avoid unintended behavior.
    *
    * @required
    */

--- a/packages/calcite-components/src/components/tooltip/tooltip.tsx
+++ b/packages/calcite-components/src/components/tooltip/tooltip.tsx
@@ -112,6 +112,8 @@ export class Tooltip extends LitElement implements FloatingUIComponent, OpenClos
    * Setting to the `HTMLElement` is preferred so the component does not need to query the DOM for the `referenceElement`.
    *
    * However, a string ID of the reference element can be used.
+   *
+   * The component should not be placed within its own `referenceElement` to avoid unintended behavior.
    */
   @property() referenceElement: ReferenceElement | string;
 


### PR DESCRIPTION
**Related Issue:** #12200 

## Summary
Update property description for `referenceElement` on `tooltip` and `popover` to include a not that those components should not be placed within their referenc eelements.