### PR TITLE
chore: add design label to new component issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-component.yml
+++ b/.github/ISSUE_TEMPLATE/new-component.yml
@@ -1,6 +1,6 @@
 name: New Component
 description: Request for a new component to be added
-labels: ["new component", "0 - new", "needs triage"]
+labels: ["new component", "0 - new", "needs triage", "design"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Adds the `design` label to the new component issue template, so design can be consulted as soon as the issue is created to decide if design expertise is needed in the request.