### PR TITLE
fix(input-time-zone): fix selected time zone label flicker and scroll delay for region mode

### DIFF
--- a/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/calcite-components/src/components/input-time-zone/input-time-zone.tsx
@@ -372,23 +372,23 @@ export class InputTimeZone
    * @param open
    * @private
    */
-  private overrideSelectedLabelForRegion(): void {
+  private overrideSelectedLabelForRegion(open: boolean): void {
     if (this.mode !== "region" || !this.selectedTimeZoneItem) {
       return;
     }
 
-    this.comboboxEl.selectedItems[0].textLabel = this.getItemLabel(this.selectedTimeZoneItem);
+    this.comboboxEl.selectedItems[0].textLabel = this.getItemLabel(this.selectedTimeZoneItem, open);
   }
 
   private onComboboxBeforeClose(event: CustomEvent): void {
     event.stopPropagation();
-    this.overrideSelectedLabelForRegion();
+    this.overrideSelectedLabelForRegion(false);
     this.calciteInputTimeZoneBeforeClose.emit();
   }
 
   private onComboboxBeforeOpen(event: CustomEvent): void {
     event.stopPropagation();
-    this.overrideSelectedLabelForRegion();
+    this.overrideSelectedLabelForRegion(true);
     this.calciteInputTimeZoneBeforeOpen.emit();
   }
 
@@ -475,12 +475,12 @@ export class InputTimeZone
     return value ? this.normalizer(value) : value;
   }
 
-  private getItemLabel(item: TimeZoneItem): string {
+  private getItemLabel(item: TimeZoneItem, open: boolean = this.open): string {
     const selected = this.selectedTimeZoneItem === item;
     const { label, metadata } = item;
-    return !this.open && item.metadata.country && selected
-      ? getSelectedRegionTimeZoneLabel(label, metadata.country, this.messages)
-      : label;
+    return !metadata.country || open || !selected
+      ? label
+      : getSelectedRegionTimeZoneLabel(label, metadata.country, this.messages);
   }
 
   //#endregion

--- a/packages/calcite-components/src/utils/openCloseComponent.ts
+++ b/packages/calcite-components/src/utils/openCloseComponent.ts
@@ -55,6 +55,8 @@ function isOpen(component: OpenCloseComponent): boolean {
  * @param component - OpenCloseComponent uses `open` prop to emit (before)open/close.
  */
 export async function toggleOpenClose(component: OpenCloseComponent): Promise<void> {
+  await component.updateComplete;
+
   if (isOpen(component)) {
     component.onBeforeOpen();
   } else {


### PR DESCRIPTION
**Related Issue:** #12375 

## Summary

This fixes a regression caused by #10980 (label update flicker) and #11965 (scroll delay).

**Note**: `openCloseComponent` was updated to ensure the component state is in sync when the events are emitted.

BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE