### PR TITLE
docs(slider, stepper-item, flow-item): feedback changes for boolean property consistency

### DIFF
--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -132,7 +132,7 @@ export class FlowItem extends LitElement implements InteractiveComponent {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /** When true, flow-item is displayed within a parent flow. */
+  /** When true, the component is displayed within a parent flow. */
   @property({ reflect: true }) selected = false;
 
   /**

--- a/packages/calcite-components/src/components/flow-item/flow-item.tsx
+++ b/packages/calcite-components/src/components/flow-item/flow-item.tsx
@@ -132,7 +132,7 @@ export class FlowItem extends LitElement implements InteractiveComponent {
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /** When true, the component is displayed within a parent flow. */
+  /** When present, the component is displayed within a parent flow. */
   @property({ reflect: true }) selected = false;
 
   /**

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -263,7 +263,7 @@ export class Slider
   @property() minValue: number;
 
   /**
-   * When `true`, the slider will display values from high to low.
+   * When `true`, the component will display values from high to low.
    *
    * Note that this value will be ignored if the slider has an associated histogram.
    */

--- a/packages/calcite-components/src/components/slider/slider.tsx
+++ b/packages/calcite-components/src/components/slider/slider.tsx
@@ -263,7 +263,7 @@ export class Slider
   @property() minValue: number;
 
   /**
-   * When `true`, the component will display values from high to low.
+   * When present, the component will display values from high to low.
    *
    * Note that this value will be ignored if the slider has an associated histogram.
    */

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -106,7 +106,7 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   @property({ reflect: true }) iconFlipRtl = false;
 
   /**
-   * When `true`, the item will be hidden
+   * When `true`, the item will be hidden.
    *
    * @private
    *  */

--- a/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/calcite-components/src/components/stepper-item/stepper-item.tsx
@@ -106,7 +106,7 @@ export class StepperItem extends LitElement implements InteractiveComponent {
   @property({ reflect: true }) iconFlipRtl = false;
 
   /**
-   * When `true`, the item will be hidden.
+   * When present, the item will be hidden.
    *
    * @private
    *  */


### PR DESCRIPTION
**Related Issue:** #12711

## Summary
Cleans up some minor boolean property documentation for consistency, based on feedback from #12791.

## Changlog
- **docs(stepper-item): add period to property doc for consistency**
- **docs(slider, flow-item): use "component" instead of component's name for consistency**
