### PR TITLE
refactor(semantic-tokens): update src token structure to align with Figma

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/border.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/border.json
@@ -1,35 +1,31 @@
 {
-  "semantic": {
-    "border": {
-      "width": {
-        "none": {
-          "value": "{core.size.default.none}",
-          "type": "borderWidth",
-          "attributes": {
-            "category": "border"
-          }
-        },
-        "sm": {
-          "value": "{core.size.default.1}",
-          "type": "borderWidth",
-          "attributes": {
-            "category": "border"
-          }
-        },
-        "md": {
-          "value": "{core.size.default.2}",
-          "type": "borderWidth",
-          "attributes": {
-            "category": "border"
-          }
-        },
-        "lg": {
-          "value": "{core.size.default.4}",
-          "type": "borderWidth",
-          "attributes": {
-            "category": "border"
-          }
-        }
+  "width": {
+    "none": {
+      "value": "{core.size.default.none}",
+      "type": "borderWidth",
+      "attributes": {
+        "category": "border"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.1}",
+      "type": "borderWidth",
+      "attributes": {
+        "category": "border"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.2}",
+      "type": "borderWidth",
+      "attributes": {
+        "category": "border"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.4}",
+      "type": "borderWidth",
+      "attributes": {
+        "category": "border"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
@@ -1,357 +1,353 @@
 {
-  "semantic": {
-    "color": {
-      "background": {
-        "default": {
-          "value": "{core.color.neutral.blk-190}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "none": {
-          "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+  "background": {
+    "default": {
+      "value": "{core.color.neutral.blk-190}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "none": {
+      "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "foreground": {
+    "1": {
+      "value": "{core.color.neutral.blk-200}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-210}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-220}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "current": {
+      "value": "{core.color.medium-saturation.blue.m-bb-090}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      },
+      "description": "deprecated, use --calcite-color-foreground-highlight instead"
+    },
+    "highlight": {
+      "value": "{core.color.medium-saturation.blue.m-bb-090}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "transparent": {
+    "default": {
+      "default": {
+        "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "foreground": {
-        "1": {
-          "value": "{core.color.neutral.blk-200}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-210}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-220}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "current": {
-          "value": "{core.color.medium-saturation.blue.m-bb-090}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          },
-          "description": "deprecated, use --calcite-color-foreground-highlight instead"
-        },
-        "highlight": {
-          "value": "{core.color.medium-saturation.blue.m-bb-090}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "hover": {
+        "value": "rgba({core.color.neutral.blk-000}, {core.opacity.12})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "transparent": {
-        "default": {
-          "default": {
-            "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "rgba({core.color.neutral.blk-000}, {core.opacity.12})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "rgba({core.color.neutral.blk-000}, {core.opacity.16})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "inverse": {
-          "hover": {
-            "value": "rgba({core.color.neutral.blk-240}, {core.opacity.4})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "rgba({core.color.neutral.blk-240}, {core.opacity.8})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "scrim": {
-          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.85})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "tint": {
-          "value": "rgba({core.color.neutral.blk-200}, {core.opacity.80})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "rgba({core.color.neutral.blk-000}, {core.opacity.16})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "inverse": {
+      "hover": {
+        "value": "rgba({core.color.neutral.blk-240}, {core.opacity.4})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "brand": {
-        "default": {
-          "default": {
-            "value": "{core.color.vibrant.blue.v-bb-160}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.high-saturation.blue.h-bb-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.blue.h-bb-070}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "underline": {
-          "type": "color",
-          "value": "rgba({core.color.dark.blue.d-bb-420}, {core.opacity.40})",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "rgba({core.color.neutral.blk-240}, {core.opacity.8})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "scrim": {
+      "value": "rgba({core.color.neutral.blk-240}, {core.opacity.85})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "tint": {
+      "value": "rgba({core.color.neutral.blk-200}, {core.opacity.80})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "brand": {
+    "default": {
+      "default": {
+        "value": "{core.color.vibrant.blue.v-bb-160}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "status": {
-        "info": {
-          "default": {
-            "value": "{core.color.dark.blue.d-bb-420}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.vibrant.blue.v-bb-140}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.vibrant.blue.v-bb-160}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "success": {
-          "default": {
-            "value": "{core.color.dark.green.d-gg-420}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.vibrant.green.v-gg-140}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.vibrant.green.v-gg-160}",
-            "type": "color",
-            "category": "color"
-          }
-        },
-        "warning": {
-          "default": {
-            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.vibrant.orange-yellow.v-oy-120}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.vibrant.orange-yellow.v-oy-140}",
-            "type": "color",
-            "category": "color"
-          }
-        },
-        "danger": {
-          "default": {
-            "value": "{core.color.dark.red.d-rr-420}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.vibrant.red.v-rr-140}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.vibrant.red.v-rr-160}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
+      "hover": {
+        "value": "{core.color.high-saturation.blue.h-bb-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "inverse": {
-        "default": {
-          "value": "{core.color.neutral.blk-005}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "hover": {
-          "value": "{core.color.neutral.blk-000}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "press": {
-          "value": "{core.color.neutral.blk-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "{core.color.high-saturation.blue.h-bb-070}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "underline": {
+      "type": "color",
+      "value": "rgba({core.color.dark.blue.d-bb-420}, {core.opacity.40})",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "status": {
+    "info": {
+      "default": {
+        "value": "{core.color.dark.blue.d-bb-420}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "text": {
-        "1": {
-          "value": "{core.color.neutral.blk-000}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-060}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-090}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "highlight": {
-          "value": "{core.color.high-saturation.blue.h-bb-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "inverse": {
-          "value": "{core.color.neutral.blk-220}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "link": {
-          "value": "{core.color.dark.blue.d-bb-420}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "hover": {
+        "value": "{core.color.vibrant.blue.v-bb-140}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "border": {
-        "1": {
-          "value": "{core.color.neutral.blk-160}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-170}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-180}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "input": {
-          "value": "{core.color.neutral.blk-130}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "ghost": {
-          "value": "rgba({core.color.neutral.blk-130}, {core.opacity.30})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "white": {
-          "value": "{core.color.neutral.blk-005}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "{core.color.vibrant.blue.v-bb-160}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "success": {
+      "default": {
+        "value": "{core.color.dark.green.d-gg-420}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "focus": {
-        "default": {
-          "value": "{semantic.color.brand.default.default}",
-          "type": "color",
-          "attributes": {
-            "category": "color",
-            "scope": "component"
-          }
+      "hover": {
+        "value": "{core.color.vibrant.green.v-gg-140}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
+      },
+      "press": {
+        "value": "{core.color.vibrant.green.v-gg-160}",
+        "type": "color",
+        "category": "color"
+      }
+    },
+    "warning": {
+      "default": {
+        "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "hover": {
+        "value": "{core.color.vibrant.orange-yellow.v-oy-120}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "press": {
+        "value": "{core.color.vibrant.orange-yellow.v-oy-140}",
+        "type": "color",
+        "category": "color"
+      }
+    },
+    "danger": {
+      "default": {
+        "value": "{core.color.dark.red.d-rr-420}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "hover": {
+        "value": "{core.color.vibrant.red.v-rr-140}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "press": {
+        "value": "{core.color.vibrant.red.v-rr-160}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    }
+  },
+  "inverse": {
+    "default": {
+      "value": "{core.color.neutral.blk-005}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "hover": {
+      "value": "{core.color.neutral.blk-000}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "press": {
+      "value": "{core.color.neutral.blk-010}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "text": {
+    "1": {
+      "value": "{core.color.neutral.blk-000}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-060}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-090}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "highlight": {
+      "value": "{core.color.high-saturation.blue.h-bb-010}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "inverse": {
+      "value": "{core.color.neutral.blk-220}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "link": {
+      "value": "{core.color.dark.blue.d-bb-420}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "border": {
+    "1": {
+      "value": "{core.color.neutral.blk-160}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-170}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-180}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "input": {
+      "value": "{core.color.neutral.blk-130}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "ghost": {
+      "value": "rgba({core.color.neutral.blk-130}, {core.opacity.30})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "white": {
+      "value": "{core.color.neutral.blk-005}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "focus": {
+    "default": {
+      "value": "{semantic.color.brand.default.default}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "scope": "component"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
@@ -1,361 +1,357 @@
 {
-  "semantic": {
-    "color": {
-      "background": {
-        "default": {
-          "value": "{core.color.neutral.blk-005}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "none": {
-          "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+  "background": {
+    "default": {
+      "value": "{core.color.neutral.blk-005}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "none": {
+      "value": "rgba({core.color.neutral.blk-000}, {core.opacity.0})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "foreground": {
+    "1": {
+      "value": "{core.color.neutral.blk-000}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-010}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-020}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "current": {
+      "value": "{core.color.high-saturation.blue.h-bb-010}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      },
+      "description": "deprecated, use --calcite-color-foreground-highlight instead"
+    },
+    "highlight": {
+      "value": "{core.color.high-saturation.blue.h-bb-010}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "transparent": {
+    "default": {
+      "default": {
+        "value": "rgba({core.color.neutral.blk-240}, {core.opacity.0})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "foreground": {
-        "1": {
-          "value": "{core.color.neutral.blk-000}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-020}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "current": {
-          "value": "{core.color.high-saturation.blue.h-bb-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          },
-          "description": "deprecated, use --calcite-color-foreground-highlight instead"
-        },
-        "highlight": {
-          "value": "{core.color.high-saturation.blue.h-bb-010}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "hover": {
+        "value": "rgba({core.color.neutral.blk-240}, {core.opacity.4})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "transparent": {
-        "default": {
-          "default": {
-            "value": "rgba({core.color.neutral.blk-240}, {core.opacity.0})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "rgba({core.color.neutral.blk-240}, {core.opacity.4})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "rgba({core.color.neutral.blk-240}, {core.opacity.8})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "inverse": {
-          "hover": {
-            "value": "rgba({core.color.neutral.blk-000}, {core.opacity.12})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "rgba({core.color.neutral.blk-000}, {core.opacity.16})",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "scrim": {
-          "value": "rgba({core.color.neutral.blk-000}, {core.opacity.85})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "tint": {
-          "value": "rgba({core.color.neutral.blk-000}, {core.opacity.80})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "rgba({core.color.neutral.blk-240}, {core.opacity.8})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "inverse": {
+      "hover": {
+        "value": "rgba({core.color.neutral.blk-000}, {core.opacity.12})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "brand": {
-        "default": {
-          "default": {
-            "value": "{core.color.high-saturation.blue.h-bb-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.high-saturation.blue.h-bb-070}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.blue.h-bb-080}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "underline": {
-          "type": "color",
-          "value": "rgba({core.color.high-saturation.blue.h-bb-070}, {core.opacity.40})",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "rgba({core.color.neutral.blk-000}, {core.opacity.16})",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "scrim": {
+      "value": "rgba({core.color.neutral.blk-000}, {core.opacity.85})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "tint": {
+      "value": "rgba({core.color.neutral.blk-000}, {core.opacity.80})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "brand": {
+    "default": {
+      "default": {
+        "value": "{core.color.high-saturation.blue.h-bb-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "status": {
-        "info": {
-          "default": {
-            "value": "{core.color.high-saturation.blue.h-bb-070}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.high-saturation.blue.h-bb-080}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.blue.h-bb-090}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "success": {
-          "default": {
-            "value": "{core.color.high-saturation.green.h-gg-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.high-saturation.green.h-gg-070}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.green.h-gg-080}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "warning": {
-          "default": {
-            "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.vibrant.orange-yellow.v-oy-180}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.orange-yellow.h-oy-080}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
-        },
-        "danger": {
-          "default": {
-            "value": "{core.color.high-saturation.red.h-rr-060}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "hover": {
-            "value": "{core.color.high-saturation.red.h-rr-070}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          },
-          "press": {
-            "value": "{core.color.high-saturation.red.h-rr-080}",
-            "type": "color",
-            "attributes": {
-              "category": "color"
-            }
-          }
+      "hover": {
+        "value": "{core.color.high-saturation.blue.h-bb-070}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "inverse": {
-        "default": {
-          "value": "{core.color.neutral.blk-190}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "hover": {
-          "value": "{core.color.neutral.blk-200}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "press": {
-          "value": "{core.color.neutral.blk-210}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "{core.color.high-saturation.blue.h-bb-080}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "underline": {
+      "type": "color",
+      "value": "rgba({core.color.high-saturation.blue.h-bb-070}, {core.opacity.40})",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "status": {
+    "info": {
+      "default": {
+        "value": "{core.color.high-saturation.blue.h-bb-070}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "text": {
-        "1": {
-          "value": "{core.color.neutral.blk-220}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-170}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-140}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "highlight": {
-          "value": "{core.color.high-saturation.blue.h-bb-080}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "inverse": {
-          "value": "{core.color.neutral.blk-000}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "link": {
-          "value": "{core.color.high-saturation.blue.h-bb-070}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "hover": {
+        "value": "{core.color.high-saturation.blue.h-bb-080}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "border": {
-        "1": {
-          "value": "{core.color.neutral.blk-050}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "2": {
-          "value": "{core.color.neutral.blk-040}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "3": {
-          "value": "{core.color.neutral.blk-030}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "input": {
-          "value": "{core.color.neutral.blk-100}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "ghost": {
-          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.30})",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
-        },
-        "white": {
-          "value": "{core.color.neutral.blk-000}",
-          "type": "color",
-          "attributes": {
-            "category": "color"
-          }
+      "press": {
+        "value": "{core.color.high-saturation.blue.h-bb-090}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "success": {
+      "default": {
+        "value": "{core.color.high-saturation.green.h-gg-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
       },
-      "focus": {
-        "default": {
-          "value": "{semantic.color.brand.default.default}",
-          "type": "color",
-          "attributes": {
-            "category": "color",
-            "scope": "component"
-          }
+      "hover": {
+        "value": "{core.color.high-saturation.green.h-gg-070}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
         }
+      },
+      "press": {
+        "value": "{core.color.high-saturation.green.h-gg-080}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "warning": {
+      "default": {
+        "value": "{core.color.high-saturation.orange-yellow.h-oy-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "hover": {
+        "value": "{core.color.vibrant.orange-yellow.v-oy-180}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "press": {
+        "value": "{core.color.high-saturation.orange-yellow.h-oy-080}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    },
+    "danger": {
+      "default": {
+        "value": "{core.color.high-saturation.red.h-rr-060}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "hover": {
+        "value": "{core.color.high-saturation.red.h-rr-070}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      },
+      "press": {
+        "value": "{core.color.high-saturation.red.h-rr-080}",
+        "type": "color",
+        "attributes": {
+          "category": "color"
+        }
+      }
+    }
+  },
+  "inverse": {
+    "default": {
+      "value": "{core.color.neutral.blk-190}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "hover": {
+      "value": "{core.color.neutral.blk-200}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "press": {
+      "value": "{core.color.neutral.blk-210}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "text": {
+    "1": {
+      "value": "{core.color.neutral.blk-220}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-170}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-140}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "highlight": {
+      "value": "{core.color.high-saturation.blue.h-bb-080}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "inverse": {
+      "value": "{core.color.neutral.blk-000}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "link": {
+      "value": "{core.color.high-saturation.blue.h-bb-070}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "border": {
+    "1": {
+      "value": "{core.color.neutral.blk-050}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "2": {
+      "value": "{core.color.neutral.blk-040}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "3": {
+      "value": "{core.color.neutral.blk-030}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "input": {
+      "value": "{core.color.neutral.blk-100}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "ghost": {
+      "value": "rgba({core.color.neutral.blk-240}, {core.opacity.30})",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    },
+    "white": {
+      "value": "{core.color.neutral.blk-000}",
+      "type": "color",
+      "attributes": {
+        "category": "color"
+      }
+    }
+  },
+  "focus": {
+    "default": {
+      "value": "{semantic.color.brand.default.default}",
+      "type": "color",
+      "attributes": {
+        "category": "color",
+        "scope": "component"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/container-size.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/container-size.json
@@ -1,171 +1,167 @@
 {
-  "semantic": {
-    "container-size": {
-      "height": {
-        "xxs": {
-          "value": {
-            "min": "0",
-            "max": "{core.container-size.154}"
-          },
-          "type": "dimension",
-          "description": "Small handheld devices and mini-windows",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "xs": {
-          "value": {
-            "min": "{core.container-size.154} + 1",
-            "max": "{core.container-size.328}"
-          },
-          "type": "dimension",
-          "description": "Handheld devices",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "sm": {
-          "value": {
-            "min": "{core.container-size.328} + 1",
-            "max": "{core.container-size.504}"
-          },
-          "type": "dimension",
-          "description": "Small tablets",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "md": {
-          "value": {
-            "min": "{core.container-size.504} + 1",
-            "max": "{core.container-size.678}"
-          },
-          "type": "dimension",
-          "description": "Small laptops",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "lg": {
-          "value": {
-            "min": "{core.container-size.678} + 1",
-            "max": "{core.container-size.854}"
-          },
-          "type": "dimension",
-          "description": "Large laptops and desktop computers",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "xl": {
-          "value": {
-            "min": "{core.container-size.854} + 1"
-          },
-          "type": "dimension",
-          "description": "Projectors and televisions",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        }
+  "height": {
+    "xxs": {
+      "value": {
+        "min": "0",
+        "max": "{core.container-size.154}"
       },
-      "width": {
-        "xxs": {
-          "value": {
-            "min": "0",
-            "max": "{core.container-size.320}"
-          },
-          "type": "dimension",
-          "description": "Small handheld devices and mini-windows",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "xs": {
-          "value": {
-            "min": "{core.container-size.320} + 1",
-            "max": "{core.container-size.476}"
-          },
-          "type": "dimension",
-          "description": "Handheld devices",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "sm": {
-          "value": {
-            "min": "{core.container-size.476} + 1",
-            "max": "{core.container-size.768}"
-          },
-          "type": "dimension",
-          "description": "Small tablets",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "md": {
-          "value": {
-            "min": "{core.container-size.768} + 1",
-            "max": "{core.container-size.1152}"
-          },
-          "type": "dimension",
-          "description": "Small laptops",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "lg": {
-          "value": {
-            "min": "{core.container-size.1152} + 1",
-            "max": "{core.container-size.1440}"
-          },
-          "type": "dimension",
-          "description": "Large laptops and desktop computers",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "xl": {
-          "value": {
-            "min": "{core.container-size.1440} + 1"
-          },
-          "type": "dimension",
-          "description": "Projectors and televisions",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        }
+      "type": "dimension",
+      "description": "Small handheld devices and mini-windows",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "xs": {
+      "value": {
+        "min": "{core.container-size.154} + 1",
+        "max": "{core.container-size.328}"
       },
-      "margin": {
-        "value": "{core.size.default.24}",
-        "type": "spacing",
-        "attributes": {
-          "category": "breakpoint"
-        }
+      "type": "dimension",
+      "description": "Handheld devices",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "sm": {
+      "value": {
+        "min": "{core.container-size.328} + 1",
+        "max": "{core.container-size.504}"
       },
-      "gutter": {
-        "value": "{core.size.default.16}",
-        "type": "spacing",
-        "attributes": {
-          "category": "breakpoint"
-        }
+      "type": "dimension",
+      "description": "Small tablets",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "md": {
+      "value": {
+        "min": "{core.container-size.504} + 1",
+        "max": "{core.container-size.678}"
       },
-      "content": {
-        "fluid": {
-          "value": "{core.size.relative.100}",
-          "type": "sizing",
-          "description": "for fluid grid widths",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        },
-        "fixed": {
-          "value": "{core.container-size.1440}",
-          "type": "sizing",
-          "description": "only for lg breakpoint fixed grid width",
-          "attributes": {
-            "category": "breakpoint"
-          }
-        }
+      "type": "dimension",
+      "description": "Small laptops",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "lg": {
+      "value": {
+        "min": "{core.container-size.678} + 1",
+        "max": "{core.container-size.854}"
+      },
+      "type": "dimension",
+      "description": "Large laptops and desktop computers",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "xl": {
+      "value": {
+        "min": "{core.container-size.854} + 1"
+      },
+      "type": "dimension",
+      "description": "Projectors and televisions",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    }
+  },
+  "width": {
+    "xxs": {
+      "value": {
+        "min": "0",
+        "max": "{core.container-size.320}"
+      },
+      "type": "dimension",
+      "description": "Small handheld devices and mini-windows",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "xs": {
+      "value": {
+        "min": "{core.container-size.320} + 1",
+        "max": "{core.container-size.476}"
+      },
+      "type": "dimension",
+      "description": "Handheld devices",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "sm": {
+      "value": {
+        "min": "{core.container-size.476} + 1",
+        "max": "{core.container-size.768}"
+      },
+      "type": "dimension",
+      "description": "Small tablets",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "md": {
+      "value": {
+        "min": "{core.container-size.768} + 1",
+        "max": "{core.container-size.1152}"
+      },
+      "type": "dimension",
+      "description": "Small laptops",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "lg": {
+      "value": {
+        "min": "{core.container-size.1152} + 1",
+        "max": "{core.container-size.1440}"
+      },
+      "type": "dimension",
+      "description": "Large laptops and desktop computers",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "xl": {
+      "value": {
+        "min": "{core.container-size.1440} + 1"
+      },
+      "type": "dimension",
+      "description": "Projectors and televisions",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    }
+  },
+  "margin": {
+    "value": "{core.size.default.24}",
+    "type": "spacing",
+    "attributes": {
+      "category": "breakpoint"
+    }
+  },
+  "gutter": {
+    "value": "{core.size.default.16}",
+    "type": "spacing",
+    "attributes": {
+      "category": "breakpoint"
+    }
+  },
+  "content": {
+    "fluid": {
+      "value": "{core.size.relative.100}",
+      "type": "sizing",
+      "description": "for fluid grid widths",
+      "attributes": {
+        "category": "breakpoint"
+      }
+    },
+    "fixed": {
+      "value": "{core.container-size.1440}",
+      "type": "sizing",
+      "description": "only for lg breakpoint fixed grid width",
+      "attributes": {
+        "category": "breakpoint"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/corner.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/corner.json
@@ -1,59 +1,55 @@
 {
-  "semantic": {
-    "corner": {
-      "radius": {
-        "default": {
-          "value": "{semantic.corner.radius.none}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          }
-        },
-        "sharp": {
-          "value": "{core.size.default.none}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          },
-          "description": "deprecated, use --calcite-corner-radius-none instead"
-        },
-        "none": {
-          "value": "{core.size.default.none}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          }
-        },
-        "xs": {
-          "value": "{core.size.default.2}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          }
-        },
-        "sm": {
-          "value": "{core.size.default.4}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          }
-        },
-        "round": {
-          "value": "{core.size.default.4}",
-          "type": "borderRadius",
-          "attributes": {
-            "category": "corner"
-          },
-          "description": "deprecated, use --calcite-corner-radius-sm instead"
-        },
-        "pill": {
-          "value": "{core.size.relative.100}",
-          "type": "borderRadius",
-          "attributes": {
-            "element": "",
-            "category": "corner"
-          }
-        }
+  "radius": {
+    "default": {
+      "value": "{semantic.corner.radius.none}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      }
+    },
+    "sharp": {
+      "value": "{core.size.default.none}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      },
+      "description": "deprecated, use --calcite-corner-radius-none instead"
+    },
+    "none": {
+      "value": "{core.size.default.none}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      }
+    },
+    "xs": {
+      "value": "{core.size.default.2}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.4}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      }
+    },
+    "round": {
+      "value": "{core.size.default.4}",
+      "type": "borderRadius",
+      "attributes": {
+        "category": "corner"
+      },
+      "description": "deprecated, use --calcite-corner-radius-sm instead"
+    },
+    "pill": {
+      "value": "{core.size.relative.100}",
+      "type": "borderRadius",
+      "attributes": {
+        "element": "",
+        "category": "corner"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/font.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/font.json
@@ -1,303 +1,299 @@
 {
-  "semantic": {
-    "font": {
-      "family": {
-        "default": {
-          "value": "{core.font.family.avenirNext},{core.font.family.avenir},{core.font.family.helveticaNeue},{core.font.family.sansSerif}",
-          "type": "fontFamilies",
-          "attributes": {
-            "group": "family"
-          },
-          "description": "Primary font with fallbacks"
-        },
-        "code": {
-          "value": "{core.font.family.monaco},{core.font.family.consolas},{core.font.family.andaleMono},{core.font.family.lucidaConsole},{core.font.family.monospace}",
-          "type": "fontFamilies",
-          "attributes": {
-            "category": "font"
-          },
-          "description": "Font family for code with fallbacks"
+  "family": {
+    "default": {
+      "value": "{core.font.family.avenirNext},{core.font.family.avenir},{core.font.family.helveticaNeue},{core.font.family.sansSerif}",
+      "type": "fontFamilies",
+      "attributes": {
+        "group": "family"
+      },
+      "description": "Primary font with fallbacks"
+    },
+    "code": {
+      "value": "{core.font.family.monaco},{core.font.family.consolas},{core.font.family.andaleMono},{core.font.family.lucidaConsole},{core.font.family.monospace}",
+      "type": "fontFamilies",
+      "attributes": {
+        "category": "font"
+      },
+      "description": "Font family for code with fallbacks"
+    }
+  },
+  "weight": {
+    "light": {
+      "value": "{core.font.weight.light}",
+      "type": "fontWeights",
+      "attributes": {
+        "category": "font"
+      },
+      "description": "For Avenir Next World (secondary font family)"
+    },
+    "normal": {
+      "value": "{core.font.weight.regular}",
+      "type": "fontWeights",
+      "extensions": {
+        "calcite.deprecated": true
+      },
+      "attributes": {
+        "category": "font"
+      },
+      "description": "For backwards compatibility only. This token will be removed from the published tokens in the next major in favor of the more descriptive word \"regular\""
+    },
+    "regular": {
+      "value": "{core.font.weight.regular}",
+      "type": "fontWeights",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "medium": {
+      "value": "{core.font.weight.medium}",
+      "type": "fontWeights",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "semibold": {
+      "value": "{core.font.weight.demi}",
+      "type": "fontWeights",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "bold": {
+      "value": "{core.font.weight.demi}",
+      "type": "fontWeights",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "size": {
+    "xs": {
+      "value": "{core.size.default.10}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.12}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "default": {
+      "value": "{core.size.default.14}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.16}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.2} * 9",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "xl": {
+      "value": "{core.size.default.20}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "xxl": {
+      "value": "{core.size.default.24}",
+      "type": "fontSizes",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "style": {
+    "emphasis": {
+      "value": "{core.font.style.italic}",
+      "type": "fontStyle",
+      "description": "used in ratings",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "line-height": {
+    "fixed": {
+      "sm": {
+        "value": "{core.size.default.12}",
+        "type": "lineHeights",
+        "attributes": {
+          "category": "font"
         }
       },
-      "weight": {
-        "light": {
-          "value": "{core.font.weight.light}",
-          "type": "fontWeights",
-          "attributes": {
-            "category": "font"
-          },
-          "description": "For Avenir Next World (secondary font family)"
-        },
-        "normal": {
-          "value": "{core.font.weight.regular}",
-          "type": "fontWeights",
-          "extensions": {
-            "calcite.deprecated": true
-          },
-          "attributes": {
-            "category": "font"
-          },
-          "description": "For backwards compatibility only. This token will be removed from the published tokens in the next major in favor of the more descriptive word \"regular\""
-        },
-        "regular": {
-          "value": "{core.font.weight.regular}",
-          "type": "fontWeights",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "medium": {
-          "value": "{core.font.weight.medium}",
-          "type": "fontWeights",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "semibold": {
-          "value": "{core.font.weight.demi}",
-          "type": "fontWeights",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "bold": {
-          "value": "{core.font.weight.demi}",
-          "type": "fontWeights",
-          "attributes": {
-            "category": "font"
-          }
+      "base": {
+        "value": "{core.size.default.16}",
+        "type": "lineHeights",
+        "attributes": {
+          "category": "font"
         }
       },
-      "size": {
-        "xs": {
-          "value": "{core.size.default.10}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "sm": {
-          "value": "{core.size.default.12}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "default": {
-          "value": "{core.size.default.14}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "md": {
-          "value": "{core.size.default.16}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "lg": {
-          "value": "{core.size.default.2} * 9",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "xl": {
-          "value": "{core.size.default.20}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "xxl": {
-          "value": "{core.size.default.24}",
-          "type": "fontSizes",
-          "attributes": {
-            "category": "font"
-          }
+      "lg": {
+        "value": "{core.size.default.20}",
+        "type": "lineHeights",
+        "attributes": {
+          "category": "font"
         }
       },
-      "style": {
-        "emphasis": {
-          "value": "{core.font.style.italic}",
-          "type": "fontStyle",
-          "description": "used in ratings",
-          "attributes": {
-            "category": "font"
-          }
+      "xl": {
+        "value": "{core.size.default.24}",
+        "type": "lineHeights",
+        "attributes": {
+          "category": "font"
+        }
+      }
+    },
+    "relative": {
+      "default": {
+        "value": "{core.size.relative.auto}",
+        "type": "lineHeights",
+        "description": "1",
+        "attributes": {
+          "category": "font"
         }
       },
-      "line-height": {
-        "fixed": {
-          "sm": {
-            "value": "{core.size.default.12}",
-            "type": "lineHeights",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "base": {
-            "value": "{core.size.default.16}",
-            "type": "lineHeights",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "lg": {
-            "value": "{core.size.default.20}",
-            "type": "lineHeights",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "xl": {
-            "value": "{core.size.default.24}",
-            "type": "lineHeights",
-            "attributes": {
-              "category": "font"
-            }
-          }
-        },
-        "relative": {
-          "default": {
-            "value": "{core.size.relative.auto}",
-            "type": "lineHeights",
-            "description": "1",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "tight": {
-            "value": "{core.size.relative.125}",
-            "type": "lineHeights",
-            "description": "1.25",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "snug": {
-            "value": "{core.size.relative.137}",
-            "type": "lineHeights",
-            "description": "1.375",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "normal": {
-            "value": "{core.size.relative.150}",
-            "type": "lineHeights",
-            "description": "1.5",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "relaxed": {
-            "value": "{core.size.relative.162}",
-            "type": "lineHeights",
-            "description": "1.625",
-            "attributes": {
-              "category": "font"
-            }
-          },
-          "loose": {
-            "value": "{core.size.relative.200}",
-            "type": "lineHeights",
-            "description": "2",
-            "attributes": {
-              "category": "font"
-            }
-          }
+      "tight": {
+        "value": "{core.size.relative.125}",
+        "type": "lineHeights",
+        "description": "1.25",
+        "attributes": {
+          "category": "font"
         }
       },
-      "letter-spacing": {
-        "tight": {
-          "value": "{core.size.default.none} - .4 ",
-          "type": "letterSpacing",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "normal": {
-          "value": "{core.size.default.none}",
-          "type": "letterSpacing",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "wide": {
-          "value": "{core.size.default.none} + .4 ",
-          "type": "letterSpacing",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
+      "snug": {
+        "value": "{core.size.relative.137}",
+        "type": "lineHeights",
+        "description": "1.375",
+        "attributes": {
+          "category": "font"
         }
       },
-      "paragraph-spacing": {
-        "normal": {
-          "value": "{core.size.default.4}",
-          "type": "paragraphSpacing",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
+      "normal": {
+        "value": "{core.size.relative.150}",
+        "type": "lineHeights",
+        "description": "1.5",
+        "attributes": {
+          "category": "font"
         }
       },
-      "text-decoration": {
-        "none": {
-          "value": "{core.font.text-decoration.none}",
-          "type": "textDecoration",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "underline": {
-          "value": "{core.font.text-decoration.underline}",
-          "type": "textDecoration",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
+      "relaxed": {
+        "value": "{core.size.relative.162}",
+        "type": "lineHeights",
+        "description": "1.625",
+        "attributes": {
+          "category": "font"
         }
       },
-      "text-case": {
-        "none": {
-          "value": "{core.font.text-case.none}",
-          "type": "textCase",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "uppercase": {
-          "value": "{core.font.text-case.uppercase}",
-          "type": "textCase",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "lowercase": {
-          "value": "{core.font.text-case.lowercase}",
-          "type": "textCase",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
-        },
-        "capitalize": {
-          "value": "{core.font.text-case.capitalize}",
-          "type": "textCase",
-          "description": "Deprecated",
-          "attributes": {
-            "category": "font"
-          }
+      "loose": {
+        "value": "{core.size.relative.200}",
+        "type": "lineHeights",
+        "description": "2",
+        "attributes": {
+          "category": "font"
         }
+      }
+    }
+  },
+  "letter-spacing": {
+    "tight": {
+      "value": "{core.size.default.none} - .4 ",
+      "type": "letterSpacing",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "normal": {
+      "value": "{core.size.default.none}",
+      "type": "letterSpacing",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "wide": {
+      "value": "{core.size.default.none} + .4 ",
+      "type": "letterSpacing",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "paragraph-spacing": {
+    "normal": {
+      "value": "{core.size.default.4}",
+      "type": "paragraphSpacing",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "text-decoration": {
+    "none": {
+      "value": "{core.font.text-decoration.none}",
+      "type": "textDecoration",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "underline": {
+      "value": "{core.font.text-decoration.underline}",
+      "type": "textDecoration",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    }
+  },
+  "text-case": {
+    "none": {
+      "value": "{core.font.text-case.none}",
+      "type": "textCase",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "uppercase": {
+      "value": "{core.font.text-case.uppercase}",
+      "type": "textCase",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "lowercase": {
+      "value": "{core.font.text-case.lowercase}",
+      "type": "textCase",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
+      }
+    },
+    "capitalize": {
+      "value": "{core.font.text-case.capitalize}",
+      "type": "textCase",
+      "description": "Deprecated",
+      "attributes": {
+        "category": "font"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/opacity.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/opacity.json
@@ -1,41 +1,37 @@
 {
-  "semantic": {
-    "opacity": {
-      "light": {
-        "value": "{core.opacity.40}",
-        "type": "opacity",
-        "attributes": {
-          "category": "opacity"
-        }
-      },
-      "half": {
-        "value": "{core.opacity.50}",
-        "type": "opacity",
-        "attributes": {
-          "category": "opacity"
-        }
-      },
-      "dark": {
-        "value": "{core.opacity.85}",
-        "type": "opacity",
-        "attributes": {
-          "category": "opacity"
-        }
-      },
-      "full": {
-        "value": "{core.opacity.100}",
-        "type": "opacity",
-        "attributes": {
-          "category": "opacity"
-        }
-      },
-      "disabled": {
-        "value": "{core.opacity.50}",
-        "type": "opacity",
-        "attributes": {
-          "category": "opacity"
-        }
-      }
+  "light": {
+    "value": "{core.opacity.40}",
+    "type": "opacity",
+    "attributes": {
+      "category": "opacity"
+    }
+  },
+  "half": {
+    "value": "{core.opacity.50}",
+    "type": "opacity",
+    "attributes": {
+      "category": "opacity"
+    }
+  },
+  "dark": {
+    "value": "{core.opacity.85}",
+    "type": "opacity",
+    "attributes": {
+      "category": "opacity"
+    }
+  },
+  "full": {
+    "value": "{core.opacity.100}",
+    "type": "opacity",
+    "attributes": {
+      "category": "opacity"
+    }
+  },
+  "disabled": {
+    "value": "{core.opacity.50}",
+    "type": "opacity",
+    "attributes": {
+      "category": "opacity"
     }
   }
 }

--- a/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
@@ -1,33 +1,29 @@
 {
-  "semantic": {
-    "shadow": {
-      "none": {
-        "value": "{core.shadow.0}",
-        "type": "boxShadow",
-        "attributes": {
-          "category": "shadow"
-        }
-      },
-      "sm": {
-        "value": [
-          "{core.shadow.1}",
-          "{core.shadow.2}"
-        ],
-        "type": "boxShadow",
-        "attributes": {
-          "category": "shadow"
-        }
-      },
-      "md": {
-        "value": [
-          "{core.shadow.3}",
-          "{core.shadow.4}"
-        ],
-        "type": "boxShadow",
-        "attributes": {
-          "category": "shadow"
-        }
-      }
+  "none": {
+    "value": "{core.shadow.0}",
+    "type": "boxShadow",
+    "attributes": {
+      "category": "shadow"
+    }
+  },
+  "sm": {
+    "value": [
+      "{core.shadow.1}",
+      "{core.shadow.2}"
+    ],
+    "type": "boxShadow",
+    "attributes": {
+      "category": "shadow"
+    }
+  },
+  "md": {
+    "value": [
+      "{core.shadow.3}",
+      "{core.shadow.4}"
+    ],
+    "type": "boxShadow",
+    "attributes": {
+      "category": "shadow"
     }
   }
 }

--- a/packages/calcite-design-tokens/src/tokens/semantic/size.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/size.json
@@ -1,167 +1,163 @@
 {
-  "semantic": {
-    "size": {
-      "fixed": {
-        "xxxs": {
-          "value": "{core.size.default.2}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "xxs": {
-          "value": "{core.size.default.4}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "xs": {
-          "value": "{core.size.default.6}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "sm": {
-          "value": "{core.size.default.8}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "sm+": {
-          "value": "{core.size.default.10}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "md": {
-          "value": "{core.size.default.12}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "md+": {
-          "value": "{core.size.default.14}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "lg": {
-          "value": "{core.size.default.16}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "xl": {
-          "value": "{core.size.default.20}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "xxl": {
-          "value": "{core.size.default.24}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        },
-        "xxxl": {
-          "value": "{core.size.default.32}",
-          "type": "spacing",
-          "attributes": {
-            "category": "size"
-          },
-          "description": "deprecated"
-        }
+  "fixed": {
+    "xxxs": {
+      "value": "{core.size.default.2}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
       },
-      "default": {
-        "px": {
-          "value": "{core.size.default.1}",
-          "type": "sizing",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xxxs": {
-          "value": "{core.size.default.12}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xxs": {
-          "value": "{core.size.default.14}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xs": {
-          "value": "{core.size.default.16}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "sm": {
-          "value": "{core.size.default.24}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "md": {
-          "value": "{core.size.default.32}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "lg": {
-          "value": "{core.size.default.44}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xl": {
-          "value": "{core.size.default.48}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xxl": {
-          "value": "{core.size.default.64}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xxxl": {
-          "value": "{core.size.default.96}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        }
+      "description": "deprecated"
+    },
+    "xxs": {
+      "value": "{core.size.default.4}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "xs": {
+      "value": "{core.size.default.6}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "sm": {
+      "value": "{core.size.default.8}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "sm+": {
+      "value": "{core.size.default.10}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "md": {
+      "value": "{core.size.default.12}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "md+": {
+      "value": "{core.size.default.14}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "lg": {
+      "value": "{core.size.default.16}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "xl": {
+      "value": "{core.size.default.20}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "xxl": {
+      "value": "{core.size.default.24}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    },
+    "xxxl": {
+      "value": "{core.size.default.32}",
+      "type": "spacing",
+      "attributes": {
+        "category": "size"
+      },
+      "description": "deprecated"
+    }
+  },
+  "default": {
+    "px": {
+      "value": "{core.size.default.1}",
+      "type": "sizing",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxs": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxs": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xs": {
+      "value": "{core.size.default.16}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.24}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.32}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.44}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xl": {
+      "value": "{core.size.default.48}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxl": {
+      "value": "{core.size.default.64}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xxxl": {
+      "value": "{core.size.default.96}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/space.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/space.json
@@ -1,167 +1,163 @@
 {
-  "semantic": {
-    "spacing": {
-      "fixed": {
-        "xxs": {
-          "value": "{core.size.default.4}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "xs": {
-          "value": "{core.size.default.6}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "sm": {
-          "value": "{core.size.default.8}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "md": {
-          "value": "{core.size.default.12}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "lg": {
-          "value": "{core.size.default.14}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "xl": {
-          "value": "{core.size.default.16}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "xxl": {
-          "value": "{core.size.default.20}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        },
-        "xxxl": {
-          "value": "{core.size.default.32}",
-          "type": "spacing",
-          "attributes": {
-            "category": "space"
-          },
-          "description": "deprecated"
-        }
+  "fixed": {
+    "xxs": {
+      "value": "{core.size.default.4}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
       },
-      "default": {
-        "none": {
-          "value": "{core.size.default.none}",
-          "type": "spacing",
-          "attributes": {
-            "pattern": "",
-            "category": "space"
-          }
-        },
-        "px": {
-          "value": "{core.size.default.1}",
-          "type": "spacing",
-          "attributes": {
-            "pattern": "",
-            "category": "space"
-          }
-        },
-        "base": {
-          "value": "{core.size.default.2}",
-          "type": "spacing",
-          "attributes": {
-            "pattern": "",
-            "category": "space"
-          }
-        },
-        "xxs": {
-          "value": "{core.size.default.4}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "xs": {
-          "value": "{core.size.default.6}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "sm": {
-          "value": "{core.size.default.8}",
-          "type": "dimension",
-          "attributes": {
-            "category": "size"
-          }
-        },
-        "sm+": {
-          "value": "{core.size.default.10}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "md": {
-          "value": "{core.size.default.12}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "md+": {
-          "value": "{core.size.default.14}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "lg": {
-          "value": "{core.size.default.16}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "xl": {
-          "value": "{core.size.default.20}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "xxl": {
-          "value": "{core.size.default.24}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        },
-        "xxxl": {
-          "value": "{core.size.default.32}",
-          "type": "dimension",
-          "attributes": {
-            "category": "space"
-          }
-        }
+      "description": "deprecated"
+    },
+    "xs": {
+      "value": "{core.size.default.6}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "sm": {
+      "value": "{core.size.default.8}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "md": {
+      "value": "{core.size.default.12}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "lg": {
+      "value": "{core.size.default.14}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "xl": {
+      "value": "{core.size.default.16}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "xxl": {
+      "value": "{core.size.default.20}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    },
+    "xxxl": {
+      "value": "{core.size.default.32}",
+      "type": "spacing",
+      "attributes": {
+        "category": "space"
+      },
+      "description": "deprecated"
+    }
+  },
+  "default": {
+    "none": {
+      "value": "{core.size.default.none}",
+      "type": "spacing",
+      "attributes": {
+        "pattern": "",
+        "category": "space"
+      }
+    },
+    "px": {
+      "value": "{core.size.default.1}",
+      "type": "spacing",
+      "attributes": {
+        "pattern": "",
+        "category": "space"
+      }
+    },
+    "base": {
+      "value": "{core.size.default.2}",
+      "type": "spacing",
+      "attributes": {
+        "pattern": "",
+        "category": "space"
+      }
+    },
+    "xxs": {
+      "value": "{core.size.default.4}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "xs": {
+      "value": "{core.size.default.6}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "sm": {
+      "value": "{core.size.default.8}",
+      "type": "dimension",
+      "attributes": {
+        "category": "size"
+      }
+    },
+    "sm+": {
+      "value": "{core.size.default.10}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "md": {
+      "value": "{core.size.default.12}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "md+": {
+      "value": "{core.size.default.14}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "lg": {
+      "value": "{core.size.default.16}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "xl": {
+      "value": "{core.size.default.20}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "xxl": {
+      "value": "{core.size.default.24}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
+      }
+    },
+    "xxxl": {
+      "value": "{core.size.default.32}",
+      "type": "dimension",
+      "attributes": {
+        "category": "space"
       }
     }
   }

--- a/packages/calcite-design-tokens/src/tokens/semantic/z-index.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/z-index.json
@@ -1,76 +1,72 @@
 {
-  "semantic": {
-    "z-index": {
-      "deep": {
-        "value": "{core.z-index.0}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "default": {
-        "value": "{core.z-index.1}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "sticky": {
-        "value": "{core.z-index.3}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "header": {
-        "value": "{core.z-index.4}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "toast": {
-        "value": "{core.z-index.5}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "dropdown": {
-        "value": "{core.z-index.6}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "overlay": {
-        "value": "{core.z-index.7}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "modal": {
-        "value": "{core.z-index.8}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "popup": {
-        "value": "{core.z-index.9}",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      },
-      "tooltip": {
-        "value": "{core.z-index.9} + 1",
-        "type": "z-index",
-        "attributes": {
-          "category": "z-index"
-        }
-      }
+  "deep": {
+    "value": "{core.z-index.0}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "default": {
+    "value": "{core.z-index.1}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "sticky": {
+    "value": "{core.z-index.3}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "header": {
+    "value": "{core.z-index.4}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "toast": {
+    "value": "{core.z-index.5}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "dropdown": {
+    "value": "{core.z-index.6}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "overlay": {
+    "value": "{core.z-index.7}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "modal": {
+    "value": "{core.z-index.8}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "popup": {
+    "value": "{core.z-index.9}",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
+    }
+  },
+  "tooltip": {
+    "value": "{core.z-index.9} + 1",
+    "type": "z-index",
+    "attributes": {
+      "category": "z-index"
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #12089

## Summary

Removes the top 2 levels from each `semantic` src token file. This includes `semantic{}` and fields that match their respective file name (eg. `color{}`, `size{}`, and `opacity{}`) to align with Figma variable structure.