### PR TITLE
docs(action): update unnamed slot description to fit more use cases

### DIFF
--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -25,7 +25,7 @@ declare global {
 }
 
 /**
- * @slot - A slot for adding a `calcite-icon`.
+ * @slot - A slot for adding non-interactive content, such as a `calcite-icon`.
  * @slot tooltip - [Deprecated] Use the `calcite-tooltip` component instead.
  */
 export class Action extends LitElement implements InteractiveComponent {


### PR DESCRIPTION
**Related Issue:** #12599

## Summary
Updates `action`'s default slot description to fit more use cases for non-interactive content.