### PR TITLE
fix(chip): adjust interactivity states enhancements

### DIFF
--- a/packages/calcite-components/src/components/chip/chip.scss
+++ b/packages/calcite-components/src/components/chip/chip.scss
@@ -38,6 +38,11 @@
 
   &:host([kind="brand"]) {
     --calcite-internal-chip-border-color: var(--calcite-chip-border-color, var(--calcite-color-brand));
+    --calcite-internal-chip-selectable-hover-border-color: var(--calcite-chip-border-color, var(--calcite-color-brand));
+    --calcite-internal-chip-selectable-active-border-color: var(
+      --calcite-chip-border-color,
+      var(--calcite-color-brand)
+    );
   }
 
   &:host([kind="inverse"]) {
@@ -56,6 +61,8 @@
 }
 :host([appearance="solid"]) {
   --calcite-internal-chip-border-color: transparent;
+  --calcite-internal-chip-selectable-hover-border-color: transparent;
+  --calcite-internal-chip-selectable-active-border-color: transparent;
 
   &:host([kind="brand"]),
   &:host([kind="inverse"]) {


### PR DESCRIPTION
**Related Issue:** [#12286](https://github.com/Esri/calcite-design-system/issues/12286)

## Summary

Remove border color changes on `:hover` and `:active` when:

- `appearance="solid"`
- `kind="brand" & appearance="outline | outline-fill"`
