### PR TITLE
docs(conventions): fix a11y conventions styling

### DIFF
--- a/packages/calcite-components/conventions/Accessibility.md
+++ b/packages/calcite-components/conventions/Accessibility.md
@@ -1,11 +1,3 @@
-<style>
-    span {
-        background-color:gray; 
-        border-radius: 0.5rem; 
-        padding:0.2rem
-    }
-</style>
-
 # Accessibility
 
 Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.org/WAI/standards-guidelines) to ensure the applications and experiences are usable by a wide range of audiences. Additional considerations in designing for individuals include:
@@ -23,43 +15,43 @@ Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.or
 
 ### Content
 
-- [ ] Information should not depend on color, sound, shape, size, or visual location <span>design</span>
-- [ ] Text and background color should have sufficient contrast <span>design</span>
-- [ ] Links should be descriptive and provide intent <span>design</span>
-- [ ] Links should be visually identifiable <span>design</span>
-- [ ] Use descriptive section headings <span>design</span>
-- [ ] Content should use semantic HTML elements <span>development</span>
-- [ ] HTML should be valid and error-free <span>development</span>
-- [ ] Forms have descriptive labels <span>design</span>
-- [ ] Forms have helpful and accessible error and verification messages <span>design</span>
-- [ ] Labels and help text should be programmatically associated with form fields <span>development</span>
-- [ ] Use correct HTML5 input types <span>development</span>
-- [ ] Content does not loose context when zoomed/enlarged <span>development</span>
-- [ ] Site should not time out unexpectedly <span>design</span>, <span>development</span>
-- [ ] Pages are understandable with no styles enabled <span>development</span>
-- [ ] Web page size should not exceed 500k <span>development</span>
+- [ ] Information should not depend on color, sound, shape, size, or visual location ==design==
+- [ ] Text and background color should have sufficient contrast ==design==
+- [ ] Links should be descriptive and provide intent ==design==
+- [ ] Links should be visually identifiable ==design==
+- [ ] Use descriptive section headings ==design==
+- [ ] Content should use semantic HTML elements ==development==
+- [ ] HTML should be valid and error-free ==development==
+- [ ] Forms have descriptive labels ==design==
+- [ ] Forms have helpful and accessible error and verification messages ==design==
+- [ ] Labels and help text should be programmatically associated with form fields ==development==
+- [ ] Use correct HTML5 input types ==development==
+- [ ] Content does not loose context when zoomed/enlarged ==development==
+- [ ] Site should not time out unexpectedly ==design==, ==development==
+- [ ] Pages are understandable with no styles enabled ==development==
+- [ ] Web page size should not exceed 500k ==development==
 
 ### Keyboard & assistive technology
 
-- [ ] Users should be able to navigate content using a screen reader <span>design</span>, <span>development</span>
-- [ ] Avoid mouse only interactions <span>design</span>, <span>development</span>
-- [ ] Support keyboard navigation <span>development</span>
-- [ ] Focus states should be visible for keyboard users <span>design</span>, <span>development</span>
-- [ ] Allow keyboard users to skip navigation <span>development</span>
-- [ ] Offer multiple ways to find pages on your website <span>design</span>
-- [ ] Use ARIA landmarks where applicable <span>development</span>
-- [ ] Set focus on modals, popovers, alerts, etc. <span>development</span>
+- [ ] Users should be able to navigate content using a screen reader ==design==, ==development==
+- [ ] Avoid mouse only interactions ==design==, ==development==
+- [ ] Support keyboard navigation ==development==
+- [ ] Focus states should be visible for keyboard users ==design==, ==development==
+- [ ] Allow keyboard users to skip navigation ==development==
+- [ ] Offer multiple ways to find pages on your website ==design==
+- [ ] Use ARIA landmarks where applicable ==development==
+- [ ] Set focus on modals, popovers, alerts, etc. ==development==
 
 ### Multimedia & data visualization
 
