### PR TITLE
docs(examples): treat tags including `calcite-` as custom elements

### DIFF
--- a/examples/components/vue/vite.config.ts
+++ b/examples/components/vue/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     vue({
       template: {
         compilerOptions: {
-          // Treat all tags including `calcite-` as custom elements
+          // Treat all tags that include `calcite-` as custom elements
           isCustomElement: (tag) => tag.includes("calcite-"),
         },
       },

--- a/examples/components/vue/vite.config.ts
+++ b/examples/components/vue/vite.config.ts
@@ -5,7 +5,16 @@ import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          // Treat all tags including `calcite-` as custom elements
+          isCustomElement: (tag) => tag.includes("calcite-"),
+        },
+      },
+    }),
+  ],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
**Related Issue:** #12522

## Summary
Resolves "Failed to resolve component: xxx" console warnings by telling Vite to treat all tags that include `calcite-' as custom elements.

Utilizes [Vue's recommended approach](https://vuejs.org/guide/extras/web-components#example-vite-config) for using custom elements.
