### PR TITLE
ci(renovate): allow prerelease bumps for arcgis deps

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -23,7 +23,9 @@
     {
       "groupName": "ArcGIS",
       "matchPackageNames": ["@arcgis/**"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "ignoreUnstable": false,
+      "respectLatest": false
     },
     {
       "groupName": "CSpell",


### PR DESCRIPTION
## Summary

The version with `latest` dist tag for `@arcgis/toolkit` is marked as deprecated, which is preventing Renovate from grabbing updates.

ref: https://docs.renovatebot.com/configuration-options#ignoreunstable
