### PR TITLE
test(custom-theme): fix non-existent icon names

### DIFF
--- a/packages/calcite-components/src/custom-theme/panel.ts
+++ b/packages/calcite-components/src/custom-theme/panel.ts
@@ -21,9 +21,9 @@ export const panelTokens = {
 
 export const panel = html`
   <calcite-panel heading="Panel Heading" description="Panel description" closable collapsible>
-    <calcite-action text="Action 1" text-enabled icon="icon1" slot="header-menu-actions"></calcite-action>
-    <calcite-action text="Action 2" text-enabled icon="icon2" slot="header-menu-actions"></calcite-action>
-    <calcite-action text="Action 3" icon="icon3" slot="header-actions-end"></calcite-action>
+    <calcite-action text="Action 1" text-enabled icon="number-circle-1" slot="header-menu-actions"></calcite-action>
+    <calcite-action text="Action 2" text-enabled icon="number-circle-2" slot="header-menu-actions"></calcite-action>
+    <calcite-action text="Action 3" icon="number-circle-3" slot="header-actions-end"></calcite-action>
     <div slot="content-top">Content at the top</div>
     <calcite-label slot="content-bottom" layout="inline-space-between" style="--calcite-label-margin-bottom: 0">
       <calcite-checkbox></calcite-checkbox>Agree to terms

--- a/packages/calcite-components/src/custom-theme/shell-panel.ts
+++ b/packages/calcite-components/src/custom-theme/shell-panel.ts
@@ -20,9 +20,9 @@ export const shellPanelTokens = {
 
 export const shellPanel = html`<calcite-shell-panel
   ><calcite-panel heading="Panel Heading" description="Panel description" closable collapsible>
-    <calcite-action text="Action 1" text-enabled icon="icon1" slot="header-menu-actions"></calcite-action>
-    <calcite-action text="Action 2" text-enabled icon="icon2" slot="header-menu-actions"></calcite-action>
-    <calcite-action text="Action 3" icon="icon3" slot="header-actions-end"></calcite-action>
+    <calcite-action text="Action 1" text-enabled icon="number-circle-1" slot="header-menu-actions"></calcite-action>
+    <calcite-action text="Action 2" text-enabled icon="number-circle-2" slot="header-menu-actions"></calcite-action>
+    <calcite-action text="Action 3" icon="number-circle-3" slot="header-actions-end"></calcite-action>
     <div slot="content-top">Content at the top</div>
     <calcite-label slot="content-bottom" layout="inline-space-between" style="--calcite-label-margin-bottom: 0">
       <calcite-checkbox></calcite-checkbox>Agree to terms


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Some custom theme components were referencing a `icon{1,3}` icon, which does not exist.
