### PR TITLE
feat(list, block-group, sort-handle): add sortDisabled property to prevent reordering

### DIFF
--- a/packages/calcite-components/src/components/block-group/block-group.e2e.ts
+++ b/packages/calcite-components/src/components/block-group/block-group.e2e.ts
@@ -44,6 +44,10 @@ describe("calcite-block-group", () => {
         propertyName: "loading",
         defaultValue: false,
       },
+      {
+        propertyName: "sortDisabled",
+        defaultValue: false,
+      },
     ]);
   });
 
@@ -63,6 +67,10 @@ describe("calcite-block-group", () => {
       },
       {
         propertyName: "loading",
+        value: true,
+      },
+      {
+        propertyName: "sortDisabled",
         value: true,
       },
     ]);
@@ -117,6 +125,36 @@ describe("calcite-block-group", () => {
 
     for (let i = 0; i < items.length; i++) {
       expect(await items[i].getProperty("dragHandle")).toBe(false);
+    }
+  });
+
+  it("should set the sortDisabled property on items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-block-group id="root" drag-enabled sort-disabled group="my-block-group">
+        <calcite-block id="one" heading="one" label="One"></calcite-block>
+        <calcite-block id="two" heading="two" label="Two"></calcite-block>
+        <calcite-block id="three" heading="three" label="Three"></calcite-block>
+      </calcite-block-group>`,
+    );
+
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.nextTick);
+
+    const items = await findAll(page, "calcite-block");
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("sortDisabled")).toBe(true);
+    }
+
+    const root = await page.find("#root");
+
+    root.setProperty("sortDisabled", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.nextTick);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("sortDisabled")).toBe(false);
     }
   });
 

--- a/packages/calcite-components/src/components/block-group/block-group.e2e.ts
+++ b/packages/calcite-components/src/components/block-group/block-group.e2e.ts
@@ -117,9 +117,9 @@ describe("calcite-block-group", () => {
       expect(await items[i].getProperty("dragHandle")).toBe(true);
     }
 
-    const root = await page.find("#root");
+    const blockGroup = await page.find("#root");
 
-    root.setProperty("dragEnabled", false);
+    blockGroup.setProperty("dragEnabled", false);
     await page.waitForChanges();
     await page.waitForTimeout(DEBOUNCE.nextTick);
 
@@ -147,9 +147,9 @@ describe("calcite-block-group", () => {
       expect(await items[i].getProperty("sortDisabled")).toBe(true);
     }
 
-    const root = await page.find("#root");
+    const blockGroup = await page.find("#root");
 
-    root.setProperty("sortDisabled", false);
+    blockGroup.setProperty("sortDisabled", false);
     await page.waitForChanges();
     await page.waitForTimeout(DEBOUNCE.nextTick);
 

--- a/packages/calcite-components/src/components/block-group/block-group.tsx
+++ b/packages/calcite-components/src/components/block-group/block-group.tsx
@@ -87,6 +87,9 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
   /** When `true`, `calcite-block`s are sortable via a draggable button. */
   @property({ reflect: true }) dragEnabled = false;
 
+  /** When `true`, and a `group` is defined, `calcite-block`s are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
+
   /**
    * The block-group's group identifier.
    *
@@ -172,7 +175,8 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
   override willUpdate(changes: PropertyValues<this>): void {
     if (
       changes.has("group") ||
-      (changes.has("dragEnabled") && (this.hasUpdated || this.dragEnabled !== false))
+      (changes.has("dragEnabled") && (this.hasUpdated || this.dragEnabled !== false)) ||
+      (changes.has("sortDisabled") && (this.hasUpdated || this.sortDisabled !== false))
     ) {
       this.updateBlockItemsDebounced();
     }
@@ -193,7 +197,7 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
 
   private updateBlockItems(): void {
     this.updateGroupItems();
-    const { dragEnabled, el, moveToItems } = this;
+    const { dragEnabled, el, moveToItems, sortDisabled } = this;
 
     const items = Array.from(this.el.querySelectorAll(blockSelector));
 
@@ -203,6 +207,7 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
           (moveToItem) => moveToItem.element !== el && !item.contains(moveToItem.element),
         );
         item.dragHandle = dragEnabled;
+        item.sortDisabled = sortDisabled;
       }
     });
 

--- a/packages/calcite-components/src/components/block-group/block-group.tsx
+++ b/packages/calcite-components/src/components/block-group/block-group.tsx
@@ -87,9 +87,6 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
   /** When `true`, `calcite-block`s are sortable via a draggable button. */
   @property({ reflect: true }) dragEnabled = false;
 
-  /** When `true`, and a `group` is defined, `calcite-block`s are no longer sortable. */
-  @property({ reflect: true }) sortDisabled = false;
-
   /**
    * The block-group's group identifier.
    *
@@ -108,6 +105,9 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
 
   /** When `true`, a busy indicator is displayed. */
   @property({ reflect: true }) loading = false;
+
+  /** When `true`, and a `group` is defined, `calcite-block`s are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
 
   // #endregion
 

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -71,6 +71,10 @@ describe("calcite-block", () => {
         propertyName: "sortHandleOpen",
         defaultValue: false,
       },
+      {
+        propertyName: "sortDisabled",
+        defaultValue: false,
+      },
     ]);
   });
 
@@ -106,6 +110,10 @@ describe("calcite-block", () => {
       },
       {
         propertyName: "sortHandleOpen",
+        value: true,
+      },
+      {
+        propertyName: "sortDisabled",
         value: true,
       },
     ]);

--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -112,10 +112,6 @@ describe("calcite-block", () => {
         propertyName: "sortHandleOpen",
         value: true,
       },
-      {
-        propertyName: "sortDisabled",
-        value: true,
-      },
     ]);
   });
 

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -148,6 +148,13 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
   @property() moveToItems: MoveTo[] = [];
 
   /**
+   * Prevents reordering the component.
+   *
+   * @private
+   */
+  @property() sortDisabled = false;
+
+  /**
    * When `true`, expands the component and its contents.
    *
    * @deprecated Use `expanded` prop instead.
@@ -480,6 +487,7 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
       setPosition,
       setSize,
       dragDisabled,
+      sortDisabled,
     } = this;
 
     const toggleLabel = expanded ? messages.collapse : messages.expand;
@@ -513,6 +521,7 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
             ref={this.setSortHandleEl}
             setPosition={setPosition}
             setSize={setSize}
+            sortDisabled={sortDisabled}
           />
         ) : null}
         {collapsible ? (

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -122,10 +122,6 @@ describe("calcite-list-item", () => {
         propertyName: "closable",
         value: true,
       },
-      {
-        propertyName: "sortDisabled",
-        value: true,
-      },
     ]);
   });
 

--- a/packages/calcite-components/src/components/list-item/list-item.e2e.ts
+++ b/packages/calcite-components/src/components/list-item/list-item.e2e.ts
@@ -89,6 +89,10 @@ describe("calcite-list-item", () => {
         propertyName: "sortHandleOpen",
         defaultValue: false,
       },
+      {
+        propertyName: "sortDisabled",
+        defaultValue: false,
+      },
     ]);
   });
 
@@ -116,6 +120,10 @@ describe("calcite-list-item", () => {
       },
       {
         propertyName: "closable",
+        value: true,
+      },
+      {
+        propertyName: "sortDisabled",
         value: true,
       },
     ]);

--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -114,6 +114,13 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
    */
   @property() bordered = false;
 
+  /**
+   * Prevents reordering the component.
+   *
+   * @private
+   */
+  @property() sortDisabled = false;
+
   /** When `true`, a close button is added to the component. */
   @property({ reflect: true }) closable = false;
 
@@ -753,7 +760,8 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
   }
 
   private renderDragHandle(): JsxNode {
-    const { label, dragHandle, dragDisabled, setPosition, setSize, moveToItems } = this;
+    const { label, dragHandle, dragDisabled, setPosition, setSize, moveToItems, sortDisabled } =
+      this;
 
     return dragHandle ? (
       <div
@@ -776,6 +784,7 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
           scale={this.scale}
           setPosition={setPosition}
           setSize={setSize}
+          sortDisabled={sortDisabled}
         />
       </div>
     ) : null;

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -347,9 +347,9 @@ describe("calcite-list", () => {
       expect(await items[i].getProperty("sortDisabled")).toBe(true);
     }
 
-    const root = await page.find("#root");
+    const list = await page.find("#root");
 
-    root.setProperty("sortDisabled", false);
+    list.setProperty("sortDisabled", false);
     await page.waitForChanges();
     await page.waitForTimeout(DEBOUNCE.nextTick);
 

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -104,6 +104,10 @@ describe("calcite-list", () => {
         propertyName: "displayMode",
         defaultValue: "flat",
       },
+      {
+        propertyName: "sortDisabled",
+        defaultValue: false,
+      },
     ]);
   });
 
@@ -112,6 +116,10 @@ describe("calcite-list", () => {
       {
         propertyName: "displayMode",
         value: "nested",
+      },
+      {
+        propertyName: "sortDisabled",
+        value: true,
       },
     ]);
   });
@@ -317,6 +325,36 @@ describe("calcite-list", () => {
 
     for (let i = 0; i < items.length; i++) {
       expect(await items[i].getProperty("dragHandle")).toBe(dragHandleValues[i]);
+    }
+  });
+
+  it("should set the sortDisabled property on items", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-list id="root" drag-enabled sort-disabled group="my-block-group">
+        <calcite-list-item id="one" heading="one" label="One"></calcite-list-item>
+        <calcite-list-item id="two" heading="two" label="Two"></calcite-list-item>
+        <calcite-list-item id="three" heading="three" label="Three"></calcite-list-item>
+      </calcite-list>`,
+    );
+
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.nextTick);
+
+    const items = await findAll(page, "calcite-list-item");
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("sortDisabled")).toBe(true);
+    }
+
+    const root = await page.find("#root");
+
+    root.setProperty("sortDisabled", false);
+    await page.waitForChanges();
+    await page.waitForTimeout(DEBOUNCE.nextTick);
+
+    for (let i = 0; i < items.length; i++) {
+      expect(await items[i].getProperty("sortDisabled")).toBe(false);
     }
   });
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -162,9 +162,6 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   /** When `true`, `calcite-list-item`s are sortable via a draggable button. */
   @property({ reflect: true }) dragEnabled = false;
 
