### PR TITLE
refactor: drop redundant hidden styles

### DIFF
--- a/packages/calcite-components/.stylelintrc.cjs
+++ b/packages/calcite-components/.stylelintrc.cjs
@@ -27,6 +27,13 @@ const rules = {
       ignore: ["selectors-within-list"],
     },
   ],
+  "selector-attribute-name-disallowed-list": [
+    ["hidden"],
+    {
+      message: "hidden styles are included in the `base-component` mixin, so make sure it's used",
+      severity: "error",
+    },
+  ],
   "selector-disallowed-list": [
     ["/:host-context/"],
     {

--- a/packages/calcite-components/src/assets/styles/includes.scss
+++ b/packages/calcite-components/src/assets/styles/includes.scss
@@ -96,6 +96,7 @@
 }
 
 @mixin base-component() {
+  /* stylelint-disable selector-attribute-name-disallowed-list -- base component mixin needs to use [hidden] */
   :host([hidden]) {
     @apply hidden;
   }
@@ -103,6 +104,7 @@
   [hidden] {
     @apply hidden;
   }
+  /* stylelint-enable selector-attribute-name-disallowed-list */
 }
 
 @mixin x-button(

--- a/packages/calcite-components/src/components/modal/modal.scss
+++ b/packages/calcite-components/src/components/modal/modal.scss
@@ -28,11 +28,6 @@ $viewport-medium: 860px;
   --calcite-modal-scrim-background-internal: #{rgba($calcite-color-neutral-blk-240, $calcite-opacity-85)};
 }
 
-.content-top[hidden],
-.content-bottom[hidden] {
-  @apply hidden;
-}
-
 .container {
   @apply text-color-2
     absolute

--- a/packages/calcite-components/src/components/panel/panel.scss
+++ b/packages/calcite-components/src/components/panel/panel.scss
@@ -114,10 +114,6 @@
   @apply box-border;
 }
 
-.container[hidden] {
-  @apply hidden;
-}
-
 .header {
   @apply flex flex-col z-header;
 

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -446,10 +446,6 @@
   }
 }
 
-.content[hidden] {
-  @apply hidden;
-}
-
 slot[name="action-bar"]::slotted(calcite-action-bar),
 .content ::slotted(calcite-flow),
 .content ::slotted(calcite-panel:not([closed])) {

--- a/packages/calcite-components/src/components/tip/tip.scss
+++ b/packages/calcite-components/src/components/tip/tip.scss
@@ -38,10 +38,6 @@
   @apply text-0h text-color-1 p-0;
 }
 
-.container[hidden] {
-  @apply hidden;
-}
-
 .content {
   @apply flex;
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

The `base-component` mixin includes common hidden styles, so separate selectors aren’t needed.  

**Note**: this also enables stylelint’s `selector-attribute-name-disallowed-list` rule to help enforce it.