### PR TITLE
fix(date-picker): honor `minAsDate` & `maxAsDate` when set

### DIFF
--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -284,10 +284,13 @@ describe("calcite-date-picker", () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-date-picker></calcite-date-picker>`);
 
-      const beforeMinDayIso = "2025-08-17T07:00:00.000Z";
-      const minDayIso = "2025-08-18T07:00:00.000Z";
-      const maxDayIso = "2025-08-20T07:00:00.000Z";
-      const afterMaxDayIso = "2025-08-23T07:00:00.000Z";
+      const beforeMinDateOnlyIso = "2025-08-17";
+      const minDateOnlyIso = "2025-08-18";
+      const maxDateOnlyIso = "2025-08-20";
+      const afterMaxDateOnlyIso = "2025-08-21";
+      const offsetIso = "T07:00:00.000Z";
+      const minDayIso = `${minDateOnlyIso}${offsetIso}`;
+      const maxDayIso = `${maxDateOnlyIso}${offsetIso}`;
 
       await page.$eval(
         "calcite-date-picker",
@@ -300,16 +303,16 @@ describe("calcite-date-picker", () => {
       );
       await page.waitForChanges();
 
-      const previousDay = await getDayById(page, beforeMinDayIso.split("T")[0].replaceAll("-", ""));
+      const previousDay = await getDayById(page, dateIsoToDayId(beforeMinDateOnlyIso));
       expect(await previousDay.getProperty("disabled")).toBe(true);
 
-      const currentDay = await getDayById(page, minDayIso.split("T")[0].replaceAll("-", ""));
+      const currentDay = await getDayById(page, dateIsoToDayId(minDateOnlyIso));
       expect(await currentDay.getProperty("disabled")).toBe(false);
 
-      const maxDay = await getDayById(page, maxDayIso.split("T")[0].replaceAll("-", ""));
+      const maxDay = await getDayById(page, dateIsoToDayId(maxDateOnlyIso));
       expect(await maxDay.getProperty("disabled")).toBe(false);
 
-      const outOfRangeDay = await getDayById(page, afterMaxDayIso.split("T")[0].replaceAll("-", ""));
+      const outOfRangeDay = await getDayById(page, dateIsoToDayId(afterMaxDateOnlyIso));
       expect(await outOfRangeDay.getProperty("disabled")).toBe(true);
     });
   });
@@ -1283,6 +1286,10 @@ describe("calcite-date-picker", () => {
     );
     await day.click();
     await page.waitForChanges();
+  }
+
+  function dateIsoToDayId(isoDate: string): string {
+    return isoDate.split("T")[0].replaceAll("-", "");
   }
 
   async function getDayById(page: E2EPage, id: string): Promise<E2EElement> {

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -871,7 +871,7 @@ describe("calcite-date-picker", () => {
       const currentDate = new Date();
       currentDate.setMonth(currentDate.getMonth() + 2);
       currentDate.setDate(12);
-      const currentISODate = currentDate.toISOString().split("T")[0];
+      const currentISODate = toDateOnlyIso(currentDate);
 
       await page.evaluate((currentISODate) => {
         const datePicker = document.querySelector("calcite-date-picker");
@@ -900,7 +900,7 @@ describe("calcite-date-picker", () => {
       if (currentDate.getDate() > 2) {
         currentDate.setDate(1);
       }
-      const currentISODate = currentDate.toISOString().split("T")[0];
+      const currentISODate = toDateOnlyIso(currentDate);
 
       await page.$eval(
         "calcite-date-picker",
@@ -921,7 +921,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
 
       const currentDayDate = new Date();
-      const currentDayISODate = currentDayDate.toISOString().split("T")[0];
+      const currentDayISODate = toDateOnlyIso(currentDayDate);
 
       expect(await datePicker.getProperty("value")).toStrictEqual([currentDayISODate, ""]);
     });
@@ -936,7 +936,7 @@ describe("calcite-date-picker", () => {
       if (currentDate.getDate() > 2) {
         currentDate.setDate(1);
       }
-      const currentISODate = currentDate.toISOString().split("T")[0];
+      const currentISODate = toDateOnlyIso(currentDate);
 
       await page.evaluate((currentISODate) => {
         const datePicker = document.querySelector("calcite-date-picker");
@@ -956,7 +956,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
 
       const currentDayDate = new Date();
-      const currentDayISODate = currentDayDate.toISOString().split("T")[0];
+      const currentDayISODate = toDateOnlyIso(currentDayDate);
 
       expect(await datePicker.getProperty("value")).toEqual(currentDayISODate);
     });
@@ -970,7 +970,7 @@ describe("calcite-date-picker", () => {
       const currentDate = new Date();
       currentDate.setMonth(currentDate.getMonth() + 2);
       currentDate.setDate(12);
-      const currentISODate = currentDate.toISOString().split("T")[0];
+      const currentISODate = toDateOnlyIso(currentDate);
 
       await page.evaluate((currentISODate) => {
         const datePicker = document.querySelector("calcite-date-picker");
@@ -1239,61 +1239,71 @@ describe("calcite-date-picker", () => {
       themed(rangeDatePickerHTML, componentTokens);
     });
   });
-});
 
-async function setActiveDate(page: E2EPage, isoDate: string): Promise<void> {
-  await page.$eval("calcite-date-picker", (datePicker, date) => (datePicker.activeDate = new Date(date)), isoDate);
-  await page.waitForChanges();
-}
-
-async function getActiveDate(page: E2EPage): Promise<string> {
-  return getDateIsoStringFromProp(page, "activeDate");
-}
-
-async function getDateIsoStringFromProp(page: E2EPage, prop: keyof ConditionalPick<DatePicker, Date>): Promise<string> {
-  return page.$eval("calcite-date-picker", (datePicker, prop) => datePicker[prop]?.toISOString(), prop);
-}
-
-async function selectDayInMonthById(id: string, page: E2EPage): Promise<void> {
-  const day = await page.find(
-    `calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[current-month][id="${id}"]`,
-  );
-  await day.click();
-  await page.waitForChanges();
-}
-
-async function selectFirstAvailableDay(page: E2EPage): Promise<void> {
-  const day = await page.find(
-    "calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day:not([selected])",
-  );
-  await day.click();
-  await page.waitForChanges();
-}
-
-async function selectSelectedDay(page: E2EPage): Promise<void> {
-  const day = await page.find(
-    "calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[selected]",
-  );
-  await day.click();
-  await page.waitForChanges();
-}
-
-async function getDayById(page: E2EPage, id: string): Promise<E2EElement> {
-  const days = await findAll(
-    page,
-    `calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[id="${id}"]`,
-  );
-  return days.find((d) => !d.classList.contains("noncurrent"));
-}
-
-async function getActiveMonth(page: E2EPage, position: Extract<"start" | "end", Position> = "start"): Promise<string> {
-  const [startMonth, endMonth] = await findAll(
-    page,
-    `calcite-date-picker >>> calcite-date-picker-month-header >>> .${MONTH_HEADER_CSS.header} >>> calcite-select.${MONTH_HEADER_CSS.monthPicker}`,
-  );
-
-  if (position === "start") {
-    return (await startMonth.find("calcite-option[selected]")).textContent;
+  function toDateOnlyIso(date: Date): string {
+    return date.toISOString().split("T")[0];
   }
-  return (await endMonth.find("calcite-option[selected]")).textContent;
-}
+
+  async function setActiveDate(page: E2EPage, isoDate: string): Promise<void> {
+    await page.$eval("calcite-date-picker", (datePicker, date) => (datePicker.activeDate = new Date(date)), isoDate);
+    await page.waitForChanges();
+  }
+
+  async function getActiveDate(page: E2EPage): Promise<string> {
+    return getDateIsoStringFromProp(page, "activeDate");
+  }
+
+  async function getDateIsoStringFromProp(
+    page: E2EPage,
+    prop: keyof ConditionalPick<DatePicker, Date>,
+  ): Promise<string> {
+    return page.$eval("calcite-date-picker", (datePicker, prop) => datePicker[prop]?.toISOString(), prop);
+  }
+
+  async function selectDayInMonthById(id: string, page: E2EPage): Promise<void> {
+    const day = await page.find(
+      `calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[current-month][id="${id}"]`,
+    );
+    await day.click();
+    await page.waitForChanges();
+  }
+
+  async function selectFirstAvailableDay(page: E2EPage): Promise<void> {
+    const day = await page.find(
+      "calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day:not([selected])",
+    );
+    await day.click();
+    await page.waitForChanges();
+  }
+
+  async function selectSelectedDay(page: E2EPage): Promise<void> {
+    const day = await page.find(
+      "calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[selected]",
+    );
+    await day.click();
+    await page.waitForChanges();
+  }
+
+  async function getDayById(page: E2EPage, id: string): Promise<E2EElement> {
+    const days = await findAll(
+      page,
+      `calcite-date-picker >>> calcite-date-picker-month >>> calcite-date-picker-day[id="${id}"]`,
+    );
+    return days.find((d) => !d.classList.contains("noncurrent"));
+  }
+
+  async function getActiveMonth(
+    page: E2EPage,
+    position: Extract<"start" | "end", Position> = "start",
+  ): Promise<string> {
+    const [startMonth, endMonth] = await findAll(
+      page,
+      `calcite-date-picker >>> calcite-date-picker-month-header >>> .${MONTH_HEADER_CSS.header} >>> calcite-select.${MONTH_HEADER_CSS.monthPicker}`,
+    );
+
+    if (position === "start") {
+      return (await startMonth.find("calcite-option[selected]")).textContent;
+    }
+    return (await endMonth.find("calcite-option[selected]")).textContent;
+  }
+});

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -868,7 +868,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
       const datePicker = await page.find("calcite-date-picker");
 
-      const currentDate = new Date();
+      const currentDate = getLocalDayDate();
       currentDate.setMonth(currentDate.getMonth() + 2);
       currentDate.setDate(12);
       const currentISODate = toDateOnlyIso(currentDate);
@@ -896,7 +896,7 @@ describe("calcite-date-picker", () => {
       await page.setContent(html`<calcite-date-picker range></calcite-date-picker>`);
       const datePicker = await page.find("calcite-date-picker");
 
-      const currentDate = new Date();
+      const currentDate = getLocalDayDate();
       if (currentDate.getDate() > 2) {
         currentDate.setDate(1);
       }
@@ -920,7 +920,7 @@ describe("calcite-date-picker", () => {
       await page.keyboard.press("Enter");
       await page.waitForChanges();
 
-      const currentDayDate = new Date();
+      const currentDayDate = getLocalDayDate();
       const currentDayISODate = toDateOnlyIso(currentDayDate);
 
       expect(await datePicker.getProperty("value")).toStrictEqual([currentDayISODate, ""]);
@@ -929,21 +929,16 @@ describe("calcite-date-picker", () => {
     it("should select current day when min is before current day but in same month", async () => {
       const page = await newE2EPage();
       await page.setContent(html`<calcite-date-picker></calcite-date-picker>`);
-      await page.waitForChanges();
       const datePicker = await page.find("calcite-date-picker");
 
-      const currentDate = new Date();
-      if (currentDate.getDate() > 2) {
-        currentDate.setDate(1);
+      const minDate = getLocalDayDate();
+      if (minDate.getDate() > 2) {
+        minDate.setDate(1);
       }
-      const currentISODate = toDateOnlyIso(currentDate);
 
-      await page.evaluate((currentISODate) => {
-        const datePicker = document.querySelector("calcite-date-picker");
-        datePicker.min = currentISODate;
-      }, currentISODate);
-
+      datePicker.setProperty("min", toDateOnlyIso(minDate));
       await page.waitForChanges();
+
       await page.keyboard.press("Tab");
       await page.waitForChanges();
       await page.keyboard.press("Tab");
@@ -955,7 +950,7 @@ describe("calcite-date-picker", () => {
       await page.keyboard.press("Enter");
       await page.waitForChanges();
 
-      const currentDayDate = new Date();
+      const currentDayDate = getLocalDayDate();
       const currentDayISODate = toDateOnlyIso(currentDayDate);
 
       expect(await datePicker.getProperty("value")).toEqual(currentDayISODate);
@@ -967,7 +962,7 @@ describe("calcite-date-picker", () => {
       await page.waitForChanges();
       const datePicker = await page.find("calcite-date-picker");
 
-      const currentDate = new Date();
+      const currentDate = getLocalDayDate();
       currentDate.setMonth(currentDate.getMonth() + 2);
       currentDate.setDate(12);
       const currentISODate = toDateOnlyIso(currentDate);
@@ -1239,6 +1234,12 @@ describe("calcite-date-picker", () => {
       themed(rangeDatePickerHTML, componentTokens);
     });
   });
+
+  function getLocalDayDate(): Date {
+    const today = new Date();
+    today.setMinutes(today.getMinutes() - today.getTimezoneOffset());
+    return today;
+  }
 
   function toDateOnlyIso(date: Date): string {
     return date.toISOString().split("T")[0];

--- a/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
+++ b/packages/calcite-components/src/components/date-picker/date-picker.e2e.ts
@@ -936,7 +936,7 @@ describe("calcite-date-picker", () => {
       if (currentDate.getDate() > 2) {
         currentDate.setDate(1);
       }
-      const currentISODate = currentDate.toISOString();
+      const currentISODate = currentDate.toISOString().split("T")[0];
 
       await page.evaluate((currentISODate) => {
         const datePicker = document.querySelector("calcite-date-picker");
@@ -1241,8 +1241,8 @@ describe("calcite-date-picker", () => {
   });
 });
 
-async function setActiveDate(page: E2EPage, date: string): Promise<void> {
-  await page.$eval("calcite-date-picker", (datePicker, date) => (datePicker.activeDate = new Date(date)), date);
+async function setActiveDate(page: E2EPage, isoDate: string): Promise<void> {
+  await page.$eval("calcite-date-picker", (datePicker, date) => (datePicker.activeDate = new Date(date)), isoDate);
   await page.waitForChanges();
 }
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -207,8 +207,6 @@ export class DatePicker extends LitElement {
 
   async load(): Promise<void> {
     await this.loadLocaleData();
-    this.onMinChanged(this.min);
-    this.onMaxChanged(this.max);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -224,12 +222,35 @@ export class DatePicker extends LitElement {
       this.valueAsDateWatcher(this.valueAsDate);
     }
 
-    if (changes.has("min")) {
+    let minSource: Extract<keyof DatePicker, "min" | "minAsDate">;
+    let maxSource: Extract<keyof DatePicker, "max" | "maxAsDate">;
+
+    if (changes.has("min") && !changes.has("minAsDate")) {
+      minSource = "min";
+    } else if (changes.has("minAsDate") && !changes.has("min")) {
+      minSource = "minAsDate";
+    }
+
+    if (changes.has("max") && !changes.has("maxAsDate")) {
+      maxSource = "max";
+    } else if (changes.has("maxAsDate") && !changes.has("max")) {
+      maxSource = "maxAsDate";
+    }
+
+    if (minSource === "min") {
       this.onMinChanged(this.min);
     }
 
-    if (changes.has("max")) {
+    if (maxSource === "max") {
       this.onMaxChanged(this.max);
+    }
+
+    if (minSource === "minAsDate") {
+      this.onMinChanged(dateToISO(this.minAsDate));
+    }
+
+    if (maxSource === "maxAsDate") {
+      this.onMaxChanged(dateToISO(this.maxAsDate));
     }
 
     if (changes.has("messages") && this.hasUpdated) {
@@ -276,18 +297,16 @@ export class DatePicker extends LitElement {
   }
 
   private onMinChanged(min: string): void {
-    if (min) {
-      this.minAsDate = dateFromISO(min);
-    }
+    this.minAsDate = dateFromISO(min);
+
     if (this.range) {
       this.setActiveStartAndEndDates();
     }
   }
 
   private onMaxChanged(max: string): void {
-    if (max) {
-      this.maxAsDate = dateFromISO(max);
-    }
+    this.maxAsDate = dateFromISO(max);
+
     if (this.range) {
       this.setActiveStartAndEndDates();
     }

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -195,13 +195,6 @@ export class DatePicker extends LitElement {
       this.valueAsDate = dateFromISO(this.value);
     }
 
-    if (this.min) {
-      this.minAsDate = dateFromISO(this.min);
-    }
-
-    if (this.max) {
-      this.maxAsDate = dateFromISO(this.max);
-    }
     this.setActiveStartAndEndDates();
   }
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -1,14 +1,14 @@
 // @ts-strict-ignore
-import { PropertyValues, isServer } from "lit";
+import { isServer, PropertyValues } from "lit";
 import {
-  LitElement,
-  property,
   createEvent,
   Fragment,
   h,
-  method,
-  state,
   JsxNode,
+  LitElement,
+  method,
+  property,
+  state,
 } from "@arcgis/lumina";
 import {
   dateFromISO,
@@ -27,7 +27,7 @@ import { HeadingLevel } from "../functional/Heading";
 import { useT9n } from "../../controllers/useT9n";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import T9nStrings from "./assets/t9n/messages.en.json";
-import { DATE_PICKER_FORMAT_OPTIONS, HEADING_LEVEL, CSS } from "./resources";
+import { CSS, DATE_PICKER_FORMAT_OPTIONS, HEADING_LEVEL } from "./resources";
 import { DateLocaleData, getLocaleData, getValueAsDateRange } from "./utils";
 import { styles } from "./date-picker.scss";
 
@@ -188,25 +188,11 @@ export class DatePicker extends LitElement {
     this.listen("keydown", this.keyDownHandler);
   }
 
-  override connectedCallback(): void {
-    if (Array.isArray(this.value)) {
-      this.valueAsDate = getValueAsDateRange(this.value);
-    } else if (this.value) {
-      this.valueAsDate = dateFromISO(this.value);
-    }
-
-    this.setActiveStartAndEndDates();
-  }
-
   async load(): Promise<void> {
     await this.loadLocaleData();
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
-    if (changes.has("activeDate")) {
-      this.activeDateWatcher(this.activeDate);
-    }
-
     if (changes.has("value")) {
       this.valueHandler(this.value);
     }
@@ -231,19 +217,27 @@ export class DatePicker extends LitElement {
     }
 
     if (minSource === "min") {
-      this.onMinChanged(this.min);
+      this.minAsDate = dateFromISO(this.min);
+    } else if (minSource === "minAsDate") {
+      this.minAsDate = dateFromISO(dateToISO(this.minAsDate));
     }
 
     if (maxSource === "max") {
-      this.onMaxChanged(this.max);
+      this.maxAsDate = dateFromISO(this.max);
+    } else if (maxSource === "maxAsDate") {
+      this.maxAsDate = dateFromISO(dateToISO(this.maxAsDate));
     }
 
-    if (minSource === "minAsDate") {
-      this.onMinChanged(dateToISO(this.minAsDate));
+    if (
+      (changes.has("range") && this.range) ||
+      changes.has("maxAsDate") ||
+      changes.has("minAsDate")
+    ) {
+      this.setActiveStartAndEndDates();
     }
 
-    if (maxSource === "maxAsDate") {
-      this.onMaxChanged(dateToISO(this.maxAsDate));
+    if (changes.has("activeDate")) {
+      this.activeDateWatcher(this.activeDate);
     }
 
     if (changes.has("messages") && this.hasUpdated) {
@@ -286,22 +280,6 @@ export class DatePicker extends LitElement {
       this.setActiveStartAndEndDates();
     } else if (newValueAsDate && newValueAsDate !== this.activeDate) {
       this.activeDate = newValueAsDate as Date;
-    }
-  }
-
-  private onMinChanged(min: string): void {
-    this.minAsDate = dateFromISO(min);
-
-    if (this.range) {
-      this.setActiveStartAndEndDates();
-    }
-  }
-
-  private onMaxChanged(max: string): void {
-    this.maxAsDate = dateFromISO(max);
-
-    if (this.range) {
-      this.setActiveStartAndEndDates();
     }
   }
 

--- a/packages/calcite-components/src/components/date-picker/date-picker.tsx
+++ b/packages/calcite-components/src/components/date-picker/date-picker.tsx
@@ -276,14 +276,18 @@ export class DatePicker extends LitElement {
   }
 
   private onMinChanged(min: string): void {
-    this.minAsDate = dateFromISO(min);
+    if (min) {
+      this.minAsDate = dateFromISO(min);
+    }
     if (this.range) {
       this.setActiveStartAndEndDates();
     }
   }
 
   private onMaxChanged(max: string): void {
-    this.maxAsDate = dateFromISO(max);
+    if (max) {
+      this.maxAsDate = dateFromISO(max);
+    }
     if (this.range) {
       this.setActiveStartAndEndDates();
     }


### PR DESCRIPTION
**Related Issue:** [#10329](https://github.com/Esri/calcite-design-system/issues/10329)

## Summary

Ensure `minAsDate` and `maxAsDate` are used in date logic when provided.

### Noteworthy changes

* updates `DatePicker#willUpdate` to use `min`/`max` OR `minAsDate`/`maxAsDate` for internal state
* removes redundant prop update on `connectedCallback`/`load` (this is handled by `willUpdate`)
* ensures user local time is used in tests that depend on current date – fixes incorrect assertions using dates affected by UTC vs local time context
* adds local test helpers for common date handling
* moves test helpers to component `describe` block for consistency
* tidy up