-- [ ] Images should have meaningful alternative text or intentionally marked decorative <span>design</span>, <span>development</span>
-- [ ] Decorative images should not be visible to screen readers <span>development</span>
-- [ ] Content that moves automatically has the ability to be paused <span>design</span>, <span>development</span>
-- [ ] Limit or remove any flashing elements <span>design</span>
-- [ ] Ensure audio and video is not played automatically unless that is the expected behavior <span>development</span>
-- [ ] Multimedia should have alternative ways to be consumed <span>design</span>, <span>development</span>
-- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology <span>design</span>, <span>development</span>
-- [ ] Table data is accessible to non-sighted users <span>development</span>
+- [ ] Images should have meaningful alternative text or intentionally marked decorative ==design==, ==development==
+- [ ] Decorative images should not be visible to screen readers ==development==
+- [ ] Content that moves automatically has the ability to be paused ==design==, ==development==
+- [ ] Limit or remove any flashing elements ==design==
+- [ ] Ensure audio and video is not played automatically unless that is the expected behavior ==development==
+- [ ] Multimedia should have alternative ways to be consumed ==design==, ==development==
+- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology ==design==, ==development==
+- [ ] Table data is accessible to non-sighted users ==development==
 
 ### Renderring SVG elements within components
 

--- a/packages/calcite-components/conventions/Accessibility.md
+++ b/packages/calcite-components/conventions/Accessibility.md
@@ -15,43 +15,43 @@ Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.or
 
 ### Content
 
-- [ ] Information should not depend on color, sound, shape, size, or visual location <mark>design</mark>
-- [ ] Text and background color should have sufficient contrast <mark>design</mark>
-- [ ] Links should be descriptive and provide intent <mark>design</mark>
-- [ ] Links should be visually identifiable <mark>design</mark>
-- [ ] Use descriptive section headings <mark>design</mark>
-- [ ] Content should use semantic HTML elements <mark>development</mark>
-- [ ] HTML should be valid and error-free <mark>development</mark>
-- [ ] Forms have descriptive labels <mark>design</mark>
-- [ ] Forms have helpful and accessible error and verification messages <mark>design</mark>
-- [ ] Labels and help text should be programmatically associated with form fields <mark>development</mark>
-- [ ] Use correct HTML5 input types <mark>development</mark>
-- [ ] Content does not loose context when zoomed/enlarged <mark>development</mark>
-- [ ] Site should not time out unexpectedly <mark>design</mark>, <mark>development</mark>
-- [ ] Pages are understandable with no styles enabled <mark>development</mark>
-- [ ] Web page size should not exceed 500k <mark>development</mark>
+- [ ] Information should not depend on color, sound, shape, size, or visual location - <mark>design</mark>
+- [ ] Text and background color should have sufficient contrast - <mark>design</mark>
+- [ ] Links should be descriptive and provide intent - <mark>design</mark>
+- [ ] Links should be visually identifiable - <mark>design</mark>
+- [ ] Use descriptive section headings - <mark>design</mark>
+- [ ] Content should use semantic HTML elements - <mark>development</mark>
+- [ ] HTML should be valid and error-free - <mark>development</mark>
+- [ ] Forms have descriptive labels - <mark>design</mark>
+- [ ] Forms have helpful and accessible error and verification messages - <mark>design</mark>
+- [ ] Labels and help text should be programmatically associated with form fields - <mark>development</mark>
+- [ ] Use correct HTML5 input types - <mark>development</mark>
+- [ ] Content does not loose context when zoomed/enlarged - <mark>development</mark>
+- [ ] Site should not time out unexpectedly - <mark>design</mark>, <mark>development</mark>
+- [ ] Pages are understandable with no styles enabled - <mark>development</mark>
+- [ ] Web page size should not exceed 500k - <mark>development</mark>
 
 ### Keyboard & assistive technology
 
