### PR TITLE
feat(input): add title to clear button

### DIFF
--- a/packages/calcite-components/src/components/input/input.tsx
+++ b/packages/calcite-components/src/components/input/input.tsx
@@ -990,6 +990,7 @@ export class Input
         disabled={this.disabled || this.readOnly}
         onClick={this.clearInputValue}
         tabIndex={-1}
+        title={this.messages.clear}
         type="button"
       >
         <calcite-icon icon={ICONS.close} scale={getIconScale(this.scale)} />


### PR DESCRIPTION
**Related Issue:** #12231

## Summary
Add a `title` attribute to the `inputClearButton` using the existing `clear` T9n string, providing a tooltip on hover.
