### PR TITLE
fix(panel): fix missing `iconFlipRtl` property on calcite-icon

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -787,6 +787,19 @@ describe("calcite-panel", () => {
     expect(collapseSpy).toHaveReceivedEventTimes(1);
   });
 
+  it.only("sets iconFlipRtl for calcite-icon", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html` <calcite-panel heading="Map Options" icon="arrow-bold-left" icon-flip-rtl> </calcite-panel>`,
+    );
+    await page.waitForChanges();
+
+    const icon = await page.find(`calcite-panel >>> calcite-icon`);
+
+    expect(await icon.getProperty("icon")).toBe("arrow-bold-left");
+    expect(await icon.getProperty("flipRtl")).toBe(true);
+  });
+
   describe("theme", () => {
     themed(
       html`<calcite-panel

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -420,7 +420,12 @@ export class Panel extends LitElement implements InteractiveComponent {
     const { heading, headingLevel, description, hasHeaderContent, icon, scale } = this;
 
     const iconNode = icon ? (
-      <calcite-icon class={CSS.icon} icon={icon} scale={getIconScale(scale)} />
+      <calcite-icon
+        class={CSS.icon}
+        flipRtl={this.iconFlipRtl}
+        icon={icon}
+        scale={getIconScale(scale)}
+      />
     ) : null;
 
     const headingNode = heading ? (


### PR DESCRIPTION
**Related Issue:** [#12635](https://github.com/Esri/calcite-design-system/issues/12635) 

## Summary
Applied `iconFlipRtl` property to calcite-icon inside calcite-panel