### PR TITLE
chore(tokens): enable `strict` and drop `typescript-strict-plugin`

### DIFF
--- a/packages/calcite-design-tokens/tsconfig-base.json
+++ b/packages/calcite-design-tokens/tsconfig-base.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "strict": true,
     "target": "ESNext"
   },
   "exclude": ["node_modules", "dist"]

--- a/packages/calcite-design-tokens/tsconfig.json
+++ b/packages/calcite-design-tokens/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "typescript-strict-plugin"
-      }
-    ]
-  },
   "extends": "./tsconfig-base",
   "include": ["src"]
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The design tokens package can now enable `strict` in its `tsconfig.json` and remove `typescript-strict-plugin`.