-- [ ] Users should be able to navigate content using a screen reader <mark>design</mark>, <mark>development</mark>
-- [ ] Avoid mouse only interactions <mark>design</mark>, <mark>development</mark>
-- [ ] Support keyboard navigation <mark>development</mark>
-- [ ] Focus states should be visible for keyboard users <mark>design</mark>, <mark>development</mark>
-- [ ] Allow keyboard users to skip navigation <mark>development</mark>
-- [ ] Offer multiple ways to find pages on your website <mark>design</mark>
-- [ ] Use ARIA landmarks where applicable <mark>development</mark>
-- [ ] Set focus on modals, popovers, alerts, etc. <mark>development</mark>
+- [ ] Users should be able to navigate content using a screen reader - <mark>design</mark>, <mark>development</mark>
+- [ ] Avoid mouse only interactions - <mark>design</mark>, <mark>development</mark>
+- [ ] Support keyboard navigation - <mark>development</mark>
+- [ ] Focus states should be visible for keyboard users - <mark>design</mark>, <mark>development</mark>
+- [ ] Allow keyboard users to skip navigation - <mark>development</mark>
+- [ ] Offer multiple ways to find pages on your website - <mark>design</mark>
+- [ ] Use ARIA landmarks where applicable - <mark>development</mark>
+- [ ] Set focus on modals, popovers, alerts, etc. - <mark>development</mark>
 
 ### Multimedia & data visualization
 
-- [ ] Images should have meaningful alternative text or intentionally marked decorative <mark>design</mark>, <mark>development</mark>
-- [ ] Decorative images should not be visible to screen readers <mark>development</mark>
-- [ ] Content that moves automatically has the ability to be paused <mark>design</mark>, <mark>development</mark>
-- [ ] Limit or remove any flashing elements <mark>design</mark>
-- [ ] Ensure audio and video is not played automatically unless that is the expected behavior <mark>development</mark>
-- [ ] Multimedia should have alternative ways to be consumed <mark>design</mark>, <mark>development</mark>
-- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology <mark>design</mark>, <mark>development</mark>
-- [ ] Table data is accessible to non-sighted users <mark>development</mark>
+- [ ] Images should have meaningful alternative text or intentionally marked decorative - <mark>design</mark>, <mark>development</mark>
+- [ ] Decorative images should not be visible to screen readers - <mark>development</mark>
+- [ ] Content that moves automatically has the ability to be paused - <mark>design</mark>, <mark>development</mark>
+- [ ] Limit or remove any flashing elements - <mark>design</mark>
+- [ ] Ensure audio and video is not played automatically unless that is the expected behavior - <mark>development</mark>
+- [ ] Multimedia should have alternative ways to be consumed - <mark>design</mark>, <mark>development</mark>
+- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology - <mark>design</mark>, <mark>development</mark>
+- [ ] Table data is accessible to non-sighted users - <mark>development</mark>
 
 ### Renderring SVG elements within components
 

--- a/packages/calcite-components/conventions/Accessibility.md
+++ b/packages/calcite-components/conventions/Accessibility.md
@@ -1,22 +1,3 @@
-<style>
-    .check-div {
-        padding: 1rem;
-    }
-    .check-div > label {
-        margin-left: 1rem;
-    }
-    fieldset {
-        padding: 3rem;
-    }
-    h2 {
-        font-size: 1.25rem;
-        padding: 0.5rem;
-    }
-    calcite-chip {
-        margin-right: 0.5rem;
-    }
-</style>
-
 # Accessibility
 
 Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.org/WAI/standards-guidelines) to ensure the applications and experiences are usable by a wide range of audiences. Additional considerations in designing for individuals include:
