### PR TITLE
chore(deps): drop dayjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11844,12 +11844,6 @@
         "node": "*"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
-    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -32186,7 +32180,6 @@
         "@types/sortablejs": "^1.15.8",
         "color": "^5.0.0",
         "composed-offset-position": "^0.0.6",
-        "dayjs": "^1.11.13",
         "es-toolkit": "^1.39.8",
         "focus-trap": "^7.6.2",
         "interactjs": "^1.10.27",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -85,7 +85,6 @@
     "@types/sortablejs": "^1.15.8",
     "color": "^5.0.0",
     "composed-offset-position": "^0.0.6",
-    "dayjs": "^1.11.13",
     "es-toolkit": "^1.39.8",
     "focus-trap": "^7.6.2",
     "interactjs": "^1.10.27",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

After the latest updates to `input-time-picker`, [`dayjs`](https://www.npmjs.com/package/dayjs) is no longer needed.