### PR TITLE
chore(icons): update missed es-toolkit import

### DIFF
--- a/packages/calcite-ui-icons/bin/server.js
+++ b/packages/calcite-ui-icons/bin/server.js
@@ -2,7 +2,7 @@
 import build from "./build.js";
 import pathData from "./path-data.js";
 import optimize from "./optimize.js";
-import debounce from "lodash-es/debounce.js";
+import { debounce } from "es-toolkit";
 import { execSync } from "node:child_process";
 import { create } from "browser-sync";
 const bs = { create }.create();


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Fixes missed import from https://github.com/Esri/calcite-design-system/pull/12639.