-  /** When `true`, and a `group` is defined, `calcite-list-item`s are no longer sortable. */
-  @property({ reflect: true }) sortDisabled = false;
-
   /** When `true`, an input appears at the top of the component that can be used by end users to filter `calcite-list-item`s. */
   @property({ reflect: true }) filterEnabled = false;
 
@@ -281,6 +278,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     "none" | "multiple" | "single" | "single-persist",
     SelectionMode
   > = "none";
+
+  /** When `true`, and a `group` is defined, `calcite-list-item`s are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
 
   //#endregion
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -162,6 +162,9 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   /** When `true`, `calcite-list-item`s are sortable via a draggable button. */
   @property({ reflect: true }) dragEnabled = false;
 
+  /** When `true`, and a `group` is defined, `calcite-list-item`s are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
+
   /** When `true`, an input appears at the top of the component that can be used by end users to filter `calcite-list-item`s. */
   @property({ reflect: true }) filterEnabled = false;
 
@@ -393,6 +396,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     if (
       (changes.has("filterEnabled") && (this.hasUpdated || this.filterEnabled !== false)) ||
       changes.has("group") ||
+      (changes.has("sortDisabled") && (this.hasUpdated || this.sortDisabled !== false)) ||
       (changes.has("dragEnabled") && (this.hasUpdated || this.dragEnabled !== false)) ||
       (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) ||
       (changes.has("selectionAppearance") &&
@@ -431,6 +435,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
       moveToItems,
       displayMode,
       scale,
+      sortDisabled,
     } = this;
 
     const items = Array.from(this.el.querySelectorAll(listItemSelector));
@@ -447,6 +452,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
 
         item.dragHandle = dragEnabled;
         item.displayMode = displayMode;
+        item.sortDisabled = sortDisabled;
       }
     });
 

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.e2e.ts
@@ -152,7 +152,7 @@ describe("calcite-sort-handle", () => {
     await skipAnimations(page);
 
     const dropdown = await page.find("calcite-sort-handle >>> calcite-dropdown");
-    expect(await dropdown.getProperty("disabled")).toBe(true);
+    expect(await dropdown.getProperty("disabled")).toBe(false);
 
     const sortHandle = await page.find("calcite-sort-handle");
 
@@ -168,6 +168,7 @@ describe("calcite-sort-handle", () => {
 
     expect(await dropdown.getProperty("disabled")).toBe(false);
 
+    sortHandle.setProperty("moveToItems", []);
     sortHandle.setProperty("setPosition", 0);
     await page.waitForChanges();
 

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -45,18 +45,15 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   // #region State Properties
 
   @state() get hasSetInfo(): boolean {
-    const { setPosition, setSize } = this;
+    return typeof this.setPosition === "number" && typeof this.setSize === "number";
+  }
 
-    return (
-      typeof setPosition === "number" &&
-      typeof setSize === "number" &&
-      setPosition > 0 &&
-      setSize > 0
-    );
+  @state() get hasValidSetInfo(): boolean {
+    return this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 : true;
   }
 
   @state() get hasReorderItems(): boolean {
-    return !this.sortDisabled && this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 : true;
+    return !this.sortDisabled && this.hasValidSetInfo;
   }
 
   @state() get hasNoItems(): boolean {

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -56,7 +56,7 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   }
 
   @state() get hasReorderItems(): boolean {
-    return this.hasSetInfo && this.setPosition > 0 && this.setSize > 1 && !this.sortDisabled;
+    return !this.sortDisabled && this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 : true;
   }
 
   @state() get hasNoItems(): boolean {

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -85,6 +85,9 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   /** When `true`, displays and positions the component. */
   @property({ reflect: true }) open = false;
 
+  /** When `true`, items are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
+
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
@@ -287,7 +290,7 @@ export class SortHandle extends LitElement implements InteractiveComponent {
             text={text}
             title={text}
           />
-          {this.renderGroup()}
+          {this.renderReorderGroup()}
           {this.renderMoveToGroup()}
         </calcite-dropdown>
       </InteractiveContainer>
@@ -307,8 +310,8 @@ export class SortHandle extends LitElement implements InteractiveComponent {
     );
   }
 
-  private renderGroup(): JsxNode {
-    return this.hasSetInfo ? (
+  private renderReorderGroup(): JsxNode {
+    return this.hasSetInfo && !this.sortDisabled ? (
       <calcite-dropdown-group
         groupTitle={this.messages.reorder}
         id={IDS.reorder}

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -271,12 +271,11 @@ export class SortHandle extends LitElement implements InteractiveComponent {
       placement,
       scale,
       widthScale,
-      hasSetInfo,
       hasNoItems,
     } = this;
 
     const text = this.getLabel();
-    const isDisabled = disabled || !hasSetInfo || hasNoItems;
+    const isDisabled = disabled || hasNoItems;
 
     return (
       <InteractiveContainer disabled={disabled}>

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -45,15 +45,22 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   // #region State Properties
 
   @state() get hasSetInfo(): boolean {
-    return typeof this.setPosition === "number" && typeof this.setSize === "number";
+    const { setPosition, setSize } = this;
+
+    return (
+      typeof setPosition === "number" &&
+      typeof setSize === "number" &&
+      setPosition > 0 &&
+      setSize > 0
+    );
   }
 
-  @state() get isSetDisabled(): boolean {
-    const { setPosition, setSize, moveToItems } = this;
+  @state() get hasReorderItems(): boolean {
+    return this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 && !this.sortDisabled : false;
+  }
 
-    return this.hasSetInfo
-      ? setPosition < 1 || setSize < 1 || (setSize < 2 && moveToItems.length < 1)
-      : false;
+  @state() get hasNoItems(): boolean {
+    return !this.hasReorderItems && this.moveToItems.length < 1;
   }
 
   // #endregion
@@ -199,9 +206,9 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   }
 
   private getLabel(): string {
-    const { label, messages, setPosition, setSize } = this;
+    const { label, messages, setPosition, setSize, hasSetInfo } = this;
 
-    if (!this.hasSetInfo) {
+    if (!hasSetInfo) {
       return label ?? "";
     }
 
@@ -256,11 +263,20 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   // #region Rendering
 
   override render(): JsxNode {
-    const { disabled, flipPlacements, open, overlayPositioning, placement, scale, widthScale } =
-      this;
+    const {
+      disabled,
+      flipPlacements,
+      open,
+      overlayPositioning,
+      placement,
+      scale,
+      widthScale,
+      hasSetInfo,
+      hasNoItems,
+    } = this;
 
     const text = this.getLabel();
-    const isDisabled = disabled || this.isSetDisabled;
+    const isDisabled = disabled || !hasSetInfo || hasNoItems;
 
     return (
       <InteractiveContainer disabled={disabled}>
@@ -311,7 +327,7 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   }
 
   private renderReorderGroup(): JsxNode {
-    return this.hasSetInfo && !this.sortDisabled ? (
+    return this.hasReorderItems ? (
       <calcite-dropdown-group
         groupTitle={this.messages.reorder}
         id={IDS.reorder}

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -56,7 +56,7 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   }
 
   @state() get hasReorderItems(): boolean {
-    return this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 && !this.sortDisabled : false;
+    return this.hasSetInfo && this.setPosition > 0 && this.setSize > 1 && !this.sortDisabled;
   }
 
   @state() get hasNoItems(): boolean {
@@ -92,9 +92,6 @@ export class SortHandle extends LitElement implements InteractiveComponent {
   /** When `true`, displays and positions the component. */
   @property({ reflect: true }) open = false;
 
-  /** When `true`, items are no longer sortable. */
-  @property({ reflect: true }) sortDisabled = false;
-
   /**
    * Determines the type of positioning to use for the overlaid content.
    *
@@ -119,6 +116,9 @@ export class SortHandle extends LitElement implements InteractiveComponent {
 
   /** The total number of sortable items. */
   @property() setSize: number;
+
+  /** When `true`, items are no longer sortable. */
+  @property({ reflect: true }) sortDisabled = false;
 
   /** Specifies the width of the component. */
   @property({ reflect: true }) widthScale: Scale;

--- a/packages/calcite-components/src/components/tree/tree.e2e.ts
+++ b/packages/calcite-components/src/components/tree/tree.e2e.ts
@@ -635,11 +635,11 @@ describe("calcite-tree", () => {
         </calcite-tree>`,
       );
 
-      const root = await page.find("#root");
+      const list = await page.find("#root");
       const parent = await page.find("#parent");
       const child2 = await page.find("#child2");
 
-      await root.focus();
+      await list.focus();
       await page.waitForChanges();
 
       expect(await getFocusedElementProp(page, "id")).toEqual("root-item-1");

--- a/packages/calcite-components/src/demos/sortable-list.html
+++ b/packages/calcite-components/src/demos/sortable-list.html
@@ -73,7 +73,7 @@
         <div class="child">calcite-sortable-list of calcite-block elements</div>
 
         <div class="child">
-          <calcite-sortable-list>
+          <calcite-sortable-list handle-selector="calcite-sort-handle">
             <calcite-block heading="First Block" summary="animals and nature" collapsible drag-handle>
               <calcite-block-section text="Animals" open>
                 <img alt="demo" width="640" height="480" src="./_assets/images/placeholder.svg" />
@@ -101,7 +101,7 @@
         <div class="child">vertical</div>
 
         <div class="child">
-          <calcite-sortable-list style="flex-direction: column">
+          <calcite-sortable-list handle-selector="calcite-sort-handle" style="flex-direction: column">
             <calcite-block heading="First Block" summary="animals and nature" collapsible drag-handle>
               <calcite-block-section text="Animals" open>
                 <img alt="demo" width="640" height="480" src="./_assets/images/placeholder.svg" />
@@ -148,7 +148,7 @@
         <div class="child">Nested Example</div>
 
         <div class="child">
-          <calcite-sortable-list>
+          <calcite-sortable-list handle-selector="calcite-sort-handle">
             <calcite-block drag-handle="true" heading="Block A" collapsible="" calcite-hydrated="" open>
               <calcite-label alignment="start" scale="m" layout="default" calcite-hydrated="">content A </calcite-label>
             </calcite-block>

--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -33,6 +33,9 @@ export interface SortableComponent {
   /** When `true`, dragging is enabled. */
   dragEnabled: boolean;
 
+  /** When `true`, sorting is disabled. */
+  sortDisabled?: boolean;
+
   /** Specifies which items inside the element should be draggable. */
   dragSelector?: string;
 
@@ -97,13 +100,14 @@ export function connectSortableComponent(component: SortableComponent): void {
   sortableComponentSet.add(component);
 
   const dataIdAttr = "id";
-  const { group, handleSelector: handle, dragSelector: draggable } = component;
+  const { group, handleSelector: handle, dragSelector: draggable, sortDisabled } = component;
 
   component.sortable = Sortable.create(component.el, {
     dataIdAttr,
     ...CSS,
     ...(!!draggable && { draggable }),
     ...(!!group && {
+      sort: !sortDisabled,
       group: {
         name: group,
         ...(!!component.canPull && {


### PR DESCRIPTION
**Related Issue:** #11953

## Summary

- add `sortDisabled` property to `list`, `block-group` and `sort-handle` components
- It is now possible to disable internal sorting in the above components
- When internal sorting is disabled, list items can still be dragged to other lists via menu or pointer device
- When internal sorting is disabled, the drag-handle-menu "Reorder" section is hidden
- If no reordering items or move to items are available the action/dropdown menu is disabled
- add tests