### PR TITLE
chore: ensure auto-generated internal custom CSS prop doc is committed by precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -92,6 +92,7 @@ update_internal_custom_prop_doc() {
 
   if [ -n "$staged_scss_files" ]; then
     npx tsx packages/calcite-components/support/addInternalCustomPropDoc.ts $staged_scss_files
+    git add $staged_scss_files
   fi
 
   unset staged_scss_files


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Improves DX by auto-committing auto-generated internal custom CSS prop doc updates.