### PR TITLE
refactor(dom): restore currentTarget in slot utils

### DIFF
--- a/packages/calcite-components/src/utils/dom.browser.spec.ts
+++ b/packages/calcite-components/src/utils/dom.browser.spec.ts
@@ -25,6 +25,7 @@ import {
   slotChangeHasContent,
   slotChangeHasTextContent,
   toAriaBoolean,
+  viewportUnitToPixel,
   whenAnimationDone,
   whenTransitionDone,
 } from "./dom";
@@ -527,13 +528,13 @@ describe("dom", () => {
 
     it("calculates the pixel value for 'vw' values", () => {
       const viewportWidth = window.innerWidth;
-      expect(getStylePixelValue("50vw")).toBe((viewportWidth / 100) * 50);
+      expect(getStylePixelValue("50vw")).toBe(viewportUnitToPixel(50, viewportWidth));
       expect(getStylePixelValue("100vw")).toBe(viewportWidth);
     });
 
     it("calculates the pixel value for 'vh' values", () => {
       const viewportHeight = window.innerHeight;
-      expect(getStylePixelValue("50vh")).toBe((viewportHeight / 100) * 50);
+      expect(getStylePixelValue("50vh")).toBe(viewportUnitToPixel(50, viewportHeight));
       expect(getStylePixelValue("100vh")).toBe(viewportHeight);
     });
 

--- a/packages/calcite-components/src/utils/dom.browser.spec.ts
+++ b/packages/calcite-components/src/utils/dom.browser.spec.ts
@@ -197,152 +197,329 @@ describe("dom", () => {
     });
   });
 
-  describe("getSlotAssignedElements()", () => {
-    it("returns slotted elements with no selector", () => {
-      const slotEl = document.createElement("slot");
-      slotEl.assignedElements = () => [document.createElement("div"), document.createElement("div")];
-      expect(getSlotAssignedElements(slotEl)).toHaveLength(2);
-    });
-    it("returns no slotted elements", () => {
-      const slotEl = document.createElement("slot");
-      slotEl.assignedElements = () => [];
-      expect(getSlotAssignedElements(slotEl)).toHaveLength(0);
-    });
-    it("returns slotted elements with direct element selector", () => {
-      const slotEl = document.createElement("slot");
-      slotEl.assignedElements = () => [
-        document.createElement("span"),
-        document.createElement("div"),
-        document.createElement("span"),
-      ];
-      expect(getSlotAssignedElements(slotEl, "div")).toHaveLength(1);
-      expect(getSlotAssignedElements(slotEl, "span")).toHaveLength(2);
-    });
-    it("returns slotted elements with class selector", () => {
-      const slotEl = document.createElement("slot");
-      const spanEl = document.createElement("span");
-      spanEl.className = "my-span";
-      const divEl = document.createElement("div");
-      divEl.className = "my-div";
-      slotEl.assignedElements = () => [document.createElement("span"), spanEl, document.createElement("div"), divEl];
-      expect(getSlotAssignedElements(slotEl, ".my-div")).toHaveLength(1);
-      expect(getSlotAssignedElements(slotEl, ".my-span")).toHaveLength(1);
-    });
-  });
+  describe("slot utils", () => {
+    function defineTestElement(slotHandler: (slotEl: HTMLSlotElement) => void, slotHtml = "<slot><slot>"): string {
+      // ensure unique tag name per test to avoid "custom element already defined" error
+      const tagName =
+        "test-element-" +
+        expect
+          .getState()
+          .currentTestName.split(">")
+          .map((part) => part.trim())
+          .join(" ")
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-") // replace non-alphanumeric with dashes
+          .replace(/^-+|-+$/g, "") // trim leading/trailing dashes
+          .replace(/--+/g, "-");
 
-  describe("slotChangeGetAssignedElements()", () => {
-    it("handles slotted elements", async () =>
-      await setUpSlotChange({
-        assignedElements: [document.createElement("div"), document.createElement("div")],
-        onSlotChange: (event) => expect(slotChangeGetAssignedElements(event)).toHaveLength(2),
-      }));
+      class TestElement extends HTMLElement {
+        constructor() {
+          super();
+          const shadow = this.attachShadow({ mode: "open" });
+          shadow.innerHTML = slotHtml;
+          shadow.querySelectorAll("slot").forEach(slotHandler);
+        }
+      }
+      customElements.define(tagName, TestElement);
 
-    it("handles no slotted elements", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeGetAssignedElements(event)).toHaveLength(0),
-      }));
-  });
+      return tagName;
+    }
 
