### PR TITLE
feat(input-number, input-text): add center alignment

### DIFF
--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -300,19 +300,19 @@ input:focus {
 
 // alignment type
 :host([alignment="start"]) {
-  & input {
+  input {
     text-align: start;
   }
 }
 
 :host([alignment="center"]) {
-  & input {
+  input {
     text-align: center;
   }
 }
 
 :host([alignment="end"]) {
-  & input {
+  input {
     text-align: end;
   }
 }

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -105,6 +105,7 @@ input {
   background-color: var(--calcite-input-number-background-color, var(--calcite-color-foreground-1));
   color: var(--calcite-input-number-text-color, var(--calcite-color-text-1));
   border-radius: var(--calcite-input-number-corner-radius, var(--calcite-corner-radius-sharp));
+  text-align: var(--calcite-internal-input-number-alignment);
   &:placeholder-shown {
     @apply text-ellipsis;
   }
@@ -300,21 +301,15 @@ input:focus {
 
 // alignment type
 :host([alignment="start"]) {
-  input {
-    text-align: start;
-  }
+  --calcite-internal-input-number-alignment: start;
 }
 
 :host([alignment="center"]) {
-  input {
-    text-align: center;
-  }
+  --calcite-internal-input-number-alignment: center;
 }
 
 :host([alignment="end"]) {
-  input {
-    text-align: end;
-  }
+  --calcite-internal-input-number-alignment: end;
 }
 
 .number-button-wrapper {

--- a/packages/calcite-components/src/components/input-number/input-number.scss
+++ b/packages/calcite-components/src/components/input-number/input-number.scss
@@ -305,6 +305,12 @@ input:focus {
   }
 }
 
+:host([alignment="center"]) {
+  & input {
+    text-align: center;
+  }
+}
+
 :host([alignment="end"]) {
   & input {
     text-align: end;

--- a/packages/calcite-components/src/components/input-number/input-number.stories.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.stories.ts
@@ -56,7 +56,7 @@ export default {
       control: { type: "select" },
     },
     alignment: {
-      options: alignment.values.filter((option) => option !== "center"),
+      options: alignment.values,
       control: { type: "select" },
     },
     numberButtonType: {

--- a/packages/calcite-components/src/components/input-number/input-number.stories.ts
+++ b/packages/calcite-components/src/components/input-number/input-number.stories.ts
@@ -227,3 +227,13 @@ export const fontSizeSetAtRoot = (): string =>
     <calcite-input-number placeholder="Placeholder" prefix-text="Prefix" suffix-text="Suffix" icon="search">
       <calcite-button slot="action"> Search </calcite-button>
     </calcite-input-number>`;
+
+export const alignmentAllOptions = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-input-number alignment="start" placeholder="Placeholder text"></calcite-input-number>
+    <br />
+    <calcite-input-number alignment="center" placeholder="Placeholder text"></calcite-input-number>
+    <br />
+    <calcite-input-number alignment="end" placeholder="Placeholder text"></calcite-input-number>
+  </div>
+`;

--- a/packages/calcite-components/src/components/input-number/input-number.tsx
+++ b/packages/calcite-components/src/components/input-number/input-number.tsx
@@ -153,7 +153,7 @@ export class InputNumber
   //#region Public Properties
 
   /** Specifies the text alignment of the component's value. */
-  @property({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
+  @property({ reflect: true }) alignment: Alignment = "start";
 
   /**
    * Specifies the type of content to autocomplete, for use in forms.

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -358,19 +358,19 @@ input[type="text"]::-ms-reveal {
 
 // alignment type
 :host([alignment="start"]) {
-  & input {
+  input {
     text-align: start;
   }
 }
 
 :host([alignment="center"]) {
-  & input {
+  input {
     text-align: center;
   }
 }
 
 :host([alignment="end"]) {
-  & input {
+  input {
     text-align: end;
   }
 }

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -363,6 +363,12 @@ input[type="text"]::-ms-reveal {
   }
 }
 
+:host([alignment="center"]) {
+  & input {
+    text-align: center;
+  }
+}
+
 :host([alignment="end"]) {
   & input {
     text-align: end;

--- a/packages/calcite-components/src/components/input-text/input-text.scss
+++ b/packages/calcite-components/src/components/input-text/input-text.scss
@@ -137,6 +137,7 @@ input {
   color: var(--calcite-input-text-text-color, var(--calcite-color-text-1));
   border-radius: var(--calcite-input-text-corner-radius, var(--calcite-corner-radius-sharp));
   border-color: var(--calcite-input-text-border-color, var(--calcite-color-border-input));
+  text-align: var(--calcite-internal-input-text-alignment);
 
   &:placeholder-shown {
     @apply text-ellipsis;
@@ -358,21 +359,15 @@ input[type="text"]::-ms-reveal {
 
 // alignment type
 :host([alignment="start"]) {
-  input {
-    text-align: start;
-  }
+  --calcite-internal-input-text-alignment: start;
 }
 
 :host([alignment="center"]) {
-  input {
-    text-align: center;
-  }
+  --calcite-internal-input-text-alignment: center;
 }
 
 :host([alignment="end"]) {
-  input {
-    text-align: end;
-  }
+  --calcite-internal-input-text-alignment: end;
 }
 
 .wrapper {

--- a/packages/calcite-components/src/components/input-text/input-text.stories.ts
+++ b/packages/calcite-components/src/components/input-text/input-text.stories.ts
@@ -177,3 +177,13 @@ export const fontSizeSetAtRoot = (): string =>
     <calcite-input-text placeholder="Placeholder" prefix-text="Prefix" suffix-text="Suffix" icon="search">
       <calcite-button slot="action"> Search </calcite-button>
     </calcite-input-text>`;
+
+export const alignmentAllOptions = (): string => html`
+  <div style="width:300px;max-width:100%;text-align:center;">
+    <calcite-input-text alignment="start" placeholder="Placeholder text"></calcite-input-text>
+    <br />
+    <calcite-input-text alignment="center" placeholder="Placeholder text"></calcite-input-text>
+    <br />
+    <calcite-input-text alignment="end" placeholder="Placeholder text"></calcite-input-text>
+  </div>
+`;

--- a/packages/calcite-components/src/components/input-text/input-text.stories.ts
+++ b/packages/calcite-components/src/components/input-text/input-text.stories.ts
@@ -48,7 +48,7 @@ export default {
       control: { type: "select" },
     },
     alignment: {
-      options: alignment.values.filter((option) => option !== "center"),
+      options: alignment.values,
       control: { type: "select" },
     },
     validationIcon: {

--- a/packages/calcite-components/src/components/input-text/input-text.tsx
+++ b/packages/calcite-components/src/components/input-text/input-text.tsx
@@ -127,7 +127,7 @@ export class InputText
   //#region Public Properties
 
   /** Specifies the text alignment of the component's value. */
-  @property({ reflect: true }) alignment: Extract<"start" | "end", Alignment> = "start";
+  @property({ reflect: true }) alignment: Alignment = "start";
 
   /**
    * Specifies the type of content to autocomplete, for use in forms.


### PR DESCRIPTION
**Related Issue:** [#12419](https://github.com/Esri/calcite-design-system/issues/12419)

## Summary
Allow `center` value in the `alignment` prop in `calcite-input-number` and `calcite-input-text`.
