### PR TITLE
docs(color-picker-swatch): Deprecate component

### DIFF
--- a/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
+++ b/packages/calcite-components/src/components/color-picker-swatch/color-picker-swatch.tsx
@@ -14,6 +14,9 @@ declare global {
   }
 }
 
+/**
+ * @deprecated Use the `calcite-swatch-group` and `calcite-swatch` components instead.
+ */
 export class ColorPickerSwatch extends LitElement {
   // #region Static Members
 

--- a/packages/calcite-components/src/components/swatch/swatch.tsx
+++ b/packages/calcite-components/src/components/swatch/swatch.tsx
@@ -21,8 +21,7 @@ import {
 import { useSetFocus } from "../../controllers/useSetFocus";
 import type { SwatchGroup } from "../swatch-group/swatch-group";
 import { hexify } from "../color-picker/utils";
-import { CHECKER_DIMENSIONS } from "../color-picker-swatch/resources";
-import { CSS, SLOTS, IDS } from "./resources";
+import { CSS, SLOTS, IDS, CHECKER_DIMENSIONS } from "./resources";
 import { styles } from "./swatch.scss";
 
 declare global {


### PR DESCRIPTION
**Related Issue:** #12734 

## Summary
Deprecates Color Picker Swatch