### PR TITLE
fix(popover, tooltip): selection range within an open component should open or close the component

### DIFF
--- a/packages/calcite-components/src/components/popover/PopoverManager.ts
+++ b/packages/calcite-components/src/components/popover/PopoverManager.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { ReferenceElement } from "../../utils/floating-ui";
 import { isActivationKey } from "../../utils/key";
-import { isKeyboardTriggeredClick } from "../../utils/dom";
+import { elementHasSelectionRange, isKeyboardTriggeredClick } from "../../utils/dom";
 import type { Popover } from "./popover";
 
 export default class PopoverManager {
@@ -86,8 +86,13 @@ export default class PopoverManager {
     }
   };
 
+  private openPopoverHasSelection(): boolean {
+    const { registeredElements } = this;
+    return Array.from(registeredElements.values()).some((popover) => popover.open && elementHasSelectionRange(popover));
+  }
+
   private clickHandler = (event: PointerEvent): void => {
-    if (isKeyboardTriggeredClick(event) || event.defaultPrevented || window.getSelection()?.type === "Range") {
+    if (isKeyboardTriggeredClick(event) || event.defaultPrevented || this.openPopoverHasSelection()) {
       return;
     }
 

--- a/packages/calcite-components/src/components/popover/popover.e2e.ts
+++ b/packages/calcite-components/src/components/popover/popover.e2e.ts
@@ -400,31 +400,6 @@ describe("calcite-popover", () => {
     expect(await popover.getProperty("open")).toBe(false);
   });
 
-  it("should not toggle popovers if selection range is present", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(html`
-      <calcite-popover reference-element="ref">Content</calcite-popover>
-      <button id="ref">Button</button>
-    `);
-
-    const popover = await page.find("calcite-popover");
-
-    expect(await popover.getProperty("open")).toBe(false);
-
-    await page.$eval("button#ref", (el) => {
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      const range = document.createRange();
-      range.selectNode(el);
-      selection.addRange(range);
-      el.click();
-    });
-    await page.waitForChanges();
-
-    expect(await popover.getProperty("open")).toBe(false);
-  });
-
   it("should not close active popover if selection range occurs within the popover", async () => {
     const page = await newE2EPage();
 

--- a/packages/calcite-components/src/components/tooltip/TooltipManager.ts
+++ b/packages/calcite-components/src/components/tooltip/TooltipManager.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { getShadowRootNode } from "../../utils/dom";
+import { elementHasSelectionRange, getShadowRootNode } from "../../utils/dom";
 import { ReferenceElement } from "../../utils/floating-ui";
 import { TOOLTIP_OPEN_DELAY_MS, TOOLTIP_QUICK_OPEN_DELAY_MS, TOOLTIP_CLOSE_DELAY_MS } from "./resources";
 import { getEffectiveReferenceElement } from "./utils";
@@ -98,11 +98,6 @@ export default class TooltipManager {
     }
   };
 
-  private activeTooltipHasSelection(): boolean {
-    const selection = window.getSelection();
-    return selection?.type === "Range" && this.activeTooltip?.contains(selection?.anchorNode);
-  }
-
   private pointerLeaveHandler = (event: PointerEvent): void => {
     if (event.defaultPrevented) {
       return;
@@ -110,7 +105,7 @@ export default class TooltipManager {
 
     this.clearHoverTimeout();
 
-    if (this.activeTooltipHasSelection()) {
+    if (elementHasSelectionRange(this.activeTooltip)) {
       return;
     }
 
@@ -127,7 +122,7 @@ export default class TooltipManager {
 
     const tooltip = this.queryTooltip(composedPath);
 
-    if (this.activeTooltipHasSelection() || this.pathHasOpenTooltip(tooltip, composedPath)) {
+    if (elementHasSelectionRange(this.activeTooltip) || this.pathHasOpenTooltip(tooltip, composedPath)) {
       this.clearHoverTimeout();
       return;
     }
@@ -160,7 +155,7 @@ export default class TooltipManager {
   }
 
   private clickHandler = (event: Event): void => {
-    if (event.defaultPrevented || window.getSelection()?.type === "Range") {
+    if (event.defaultPrevented) {
       return;
     }
 

--- a/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/calcite-components/src/components/tooltip/tooltip.e2e.ts
@@ -706,44 +706,6 @@ describe("calcite-tooltip", () => {
     expect(await hoverTip.getProperty("open")).toBe(false);
   });
 
-  it("should not open on click if selection range is present", async () => {
-    const page = await newE2EPage();
-
-    await page.setContent(html`
-      <calcite-tooltip id="hoverTip" reference-element="hoverRef">Content</calcite-tooltip>
-      <button id="hoverRef">Button</button>
-      <div id="selection">Selection</div>
-    `);
-
-    const hoverTip = await page.find("#hoverTip");
-
-    expect(await hoverTip.getProperty("open")).toBe(false);
-
-    await page.$eval("div#selection", (el) => {
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-      const range = document.createRange();
-      range.selectNode(el);
-      selection.addRange(range);
-    });
-
-    await dispatchClickEvent(page, "#hoverRef");
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
-
-    expect(await hoverTip.getProperty("open")).toBe(false);
-
-    await page.evaluate(() => {
-      const selection = window.getSelection();
-      selection.removeAllRanges();
-    });
-    await page.waitForChanges();
-
-    await dispatchClickEvent(page, "#hoverRef");
-    await page.waitForTimeout(TOOLTIP_OPEN_DELAY_MS);
-
-    expect(await hoverTip.getProperty("open")).toBe(true);
-  });
-
   it("should not close if selection range occurs within the tooltip", async () => {
     const page = await newE2EPage();
 

--- a/packages/calcite-components/src/utils/dom.ts
+++ b/packages/calcite-components/src/utils/dom.ts
@@ -730,3 +730,14 @@ export function viewportUnitToPixel(value: number, viewportSize: number): number
   // intentionally dividing last to avoid rounding errors
   return (value * viewportSize) / 100;
 }
+
+/**
+ * Checks if the given element contains the current text selection.
+ *
+ * @param {HTMLElement} el - The element to check for selection containment.
+ * @returns {boolean} True if the element contains a non-empty selection, otherwise false.
+ */
+export function elementHasSelectionRange(el: HTMLElement): boolean {
+  const selection = window.getSelection();
+  return selection.type === "Range" && el && (el.contains(selection.anchorNode) || el.contains(selection.focusNode));
+}


### PR DESCRIPTION
**Related Issue:** #12589

## Summary

- selection range within an open component should open or close the component
- adds e2e tests for dom
- updates tests in popover and tooltip