### PR TITLE
chore(deps): unpin lit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33247,7 +33247,7 @@
         "dayjs": "^1.11.13",
         "focus-trap": "^7.6.2",
         "interactjs": "^1.10.27",
-        "lit": "3.3.0",
+        "lit": "^3.3.0",
         "lodash-es": "^4.17.21",
         "sortablejs": "^1.15.6",
         "timezone-groups": "^0.10.4",
@@ -33272,7 +33272,7 @@
         "@arcgis/lumina": "^4.34.0-next.49",
         "@esri/calcite-components": "3.3.0-next.50",
         "@lit/react": "1.0.8",
-        "lit": "3.3.0"
+        "lit": "^3.3.0"
       },
       "peerDependencies": {
         "react": ">=18.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33271,7 +33271,7 @@
       "dependencies": {
         "@arcgis/lumina": "^4.34.0-next.49",
         "@esri/calcite-components": "3.3.0-next.51",
-        "@lit/react": "1.0.8",
+        "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },
       "peerDependencies": {

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -31,7 +31,7 @@
     "@arcgis/lumina": "^4.34.0-next.49",
     "@esri/calcite-components": "3.3.0-next.50",
     "@lit/react": "1.0.8",
-    "lit": "3.3.0"
+    "lit": "^3.3.0"
   },
   "peerDependencies": {
     "react": ">=18.3",

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@arcgis/lumina": "^4.34.0-next.49",
     "@esri/calcite-components": "3.3.0-next.51",
-    "@lit/react": "1.0.8",
+    "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },
   "peerDependencies": {

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -87,7 +87,7 @@
     "dayjs": "^1.11.13",
     "focus-trap": "^7.6.2",
     "interactjs": "^1.10.27",
-    "lit": "3.3.0",
+    "lit": "^3.3.0",
     "lodash-es": "^4.17.21",
     "sortablejs": "^1.15.6",
     "timezone-groups": "^0.10.4",


### PR DESCRIPTION
**Related Issue:** #12613

## Summary

Unpins the `lit` dependency, which will allow more flexibility with downstream packages that are consuming both calcite and lumina