### PR TITLE
fix(input-number): add token to customize icon color

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -1974,6 +1974,7 @@ describe("calcite-input-number", () => {
             value="2"
             clearable
             loading
+            icon="layers"
           ></calcite-input-number>
         `,
         {
@@ -2094,6 +2095,10 @@ describe("calcite-input-number", () => {
             shadowSelector: `input`,
             targetProp: "color",
             state: "focus",
+          },
+          "--calcite-input-number-icon-color": {
+            shadowSelector: `.${CSS.inputIcon}`,
+            targetProp: "color",
           },
           "--calcite-input-prefix-background-color": {
             shadowSelector: `.${CSS.prefix}`,

--- a/packages/calcite-components/src/components/input-number/input-number.e2e.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.e2e.ts
@@ -2014,11 +2014,11 @@ describe("calcite-input-number", () => {
           ],
           "--calcite-input-actions-icon-color": {
             shadowSelector: `calcite-icon`,
-            targetProp: "color",
+            targetProp: "--calcite-icon-color",
           },
           "--calcite-input-actions-icon-color-hover": {
             shadowSelector: `calcite-icon`,
-            targetProp: "color",
+            targetProp: "--calcite-icon-color",
             state: "hover",
           },
           "--calcite-input-loading-background-color": {
@@ -2098,7 +2098,7 @@ describe("calcite-input-number", () => {
           },
           "--calcite-input-number-icon-color": {
             shadowSelector: `.${CSS.inputIcon}`,
-            targetProp: "color",
+            targetProp: "--calcite-icon-color",
           },
           "--calcite-input-prefix-background-color": {
             shadowSelector: `.${CSS.prefix}`,

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -14,6 +14,7 @@
  * @prop --calcite-input-number-background-color: Specifies the background color of the component.
  * @prop --calcite-input-number-border-color: Specifies the border color of the component.
  * @prop --calcite-input-number-corner-radius: Specifies the border radius of the component.
+ * @prop --calcite-input-number-icon-color: Specifies the component's icon color.
  * @prop --calcite-input-number-height: Specifies the height of the component.
  * @prop --calcite-input-number-placeholder-text-color: Specifies the text color of the placeholder in the component.
  * @prop --calcite-input-number-text-color: Specifies the text color of the component.
@@ -134,10 +135,6 @@ input[readonly]:focus {
   color: var(--calcite-input-number-text-color-focus, var(--calcite-color-text-1));
 }
 
-calcite-icon {
-  color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
-}
-
 //focus
 input {
   @apply focus-base;
@@ -202,6 +199,7 @@ input:focus {
     absolute
     block
     z-default; // needed for firefox to display the icon properly
+  color: var(--calcite-input-number-icon-color, var(--calcite-color-text-3));
 }
 
 .clear-button {
@@ -222,6 +220,10 @@ input:focus {
   border-color: var(--calcite-input-number-border-color, var(--calcite-color-border-input));
   background-color: var(--calcite-input-actions-background-color, var(--calcite-color-foreground-1));
   border-inline-start-width: theme("borderWidth.0");
+
+  calcite-icon {
+    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
+  }
 
   &:hover {
     @apply transition-default;
@@ -385,6 +387,7 @@ input:focus {
 
   & calcite-icon {
     @apply transition-default pointer-events-none;
+    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
   }
 
   &:disabled {

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -199,7 +199,7 @@ input:focus {
     absolute
     block
     z-default; // needed for firefox to display the icon properly
-  color: var(--calcite-input-number-icon-color, var(--calcite-color-text-3));
+  --calcite-icon-color: var(--calcite-input-number-icon-color, var(--calcite-color-text-3));
 }
 
 .clear-button {
@@ -222,7 +222,7 @@ input:focus {
   border-inline-start-width: theme("borderWidth.0");
 
   calcite-icon {
-    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
+    --calcite-icon-color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
   }
 
   &:hover {
@@ -230,13 +230,13 @@ input:focus {
     background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
       @apply transition-default;
-      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
+      --calcite-icon-color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
     }
   }
   &:active {
     background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
+      --calcite-icon-color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
     }
   }
   &:focus {
@@ -387,7 +387,7 @@ input:focus {
 
   & calcite-icon {
     @apply transition-default pointer-events-none;
-    color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
+    --calcite-icon-color: var(--calcite-input-actions-icon-color, var(--calcite-color-text-3));
   }
 
   &:disabled {
@@ -397,14 +397,14 @@ input:focus {
   &:hover {
     background-color: var(--calcite-input-actions-background-color-hover, var(--calcite-color-foreground-2));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
+      --calcite-icon-color: var(--calcite-input-actions-icon-color-hover, var(--calcite-color-text-1));
     }
   }
 
   &:active {
     background-color: var(--calcite-input-actions-background-color-press, var(--calcite-color-foreground-3));
     calcite-icon {
-      color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
+      --calcite-icon-color: var(--calcite-input-actions-icon-color-press, var(--calcite-color-text-1));
     }
   }
 }

--- a/packages/calcite-components/src/custom-theme/input-number.ts
+++ b/packages/calcite-components/src/custom-theme/input-number.ts
@@ -12,6 +12,7 @@ export const inputNumberTokens = {
   calciteInputNumberBackgroundColor: "",
   calciteInputNumberBorderColor: "",
   calciteInputNumberCornerRadius: "",
+  calciteInputNumberIconColor: "",
   calciteInputNumberHeight: "",
   calciteInputNumberPlaceholderTextColor: "",
   calciteInputNumberTextColor: "",

--- a/packages/calcite-components/src/demos/input-number.html
+++ b/packages/calcite-components/src/demos/input-number.html
@@ -68,6 +68,7 @@
         --calcite-input-number-background-color: yellow;
         --calcite-input-number-border-color: #1e88e5;
         --calcite-input-number-corner-radius: 4px;
+        --calcite-input-number-icon-color: red;
         --calcite-input-number-height: 40px;
         --calcite-input-number-placeholder-text-color: #9e9e9e;
         --calcite-input-number-text-color: #212121;
@@ -712,6 +713,7 @@
             clearable
             value="100"
             loading
+            icon="layers"
           ></calcite-input-number>
         </div>
       </div>


### PR DESCRIPTION
**Related Issue:** #12408 

## Summary

No longer inherits `icon` color from `--calcite-input-actions-icon-color` & adds `--calcite-input-number-icon-color` token to customize `icon` color in `input-number`.