@@ -30,209 +11,209 @@ Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.or
 | <p>Who are deaf or hard of hearing</p>     | <p>Use subtitles or provide transcripts for video.</p> <img src="https://user-images.githubusercontent.com/5023024/173696320-c06c6999-2397-4390-a1f1-e4929510de90.svg" alt="" /> | <p>Put content in audio or video formats only.</p> <img src="https://user-images.githubusercontent.com/5023024/173696314-00c0911d-0acc-473d-a527-65b61f0d2101.svg" alt="" />           |
 | <p>With Dyslexia</p>                       | <p>Provide reminders & prompts.</p> <img src="https://user-images.githubusercontent.com/5023024/173696328-767d2cc3-2635-449b-9159-1cea1dcdcc14.svg" alt="" />                    | <p>Force people to remember things from previous places.</p> <img src="https://user-images.githubusercontent.com/5023024/173696321-6655f279-71c0-4a8d-836f-5f429721e64a.svg" alt="" /> |
 
-<fieldset>
+<fieldset style="padding:3rem">
     <legend># Checklist</legend>
 
 ## Content
 
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="1" id="1">
-    <label for="1">Information should not depend on color, sound, shape, size, or visual location
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="1">Information should not depend on color, sound, shape, size, or visual location
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="2" id="2">
-    <label for="2">Text and background color should have sufficient contrast
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="2">Text and background color should have sufficient contrast
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="3" id="3">
-    <label for="3">Links should be descriptive and provide intent
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="3">Links should be descriptive and provide intent
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="4" id="4">
-    <label for="4">Links should be visually identifiable
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="4">Links should be visually identifiable
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="5" id="5">
-    <label for="5">Use descriptive section headings
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="5">Use descriptive section headings
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="6" id="6">
-    <label for="6">Content should use semantic HTML elements
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="6">Content should use semantic HTML elements
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="7" id="7">
-    <label for="7">HTML should be valid and error-free
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="7">HTML should be valid and error-free
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="8" id="8">
-    <label for="8">Forms have descriptive labels
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="8">Forms have descriptive labels
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="9" id="9">
-    <label for="9">Forms have helpful and accessible error and verification messages
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="9">Forms have helpful and accessible error and verification messages
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="10" id="10">
-    <label for="10">Labels and help text should be programmatically associated with form fields
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="10">Labels and help text should be programmatically associated with form fields
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="11" id="11">
-    <label for="11">Use correct HTML5 input types
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="11">Use correct HTML5 input types
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="12" id="12">
-    <label for="12">Content does not loose context when zoomed/enlarged
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="12">Content does not loose context when zoomed/enlarged
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="13" id="13">
-    <label for="13">Site should not time out unexpectedly
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="13">Site should not time out unexpectedly
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="14" id="14">
-    <label for="14">Pages are understandable with no styles enabled
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="14">Pages are understandable with no styles enabled
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="15" id="15">
-    <label for="15">Web page size should not exceed 500k
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="15">Web page size should not exceed 500k
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
 
 ## Keyboard & Assistive Tech
 
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="16" id="16">
-    <label for="16">Users should be able to navigate content using a screen reader
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="16">Users should be able to navigate content using a screen reader
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="17" id="17">
-    <label for="17">Avoid mouse only interactions
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="17">Avoid mouse only interactions
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="18" id="18">
-    <label for="18">Support keyboard navigation
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="18">Support keyboard navigation
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="19" id="19">
-    <label for="19">Focus states should be visible for keyboard users
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="19">Focus states should be visible for keyboard users
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="20" id="20">
-    <label for="20">Allow keyboard users to skip navigation
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="20">Allow keyboard users to skip navigation
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="21" id="21">
-    <label for="21">Offer multiple ways to find pages on your website
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="21">Offer multiple ways to find pages on your website
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="22" id="22">
-    <label for="22">Use ARIA landmarks where applicable
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="22">Use ARIA landmarks where applicable
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="23" id="23">
-    <label for="23">Set focus on modals, popovers, alerts, etc.
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="23">Set focus on modals, popovers, alerts, etc.
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
 
 ## Multimedia & Data Viz
 
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="25" id="25">
-    <label for="25">Images should have meaningful alternative text or intentionally marked decorative
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="25">Images should have meaningful alternative text or intentionally marked decorative
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="26" id="26">
-    <label for="26">Decorative images should not be visible to screen readers
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="26">Decorative images should not be visible to screen readers
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="27" id="27">
-    <label for="27">Content that moves automatically has the ability to be paused
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="27">Content that moves automatically has the ability to be paused
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="28" id="28">
-    <label for="28">Limit or remove any flashing elements
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <label style="margin-left: 1rem" for="28">Limit or remove any flashing elements
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="29" id="29">
-    <label for="29">Ensure audio and video is not played automatically unless that is the expected behavior
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="29">Ensure audio and video is not played automatically unless that is the expected behavior
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="30" id="30">
-    <label for="30">Multimedia should have alternative ways to be consumed
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="30">Multimedia should have alternative ways to be consumed
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="31" id="31">
-    <label for="31">Make data available for graphs, charts, maps, SVGs, etc. through assistive technology
-    <calcite-chip appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="31">Make data available for graphs, charts, maps, SVGs, etc. through assistive technology
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
-<div class="check-div">
+<div class="check-div" style="padding: 1rem">
     <input type="checkbox" name="32" id="32">