-  describe("slotChangeHasAssignedElement()", () => {
-    it("handles slotted elements", async () =>
-      await setUpSlotChange({
-        assignedElements: [document.createElement("div"), document.createElement("div")],
-        onSlotChange: (event) => expect(slotChangeHasAssignedElement(event)).toBe(true),
-      }));
+    function appendChildren(parent: HTMLElement, children: Node[]): void {
+      parent.append(...children);
+      document.body.append(parent);
+    }
 
-    it("handles no slotted elements", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeHasAssignedElement(event)).toBe(false),
-      }));
-  });
+    function createEl<K extends keyof HTMLElementTagNameMap>(
+      tag: string,
+      props?: Partial<HTMLElementTagNameMap[K]>,
+    ): HTMLElement {
+      const el = document.createElement(tag);
 
-  describe("slotChangeHasAssignedNode()", () => {
-    it("handles slotted nodes", async () =>
-      await setUpSlotChange({
-        assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
-        onSlotChange: (event) => expect(slotChangeHasAssignedNode(event)).toBe(true),
-      }));
+      if (props) {
+        Object.entries(props).forEach(([key, value]) => {
+          el[key] = value;
+        });
+      }
 
-    it("handles no slotted nodes", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeHasAssignedNode(event)).toBe(false),
-      }));
-  });
+      return el;
+    }
 
