### PR TITLE
fix(input-time-picker): add label property

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -125,6 +125,9 @@ export class InputTimePicker
    */
   @property({ reflect: true }) hourFormat: HourFormat = "user";
 
+  /** Accessible name for the component. */
+  @property() label: string;
+
   /**
    * When the component resides in a form,
    * specifies the maximum value.

--- a/packages/calcite-components/src/utils/label.ts
+++ b/packages/calcite-components/src/utils/label.ts
@@ -166,13 +166,7 @@ function sortByDOMOrder(a: LabelableComponent, b: LabelableComponent): number {
  * @param component
  */
 export function getLabelText(component: LabelableComponent): string {
-  return (
-    component.label ||
-    component.labelEl?.textContent?.trim() ||
-    component.el?.getAttribute("label") ||
-    component.el?.getAttribute("aria-label") ||
-    ""
-  );
+  return component.label || component.labelEl?.textContent?.trim() || "";
 }
 
 function onLabelClick(this: Label["el"], event: CustomEvent<{ sourceEvent: MouseEvent }>): void {

--- a/packages/calcite-components/src/utils/label.ts
+++ b/packages/calcite-components/src/utils/label.ts
@@ -166,7 +166,13 @@ function sortByDOMOrder(a: LabelableComponent, b: LabelableComponent): number {
  * @param component
  */
 export function getLabelText(component: LabelableComponent): string {
-  return component.label || component.labelEl?.textContent?.trim() || "";
+  return (
+    component.label ||
+    component.labelEl?.textContent?.trim() ||
+    component.el?.getAttribute("label") ||
+    component.el?.getAttribute("aria-label") ||
+    ""
+  );
 }
 
 function onLabelClick(this: Label["el"], event: CustomEvent<{ sourceEvent: MouseEvent }>): void {


### PR DESCRIPTION
**Related Issue:** #12153

## Summary

This fixes an issue with `calcite-input-time-picker` where setting a `label` attribute wouldn't apply correctly, resulting in an accessibility warning.