### PR TITLE
docs(conventions): add boolean attribute rule to Documentation Style Guide

### DIFF
--- a/packages/calcite-components/conventions/Documentation.md
+++ b/packages/calcite-components/conventions/Documentation.md
@@ -13,6 +13,7 @@ Follow these conventions when adding or editing API reference:
 - Only use single quotes (`'`) as apostrophes.
 - No links or URLs allowed in descriptions. If a link is necessary, a custom JSDoc tag should be added and parsed in the SDK site.
 - Refrain from using "e.g." or "i.e." references. Leverage "such as" (or similar) where examples are referenced.
+- For boolean attributes, refrain from using `true` or `false` as values. Instead, use "When present", "When not present", or similar.
 - Use "Accessible" instead of "Aria" or "a11y" language.
 - Verify slots and properties/attributes don't use the text "optional" in their descriptions.
 


### PR DESCRIPTION
**Related Issue:** #12711

## Summary
With the effort to clarify the usage of boolean attributes, updates the Documentation Style Guide to include a rule for the recommended "When present, ..." wording.
