### PR TITLE
fix(list, block-group): update menu item labels and call 'canPut/canPull' when opening sort handle

### DIFF
--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -211,6 +211,12 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
 
   //#region Events
 
+  /**
+   *
+   * @private
+   */
+  calciteInternalBlockUpdateMoveToItems = createEvent({ cancelable: false });
+
   /** Fires when the component is requested to be closed and before the closing transition begins. */
   calciteBlockBeforeClose = createEvent({ cancelable: false });
 
@@ -313,6 +319,7 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
   private handleSortHandleBeforeOpen(event: CustomEvent<void>): void {
     event.stopPropagation();
     this.calciteBlockSortHandleBeforeOpen.emit();
+    this.calciteInternalBlockUpdateMoveToItems.emit();
   }
 
   private handleSortHandleBeforeClose(event: CustomEvent<void>): void {

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -324,7 +324,7 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
    *
    * @private
    */
-  calciteInternalListItemSortHandleBeforeOpen = createEvent({ cancelable: false });
+  calciteInternalListItemUpdateMoveToItems = createEvent({ cancelable: false });
 
   /** Fires when the close button is clicked. */
   calciteListItemClose = createEvent({ cancelable: false });
@@ -461,7 +461,7 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   private handleSortHandleBeforeOpen(event: CustomEvent<void>): void {
     event.stopPropagation();
     this.calciteListItemSortHandleBeforeOpen.emit();
-    this.calciteInternalListItemSortHandleBeforeOpen.emit();
+    this.calciteInternalListItemUpdateMoveToItems.emit();
   }
 
   private handleSortHandleBeforeClose(event: CustomEvent<void>): void {

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -320,6 +320,12 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
    */
   calciteInternalListItemToggle = createEvent({ cancelable: false });
 
+  /**
+   *
+   * @private
+   */
+  calciteInternalListItemSortHandleBeforeOpen = createEvent({ cancelable: false });
+
   /** Fires when the close button is clicked. */
   calciteListItemClose = createEvent({ cancelable: false });
 
@@ -455,6 +461,7 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   private handleSortHandleBeforeOpen(event: CustomEvent<void>): void {
     event.stopPropagation();
     this.calciteListItemSortHandleBeforeOpen.emit();
+    this.calciteInternalListItemSortHandleBeforeOpen.emit();
   }
 
   private handleSortHandleBeforeClose(event: CustomEvent<void>): void {

--- a/packages/calcite-components/src/demos/block.html
+++ b/packages/calcite-components/src/demos/block.html
@@ -340,6 +340,48 @@
           </calcite-block-group>
         </div>
       </div>
+
+      <div class="parent">
+        <div class="child right-aligned-text">canPull & canPut</div>
+
+        <div class="child">
+          <div style="display: flex; gap: 20px">
+            <div>
+              <h2>Block 1</h2>
+              <calcite-block-group id="pull-put-block-1" drag-enabled group="pull-put-group" label="Block 1">
+                <calcite-block sort-handle-open heading="One"></calcite-block>
+                <calcite-block heading="Two"></calcite-block>
+                <calcite-block heading="Three"></calcite-block>
+              </calcite-block-group>
+            </div>
+            <div>
+              <h2>Block 2</h2>
+              <calcite-block-group id="pull-put-block-2" drag-enabled group="pull-put-group" label="Block 2">
+                <calcite-block heading="Four"></calcite-block>
+                <calcite-block heading="Five"></calcite-block>
+                <calcite-block heading="Six"></calcite-block>
+              </calcite-block-group>
+            </div>
+            <script>
+              document.addEventListener("DOMContentLoaded", async () => {
+                const block1 = document.getElementById("pull-put-block-1");
+                const block2 = document.getElementById("pull-put-block-2");
+
+                await block1.componentOnReady();
+                await block2.componentOnReady();
+                block1.canPut = () => {
+                  console.log("canPut called for block 1");
+                  return true;
+                };
+                block2.canPut = () => {
+                  console.log("canPut called for block 2");
+                  return false;
+                };
+              });
+            </script>
+          </div>
+        </div>
+      </div>
     </demo-dom-swapper>
   </body>
 </html>

--- a/packages/calcite-components/src/demos/list.html
+++ b/packages/calcite-components/src/demos/list.html
@@ -5801,6 +5801,42 @@
           </script>
         </div>
       </div>
+
+      <div class="parent">
+        <div class="child right-aligned-text">canPull & canPut</div>
+
+        <div class="child">
+          <div style="display: flex; gap: 20px">
+            <div>
+              <h2>List 1</h2>
+              <calcite-list id="pull-put-list-1" drag-enabled group="pull-put-group" label="List 1">
+                <calcite-list-item label="One"></calcite-list-item>
+                <calcite-list-item label="Two"></calcite-list-item>
+                <calcite-list-item label="Three"></calcite-list-item>
+              </calcite-list>
+            </div>
+            <div>
+              <h2>List 2</h2>
+              <calcite-list id="pull-put-list-2" drag-enabled group="pull-put-group" label="List 2">
+                <calcite-list-item label="Four"></calcite-list-item>
+                <calcite-list-item label="Five"></calcite-list-item>
+                <calcite-list-item label="Six"></calcite-list-item>
+              </calcite-list>
+            </div>
+            <script>
+              document.addEventListener("DOMContentLoaded", async () => {
+                const list1 = document.getElementById("pull-put-list-1");
+                const list2 = document.getElementById("pull-put-list-2");
+
+                await list1.componentOnReady();
+                await list2.componentOnReady();
+                list1.canPut = () => true;
+                list2.canPut = () => false;
+              });
+            </script>
+          </div>
+        </div>
+      </div>
     </demo-dom-swapper>
   </body>
 </html>

--- a/packages/calcite-components/src/demos/list.html
+++ b/packages/calcite-components/src/demos/list.html
@@ -5810,7 +5810,7 @@
             <div>
               <h2>List 1</h2>
               <calcite-list id="pull-put-list-1" drag-enabled group="pull-put-group" label="List 1">
-                <calcite-list-item label="One"></calcite-list-item>
+                <calcite-list-item sort-handle-open label="One"></calcite-list-item>
                 <calcite-list-item label="Two"></calcite-list-item>
                 <calcite-list-item label="Three"></calcite-list-item>
               </calcite-list>

--- a/packages/calcite-components/src/demos/list.html
+++ b/packages/calcite-components/src/demos/list.html
@@ -5830,8 +5830,14 @@
 
                 await list1.componentOnReady();
                 await list2.componentOnReady();
-                list1.canPut = () => true;
-                list2.canPut = () => false;
+                list1.canPut = () => {
+                  console.log("canPut called for list 1");
+                  return true;
+                };
+                list2.canPut = () => {
+                  console.log("canPut called for list 2");
+                  return false;
+                };
               });
             </script>
           </div>


### PR DESCRIPTION
**Related Issue:** #12361 #12273

## Summary
