### PR TITLE
fix(block): allow customizing heading text color when expanded & deprecate tokens

### DIFF
--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -555,11 +555,7 @@ describe("calcite-block", () => {
             targetProp: "backgroundColor",
             state: { press: `calcite-block >>> .${CSS.toggle}` },
           },
-          "--calcite-block-text-color": {
-            shadowSelector: `.${CSS.contentStart}`,
-            targetProp: "color",
-          },
-          "--calcite-block-heading-text-color-press": {
+          "--calcite-block-heading-text-color": {
             shadowSelector: `.${CSS.heading}`,
             targetProp: "color",
             state: { press: { attribute: "class", value: CSS.heading } },
@@ -590,10 +586,38 @@ describe("calcite-block", () => {
         },
       );
     });
+
     describe("collapsed", () => {
       themed(html`<calcite-block heading="heading"></calcite-block>`, {
         "--calcite-block-heading-text-color": { shadowSelector: `.${CSS.heading}`, targetProp: "color" },
       });
+    });
+
+    describe("deprecated", () => {
+      themed(
+        html`<calcite-block
+          heading="heading"
+          description="description"
+          expanded
+          collapsible
+          icon-end="pen"
+          icon-start="pen"
+        >
+          <calcite-icon icon="compass" slot="content-start"></calcite-icon>
+          <div>content</div>
+        </calcite-block>`,
+        {
+          "--calcite-block-text-color": {
+            shadowSelector: `.${CSS.contentStart}`,
+            targetProp: "color",
+          },
+          "--calcite-block-heading-text-color-press": {
+            shadowSelector: `.${CSS.heading}`,
+            targetProp: "color",
+            state: { press: { attribute: "class", value: CSS.heading } },
+          },
+        },
+      );
     });
   });
 });

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -9,9 +9,9 @@
  * @prop --calcite-block-header-background-color-hover: Specifies the component's `heading` background color when hovered.
  * @prop --calcite-block-header-background-color-press: Specifies the component's `heading` background color when pressed.
  * @prop --calcite-block-heading-text-color: Specifies the component's `heading` text color.
- * @prop --calcite-block-heading-text-color-press: When the component is `expanded`, specifies the `heading` text color.
+ * @prop --calcite-block-heading-text-color-press: [Deprecated]  use `--calcite-block-heading-text-color` instead - When the component is `expanded`, specifies the `heading` text color.
  * @prop --calcite-block-padding: [Deprecated] use `--calcite-block-content-space` instead - Specifies the padding of the component's `default` slot.
- * @prop --calcite-block-text-color: Specifies the component's text color.
+ * @prop --calcite-block-text-color:[Deprecated] Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
  * @prop --calcite-block-icon-color: Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
  * @prop --calcite-block-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
@@ -260,6 +260,7 @@ calcite-handle {
 .content-start {
   @apply flex items-center;
 
+  // Deprecated
   color: var(--calcite-block-text-color, var(--calcite-color-text-3));
 }
 
@@ -280,7 +281,10 @@ calcite-action-menu {
   @apply my-2;
 
   .header .title .heading {
-    color: var(--calcite-block-heading-text-color-press, var(--calcite-color-text-1));
+    color: var(
+      --calcite-block-heading-text-color,
+      var(--calcite-block-heading-text-color-press, var(--calcite-color-text-1))
+    );
   }
 
   .description {


### PR DESCRIPTION

**Related Issue:** #12633 

## Summary

Customize heading text color when expanded using `--calcite-block-heading-text-color` token.

Example:

```
calcite-block[expanded] {
--calcite-heading-text-color:  blue;
}
```

Deprecates following tokens in block:

- --calcite-block-text-color
- --calcite-block-heading-text-color-press