### PR TITLE
chore(translations): automate t9nmanifest

### DIFF
--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -67,10 +67,11 @@
     "util:copy-assets": "npm run util:copy-icons",
     "util:copy-icons": "cpy \"../../node_modules/@esri/calcite-ui-icons/js/*.json\" \"./src/components/icon/assets/\" --flat",
     "util:generate-t9n-docs-json": "tsx support/generateT9nDocsJSON.ts",
+    "util:generate-t9n-manifest": "tsx support/generateT9nManifest.ts",
     "util:generate-supported-browsers-json": "tsx support/generateSupportedBrowsersJSON.ts",
     "util:hydration-styles": "tsx support/hydrationStyles.ts",
     "util:is-working-tree-clean": "[ -z \"$(git status --porcelain=v1)\" ]",
-    "util:prep-build-reqs": "npm run util:copy-assets",
+    "util:prep-build-reqs": "npm run util:copy-assets  && npm run util:generate-t9n-manifest",
     "util:test-types": "! grep -rnw 'dist/types' -e '<reference types='",
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },

--- a/packages/calcite-components/src/demos/sortable-list.html
+++ b/packages/calcite-components/src/demos/sortable-list.html
@@ -152,15 +152,7 @@
             <calcite-block drag-handle="true" heading="Block A" collapsible="" calcite-hydrated="" open>
               <calcite-label alignment="start" scale="m" layout="default" calcite-hydrated="">content A </calcite-label>
             </calcite-block>
-            <calcite-block
-              drag-handle="true"
-              heading="Block B"
-              intl-collapse="Collapse"
-              intl-expand="Expand"
-              collapsible=""
-              calcite-hydrated=""
-              open
-            >
+            <calcite-block drag-handle="true" heading="Block B" collapsible="" calcite-hydrated="" open>
               <calcite-label alignment="start" scale="m" layout="default" calcite-hydrated="">content B </calcite-label>
               <calcite-list drag-enabled>
                 <calcite-list-item label="Rent" description="Mortgage + housing costs" value="rent">

--- a/packages/calcite-components/support/generateT9nManifest.ts
+++ b/packages/calcite-components/support/generateT9nManifest.ts
@@ -1,0 +1,34 @@
+import { globby } from "globby";
+
+(async () => {
+  const {
+    promises: { writeFile },
+  } = await import("fs");
+
+  const rootBundleFile = "messages.json";
+  const rootBundlePattern = `src/components/**/assets/t9n/${rootBundleFile}`;
+  const rootManifestFilePath = "packages/calcite-components/";
+
+  const rootBundles = await globby([rootBundlePattern]);
+  const manifestFilePathSeparator = "\\";
+
+  const paths = await Promise.all(
+    rootBundles.map(async (bundle) => {
+      const t9nPath = `${bundle.split("/t9n")[0]}/t9n`;
+      const relativeT9nPath = `${rootManifestFilePath}${t9nPath}`;
+      return relativeT9nPath.replace(/\//g, manifestFilePathSeparator);
+    }),
+  );
+
+  const manifestFileContents = paths
+    .sort((pathA, pathB) => {
+      // ensure paths are sorted per component-name as `globby` does not guarantee order (see https://github.com/sindresorhus/globby/issues/131)
+      const componentAName = pathA.split(manifestFilePathSeparator).at(-3);
+      const componentBName = pathB.split(manifestFilePathSeparator).at(-3);
+      console.log("pathA, pathB", componentAName, componentBName);
+      return componentAName && componentBName ? componentAName?.localeCompare(componentBName) : 0;
+    })
+    .join("\n");
+  await writeFile("../../t9nmanifest.txt", manifestFileContents);
+  console.log("finished writing manifest");
+})();

--- a/t9nmanifest.txt
+++ b/t9nmanifest.txt
@@ -49,5 +49,3 @@ packages\calcite-components\src\components\text-area\assets\t9n
 packages\calcite-components\src\components\time-picker\assets\t9n
 packages\calcite-components\src\components\tip\assets\t9n
 packages\calcite-components\src\components\tip-manager\assets\t9n
-
-


### PR DESCRIPTION
**Related Issue:** # N/A

## Summary

Add back `t9nmanifest` generate script which is removed as side-effect of [Lumina migration](https://github.com/Esri/calcite-design-system/pull/10482/files).