### PR TITLE
fix(list): fix visual artifacts when you initiate a drag operation with the drag handle menu open

### DIFF
--- a/packages/calcite-components/src/assets/styles/_sortable.scss
+++ b/packages/calcite-components/src/assets/styles/_sortable.scss
@@ -1,3 +1,6 @@
+:host(.calcite-sortable--chosen),
+:host(.calcite-sortable--drag),
+:host(.calcite-sortable--fallback),
 :host(.calcite-sortable--ghost) {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
**Related Issue:** #12204

## Summary

- restores CSS we had removed to handle a firefox bug
- see https://github.com/Esri/calcite-design-system/pull/11883
