### PR TITLE
fix(block): no longer renders an empty header

### DIFF
--- a/packages/calcite-components/src/components/block/block.e2e.ts
+++ b/packages/calcite-components/src/components/block/block.e2e.ts
@@ -427,17 +427,17 @@ describe("calcite-block", () => {
       block.setAttribute("heading", "test-heading");
       await page.waitForChanges();
 
-      expect(header).toHaveClass(CSS.headerHasText);
+      expect(header).toHaveClass(CSS.headerHasContent);
 
       block.removeAttribute("heading");
       await page.waitForChanges();
 
-      expect(header).not.toHaveClass(CSS.headerHasText);
+      expect(header).not.toHaveClass(CSS.headerHasContent);
 
       block.setAttribute("description", "test-description");
       await page.waitForChanges();
 
-      expect(header).toHaveClass(CSS.headerHasText);
+      expect(header).toHaveClass(CSS.headerHasContent);
     });
   });
 

--- a/packages/calcite-components/src/components/block/block.scss
+++ b/packages/calcite-components/src/components/block/block.scss
@@ -26,8 +26,11 @@
 
 :host([scale="s"]) {
   .header {
-    padding: var(--calcite-spacing-sm);
     gap: var(--calcite-spacing-sm);
+  }
+
+  .header--has-content {
+    padding: var(--calcite-spacing-sm);
   }
 
   .icon-end-container {
@@ -55,8 +58,11 @@
 
 :host([scale="m"]) {
   .header {
-    padding: var(--calcite-spacing-md);
     gap: var(--calcite-spacing-md);
+  }
+
+  .header--has-content {
+    padding: var(--calcite-spacing-md);
   }
 
   .icon-end-container {
@@ -84,8 +90,11 @@
 
 :host([scale="l"]) {
   .header {
-    padding: var(--calcite-spacing-lg);
     gap: var(--calcite-spacing-lg);
+  }
+
+  .header--has-content {
+    padding: var(--calcite-spacing-lg);
   }
 
   .icon-end-container {

--- a/packages/calcite-components/src/components/block/block.stories.ts
+++ b/packages/calcite-components/src/components/block/block.stories.ts
@@ -387,3 +387,12 @@ export const allScales = (): string =>
       }
     </style>
     <div class="container">${blockHTML("s")} ${blockHTML("m")} ${blockHTML("l")}</div>`;
+
+export const emptyHeader = (): string => html`
+  <calcite-block expanded calcite-hydrated>
+    <calcite-label layout="inline-space-between">
+      <div>Favorite vegetable</div>
+      <calcite-icon icon="information" />
+    </calcite-label>
+  </calcite-block>
+`;

--- a/packages/calcite-components/src/components/block/block.tsx
+++ b/packages/calcite-components/src/components/block/block.tsx
@@ -530,13 +530,26 @@ export class Block extends LitElement implements InteractiveComponent, OpenClose
       setSize,
       dragDisabled,
       sortDisabled,
+      hasContentStart,
+      iconStart,
     } = this;
 
     const toggleLabel = expanded ? messages.collapse : messages.expand;
+    const headerHasContent = !!(
+      heading ||
+      description ||
+      hasContentStart ||
+      iconStart ||
+      loading ||
+      status
+    );
 
     const headerContent = (
       <header
-        class={{ [CSS.header]: true, [CSS.headerHasText]: !!(heading || description) }}
+        class={{
+          [CSS.header]: true,
+          [CSS.headerHasContent]: headerHasContent,
+        }}
         id={IDS.header}
       >
         {this.renderIcon("start")}

--- a/packages/calcite-components/src/components/block/resources.ts
+++ b/packages/calcite-components/src/components/block/resources.ts
@@ -14,7 +14,7 @@ export const CSS = {
   description: "description",
   header: "header",
   headerContainer: "header-container",
-  headerHasText: "header--has-text",
+  headerHasContent: "header--has-content",
   heading: "heading",
   icon: "icon",
   iconStart: "icon--start",


### PR DESCRIPTION
**Related Issue:** #12797 

## Summary

No longer renders an empty header when below configurable options are empty or set to false.

- heading
- description
- icon-start
- content-start slot
- status
- loading
