### PR TITLE
fix(card): ensure `setFocus` focuses card when it contains nested interactive children

### DIFF
--- a/packages/calcite-components/src/components/card/card.e2e.ts
+++ b/packages/calcite-components/src/components/card/card.e2e.ts
@@ -20,7 +20,17 @@ describe("calcite-card", () => {
   });
 
   describe("focusable", () => {
-    focusable("calcite-card");
+    describe("default", () => {
+      focusable("calcite-card");
+    });
+
+    describe("with interactive children", () => {
+      focusable(html`
+        <calcite-card id="parent">
+          <div tabindex="0">focusable child</div>
+        </calcite-card>
+      `);
+    });
   });
 
   describe("accessible", () => {

--- a/packages/calcite-components/src/components/card/card.tsx
+++ b/packages/calcite-components/src/components/card/card.tsx
@@ -1,13 +1,13 @@
 // @ts-strict-ignore
 import { createRef } from "lit-html/directives/ref.js";
 import {
-  LitElement,
-  property,
   createEvent,
   h,
-  method,
-  state,
   JsxNode,
+  LitElement,
+  method,
+  property,
+  state,
   ToEvents,
 } from "@arcgis/lumina";
 import { slotChangeHasAssignedElement } from "../../utils/dom";
@@ -135,9 +135,10 @@ export class Card extends LitElement implements InteractiveComponent {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => {
-      return this.containerEl.value;
-    }, options);
+    return this.focusSetter(
+      () => ({ target: this.containerEl.value, includeContainer: true }),
+      options,
+    );
   }
 
   //#endregion


### PR DESCRIPTION
**Related Issue:** #12714 

## Summary

Fixes issue where `setFocus` would target focusable children instead of the card itself.