### PR TITLE
chore(linting): consolidate prettier ignore files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 **/*.d.ts
-**/dist
-**/.turbo
+**/package-lock.json
 
 # prevents modifying licenses
 THIRD-PARTY-LICENSES.md
+
+# calcite-design-tokens
+
+## source tokens are managed by the Tokens Studio plugin, which syncs directly to GitHub
+src/tokens/**/*.json

--- a/packages/calcite-components/.prettierignore
+++ b/packages/calcite-components/.prettierignore
@@ -1,4 +1,0 @@
-docs/
-dist/
-hydrate/
-**/*.d.ts

--- a/packages/calcite-design-tokens/.prettierignore
+++ b/packages/calcite-design-tokens/.prettierignore
@@ -1,2 +1,0 @@
-# source tokens are managed by the Tokens Studio plugin, which syncs directly to GitHub
-src/tokens/**/*.json


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Consolidates ignore files as Prettier will [honor `.gitignore` by default](https://prettier.io/blog/2023/07/05/3.0.0.html#cli) and needs its ignore file to be at the root since it [does not allow for hierarchical configuration](https://github.com/prettier/prettier/issues/4081).