### PR TITLE
docs(button): correct conflicting JSDoc for `loading` prop

### DIFF
--- a/packages/calcite-components/src/components/button/button.tsx
+++ b/packages/calcite-components/src/components/button/button.tsx
@@ -142,7 +142,7 @@ export class Button
   /** Accessible name for the component. */
   @property() label: string;
 
-  /** When `true`, a busy indicator is displayed and interaction is disabled. */
+  /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
 
   /** Use this property to override individual strings used by the component. */


### PR DESCRIPTION
**Related Issue:** #12294

## Summary
To stay in line with the [Best Practices - Recommendations](https://developers.arcgis.com/calcite-design-system/components/button/#recommendations), updates the `loading` property JSDoc to communicate only the busy indicator behavior. The JSDoc previously stated that the `loading` prop disabled interaction, which is incorrect.
