### PR TITLE
chore(button): tighten `type` prop's type from `string` to three standard values

### DIFF
--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -179,7 +179,7 @@ export class Button
    *
    * @mdn [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)
    */
-  @property({ reflect: true }) type = "button";
+  @property({ reflect: true }) type: "submit" | "reset" | "button" = "button";
 
   /** Specifies the width of the component. [Deprecated] The `"half"` value is deprecated, use `"full"` instead. */
   @property({ reflect: true }) width: Extract<Width, "auto" | "half" | "full"> = "auto";
@@ -360,11 +360,7 @@ export class Button
           tabIndex={this.disabled ? -1 : null}
           target={childElType === "a" && this.target}
           title={this.tooltipText}
-          type={
-            childElType === "button"
-              ? (this.type as LuminaJsx.HTMLElementTags["button"]["type"])
-              : null
-          }
+          type={childElType === "button" ? this.type : null}
         >
           {loaderNode}
           {this.iconStart ? iconStartEl : null}


### PR DESCRIPTION
**Related Issue:** #10437

## Summary
Tightens the `button` component's public `type` property down to the
three standard values (`"submit" | "reset" | "button"`) from the non-restrictive
`string` type.
