### PR TITLE
fix(input): ensure overlay does not obscure input icon

### DIFF
--- a/packages/calcite-components/src/components/input/input.scss
+++ b/packages/calcite-components/src/components/input/input.scss
@@ -257,6 +257,11 @@ input:focus {
 
 // ICONS
 
+// type
+:host([icon="check-square-f"]) {
+  isolation: isolate;
+}
+
 // position icons
 
 :host([scale="s"]) .icon {

--- a/packages/calcite-components/src/components/input/input.stories.ts
+++ b/packages/calcite-components/src/components/input/input.stories.ts
@@ -260,3 +260,15 @@ export const fontSizeSetAtRoot = (): string =>
     <calcite-input placeholder="Placeholder" prefix-text="Prefix" suffix-text="Suffix" type="text" icon="search">
       <calcite-button slot="action"> Search </calcite-button>
     </calcite-input>`;
+
+export const overlayDoesNotObscureIcon = (): string =>
+  html` <style>
+      .overlay {
+        position: absolute;
+        inset: 0;
+        background-color: white;
+        opacity: 0.75;
+      }
+    </style>
+    <calcite-input icon="check-square-f"></calcite-input>
+    <div class="overlay"></div>`;


### PR DESCRIPTION
**Related Issue:** #10269 

## Summary
Created new stacking context for input icon so that it is not obscured by layer with higher z-index.