### PR TITLE
refactor(input-time-picker): add useTime functional controller

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -39,7 +39,7 @@ import type { TimePicker } from "../time-picker/time-picker";
 import type { Popover } from "../popover/popover";
 import type { Label } from "../label/label";
 import { isValidNumber } from "../../utils/number";
-import { TimeComponent, TimeController } from "../../controllers/time/time";
+import { TimeComponent, useTime } from "../../controllers/time/time";
 import { styles } from "./input-time-picker.scss";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS } from "./resources";
@@ -95,7 +95,7 @@ export class InputTimePicker
 
   private secondEl: HTMLSpanElement;
 
-  private time = new TimeController(this);
+  private time = useTime(this);
 
   //#endregion
 

--- a/packages/calcite-components/src/controllers/time/time.ts
+++ b/packages/calcite-components/src/controllers/time/time.ts
@@ -1,5 +1,5 @@
 import { PropertyValues } from "lit";
-import { GenericController, T9nMeta } from "@arcgis/lumina/controllers";
+import { GenericController, T9nMeta, toFunction } from "@arcgis/lumina/controllers";
 import { GenericT9nStrings } from "@arcgis/components-utils";
 import { createEvent, LitElement } from "@arcgis/lumina";
 import {
@@ -668,3 +668,5 @@ export class TimeController extends GenericController<TimeProperties, TimeCompon
 
   //#endregion
 }
+
+export const useTime = toFunction(TimeController);


### PR DESCRIPTION
**Related Issue:** #12090

## Summary

This PR updates `input-time-picker` to use the functional `useTime` controller to match the pattern with other controllers.