### PR TITLE
refactor: drop calcite-base dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@cspell/dict-scientific-terms-us": "3.0.6",
         "@cspell/eslint-plugin": "8.19.1",
         "@eslint/js": "9.25.0",
-        "@esri/calcite-base": "1.2.0",
         "@octokit/webhooks-types": "7.6.1",
         "@prettier/sync": "0.5.5",
         "@storybook/addon-a11y": "8.6.12",
@@ -2005,13 +2004,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@esri/calcite-base": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-base/-/calcite-base-1.2.0.tgz",
-      "integrity": "sha512-xcEfk/lsj8SqHXDA8ekgZVCVZsRtfGiZDd6eGI/+U1QCqPhy8lmHh50fQhDiQvSOQ4NFWPXems5xaTQoQdiA8A==",
-      "dev": true,
-      "license": "SEE LICENSE IN README.md"
     },
     "node_modules/@esri/calcite-components": {
       "resolved": "packages/calcite-components",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@cspell/dict-scientific-terms-us": "3.0.6",
     "@cspell/eslint-plugin": "8.19.1",
     "@eslint/js": "9.25.0",
-    "@esri/calcite-base": "1.2.0",
     "@octokit/webhooks-types": "7.6.1",
     "@prettier/sync": "0.5.5",
     "@storybook/addon-a11y": "8.6.12",

--- a/packages/calcite-components/src/assets/styles/_animation.scss
+++ b/packages/calcite-components/src/assets/styles/_animation.scss
@@ -1,3 +1,5 @@
+$easing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88);
+
 @mixin animation-helper-classes() {
   @keyframes in {
     0% {

--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -1,3 +1,4 @@
+$floating-ui-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.16);
 $floating-ui-transition-offset: 5px;
 
 @mixin floating-ui-offset-bottom {
@@ -30,7 +31,7 @@ $floating-ui-transition-offset: 5px;
     /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
     transition-property: inset, left, opacity;
     opacity: 0;
-    box-shadow: $shadow-2;
+    box-shadow: $floating-ui-shadow;
     @apply rounded z-default;
   }
 }

--- a/packages/calcite-components/src/assets/styles/_spacing.scss
+++ b/packages/calcite-components/src/assets/styles/_spacing.scss
@@ -1,3 +1,5 @@
+$baseline: 1.5rem;
+
 %component-spacing {
   /* Component spacing variables */
 

--- a/packages/calcite-components/src/assets/styles/global.scss
+++ b/packages/calcite-components/src/assets/styles/global.scss
@@ -1,4 +1,3 @@
-@import "@esri/calcite-base/dist/index";
 @import "@esri/calcite-design-tokens/dist/scss/index";
 @import "@esri/calcite-design-tokens/dist/scss/core";
 

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -1,4 +1,3 @@
-@import "@esri/calcite-base/dist/index";
 @import "@esri/calcite-design-tokens/dist/scss/index";
 @import "@esri/calcite-design-tokens/dist/scss/core";
 

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -11,6 +11,9 @@
  *
  */
 
+$viewport-small: 480px;
+$viewport-medium: 860px;
+
 :host {
   --calcite-modal-scrim-background: #{rgba($calcite-color-neutral-blk-240, $calcite-opacity-85)};
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

`calcite-base` is a legacy dependency that is used for a small set of Sass variables. This PR drops it as dependency by inlining some values within our style files. 📦✂️

### Notes

- This will help with #10585 and #10583
- I'll create a follow-up issue to replace `$baseline`, `$easing-function` and `$floating-ui-shadow` with token or alternate styling (if applicable)