### PR TITLE
ci: fix next deployments by restoring version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36415,7 +36415,7 @@
     },
     "packages/calcite-components": {
       "name": "@esri/calcite-components",
-      "version": "3.2.1",
+      "version": "3.3.0-next.10",
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/components-utils": "^4.33.0-next.121",
@@ -36446,10 +36446,10 @@
     },
     "packages/calcite-components-react": {
       "name": "@esri/calcite-components-react",
-      "version": "3.2.1",
+      "version": "3.3.0-next.10",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-components": "3.2.1",
+        "@esri/calcite-components": "3.3.0-next.10",
         "@lit/react": "1.0.7"
       },
       "peerDependencies": {

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components-react",
-  "version": "3.2.1",
+  "version": "3.3.0-next.10",
   "description": "A set of React components that wrap calcite components",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {
@@ -28,7 +28,7 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@esri/calcite-components": "3.2.1",
+    "@esri/calcite-components": "3.3.0-next.10",
     "@lit/react": "1.0.7"
   },
   "peerDependencies": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/calcite-components",
-  "version": "3.2.1",
+  "version": "3.3.0-next.10",
   "description": "Web Components for Esri's Calcite Design System.",
   "homepage": "https://developers.arcgis.com/calcite-design-system/",
   "repository": {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Automated next deployments were failing because the cherry-picked [release commit](https://github.com/Esri/calcite-design-system/pull/12247) reverted the version to an earlier patch, which caused a conflict when calculating the next version.