### PR TITLE
fix(input-time-picker): apply aria-label and aria-controls attributes correctly to support NVDA and JAWS

### DIFF
--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -564,7 +564,7 @@ export class InputTimePicker
     return (
       <InteractiveContainer disabled={this.disabled}>
         <div
-          aria-label={getLabelText(this)}
+          aria-controls={CSS.inputContainer}
           class={{
             [CSS.container]: true,
             [CSS.readOnly]: readOnly,
@@ -573,7 +573,12 @@ export class InputTimePicker
           role="combobox"
         >
           <calcite-icon class={CSS.clockIcon} icon="clock" scale={scale === "l" ? "m" : "s"} />
-          <div class={CSS.inputContainer} dir="ltr">
+          <div
+            aria-label={getLabelText(this)}
+            class={CSS.inputContainer}
+            dir="ltr"
+            id={CSS.inputContainer}
+          >
             {showMeridiem && meridiemStart && this.renderMeridiem("start")}
             <span
               aria-label={this.messages.hour}

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -578,6 +578,7 @@ export class InputTimePicker
             class={CSS.inputContainer}
             dir="ltr"
             id={CSS.inputContainer}
+            role="group"
           >
             {showMeridiem && meridiemStart && this.renderMeridiem("start")}
             <span

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -565,6 +565,7 @@ export class InputTimePicker
       <InteractiveContainer disabled={this.disabled}>
         <div
           aria-controls={CSS.inputContainer}
+          aria-labelledby={CSS.inputContainer}
           class={{
             [CSS.container]: true,
             [CSS.readOnly]: readOnly,

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.tsx
@@ -565,7 +565,7 @@ export class InputTimePicker
       <InteractiveContainer disabled={this.disabled}>
         <div
           aria-controls={CSS.inputContainer}
-          aria-labelledby={CSS.inputContainer}
+          aria-labelledby={IDS.inputContainer}
           class={{
             [CSS.container]: true,
             [CSS.readOnly]: readOnly,
@@ -578,7 +578,7 @@ export class InputTimePicker
             aria-label={getLabelText(this)}
             class={CSS.inputContainer}
             dir="ltr"
-            id={CSS.inputContainer}
+            id={IDS.inputContainer}
             role="group"
           >
             {showMeridiem && meridiemStart && this.renderMeridiem("start")}

--- a/packages/calcite-components/src/components/input-time-picker/resources.ts
+++ b/packages/calcite-components/src/components/input-time-picker/resources.ts
@@ -21,5 +21,6 @@ export const CSS = {
 };
 
 export const IDS = {
+  inputContainer: "inputContainer",
   validationMessage: "inputTimePickerValidationMessage",
 };


### PR DESCRIPTION
**Related Issue:** #12153

## Summary

This PR fixes an issue where NVDA and JAWS don't read out the `aria-label` set on `calcite-input-time-picker`.