### PR TITLE
chore(storybook): restore `@whitespace/storybook-addon-html`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@typescript-eslint/utils": "8.41.0",
         "@vitest/coverage-v8": "3.2.4",
         "@vitest/eslint-plugin": "1.3.4",
+        "@whitespace/storybook-addon-html": "8.0.2",
         "autoprefixer": "10.4.21",
         "axe-core": "4.10.3",
         "change-case": "5.4.4",
@@ -7839,6 +7840,16 @@
       "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@whitespace/storybook-addon-html": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-8.0.2.tgz",
+      "integrity": "sha512-NsCpY+jWl6MamuQuSptuC5A1Xa4UWNtqhbBjv710C8Ka+n+t2e/tCfx1UAsB6m3linja2jU4Zmxu8W026lzLGQ==",
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "peerDependencies": {
+        "storybook": "^9.0.0"
+      }
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.7.13",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/utils": "8.41.0",
     "@vitest/coverage-v8": "3.2.4",
     "@vitest/eslint-plugin": "1.3.4",
+    "@whitespace/storybook-addon-html": "8.0.2",
     "autoprefixer": "10.4.21",
     "axe-core": "4.10.3",
     "change-case": "5.4.4",

--- a/packages/calcite-components/.storybook/main.ts
+++ b/packages/calcite-components/.storybook/main.ts
@@ -2,7 +2,13 @@ import { UserConfig } from "vite";
 import { html } from "../support/formatting";
 
 module.exports = {
-  addons: ["@storybook/addon-a11y", "@storybook/addon-docs", "@storybook/addon-themes", "storybook-addon-rtl"],
+  addons: [
+    "@storybook/addon-a11y",
+    "@storybook/addon-docs",
+    "@storybook/addon-themes",
+    "@whitespace/storybook-addon-html",
+    "storybook-addon-rtl",
+  ],
   core: {
     builder: "@storybook/builder-vite",
   },


### PR DESCRIPTION
**Related Issue:** #12472 

## Summary

Restores `@whitespace/storybook-addon-html` now that it [supports v9](https://github.com/whitespace-se/storybook-addon-html/issues/141#issuecomment-3234790740).
