### PR TITLE
fix(input-date-picker): update start & end date correctly when `proximity-selection-disabled` is true

### DIFF
--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -454,12 +454,12 @@ export class DatePicker extends LitElement {
     return (Array.isArray(this.valueAsDate) && this.valueAsDate[1]) || undefined;
   }
 
-  private setEndDate(date: Date): void {
+  private setEndDate(date: Date, emitChangeEvent = true): void {
     const startDate = this.getStartDate();
     this.rangeValueChangedByUser = true;
     this.value = [dateToISO(startDate), dateToISO(date)];
     this.valueAsDate = [startDate, date];
-    if (date) {
+    if (emitChangeEvent) {
       this.calciteDatePickerRangeChange.emit();
     }
   }
@@ -468,12 +468,14 @@ export class DatePicker extends LitElement {
     return Array.isArray(this.valueAsDate) && this.valueAsDate[0];
   }
 
-  private setStartDate(date: Date): void {
+  private setStartDate(date: Date, emitChangeEvent = true): void {
     const endDate = this.getEndDate();
     this.rangeValueChangedByUser = true;
     this.value = [dateToISO(date), dateToISO(endDate)];
     this.valueAsDate = [date, endDate];
-    this.calciteDatePickerRangeChange.emit();
+    if (emitChangeEvent) {
+      this.calciteDatePickerRangeChange.emit();
+    }
   }
 
   /**
@@ -513,8 +515,9 @@ export class DatePicker extends LitElement {
       this.setEndDate(date);
     } else {
       if (this.proximitySelectionDisabled) {
-        this.setStartDate(date);
-        this.setEndDate(null);
+        this.setStartDate(date, false);
+        this.setEndDate(null, false);
+        this.calciteDatePickerRangeChange.emit();
       } else {
         if (this.activeRange) {
           if (this.activeRange == "end") {

--- a/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/calcite-components/src/components/input-date-picker/input-date-picker.tsx
@@ -914,6 +914,11 @@ export class InputDatePicker
     if (this.shouldFocusRangeStart() || this.rangeStartValueChangedByUser) {
       return;
     }
+
+    if (this.proximitySelectionDisabled && this.valueAsDate[1] === null) {
+      return;
+    }
+
     this.open = false;
     this.focusInput();
   }


### PR DESCRIPTION


**Related Issue:** #12301 

## Summary
