### PR TITLE
fix: ensure initial transitions are applied consistently

### DIFF
--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -6,13 +6,45 @@ $floating-ui-transition-offset: 5px;
   --calcite-floating-ui-z-index: theme("zIndex.dropdown");
 }
 
+@mixin floating-ui-anim {
+  .calcite-floating-ui-anim {
+    position: relative;
+    transition-duration: var(--calcite-floating-ui-transition);
+    /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+    transition-property: inset, left, opacity, display;
+    opacity: 0;
+    box-shadow: $floating-ui-shadow;
+    @apply rounded z-default;
+    @include floating-ui-anim-starting-style;
+  }
+}
+
+@mixin floating-ui-anim-starting-style {
+  @starting-style {
+    opacity: 0;
+    inset-block-start: -$floating-ui-transition-offset;
+    /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+    left: auto;
+  }
+}
+
+@mixin floating-ui-anim-active {
+  opacity: 1;
+  inset-block-start: 0;
+  /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+  left: 0;
+
+  @include floating-ui-anim-starting-style;
+}
+
 @mixin floating-ui-elem-anim($selector) {
   #{$selector} {
     .calcite-floating-ui-anim {
       position: relative;
-      transition: var(--calcite-floating-ui-transition);
+      transition-duration: var(--calcite-floating-ui-transition);
       /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
-      transition-property: inset, left, opacity;
+      transition-property: inset-block-start, left, opacity, display;
+      transition-behavior: allow-discrete;
       opacity: 0;
       box-shadow: $floating-ui-shadow;
       @apply rounded z-default;
@@ -41,6 +73,10 @@ $floating-ui-transition-offset: 5px;
       inset-block-start: 0;
       /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
       left: 0;
+
+      @starting-style {
+        opacity: 0;
+      }
     }
   }
 }
@@ -54,6 +90,13 @@ $floating-ui-transition-offset: 5px;
   /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
   left: 0;
   z-index: var(--calcite-floating-ui-z-index);
+
+  @starting-style {
+    opacity: 0;
+    inset-block-start: 0;
+    /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+    left: 0;
+  }
 }
 
 @mixin floating-ui-arrow {

--- a/packages/calcite-components/src/assets/styles/_floating-ui.scss
+++ b/packages/calcite-components/src/assets/styles/_floating-ui.scss
@@ -1,70 +1,46 @@
 $floating-ui-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.16);
 $floating-ui-transition-offset: 5px;
 
-@mixin floating-ui-offset-bottom {
-  inset-block-start: -$floating-ui-transition-offset;
-}
-
-@mixin floating-ui-offset-top {
-  inset-block-start: $floating-ui-transition-offset;
-}
-
-@mixin floating-ui-offset-left {
-  /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
-  left: $floating-ui-transition-offset;
-}
-
-@mixin floating-ui-offset-right {
-  /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
-  left: -$floating-ui-transition-offset;
-}
-
 @mixin floating-ui-base {
   --calcite-floating-ui-transition: var(--calcite-animation-timing);
   --calcite-floating-ui-z-index: theme("zIndex.dropdown");
 }
 
-@mixin floating-ui-anim {
-  .calcite-floating-ui-anim {
-    position: relative;
-    transition: var(--calcite-floating-ui-transition);
-    /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
-    transition-property: inset, left, opacity;
-    opacity: 0;
-    box-shadow: $floating-ui-shadow;
-    @apply rounded z-default;
-  }
-}
-
-@mixin floating-ui-anim-active {
-  opacity: 1;
-  inset-block-start: 0;
-  /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
-  left: 0;
-}
-
 @mixin floating-ui-elem-anim($selector) {
   #{$selector} {
-    @include floating-ui-anim();
+    .calcite-floating-ui-anim {
+      position: relative;
+      transition: var(--calcite-floating-ui-transition);
+      /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+      transition-property: inset, left, opacity;
+      opacity: 0;
+      box-shadow: $floating-ui-shadow;
+      @apply rounded z-default;
+    }
 
     &[data-placement^="bottom"] .calcite-floating-ui-anim {
-      @include floating-ui-offset-bottom();
+      inset-block-start: -$floating-ui-transition-offset;
     }
 
     &[data-placement^="top"] .calcite-floating-ui-anim {
-      @include floating-ui-offset-top();
+      inset-block-start: $floating-ui-transition-offset;
     }
 
     &[data-placement^="left"] .calcite-floating-ui-anim {
-      @include floating-ui-offset-left();
+      /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+      left: $floating-ui-transition-offset;
     }
 
     &[data-placement^="right"] .calcite-floating-ui-anim {
-      @include floating-ui-offset-right();
+      /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+      left: -$floating-ui-transition-offset;
     }
 
     &[data-placement] .calcite-floating-ui-anim--active {
-      @include floating-ui-anim-active();
+      opacity: 1;
+      inset-block-start: 0;
+      /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
+      left: 0;
     }
   }
 }

--- a/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
+++ b/packages/calcite-components/src/components/input-time-picker/input-time-picker.e2e.ts
@@ -129,7 +129,7 @@ describe("calcite-input-time-picker", () => {
   describe("openClose", () => {
     openClose("calcite-input-time-picker");
 
-    describe.skip("initially open", () => {
+    describe("initially open", () => {
       openClose.initial("calcite-input-time-picker");
     });
   });

--- a/packages/calcite-components/src/tests/commonTests/openClose.ts
+++ b/packages/calcite-components/src/tests/commonTests/openClose.ts
@@ -47,7 +47,7 @@ export function openClose(componentTestSetup: ComponentTestSetup, options?: Open
   it(`emits with animations enabled`, async () => {
     const { page, tag } = await getTagAndPage(componentTestSetup);
     await page.addStyleTag({
-      content: `:root { --calcite-duration-factor: 2; }`,
+      content: `:root { --calcite-duration-factor: 3; }`,
     });
 
     await setUpEventListeners(tag, page);
@@ -96,7 +96,7 @@ openClose.initial = function openCloseInitial(
   it("emits on initialization with animations enabled", async () => {
     const page = await newProgrammaticE2EPage();
     await page.addStyleTag({
-      content: `:root { --calcite-duration-factor: 2; }`,
+      content: `:root { --calcite-duration-factor: 3; }`,
     });
     await beforeContent(page);
     await setUpEventListeners(tag, page);


### PR DESCRIPTION
**Related Issue:** #12399, #10227

## Summary

This fixes an issue where initial animations would be interrupted on DOM attachment.

### Noteworthy changes

* bumps `--calcite-duration-factor` to 3 for `openClose` test util animation-enabled tests
* simplifies `floating-ui.scss`
* uses [`@starting-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style) and [`transition-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior) to help with animation consistency
  * baseline supported Safari version will go from 17.4 to 18 in our 2025.R3 release



