### PR TITLE
fix(inline-editable)!: no longer set scale based on the slotted `calcite-input`'s scale

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -82,7 +82,7 @@ describe("calcite-inline-editable", () => {
       }
     });
 
-    it("uses a child input's scale when none are provided", async () => {
+    it("does not use child input's scale when none are provided", async () => {
       const page = await newE2EPage();
       await page.setContent(`
       <calcite-label>
@@ -93,7 +93,7 @@ describe("calcite-inline-editable", () => {
       `);
       await page.waitForChanges();
       const element = await page.find("calcite-inline-editable");
-      expect(element).toEqualAttribute("scale", "l");
+      expect(element).toEqualAttribute("scale", "m");
     });
 
     it("renders requested props when valid props are provided", async () => {

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -195,7 +195,6 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
     inputElement.editingEnabled = this.editingEnabled;
     inputElement.disabled = this.disabled;
     inputElement.label = inputElement.label || getLabelText(this);
-    this.scale = this.scale || this.inputElement?.scale || "m";
   }
 
   onLabelClick(): void {


### PR DESCRIPTION
**Related Issue:** #10466

## Summary

- removes scale logic
- updates test

BREAKING CHANGE: No longer sets component's scale based on the slotted `calcite-input`'s scale.
