### PR TITLE
build: restore usage of monorepo package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36440,7 +36440,7 @@
       "dependencies": {
         "@arcgis/components-utils": "^4.33.0-next.155",
         "@arcgis/lumina": "^4.33.0-next.155",
-        "@esri/calcite-ui-icons": "4.2.0",
+        "@esri/calcite-ui-icons": "4.3.0-next.1",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
@@ -36456,9 +36456,9 @@
       },
       "devDependencies": {
         "@arcgis/lumina-compiler": "^4.33.0-next.155",
-        "@esri/calcite-design-tokens": "3.1.0",
+        "@esri/calcite-design-tokens": "3.2.0-next.0",
         "@esri/calcite-tailwind-preset": "1.0.1-next.3",
-        "@esri/eslint-plugin-calcite-components": "2.0.2",
+        "@esri/eslint-plugin-calcite-components": "2.0.3-next.1",
         "@vitest/browser": "3.1.4",
         "playwright": "1.52.0",
         "vitest": "3.1.4"
@@ -36484,33 +36484,6 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "tslib": "^2.8.1"
-      }
-    },
-    "packages/calcite-components/node_modules/@esri/calcite-design-tokens": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-design-tokens/-/calcite-design-tokens-3.1.0.tgz",
-      "integrity": "sha512-bSbhhObBiBWMTF+SxL2DdHP6Agt8Zvc8q+THYn9ThCiTBihTrSgZwRCWW/t2zbpm4L7kTNshDGdLqM2VpW417A==",
-      "dev": true,
-      "license": "SEE LICENSE.md"
-    },
-    "packages/calcite-components/node_modules/@esri/calcite-ui-icons": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.2.0.tgz",
-      "integrity": "sha512-GS41gUt1tgnqG+U1a6yDRiKOHmuLST2uyOI7+cJ83JtLJ7CGduH9K6RERabTE2vRYbudaebI8jZgKNSNOHdGzw==",
-      "license": "SEE LICENSE.md",
-      "bin": {
-        "spriter": "bin/spriter.js"
-      }
-    },
-    "packages/calcite-components/node_modules/@esri/eslint-plugin-calcite-components": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/eslint-plugin-calcite-components/-/eslint-plugin-calcite-components-2.0.2.tgz",
-      "integrity": "sha512-6to00B1nqmgPNbc4yLLNuae7GSK8I4RlsSbuJQ6bP9nhslwaIpGW2JrKVjDKPvfJd7oKmeUyhPEs14kHG9NhoA==",
-      "dev": true,
-      "license": "SEE LICENSE.md",
-      "peerDependencies": {
-        "@typescript-eslint/utils": ">=8.0.0",
-        "eslint": ">=8.0.0"
       }
     },
     "packages/calcite-design-tokens": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@arcgis/components-utils": "^4.33.0-next.155",
     "@arcgis/lumina": "^4.33.0-next.155",
-    "@esri/calcite-ui-icons": "4.2.0",
+    "@esri/calcite-ui-icons": "4.3.0-next.1",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
@@ -93,9 +93,9 @@
   },
   "devDependencies": {
     "@arcgis/lumina-compiler": "^4.33.0-next.155",
-    "@esri/calcite-design-tokens": "3.1.0",
+    "@esri/calcite-design-tokens": "3.2.0-next.0",
     "@esri/calcite-tailwind-preset": "1.0.1-next.3",
-    "@esri/eslint-plugin-calcite-components": "2.0.2",
+    "@esri/eslint-plugin-calcite-components": "2.0.3-next.1",
     "@vitest/browser": "3.1.4",
     "playwright": "1.52.0",
     "vitest": "3.1.4"


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Similar to https://github.com/Esri/calcite-design-system/pull/12318, automated next deployments for the icons, tokens and ESLint plugin packages were stalled due to the cherry-picked [release commit](https://github.com/Esri/calcite-design-system/pull/12247) that ended up reverting them to earlier, non-next versions.