### PR TITLE
fix: map `bs` locale to `sr-Latn-CS`

### DIFF
--- a/packages/calcite-components/src/utils/locale.spec.ts
+++ b/packages/calcite-components/src/utils/locale.spec.ts
@@ -248,8 +248,8 @@ describe("getDateFormatSupportedLocale", () => {
       assertLocaleMapping("it-CH", "de-CH");
     });
 
-    it("maps `bs` to `bs-Cyrl`", () => {
-      assertLocaleMapping("bs", "bs-Cyrl");
+    it("maps `bs` to `sr-Latn-CS`", () => {
+      assertLocaleMapping("bs", "sr-Latn-CS");
     });
 
     it("maps `en` to `en`", () => {

--- a/packages/calcite-components/src/utils/locale.ts
+++ b/packages/calcite-components/src/utils/locale.ts
@@ -170,7 +170,7 @@ export function getDateFormatSupportedLocale(locale: string): string {
     case "it-CH":
       return "de-CH";
     case "bs":
-      return "bs-Cyrl";
+      return "sr-Latn-CS";
     default:
       return locale;
   }


### PR DESCRIPTION
**Related Issue:** #12274 

## Summary

Maps `bs` locale to `sr-Latn-CS` for dateTimeFormat data.