### PR TITLE
fix(tile): alignment not applying on slotted content

### DIFF
--- a/packages/calcite-components/src/components/tile/tile.scss
+++ b/packages/calcite-components/src/components/tile/tile.scss
@@ -127,6 +127,8 @@ calcite-link {
   .text-content {
     text-align: center;
   }
+  slot[name="content-bottom"]::slotted(*),
+  slot[name="content-top"]::slotted(*),
   slot[name="content-start"]::slotted(*),
   slot[name="content-end"]::slotted(*) {
     align-self: center;


### PR DESCRIPTION
**Related Issue:** [#10525](https://github.com/Esri/calcite-design-system/issues/10525)

## Summary
Fixed alignment center for slotted content.