### PR TITLE
fix(input-time-picker): ensure programmatic value setting updates input display

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -134,6 +134,43 @@ describe("calcite-input-time-picker", () => {
     });
   });
 
+  it("allows resetting after value is set programmatically, modified via the time-picker then reset", async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<calcite-input-time-picker></calcite-input-time-picker>`);
+    await skipAnimations(page);
+    const inputTimePicker = await page.find("calcite-input-time-picker");
+
+    inputTimePicker.setProperty("value", "04:35");
+    await page.waitForChanges();
+
+    await assertDisplayedTime(page, "04:35 AM");
+
+    const openEvent = page.waitForEvent("calciteInputTimePickerOpen");
+    inputTimePicker.setProperty("open", true);
+    await page.waitForChanges();
+    await openEvent;
+
+    const hourUpEl = await page.find(`calcite-input-time-picker >>> .${TimePickerCSS.buttonHourUp}`);
+    const minuteUpEl = await page.find(`calcite-input-time-picker >>> .${TimePickerCSS.buttonMinuteUp}`);
+
+    await hourUpEl.click();
+    await minuteUpEl.click();
+
+    const closeEvent = page.waitForEvent("calciteInputTimePickerClose");
+    await page.keyboard.press("Escape");
+    await page.waitForChanges();
+    await closeEvent;
+
+    expect(await inputTimePicker.getProperty("value")).toBe("05:36");
+    await assertDisplayedTime(page, "05:36 AM");
+
+    inputTimePicker.setProperty("value", "04:35");
+    await page.waitForChanges();
+
+    expect(await inputTimePicker.getProperty("value")).toBe("04:35");
+    await assertDisplayedTime(page, "04:35 AM");
+  });
+
   it("resets to previous value when default event behavior is prevented", async () => {
     const page = await newE2EPage();
     await page.setContent(`<calcite-input-time-picker value="14:59"></calcite-input-time-picker>`);

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -297,10 +297,10 @@ export class InputTimePicker
 
     if (changes.has("value")) {
       if (this.hasUpdated) {
-        this.time.setValue(this.value);
         if (!this.time.userChangedValue) {
           this.previousEmittedValue = this.value;
         }
+        this.time.setValue(this.value);
       } else {
         this.previousEmittedValue = this.value;
       }

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -496,7 +496,9 @@ export class InputTimePicker
     syncHiddenFormInput("time", this, input);
   }
 
-  private timeChangeHandler(event): void {
+  private timeChangeHandler(event: CustomEvent<string>): void {
+    event.stopPropagation();
+
     if (this.disabled) {
       return;
     }

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -297,8 +297,8 @@ export class InputTimePicker
 
     if (changes.has("value")) {
       if (this.hasUpdated) {
+        this.time.setValue(this.value);
         if (!this.time.userChangedValue) {
-          this.time.setValue(this.value);
           this.previousEmittedValue = this.value;
         }
       } else {

--- a/packages/calcite-components/src/controllers/time/time.ts
+++ b/packages/calcite-components/src/controllers/time/time.ts
@@ -63,7 +63,7 @@ type TimeProperties = {
   /**
    * Change event that fires when the value is committed on Enter keypress or blur
    */
-  calciteTimeChange: CustomEvent;
+  calciteTimeChange: CustomEvent<string>;
   /**
    * The fractional second portion of the time value.
    */


### PR DESCRIPTION
**Related Issue:** #12230

## Summary

Sets the internal value whenever the `value` prop changes to keep the input in sync. This ensures the controller’s user-set value stays up to date since it could get out of sync if a user-driven time-picker update is followed by a programmatic one.