### PR TITLE
refactor(semantic-tokens): update spacing tokens' categories to "spacing"

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/space.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/space.json
@@ -6,7 +6,7 @@
           "value": "{core.size.default.4}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -14,7 +14,7 @@
           "value": "{core.size.default.6}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -22,7 +22,7 @@
           "value": "{core.size.default.8}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -30,7 +30,7 @@
           "value": "{core.size.default.12}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -38,7 +38,7 @@
           "value": "{core.size.default.14}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -46,7 +46,7 @@
           "value": "{core.size.default.16}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -54,7 +54,7 @@
           "value": "{core.size.default.20}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         },
@@ -62,7 +62,7 @@
           "value": "{core.size.default.32}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           },
           "description": "deprecated"
         }
@@ -72,91 +72,91 @@
           "value": "{core.size.default.none}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "px": {
           "value": "{core.size.default.1}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "base": {
           "value": "{core.size.default.2}",
           "type": "spacing",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "xxs": {
           "value": "{core.size.default.4}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "xs": {
           "value": "{core.size.default.6}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "sm": {
           "value": "{core.size.default.8}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "sm+": {
           "value": "{core.size.default.10}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "md": {
           "value": "{core.size.default.12}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "md+": {
           "value": "{core.size.default.14}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "lg": {
           "value": "{core.size.default.16}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "xl": {
           "value": "{core.size.default.20}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "xxl": {
           "value": "{core.size.default.24}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         },
         "xxxl": {
           "value": "{core.size.default.32}",
           "type": "dimension",
           "attributes": {
-            "category": "space"
+            "category": "spacing"
           }
         }
       }


### PR DESCRIPTION
**Related Issue:** #12089

## Summary

Syncs the semantic spacing tokens' `category` values to their `type` values

- [ ] update `space` to `spacing`