### PR TITLE
docs(flow-item): `beforeBack` property should be optional

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -69,7 +69,7 @@ export class FlowItem extends LitElement implements InteractiveComponent {
   //#region Public Properties
 
   /** When provided, the method will be called before it is removed from its parent `calcite-flow`. */
-  @property() beforeBack: () => Promise<void>;
+  @property() beforeBack?: () => Promise<void>;
 
   /** Passes a function to run before the component closes. */
   @property() beforeClose: () => Promise<void>;


### PR DESCRIPTION
**Related Issue:** [#12551](https://github.com/Esri/calcite-design-system/issues/12551) 

## Summary
Updated beforeBack() to be optional as per the description.