-  describe("slotChangeGetAssignedNodes()", () => {
-    it("handles slotted nodes", async () =>
-      await setUpSlotChange({
-        assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
-        onSlotChange: (event) => expect(slotChangeGetAssignedNodes(event)).toHaveLength(2),
-      }));
-
-    it("handles no slotted nodes", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeGetAssignedNodes(event)).toHaveLength(0),
-      }));
-  });
-
-  describe("slotChangeGetTextContent()", () => {
-    it("handles slotted nodes", async () => {
-      await setUpSlotChange({
-        assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
-        onSlotChange: (event) => expect(slotChangeGetTextContent(event)).toEqual("helloworld"),
+    describe("getSlotAssignedElements()", () => {
+      it("returns slotted elements with no selector", () => {
+        const slotEl = document.createElement("slot");
+        slotEl.assignedElements = () => [document.createElement("div"), document.createElement("div")];
+        expect(getSlotAssignedElements(slotEl)).toHaveLength(2);
+      });
+      it("returns no slotted elements", () => {
+        const slotEl = document.createElement("slot");
+        slotEl.assignedElements = () => [];
+        expect(getSlotAssignedElements(slotEl)).toHaveLength(0);
+      });
+      it("returns slotted elements with direct element selector", () => {
+        const slotEl = document.createElement("slot");
+        slotEl.assignedElements = () => [
+          document.createElement("span"),
+          document.createElement("div"),
+          document.createElement("span"),
+        ];
+        expect(getSlotAssignedElements(slotEl, "div")).toHaveLength(1);
+        expect(getSlotAssignedElements(slotEl, "span")).toHaveLength(2);
+      });
+      it("returns slotted elements with class selector", () => {
+        const slotEl = document.createElement("slot");
+        const spanEl = document.createElement("span");
+        spanEl.className = "my-span";
+        const divEl = document.createElement("div");
+        divEl.className = "my-div";
+        slotEl.assignedElements = () => [document.createElement("span"), spanEl, document.createElement("div"), divEl];
+        expect(getSlotAssignedElements(slotEl, ".my-div")).toHaveLength(1);
+        expect(getSlotAssignedElements(slotEl, ".my-span")).toHaveLength(1);
       });
     });
 
-    it("handles no slotted nodes", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeGetTextContent(event)).toEqual(""),
-      }));
-  });
+    describe("slotChangeGetAssignedElements()", () => {
+      it("handles slotted elements", async () => {
+        let assigned: Element[];
+        const testElName = defineTestElement((slotEl) => {
+          slotEl.addEventListener("slotchange", (event) => {
+            assigned = slotChangeGetAssignedElements(event);
+          });
+        });
+        const testEl = createEl(testElName);
+        const slottedEls = [createEl("div"), createEl("div")];
 
-  describe("slotChangeHasContent()", () => {
-    it("handles slotted nodes", async () =>
-      await setUpSlotChange({
-        assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
-        onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(true),
-      }));
+        appendChildren(testEl, slottedEls);
+        await waitForAnimationFrame();
 
-    it("handles slotted elements", async () =>
-      await setUpSlotChange({
-        assignedElements: [document.createElement("div")],
-        onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(true),
-      }));
+        expect(assigned).toEqual(slottedEls);
 
-    it("handles no slotted nodes or elements", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(false),
-      }));
-  });
+        assigned = null;
+        slottedEls.forEach((el) => el.remove());
+        await waitForAnimationFrame();
 
-  describe("slotChangeHasTextContent()", () => {
-    it("handles slotted nodes", async () =>
-      await setUpSlotChange({
-        assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
-        onSlotChange: (event) => expect(slotChangeHasTextContent(event)).toEqual(true),
-      }));
+        expect(assigned).toEqual([]);
+      });
 
-    it("handles no slotted nodes", async () =>
-      await setUpSlotChange({
-        onSlotChange: (event) => expect(slotChangeHasTextContent(event)).toEqual(false),
-      }));
-  });
+      it("handles nested slot structure", async () => {
+        const slotToAssigned: Record<string, Element[]> = {};
+        const slotHtml = html`
+          <slot></slot>
+          <!-- using comments between slots to avoid introducing whitespace-->
+          <slot name="foo"
+            ><!--
+          --><slot name="bar"></slot
+            ><!--
+          --><slot name="baz"></slot
+            ><!--
+        --></slot
+          >
+        `;
+        const testElName = defineTestElement((slotEl) => {
+          slotEl.addEventListener("slotchange", (event) => {
+            slotToAssigned[slotEl.name] = slotChangeGetAssignedElements(event);
+          });
+        }, slotHtml);
+        const testEl = createEl(testElName);
+        const nodes = [
+          document.createTextNode("hello"),
+          createEl("div"),
+          createEl("div", { slot: "foo" }),
+          createEl("div", { slot: "bar" }),
+          createEl("div", { slot: "bar" }),
+          createEl("div", { slot: "baz" }),
+          createEl("div", { slot: "baz" }),
+          createEl("div", { slot: "baz" }),
+        ];
 
-  describe("hasVisibleContent", () => {
-    it("should return true if element has visible content", () => {
-      const element = document.createElement("div");
-      element.innerHTML = "<p>hello</p>";
-      document.body.append(element);
-      expect(hasVisibleContent(element)).toBe(true);
+        appendChildren(testEl, nodes);
+        await waitForAnimationFrame();
+
+        expect(slotToAssigned).toEqual({
+          "": [nodes[1]],
+          foo: [nodes[2]],
+          bar: [nodes[3], nodes[4]],
+          baz: [nodes[5], nodes[6], nodes[7]],
+        });
+
+        Object.keys(slotToAssigned).forEach((key) => delete slotToAssigned[key]);
+        nodes.forEach((el) => el.remove());
+        await waitForAnimationFrame();
+
+        expect(slotToAssigned).toEqual({
+          "": [],
+          foo: [],
+          bar: [],
+          baz: [],
+        });
+      });
     });
 
-    it("should return false if element has no visible content", () => {
-      const element = document.createElement("div");
-      document.body.append(element);
-      expect(hasVisibleContent(element)).toBe(false);
+    describe("slotChangeHasAssignedElement()", () => {
+      it("handles slotted elements", async () =>
+        await setUpSlotChange({
+          assignedElements: [document.createElement("div"), document.createElement("div")],
+          onSlotChange: (event) => expect(slotChangeHasAssignedElement(event)).toBe(true),
+        }));
 
-      element.innerHTML = "\n<!-- some comment -->\n";
-      expect(hasVisibleContent(element)).toBe(false);
+      it("handles no slotted elements", async () =>
+        await setUpSlotChange({
+          onSlotChange: (event) => expect(slotChangeHasAssignedElement(event)).toBe(false),
+        }));
+    });
+
+    describe("slotChangeHasAssignedNode()", () => {
+      it("handles slotted nodes", async () =>
+        await setUpSlotChange({
+          assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
+          onSlotChange: (event) => expect(slotChangeHasAssignedNode(event)).toBe(true),
+        }));
+
+      it("handles no slotted nodes", async () =>
+        await setUpSlotChange({
+          onSlotChange: (event) => expect(slotChangeHasAssignedNode(event)).toBe(false),
+        }));
+    });
+
+    describe("slotChangeGetAssignedNodes()", () => {
+      it("returns assigned nodes on slotchange", async () => {
+        let assigned: Node[];
+        const testElName = defineTestElement((slotEl) => {
+          slotEl.addEventListener("slotchange", (event) => {
+            assigned = slotChangeGetAssignedNodes(event);
+          });
+        });
+        const testEl = createEl(testElName);
+        const nodes = [document.createTextNode("hello"), createEl("div"), document.createTextNode("world")];
+
+        appendChildren(testEl, nodes);
+        await waitForAnimationFrame();
+
+        expect(assigned).toEqual(nodes);
+
+        assigned = null;
+        nodes.forEach((el) => el.remove());
+        await waitForAnimationFrame();
+
+        expect(assigned).toEqual([]);
+      });
+
+      it("handles nested slot structure", async () => {
+        const slotToAssigned: Record<string, Node[]> = {};
+        const slotHtml = html`
+          <slot></slot>
+          <!-- using comments between slots to avoid introducing whitespace-->
+          <slot name="foo"
+            ><!--
+          --><slot name="bar"></slot
+            ><!--
+          --><slot name="baz"></slot
+            ><!--
+        --></slot
+          >
+        `;
+        const testElName = defineTestElement((slotEl) => {
+          slotEl.addEventListener("slotchange", (event) => {
+            slotToAssigned[slotEl.name] = slotChangeGetAssignedNodes(event);
+          });
+        }, slotHtml);
+        const testEl = createEl(testElName);
+        const nodes = [
+          document.createTextNode("hello"),
+          createEl("div"),
+          createEl("div", { slot: "foo" }),
+          createEl("div", { slot: "bar" }),
+          createEl("div", { slot: "bar" }),
+          createEl("div", { slot: "baz" }),
+          createEl("div", { slot: "baz" }),
+          createEl("div", { slot: "baz" }),
+        ];
+
+        appendChildren(testEl, nodes);
+        await waitForAnimationFrame();
+
+        expect(slotToAssigned).toEqual({
+          "": [nodes[0], nodes[1]],
+          foo: [nodes[2]],
+          bar: [nodes[3], nodes[4]],
+          baz: [nodes[5], nodes[6], nodes[7]],
+        });
+
+        Object.keys(slotToAssigned).forEach((key) => delete slotToAssigned[key]);
+        nodes.forEach((node) => node.remove());
+        await waitForAnimationFrame();
+
+        expect(slotToAssigned).toEqual({
+          "": [],
+          foo: [],
+          bar: [],
+          baz: [],
+        });
+      });
+    });
+
+    describe("slotChangeGetTextContent()", () => {
+      it("handles slotted nodes", async () => {
+        await setUpSlotChange({
+          assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
+          onSlotChange: (event) => expect(slotChangeGetTextContent(event)).toEqual("helloworld"),
+        });
+      });
+
+      it("handles no slotted nodes", async () =>
+        await setUpSlotChange({
+          onSlotChange: (event) => expect(slotChangeGetTextContent(event)).toEqual(""),
+        }));
+    });
+
+    describe("slotChangeHasContent()", () => {
+      it("handles slotted nodes", async () =>
+        await setUpSlotChange({
+          assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
+          onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(true),
+        }));
+
+      it("handles slotted elements", async () =>
+        await setUpSlotChange({
+          assignedElements: [document.createElement("div")],
+          onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(true),
+        }));
+
+      it("handles no slotted nodes or elements", async () =>
+        await setUpSlotChange({
+          onSlotChange: (event) => expect(slotChangeHasContent(event)).toEqual(false),
+        }));
+    });
+
+    describe("slotChangeHasTextContent()", () => {
+      it("handles slotted nodes", async () =>
+        await setUpSlotChange({
+          assignedNodes: [document.createTextNode("hello"), document.createTextNode("world")],
+          onSlotChange: (event) => expect(slotChangeHasTextContent(event)).toEqual(true),
+        }));
+
+      it("handles no slotted nodes", async () =>
+        await setUpSlotChange({
+          onSlotChange: (event) => expect(slotChangeHasTextContent(event)).toEqual(false),
+        }));
+    });
+
+    describe("hasVisibleContent", () => {
+      it("should return true if element has visible content", () => {
+        const element = document.createElement("div");
+        element.innerHTML = "<p>hello</p>";
+        document.body.append(element);
+        expect(hasVisibleContent(element)).toBe(true);
+      });
+
+      it("should return false if element has no visible content", () => {
+        const element = document.createElement("div");
+        document.body.append(element);
+        expect(hasVisibleContent(element)).toBe(false);
+
+        element.innerHTML = "\n<!-- some comment -->\n";
+        expect(hasVisibleContent(element)).toBe(false);
+      });
     });
   });
 

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -483,7 +483,7 @@ export function slotChangeHasAssignedElement(event: Event): boolean {
  * @returns {Element[]} An array of elements.
  */
 export function slotChangeGetAssignedElements<T extends Element>(event: Event, selector?: string): T[] | null {
-  return getSlotAssignedElements(event.target as HTMLSlotElement, selector);
+  return getSlotAssignedElements(event.currentTarget as HTMLSlotElement, selector);
 }
 
 /**

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -662,14 +662,23 @@ function nextFrame(): Promise<void> {
  * @returns {number} The pixel equivalent of the provided value.
  */
 export function getStylePixelValue(value: string): number {
-  switch (true) {
-    case value.endsWith("px"):
-      return parseFloat(value);
-    case value.endsWith("vw"):
-      return (window.innerWidth / 100) * parseFloat(value);
-    case value.endsWith("vh"):
-      return (window.innerHeight / 100) * parseFloat(value);
-    default:
-      return 0;
+  if (value.endsWith("px")) {
+    return parseFloat(value);
+  } else if (value.endsWith("vw")) {
+    return viewportUnitToPixel(parseFloat(value), window.innerWidth);
+  } else if (value.endsWith("vh")) {
+    return viewportUnitToPixel(parseFloat(value), window.innerHeight);
   }
+
+  return 0;
+}
+
+/**
+ * Exported for testing purposes only.
+ *
+ * @private
+ */
+export function viewportUnitToPixel(value: number, viewportSize: number): number {
+  // intentionally dividing last to avoid rounding errors
+  return (value * viewportSize) / 100;
 }


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restores `currentTarget` usage in slot utils introduced in https://github.com/Esri/calcite-design-system/pull/9768, which was unintentionally removed by https://github.com/Esri/calcite-design-system/pull/9374/files#diff-289d1884a42555c239e4e403d4ea7d10b281307f0eeda6da7e9c573c9bcaffc7.

Depending on the slot structure, `target` will not be the expected slot (see https://codepen.io/jcfranco/pen/WbQegmz).

### Noteworthy changes

* converted `dom` util test suite to browser-mode spec test
* updated `getStylePixelValue` logic to avoid precision errors causing test failure
* update `slotChangeGetAssignedElements` and `slotChangeGetAssignedNodes` tests to use browser - other utils should follow suit