### PR TITLE
fix(slider): remove fill color when dragged handle is released and no longer has focus

### DIFF
--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -66,8 +66,6 @@ export class Slider
 
   // #region Private Properties
 
-  private activeProp: ActiveSliderProperty = "value";
-
   defaultValue: Slider["value"];
 
   private dragEnd = (event: PointerEvent): void => {
@@ -166,6 +164,8 @@ export class Slider
   // #endregion
 
   // #region State Properties
+
+  @state() activeProp: ActiveSliderProperty = "value";
 
   @state() private maxValueDragRange: number = null;
 


### PR DESCRIPTION
**Related Issue:** #12132

## Summary

This PR fixes an issue where the fill color of the last dragged handle in the slider doesn't reset after dragging and focus has moved away from the handle.