-    <label for="32">Table data is accessible to non-sighted users
-    <calcite-chip appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
+    <label style="margin-left: 1rem" for="32">Table data is accessible to non-sighted users
+    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
     </label>
 </div>
 

--- a/packages/calcite-components/conventions/Accessibility.md
+++ b/packages/calcite-components/conventions/Accessibility.md
@@ -15,43 +15,43 @@ Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.or
 
 ### Content
 
-- [ ] Information should not depend on color, sound, shape, size, or visual location ==design==
-- [ ] Text and background color should have sufficient contrast ==design==
-- [ ] Links should be descriptive and provide intent ==design==
-- [ ] Links should be visually identifiable ==design==
-- [ ] Use descriptive section headings ==design==
-- [ ] Content should use semantic HTML elements ==development==
-- [ ] HTML should be valid and error-free ==development==
-- [ ] Forms have descriptive labels ==design==
-- [ ] Forms have helpful and accessible error and verification messages ==design==
-- [ ] Labels and help text should be programmatically associated with form fields ==development==
-- [ ] Use correct HTML5 input types ==development==
-- [ ] Content does not loose context when zoomed/enlarged ==development==
-- [ ] Site should not time out unexpectedly ==design==, ==development==
-- [ ] Pages are understandable with no styles enabled ==development==
-- [ ] Web page size should not exceed 500k ==development==
+- [ ] Information should not depend on color, sound, shape, size, or visual location <mark>design</mark>
+- [ ] Text and background color should have sufficient contrast <mark>design</mark>
+- [ ] Links should be descriptive and provide intent <mark>design</mark>
+- [ ] Links should be visually identifiable <mark>design</mark>
+- [ ] Use descriptive section headings <mark>design</mark>
+- [ ] Content should use semantic HTML elements <mark>development</mark>
+- [ ] HTML should be valid and error-free <mark>development</mark>
+- [ ] Forms have descriptive labels <mark>design</mark>
+- [ ] Forms have helpful and accessible error and verification messages <mark>design</mark>
+- [ ] Labels and help text should be programmatically associated with form fields <mark>development</mark>
+- [ ] Use correct HTML5 input types <mark>development</mark>
+- [ ] Content does not loose context when zoomed/enlarged <mark>development</mark>
+- [ ] Site should not time out unexpectedly <mark>design</mark>, <mark>development</mark>
+- [ ] Pages are understandable with no styles enabled <mark>development</mark>
+- [ ] Web page size should not exceed 500k <mark>development</mark>
 
 ### Keyboard & assistive technology
 
