### PR TITLE
docs: restore unintentionally removed options param doc for `scrollContentTo`

### DIFF
--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -366,7 +366,7 @@ export class Autocomplete
    *   top: 0, // Specifies the number of pixels along the Y axis to scroll the window or element
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
-   * @param options
+   * @param options - allows specific coordinates to be defined.
    * @returns - promise that resolves once the content is scrolled to.
    */
   @method()

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -254,7 +254,7 @@ export class Dialog extends LitElement implements OpenCloseComponent {
    *   top: 0, // Specifies the number of pixels along the Y axis to scroll the window or element
    *   behavior: "auto" // Specifies whether the scrolling should animate smoothly (smooth), or happen instantly in a single jump (auto, the default value).
    * });
-   * @param options
+   * @param options - allows specific coordinates to be defined.
    * @returns - promise that resolves once the content is scrolled to.
    */
   @method()


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

This restores doc unintentionally removed in https://github.com/Esri/calcite-design-system/pull/12555.