### PR TITLE
fix(color-picker): ensure channel values are rounded

### DIFF
--- a/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
+++ b/packages/calcite-components/src/components/color-picker/color-picker.e2e.ts
@@ -1077,13 +1077,13 @@ describe("calcite-color-picker", () => {
 
       describe("color gets propagated to support inputs", () => {
         describe("valid color", () => {
-          it("color gets propagated to hex, RGB & HSV inputs", async () => {
+          it("color gets propagated to hex, RGB (rounded) & HSV (rounded) inputs", async () => {
             const page = await newE2EPage();
-            await page.setContent(html`<calcite-color-picker value="#fff000"></calcite-color-picker>`);
+            await page.setContent(html`<calcite-color-picker value="#ff1500"></calcite-color-picker>`);
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
-            expect(await hexInput.getProperty("value")).toBe("#fff000");
+            expect(await hexInput.getProperty("value")).toBe("#ff1500");
 
             const [rgbModeButton, hsvModeButton] = await findAll(page, `calcite-color-picker >>> .${CSS.colorMode}`);
             const [rInput, gInput, bInput, hInput, sInput, vInput] = await findAll(
@@ -1094,12 +1094,12 @@ describe("calcite-color-picker", () => {
             await rgbModeButton.click();
 
             expect(await rInput.getProperty("value")).toBe("255");
-            expect(await gInput.getProperty("value")).toBe("240");
+            expect(await gInput.getProperty("value")).toBe("21");
             expect(await bInput.getProperty("value")).toBe("0");
 
             await hsvModeButton.click();
 
-            expect(await hInput.getProperty("value")).toBe("56");
+            expect(await hInput.getProperty("value")).toBe("5");
             expect(await sInput.getProperty("value")).toBe("100");
             expect(await vInput.getProperty("value")).toBe("100");
           });
@@ -1606,13 +1606,13 @@ describe("calcite-color-picker", () => {
 
       describe("color gets propagated to support inputs", () => {
         describe("valid color", () => {
-          it("color gets propagated to hex, RGB, HSV", async () => {
+          it("color gets propagated to hex, RGB (rounded), HSV (rounded)", async () => {
             const page = await newE2EPage();
-            await page.setContent(html`<calcite-color-picker alpha-channel value="#fff00000"></calcite-color-picker>`);
+            await page.setContent(html`<calcite-color-picker alpha-channel value="#ff150000"></calcite-color-picker>`);
 
             const hexInput = await page.find(`calcite-color-picker >>> calcite-color-picker-hex-input`);
 
-            expect(await hexInput.getProperty("value")).toBe("#fff00000");
+            expect(await hexInput.getProperty("value")).toBe("#ff150000");
 
             const [rgbModeButton, hsvModeButton] = await findAll(page, `calcite-color-picker >>> .${CSS.colorMode}`);
             const [rInput, gInput, bInput, rgbAInput, hInput, sInput, vInput, hsvAInput] = await findAll(
@@ -1623,13 +1623,13 @@ describe("calcite-color-picker", () => {
             await rgbModeButton.click();
 
             expect(await rInput.getProperty("value")).toBe("255");
-            expect(await gInput.getProperty("value")).toBe("240");
+            expect(await gInput.getProperty("value")).toBe("21");
             expect(await bInput.getProperty("value")).toBe("0");
             expect(await rgbAInput.getProperty("value")).toBe("0");
 
             await hsvModeButton.click();
 
-            expect(await hInput.getProperty("value")).toBe("56");
+            expect(await hInput.getProperty("value")).toBe("5");
             expect(await sInput.getProperty("value")).toBe("100");
             expect(await vInput.getProperty("value")).toBe("100");
             expect(await hsvAInput.getProperty("value")).toBe("0");

--- a/packages/calcite-components/src/components/color-picker/color-picker.tsx
+++ b/packages/calcite-components/src/components/color-picker/color-picker.tsx
@@ -1438,13 +1438,7 @@ export class ColorPicker extends LitElement implements InteractiveComponent {
 
   private toChannels(color: ColorInstance): Channels {
     const { channelMode } = this;
-
-    const channels = color[channelMode]()
-      .array()
-      .map((value, index) => {
-        const isAlpha = index === 3;
-        return isAlpha ? value : Math.floor(value);
-      });
+    const channels = color[channelMode]().round().array();
 
     if (channels.length === 3) {
       channels.push(1); // Color omits alpha when 1


### PR DESCRIPTION
**Related Issue:** #12227 

## Summary

Updates the color-to-channels logic to use rounding instead of flooring each channel's value. 

**Note**: this behavior has been in place [since the component was introduced](https://github.com/Esri/calcite-design-system/pull/592/files#diff-406257c24372573bea6f61d161e358c1f9f33be0c23530546c53618a2342a0f2R927).