### PR TITLE
refactor(block-section): use appropriate class name for `icon-end` element

### DIFF
--- a/packages/calcite-components/src/components/block-section/block-section.e2e.ts
+++ b/packages/calcite-components/src/components/block-section/block-section.e2e.ts
@@ -294,6 +294,7 @@ describe("calcite-block-section", () => {
           "--calcite-block-section-text-color": [
             { shadowSelector: `.${CSS.chevronIcon}`, targetProp: "color" },
             { shadowSelector: `.${CSS.iconStart}`, targetProp: "color" },
+            { shadowSelector: `.${CSS.iconEnd}`, targetProp: "color" },
           ],
           "--calcite-block-section-text-color-hover": [
             {
@@ -313,6 +314,11 @@ describe("calcite-block-section", () => {
             },
             {
               shadowSelector: `.${CSS.iconStart}`,
+              targetProp: "color",
+              state: "hover",
+            },
+            {
+              shadowSelector: `.${CSS.iconEnd}`,
               targetProp: "color",
               state: "hover",
             },

--- a/packages/calcite-components/src/components/block-section/block-section.tsx
+++ b/packages/calcite-components/src/components/block-section/block-section.tsx
@@ -144,8 +144,10 @@ export class BlockSection extends LitElement {
     ) : null;
   }
 
-  private renderIcon(icon: string): JsxNode {
-    const { iconFlipRtl } = this;
+  private renderIcon(position: "start" | "end"): JsxNode {
+    const { iconFlipRtl, iconStart, iconEnd } = this;
+
+    const icon = position === "start" ? iconStart : iconEnd;
 
     if (icon === undefined) {
       return null;
@@ -153,16 +155,15 @@ export class BlockSection extends LitElement {
 
     const flipRtlStart = iconFlipRtl === "both" || iconFlipRtl === "start";
     const flipRtlEnd = iconFlipRtl === "both" || iconFlipRtl === "end";
-
-    const isIconStart = icon === this.iconStart;
+    const isIconStart = position === "start";
 
     /** Icon scale is not variable as the component does not have a scale property */
     return (
       <calcite-icon
         class={isIconStart ? CSS.iconStart : CSS.iconEnd}
         flipRtl={isIconStart ? flipRtlStart : flipRtlEnd}
-        icon={isIconStart ? this.iconStart : this.iconEnd}
-        key={isIconStart ? this.iconStart : this.iconEnd}
+        icon={isIconStart ? iconStart : iconEnd}
+        key={isIconStart ? iconStart : iconEnd}
         scale="s"
       />
     );
@@ -195,12 +196,12 @@ export class BlockSection extends LitElement {
             tabIndex={0}
             title={toggleLabel}
           >
-            {this.renderIcon(this.iconStart)}
+            {this.renderIcon("start")}
             <div class={CSS.toggleSwitchContent}>
               <span class={CSS.toggleSwitchText}>{text}</span>
             </div>
 
-            {this.renderIcon(this.iconEnd)}
+            {this.renderIcon("end")}
             {this.renderStatusIcon()}
             <calcite-switch
               checked={expanded}
@@ -227,9 +228,9 @@ export class BlockSection extends LitElement {
             id={IDS.toggle}
             onClick={this.toggleSection}
           >
-            {this.renderIcon(this.iconStart)}
+            {this.renderIcon("start")}
             <span class={CSS.sectionHeaderText}>{text}</span>
-            {this.renderIcon(this.iconEnd)}
+            {this.renderIcon("end")}
             {this.renderStatusIcon()}
             <calcite-icon class={CSS.chevronIcon} icon={arrowIcon} scale="s" />
           </button>


### PR DESCRIPTION
**Related Issue:** #11053 

## Summary

Use appropriate class name for `icon-end` element which is using `icon--start` before. 