### PR TITLE
chore: restore sass deprecation warning silencing

### DIFF
--- a/packages/calcite-components/src/components/popover/popover.scss
+++ b/packages/calcite-components/src/components/popover/popover.scss
@@ -18,7 +18,10 @@
 
 .position-container {
   @include floating-ui-container();
-  max-inline-size: var(--calcite-popover-max-size-x, 100vw);
+
+  & {
+    max-inline-size: var(--calcite-popover-max-size-x, 100vw);
+  }
 }
 
 @include floating-ui-elem-anim(".position-container");

--- a/packages/calcite-components/vite.config.ts
+++ b/packages/calcite-components/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           }
           return `@import "${globalCss}";\n${code}`;
         },
+        silenceDeprecations: ["import", "global-builtin"],
       },
     },
     postcss: {


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restores deprecated warnings prematurely removed in https://github.com/Esri/calcite-design-system/pull/12465/files#diff-50e581eb0e72b23e2222ae7118aad3c0a006d398318cb468fef90c04be473012L77-L82. 

Also addresses a new `mixed-decls` warning introduced in https://github.com/Esri/calcite-design-system/pull/12516:

> @esri/calcite-components:build: Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
@esri/calcite-components:build: rules will be changing to match the behavior specified by CSS in an upcoming
@esri/calcite-components:build: version. To keep the existing behavior, move the declaration above the nested
@esri/calcite-components:build: rule. To opt into the new behavior, wrap the declaration in `& {}`.
@esri/calcite-components:build:
@esri/calcite-components:build: More info: https://sass-lang.com/d/mixed-decls
@esri/calcite-components:build:
@esri/calcite-components:build:    ┌──> ../../../../packages/calcite-components/src/components/popover/popover.scss
@esri/calcite-components:build: 22 │     max-inline-size: var(--calcite-popover-max-size-x, 100vw);
@esri/calcite-components:build:    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
@esri/calcite-components:build:    ╵
@esri/calcite-components:build:    ┌──> ../../../../packages/calcite-components/src/assets/styles/_floating-ui.scss
@esri/calcite-components:build: 94 │ ┌   @starting-style {
@esri/calcite-components:build: 95 │ │     opacity: 0;
@esri/calcite-components:build: 96 │ │     inset-block-start: 0;
@esri/calcite-components:build: 97 │ │     /* stylelint-disable-next-line liberty/use-logical-spec -- explicit position */
@esri/calcite-components:build: 98 │ │     left: 0;
@esri/calcite-components:build: 99 │ │   }
@esri/calcite-components:build:    │ └─── nested rule
@esri/calcite-components:build:    ╵
@esri/calcite-components:build:     ../../../../packages/calcite-components/src/components/popover/popover.scss 22:3  root stylesheet

**Note**: deprecation silencing will be removed in https://github.com/Esri/calcite-design-system/pull/12216/files#diff-50e581eb0e72b23e2222ae7118aad3c0a006d398318cb468fef90c04be473012.
