### PR TITLE
fix(list, block-group): fix canPull when cloning and "Add to" menu on block-group

### DIFF
--- a/packages/calcite-components/src/components/block-group/block-group.tsx
+++ b/packages/calcite-components/src/components/block-group/block-group.tsx
@@ -405,7 +405,7 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
         oldIndex,
       }) ?? true;
 
-    return type === "add" ? canPull === "clone" : canPull === true && canPut;
+    return (type === "add" ? canPull === "clone" : canPull === true) && canPut;
   }
 
   private handleAdd(event: CustomEvent<AddEventDetail>): void {
@@ -418,7 +418,7 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
     const oldIndex = fromElItems.indexOf(dragEl);
     const newIndex = 0;
 
-    if (!this.validateSortMenuItem({ type: "move", fromEl, toEl, dragEl, newIndex, oldIndex })) {
+    if (!this.validateSortMenuItem({ type: "add", fromEl, toEl, dragEl, newIndex, oldIndex })) {
       return;
     }
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -1032,7 +1032,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
         oldIndex,
       }) ?? true;
 
-    return type === "add" ? canPull === "clone" : canPull === true && canPut;
+    return (type === "add" ? canPull === "clone" : canPull === true) && canPut;
   }
 
   private handleAdd(event: CustomEvent<AddEventDetail>): void {


### PR DESCRIPTION
**Related Issue:** #11952

## Summary
