### PR TITLE
fix(list): prevent drag flickering while sorting

### DIFF
--- a/packages/calcite-components/src/utils/sortableComponent.ts
+++ b/packages/calcite-components/src/utils/sortableComponent.ts
@@ -101,6 +101,7 @@ export function connectSortableComponent(component: SortableComponent): void {
 
   component.sortable = Sortable.create(component.el, {
     dataIdAttr,
+    swapThreshold: 0.5,
     ...CSS,
     ...(!!draggable && { draggable }),
     ...(!!group && {


### PR DESCRIPTION
**Related Issue:** #12583

## Summary

prevent drag flickering while sorting