### PR TITLE
refactor: drop futile `state()` usage

### DIFF
--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -158,12 +158,10 @@ export class Autocomplete
 
   @state() groups: AutocompleteItemGroup["el"][] = [];
 
-  @state()
   get isOpen(): boolean {
     return this.open && (this.hasContentTop || this.hasContentBottom || this.items.length > 0);
   }
 
-  @state()
   get enabledItems(): AutocompleteItem["el"][] {
     return this.items.filter((item) => !item.disabled);
   }

--- a/packages/calcite-components/src/components/combobox/combobox.tsx
+++ b/packages/calcite-components/src/components/combobox/combobox.tsx
@@ -292,17 +292,14 @@ export class Combobox
 
   @state() items: HTMLCalciteComboboxItemElement["el"][] = [];
 
-  @state()
   get allSelected(): boolean {
     return this.selectedItems.length === this.items.length;
   }
 
-  @state()
   get indeterminate(): boolean {
     return this.selectedItems.length > 0 && !this.allSelected;
   }
 
-  @state()
   get keyboardNavItems(): HTMLCalciteComboboxItemElement["el"][] {
     const { selectAllComboboxItemReferenceEl } = this;
 

--- a/packages/calcite-components/src/components/dialog/dialog.tsx
+++ b/packages/calcite-components/src/components/dialog/dialog.tsx
@@ -117,7 +117,7 @@ export class Dialog extends LitElement implements OpenCloseComponent {
 
   @state() opened = false;
 
-  @state() get preventDocumentScroll(): boolean {
+  get preventDocumentScroll(): boolean {
     return !this.embedded && this.modal;
   }
 

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -133,7 +133,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
 
   @state() sortHandleMenuItems: SortMenuItem[] = [];
 
-  @state() get hasActiveFilter(): boolean {
+  get hasActiveFilter(): boolean {
     return (
       this.filterEnabled &&
       this.filterText &&
@@ -141,7 +141,7 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     );
   }
 
-  @state() get showNoResultsContainer(): boolean {
+  get showNoResultsContainer(): boolean {
     return (
       this.filterEnabled &&
       this.filterText &&

--- a/packages/calcite-components/src/components/modal/modal.tsx
+++ b/packages/calcite-components/src/components/modal/modal.tsx
@@ -146,7 +146,7 @@ export class Modal extends LitElement implements OpenCloseComponent {
 
   @state() titleEl: HTMLElement;
 
-  @state() get preventDocumentScroll(): boolean {
+  get preventDocumentScroll(): boolean {
     return !this.embedded;
   }
 

--- a/packages/calcite-components/src/components/sheet/sheet.tsx
+++ b/packages/calcite-components/src/components/sheet/sheet.tsx
@@ -115,7 +115,7 @@ export class Sheet extends LitElement implements OpenCloseComponent {
     maxBlockSize: null,
   };
 
-  @state() get preventDocumentScroll(): boolean {
+  get preventDocumentScroll(): boolean {
     return !this.embedded;
   }
 

--- a/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
+++ b/packages/calcite-components/src/components/sort-handle/sort-handle.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
-import { LitElement, property, createEvent, h, method, JsxNode, state } from "@arcgis/lumina";
+import { LitElement, property, createEvent, h, method, JsxNode } from "@arcgis/lumina";
 import {
   InteractiveComponent,
   InteractiveContainer,
@@ -50,19 +50,19 @@ export class SortHandle extends LitElement implements InteractiveComponent {
 
   // #region State Properties
 
-  @state() get hasSetInfo(): boolean {
+  get hasSetInfo(): boolean {
     return typeof this.setPosition === "number" && typeof this.setSize === "number";
   }
 
-  @state() get hasValidSetInfo(): boolean {
+  get hasValidSetInfo(): boolean {
     return this.hasSetInfo ? this.setPosition > 0 && this.setSize > 1 : true;
   }
 
-  @state() get hasReorderItems(): boolean {
+  get hasReorderItems(): boolean {
     return !this.sortDisabled && this.hasValidSetInfo;
   }
 
-  @state() get hasNoItems(): boolean {
+  get hasNoItems(): boolean {
     return !this.hasReorderItems && this.moveToItems.length < 1 && this.addToItems.length < 1;
   }
 


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Per the [Lit docs](https://lit.dev/docs/components/properties/#internal-reactive-state), `state` is meant for internal reactive state that the component manages itself. 

The [implementation](https://github.com/lit/lit/blob/main/packages/reactive-element/src/decorators/state.ts) and the [tests](https://github.com/lit/lit/blob/main/packages/reactive-element/src/test/decorators/state_test.ts) show that it only works when the value is set by the component.