-- [ ] Users should be able to navigate content using a screen reader ==design==, ==development==
-- [ ] Avoid mouse only interactions ==design==, ==development==
-- [ ] Support keyboard navigation ==development==
-- [ ] Focus states should be visible for keyboard users ==design==, ==development==
-- [ ] Allow keyboard users to skip navigation ==development==
-- [ ] Offer multiple ways to find pages on your website ==design==
-- [ ] Use ARIA landmarks where applicable ==development==
-- [ ] Set focus on modals, popovers, alerts, etc. ==development==
+- [ ] Users should be able to navigate content using a screen reader <mark>design</mark>, <mark>development</mark>
+- [ ] Avoid mouse only interactions <mark>design</mark>, <mark>development</mark>
+- [ ] Support keyboard navigation <mark>development</mark>
+- [ ] Focus states should be visible for keyboard users <mark>design</mark>, <mark>development</mark>
+- [ ] Allow keyboard users to skip navigation <mark>development</mark>
+- [ ] Offer multiple ways to find pages on your website <mark>design</mark>
+- [ ] Use ARIA landmarks where applicable <mark>development</mark>
+- [ ] Set focus on modals, popovers, alerts, etc. <mark>development</mark>
 
 ### Multimedia & data visualization
 
-- [ ] Images should have meaningful alternative text or intentionally marked decorative ==design==, ==development==
-- [ ] Decorative images should not be visible to screen readers ==development==
-- [ ] Content that moves automatically has the ability to be paused ==design==, ==development==
-- [ ] Limit or remove any flashing elements ==design==
-- [ ] Ensure audio and video is not played automatically unless that is the expected behavior ==development==
-- [ ] Multimedia should have alternative ways to be consumed ==design==, ==development==
-- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology ==design==, ==development==
-- [ ] Table data is accessible to non-sighted users ==development==
+- [ ] Images should have meaningful alternative text or intentionally marked decorative <mark>design</mark>, <mark>development</mark>
+- [ ] Decorative images should not be visible to screen readers <mark>development</mark>
+- [ ] Content that moves automatically has the ability to be paused <mark>design</mark>, <mark>development</mark>
+- [ ] Limit or remove any flashing elements <mark>design</mark>
+- [ ] Ensure audio and video is not played automatically unless that is the expected behavior <mark>development</mark>
+- [ ] Multimedia should have alternative ways to be consumed <mark>design</mark>, <mark>development</mark>
+- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology <mark>design</mark>, <mark>development</mark>
+- [ ] Table data is accessible to non-sighted users <mark>development</mark>
 
 ### Renderring SVG elements within components
 

--- a/packages/calcite-components/conventions/Accessibility.md
+++ b/packages/calcite-components/conventions/Accessibility.md
@@ -1,3 +1,11 @@
+<style>
+    span {
+        background-color:gray; 
+        border-radius: 0.5rem; 
+        padding:0.2rem
+    }
+</style>
+
 # Accessibility
 
 Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.org/WAI/standards-guidelines) to ensure the applications and experiences are usable by a wide range of audiences. Additional considerations in designing for individuals include:
