### PR TITLE
fix(list, block-group): emit calciteListOrderChange on destination when adding or moving from the menu

### DIFF
--- a/packages/calcite-components/src/components/block-group/block-group.e2e.ts
+++ b/packages/calcite-components/src/components/block-group/block-group.e2e.ts
@@ -591,8 +591,7 @@ describe("calcite-block-group", () => {
       await page.waitForChanges();
       await page.waitForTimeout(DEBOUNCE.nextTick);
 
-      let component1Moves = 0;
-      let component2Moves = 0;
+      let componentMoves = 0;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("#component1", (blockGroup: BlockGroup["el"]) => {
@@ -689,8 +688,10 @@ describe("calcite-block-group", () => {
           };
         });
 
-        expect(results.component1CalledTimes).toBe(moveFromId === component1Id ? ++component1Moves : component1Moves);
-        expect(results.component2CalledTimes).toBe(moveFromId === component2Id ? ++component2Moves : component2Moves);
+        ++componentMoves;
+
+        expect(results.component1CalledTimes).toBe(componentMoves);
+        expect(results.component2CalledTimes).toBe(componentMoves);
         expect(results.newIndex).toBe(newIndex);
         expect(results.oldIndex).toBe(oldIndex);
         expect(results.fromEl).toBe(moveFromId);

--- a/packages/calcite-components/src/components/block-group/block-group.tsx
+++ b/packages/calcite-components/src/components/block-group/block-group.tsx
@@ -139,6 +139,16 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
     }, options);
   }
 
+  /**
+   * Emits the `calciteBlockGroupOrderChange` event.
+   *
+   * @private
+   */
+  @method()
+  emitOrderChangeEvent(detail: BlockDragDetail): void {
+    this.calciteBlockGroupOrderChange.emit(detail);
+  }
+
   // #endregion
 
   // #region Events
@@ -430,6 +440,17 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
     toEl.prepend(newEl);
     this.updateBlockItemsDebounced();
     this.connectObserver();
+
+    const eventDetail = {
+      dragEl,
+      fromEl,
+      toEl,
+      newIndex,
+      oldIndex,
+    };
+
+    this.calciteBlockGroupOrderChange.emit(eventDetail);
+    toEl.emitOrderChangeEvent(eventDetail);
   }
 
   private handleMove(event: CustomEvent<MoveEventDetail>): void {
@@ -455,13 +476,16 @@ export class BlockGroup extends LitElement implements InteractiveComponent, Sort
     this.updateBlockItemsDebounced();
     this.connectObserver();
 
-    this.calciteBlockGroupOrderChange.emit({
+    const eventDetail = {
       dragEl,
       fromEl,
       toEl,
       newIndex,
       oldIndex,
-    });
+    };
+
+    this.calciteBlockGroupOrderChange.emit(eventDetail);
+    toEl.emitOrderChangeEvent(eventDetail);
   }
 
   private handleReorder(event: CustomEvent<ReorderEventDetail>): void {

--- a/packages/calcite-components/src/components/list/list.e2e.ts
+++ b/packages/calcite-components/src/components/list/list.e2e.ts
@@ -2089,8 +2089,7 @@ describe("calcite-list", () => {
       await page.waitForChanges();
       await page.waitForTimeout(DEBOUNCE.filter);
 
-      let list1Moves = 0;
-      let list2Moves = 0;
+      let listMoves = 0;
 
       // Workaround for page.spyOnEvent() failing due to drag event payload being serialized and there being circular JSON structures from the payload elements. See: https://github.com/Esri/calcite-design-system/issues/7643
       await page.$eval("#list1", (list: List["el"]) => {
@@ -2186,8 +2185,10 @@ describe("calcite-list", () => {
           };
         });
 
-        expect(results.list1CalledTimes).toBe(moveFromListId === list1Id ? ++list1Moves : list1Moves);
-        expect(results.list2CalledTimes).toBe(moveFromListId === list2Id ? ++list2Moves : list2Moves);
+        ++listMoves;
+
+        expect(results.list1CalledTimes).toBe(listMoves);
+        expect(results.list2CalledTimes).toBe(listMoves);
         expect(results.newIndex).toBe(newIndex);
         expect(results.oldIndex).toBe(oldIndex);
         expect(results.fromEl).toBe(moveFromListId);

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -308,6 +308,16 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     }, options);
   }
 
+  /**
+   * Emits the `calciteListOrderChange` event.
+   *
+   * @private
+   */
+  @method()
+  emitOrderChangeEvent(detail: ListDragDetail): void {
+    this.calciteListOrderChange.emit(detail);
+  }
+
   //#endregion
 
   //#region Events
@@ -1058,6 +1068,17 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     expandedAncestors(dragEl);
     this.updateListItemsDebounced();
     this.connectObserver();
+
+    const eventDetail = {
+      dragEl,
+      fromEl,
+      toEl,
+      newIndex,
+      oldIndex,
+    };
+
+    this.calciteListOrderChange.emit(eventDetail);
+    toEl.emitOrderChangeEvent(eventDetail);
   }
 
   private handleMove(event: CustomEvent<MoveEventDetail>): void {
@@ -1083,13 +1104,16 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
     this.updateListItemsDebounced();
     this.connectObserver();
 
-    this.calciteListOrderChange.emit({
+    const eventDetail = {
       dragEl,
       fromEl,
       toEl,
       newIndex,
       oldIndex,
-    });
+    };
+
+    this.calciteListOrderChange.emit(eventDetail);
+    toEl.emitOrderChangeEvent(eventDetail);
   }
 
   private handleReorder(event: CustomEvent<ReorderEventDetail>): void {


### PR DESCRIPTION
**Related Issue:** #12490

## Summary

- Emit `calciteListOrderChange` on the destination list for move
- Emit `calciteListOrderChange` on the destination list for add
- adds tests
