### PR TITLE
Matgalla/#10050 update inconsistent shadow tokens option 3

### DIFF
--- a/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/dark.json
@@ -343,6 +343,29 @@
           }
         }
       },
+      "shadow": {
+        "1": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.12})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        },
+        "2": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.12})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        },
+        "3": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.16})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        }
+      },
       "focus": {
         "default": {
           "value": "{semantic.color.brand.default.default}",

--- a/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/color/light.json
@@ -347,6 +347,29 @@
           }
         }
       },
+      "shadow": {
+        "1": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.4})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        },
+        "2": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.8})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        },
+        "3": {
+          "value": "rgba({core.color.neutral.blk-240}, {core.opacity.10})",
+          "type": "color",
+          "attributes": {
+            "category": "color"
+          }
+        }
+      },
       "focus": {
         "default": {
           "value": "{semantic.color.brand.default.default}",

--- a/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
@@ -2,30 +2,117 @@
   "semantic": {
     "shadow": {
       "none": {
-        "value": "{core.shadow.0}",
+        "value": {
+          "x": "0",
+          "y": "0",
+          "blur": "0",
+          "spread": "0",
+          "color": "rgba(0,0,0,0,0)",
+          "type": "dropShadow"
+        },
         "type": "boxShadow",
         "attributes": {
           "category": "shadow"
         }
       },
       "sm": {
-        "value": [
-          "{core.shadow.1}",
-          "{core.shadow.2}"
-        ],
-        "type": "boxShadow",
-        "attributes": {
-          "category": "shadow"
+        "light": {
+          "value": [
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.1)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.04)",
+              "type": "dropShadow"
+            }
+          ],
+          "type": "boxShadow",
+          "attributes": {
+            "category": "shadow"
+          }
+        },
+        "dark": {
+          "value": [
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.16)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "2",
+              "blur": "8",
+              "spread": "0",
+              "color": "rgba(0,0,0,0.12)",
+              "type": "dropShadow"
+            }
+          ],
+          "type": "boxShadow",
+          "attributes": {
+            "category": "shadow"
+          }
         }
       },
       "md": {
-        "value": [
-          "{core.shadow.3}",
-          "{core.shadow.4}"
-        ],
-        "type": "boxShadow",
-        "attributes": {
-          "category": "shadow"
+        "light": {
+          "value": [
+            {
+              "x": "0",
+              "y": "6",
+              "blur": "20",
+              "spread": "-4",
+              "color": "rgba(0,0,0,0.1)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "4",
+              "blur": "12",
+              "spread": "-2",
+              "color": "rgba(0,0,0,0.08)",
+              "type": "dropShadow"
+            }
+          ],
+          "type": "boxShadow",
+          "attributes": {
+            "category": "shadow"
+          }
+        },
+        "dark": {
+          "value": [
+            {
+              "x": "0",
+              "y": "6",
+              "blur": "20",
+              "spread": "-4",
+              "color": "rgba(0,0,0,0.16)",
+              "type": "dropShadow"
+            },
+            {
+              "x": "0",
+              "y": "4",
+              "blur": "12",
+              "spread": "-2",
+              "color": "rgba(0,0,0,0.12)",
+              "type": "dropShadow"
+            }
+          ],
+          "type": "boxShadow",
+          "attributes": {
+            "category": "shadow"
+          }
         }
       }
     }

--- a/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
+++ b/packages/calcite-design-tokens/src/tokens/semantic/shadow.json
@@ -37,7 +37,8 @@
           ],
           "type": "boxShadow",
           "attributes": {
-            "category": "shadow"
+            "category": "shadow",
+            "mode": "light"
           }
         },
         "dark": {
@@ -61,7 +62,8 @@
           ],
           "type": "boxShadow",
           "attributes": {
-            "category": "shadow"
+            "category": "shadow",
+            "mode": "dark"
           }
         }
       },
@@ -87,7 +89,8 @@
           ],
           "type": "boxShadow",
           "attributes": {
-            "category": "shadow"
+            "category": "shadow",
+            "mode": "light"
           }
         },
         "dark": {
@@ -111,7 +114,8 @@
           ],
           "type": "boxShadow",
           "attributes": {
-            "category": "shadow"
+            "category": "shadow",
+            "mode": "dark"
           }
         }
       }


### PR DESCRIPTION
**Related Issue:** #10050

## Summary

- separates semantic shadow tokens into individual light/dark mode versions
  - these use raw values for now
- adds semantic color tokens for shadows
  - `--calcite-color-shadow-1`
  - `--calcite-color-shadow-2`
  - `--calcite-color-shadow-3`