@@ -11,215 +19,49 @@ Calcite Components leverages the [W3C Accessibility Standards](https://www.w3.or
 | <p>Who are deaf or hard of hearing</p>     | <p>Use subtitles or provide transcripts for video.</p> <img src="https://user-images.githubusercontent.com/5023024/173696320-c06c6999-2397-4390-a1f1-e4929510de90.svg" alt="" /> | <p>Put content in audio or video formats only.</p> <img src="https://user-images.githubusercontent.com/5023024/173696314-00c0911d-0acc-473d-a527-65b61f0d2101.svg" alt="" />           |
 | <p>With Dyslexia</p>                       | <p>Provide reminders & prompts.</p> <img src="https://user-images.githubusercontent.com/5023024/173696328-767d2cc3-2635-449b-9159-1cea1dcdcc14.svg" alt="" />                    | <p>Force people to remember things from previous places.</p> <img src="https://user-images.githubusercontent.com/5023024/173696321-6655f279-71c0-4a8d-836f-5f429721e64a.svg" alt="" /> |
 
-<fieldset style="padding:3rem">
-    <legend># Checklist</legend>
+## Checklist
 
-## Content
+### Content
 
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="1" id="1">
-    <label style="margin-left: 1rem" for="1">Information should not depend on color, sound, shape, size, or visual location
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="2" id="2">
-    <label style="margin-left: 1rem" for="2">Text and background color should have sufficient contrast
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="3" id="3">
-    <label style="margin-left: 1rem" for="3">Links should be descriptive and provide intent
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="4" id="4">
-    <label style="margin-left: 1rem" for="4">Links should be visually identifiable
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="5" id="5">
-    <label style="margin-left: 1rem" for="5">Use descriptive section headings
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="6" id="6">
-    <label style="margin-left: 1rem" for="6">Content should use semantic HTML elements
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="7" id="7">
-    <label style="margin-left: 1rem" for="7">HTML should be valid and error-free
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="8" id="8">
-    <label style="margin-left: 1rem" for="8">Forms have descriptive labels
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="9" id="9">
-    <label style="margin-left: 1rem" for="9">Forms have helpful and accessible error and verification messages
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="10" id="10">
-    <label style="margin-left: 1rem" for="10">Labels and help text should be programmatically associated with form fields
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="11" id="11">
-    <label style="margin-left: 1rem" for="11">Use correct HTML5 input types
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="12" id="12">
-    <label style="margin-left: 1rem" for="12">Content does not loose context when zoomed/enlarged
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="13" id="13">
-    <label style="margin-left: 1rem" for="13">Site should not time out unexpectedly
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="14" id="14">
-    <label style="margin-left: 1rem" for="14">Pages are understandable with no styles enabled
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="15" id="15">
-    <label style="margin-left: 1rem" for="15">Web page size should not exceed 500k
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
+- [ ] Information should not depend on color, sound, shape, size, or visual location <span>design</span>
+- [ ] Text and background color should have sufficient contrast <span>design</span>
+- [ ] Links should be descriptive and provide intent <span>design</span>
+- [ ] Links should be visually identifiable <span>design</span>
+- [ ] Use descriptive section headings <span>design</span>
+- [ ] Content should use semantic HTML elements <span>development</span>
+- [ ] HTML should be valid and error-free <span>development</span>
+- [ ] Forms have descriptive labels <span>design</span>
+- [ ] Forms have helpful and accessible error and verification messages <span>design</span>
+- [ ] Labels and help text should be programmatically associated with form fields <span>development</span>
+- [ ] Use correct HTML5 input types <span>development</span>
+- [ ] Content does not loose context when zoomed/enlarged <span>development</span>
+- [ ] Site should not time out unexpectedly <span>design</span>, <span>development</span>
+- [ ] Pages are understandable with no styles enabled <span>development</span>
+- [ ] Web page size should not exceed 500k <span>development</span>
 
-## Keyboard & Assistive Tech
+### Keyboard & assistive technology
 
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="16" id="16">
-    <label style="margin-left: 1rem" for="16">Users should be able to navigate content using a screen reader
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="17" id="17">
-    <label style="margin-left: 1rem" for="17">Avoid mouse only interactions
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="18" id="18">
-    <label style="margin-left: 1rem" for="18">Support keyboard navigation
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="19" id="19">
-    <label style="margin-left: 1rem" for="19">Focus states should be visible for keyboard users
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="20" id="20">
-    <label style="margin-left: 1rem" for="20">Allow keyboard users to skip navigation
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="21" id="21">
-    <label style="margin-left: 1rem" for="21">Offer multiple ways to find pages on your website
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="22" id="22">
-    <label style="margin-left: 1rem" for="22">Use ARIA landmarks where applicable
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="23" id="23">
-    <label style="margin-left: 1rem" for="23">Set focus on modals, popovers, alerts, etc.
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
+- [ ] Users should be able to navigate content using a screen reader <span>design</span>, <span>development</span>
+- [ ] Avoid mouse only interactions <span>design</span>, <span>development</span>
+- [ ] Support keyboard navigation <span>development</span>
+- [ ] Focus states should be visible for keyboard users <span>design</span>, <span>development</span>
+- [ ] Allow keyboard users to skip navigation <span>development</span>
+- [ ] Offer multiple ways to find pages on your website <span>design</span>
+- [ ] Use ARIA landmarks where applicable <span>development</span>
+- [ ] Set focus on modals, popovers, alerts, etc. <span>development</span>
 
-## Multimedia & Data Viz
+### Multimedia & data visualization
 
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="25" id="25">
-    <label style="margin-left: 1rem" for="25">Images should have meaningful alternative text or intentionally marked decorative
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="26" id="26">
-    <label style="margin-left: 1rem" for="26">Decorative images should not be visible to screen readers
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="27" id="27">
-    <label style="margin-left: 1rem" for="27">Content that moves automatically has the ability to be paused
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="28" id="28">
-    <label style="margin-left: 1rem" for="28">Limit or remove any flashing elements
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="29" id="29">
-    <label style="margin-left: 1rem" for="29">Ensure audio and video is not played automatically unless that is the expected behavior
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="30" id="30">
-    <label style="margin-left: 1rem" for="30">Multimedia should have alternative ways to be consumed
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="31" id="31">
-    <label style="margin-left: 1rem" for="31">Make data available for graphs, charts, maps, SVGs, etc. through assistive technology
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" icon="palette" scale="s">Design</calcite-chip>
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
-<div class="check-div" style="padding: 1rem">
-    <input type="checkbox" name="32" id="32">
-    <label style="margin-left: 1rem" for="32">Table data is accessible to non-sighted users
-    <calcite-chip style="margin-right: 0.5rem" style="margin-right: 0.5rem" appearance="solid" kind="neutral" icon="code" scale="s">Development</calcite-chip>
-    </label>
-</div>
+- [ ] Images should have meaningful alternative text or intentionally marked decorative <span>design</span>, <span>development</span>
+- [ ] Decorative images should not be visible to screen readers <span>development</span>
+- [ ] Content that moves automatically has the ability to be paused <span>design</span>, <span>development</span>
+- [ ] Limit or remove any flashing elements <span>design</span>
+- [ ] Ensure audio and video is not played automatically unless that is the expected behavior <span>development</span>
+- [ ] Multimedia should have alternative ways to be consumed <span>design</span>, <span>development</span>
+- [ ] Make data available for graphs, charts, maps, SVGs, etc. through assistive technology <span>design</span>, <span>development</span>
+- [ ] Table data is accessible to non-sighted users <span>development</span>
 
-</fieldset>
-
-## Renderring SVG elements within components
+### Renderring SVG elements within components
 
 SVGs are visual elements. When rendering them in a component, assess if the SVG has semantic meaning that needs to be described.
 


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/12538

## Summary
Fixes the a11y convention documentation page, which was previously showcasing the CSS in the markdown in GitHub's UI.

A preview can be viewed on the branch in [this markdown file](https://github.com/Esri/calcite-design-system/blob/geospatialem/docs-a11y-convention/packages/calcite-components/conventions/Accessibility.md).


| Before | After |
| ----------- | ----------- |
| <img width="1587" height="453" alt="image" src="https://github.com/user-attachments/assets/e5d5e03b-17bc-4083-9080-5100e138740f" />| <img width="1589" height="755" alt="image" src="https://github.com/user-attachments/assets/27752d57-1140-4a93-a2da-47fbc41a5a38" />|