### PR TITLE
feat(accordion-item): add content-start and content-end slots

### DIFF
--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -24,6 +24,20 @@
  * @prop --calcite-accordion-item-text-color-press: [Deprecated] Use `--calcite-accordion-text-color-press`. Specifies the component's text color on press.
  */
 
+// AUTO-GENERATED — do not modify. Changes will be overwritten.
+//
+// Internal CSS custom properties for component use only. Overwriting is not recommended.
+//
+// --calcite-internal-accordion-item-active-icon-rotation
+// --calcite-internal-accordion-item-active-icon-rotation-rtl
+// --calcite-internal-accordion-item-flex-direction
+// --calcite-internal-accordion-item-header-background-color-hover
+// --calcite-internal-accordion-item-header-background-color-press
+// --calcite-internal-accordion-item-icon-rotation
+// --calcite-internal-accordion-item-icon-rotation-rtl
+// --calcite-internal-accordion-item-icon-spacing-end
+// --calcite-internal-accordion-item-icon-spacing-start
+
 %icon-position {
   /* icon rotation variables */
   --calcite-internal-accordion-item-icon-rotation: calc(theme("rotate.90") * -1);
@@ -165,6 +179,10 @@
 
 .header-container {
   inline-size: 100%;
+}
+
+.slot-content-start {
+  margin-inline-end: var(--calcite-internal-accordion-icon-margin);
 }
 
 // accordion item title

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.scss
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.scss
@@ -181,6 +181,10 @@
   inline-size: 100%;
 }
 
+.slot-content-end {
+  margin-inline-start: var(--calcite-internal-accordion-icon-margin);
+}
+
 .slot-content-start {
   margin-inline-end: var(--calcite-internal-accordion-icon-margin);
 }

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -30,6 +30,8 @@ declare global {
  * @slot - A slot for adding custom content, including nested `calcite-accordion-item`s.
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component's header.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component's header.
+ * @slot content-end - A slot for adding non-actionable elements after the component's header text.
+ * @slot content-start - A slot for adding non-actionable elements before the component's header text.
  */
 export class AccordionItem extends LitElement {
   //#region Static Members
@@ -349,6 +351,10 @@ export class AccordionItem extends LitElement {
             tabIndex="0"
           >
             <div class={CSS.headerContainer}>
+              <div class={CSS.slotContentStart}>
+                <slot name={SLOTS.contentStart} />
+              </div>
+
               {iconStartEl}
               <div class={CSS.headerText}>
                 <Heading class={CSS.heading} level={headingLevel}>
@@ -357,6 +363,7 @@ export class AccordionItem extends LitElement {
                 {description ? <span class={CSS.description}>{description}</span> : null}
               </div>
               {iconEndEl}
+              <slot name={SLOTS.contentEnd} />
             </div>
             <calcite-icon
               class={CSS.expandIcon}

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -61,6 +61,8 @@ export class AccordionItem extends LitElement {
 
   @state() hasActionsStart = false;
 
+  @state() hasContentStart = false;
+
   //#endregion
 
   //#region Public Properties
@@ -249,6 +251,10 @@ export class AccordionItem extends LitElement {
     this.hasActionsEnd = slotChangeHasAssignedElement(event);
   }
 
+  private handleContentStartSlotChange(event: Event): void {
+    this.hasContentStart = slotChangeHasAssignedElement(event);
+  }
+
   /** handle clicks on item header */
   private itemHeaderClickHandler(): void {
     this.emitRequestedItem();
@@ -297,6 +303,14 @@ export class AccordionItem extends LitElement {
     return (
       <div class={CSS.actionsEnd} hidden={!this.hasActionsEnd}>
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
+      </div>
+    );
+  }
+
+  private renderContentStart(): JsxNode {
+    return (
+      <div class={CSS.slotContentStart} hidden={!this.hasContentStart}>
+        <slot name={SLOTS.contentStart} onSlotChange={this.handleContentStartSlotChange} />
       </div>
     );
   }
@@ -351,10 +365,7 @@ export class AccordionItem extends LitElement {
             tabIndex="0"
           >
             <div class={CSS.headerContainer}>
-              <div class={CSS.slotContentStart}>
-                <slot name={SLOTS.contentStart} />
-              </div>
-
+              {this.renderContentStart()}
               {iconStartEl}
               <div class={CSS.headerText}>
                 <Heading class={CSS.heading} level={headingLevel}>

--- a/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/calcite-components/src/components/accordion-item/accordion-item.tsx
@@ -61,6 +61,8 @@ export class AccordionItem extends LitElement {
 
   @state() hasActionsStart = false;
 
+  @state() hasContentEnd = false;
+
   @state() hasContentStart = false;
 
   //#endregion
@@ -251,6 +253,10 @@ export class AccordionItem extends LitElement {
     this.hasActionsEnd = slotChangeHasAssignedElement(event);
   }
 
+  private handleContentEndSlotChange(event: Event): void {
+    this.hasContentEnd = slotChangeHasAssignedElement(event);
+  }
+
   private handleContentStartSlotChange(event: Event): void {
     this.hasContentStart = slotChangeHasAssignedElement(event);
   }
@@ -303,6 +309,14 @@ export class AccordionItem extends LitElement {
     return (
       <div class={CSS.actionsEnd} hidden={!this.hasActionsEnd}>
         <slot name={SLOTS.actionsEnd} onSlotChange={this.handleActionsEndSlotChange} />
+      </div>
+    );
+  }
+
+  private renderContentEnd(): JsxNode {
+    return (
+      <div class={CSS.slotContentEnd} hidden={!this.hasContentEnd}>
+        <slot name={SLOTS.contentEnd} onSlotChange={this.handleContentEndSlotChange} />
       </div>
     );
   }
@@ -374,7 +388,7 @@ export class AccordionItem extends LitElement {
                 {description ? <span class={CSS.description}>{description}</span> : null}
               </div>
               {iconEndEl}
-              <slot name={SLOTS.contentEnd} />
+              {this.renderContentEnd()}
             </div>
             <calcite-icon
               class={CSS.expandIcon}

--- a/packages/calcite-components/src/components/accordion-item/resources.ts
+++ b/packages/calcite-components/src/components/accordion-item/resources.ts
@@ -3,6 +3,8 @@ import { Appearance, Position, IconType } from "../interfaces";
 export const SLOTS = {
   actionsStart: "actions-start",
   actionsEnd: "actions-end",
+  contentEnd: "content-end",
+  contentStart: "content-start",
 };
 
 export const CSS = {
@@ -23,6 +25,7 @@ export const CSS = {
   iconPosition: (iconPosition: Position) => `icon-position--${iconPosition}` as const,
   iconType: (iconType: IconType) => `icon-type--${iconType}` as const,
   item: "item",
+  slotContentStart: "slot-content-start",
 };
 
 export const IDS = {

--- a/packages/calcite-components/src/components/accordion-item/resources.ts
+++ b/packages/calcite-components/src/components/accordion-item/resources.ts
@@ -25,6 +25,7 @@ export const CSS = {
   iconPosition: (iconPosition: Position) => `icon-position--${iconPosition}` as const,
   iconType: (iconType: IconType) => `icon-type--${iconType}` as const,
   item: "item",
+  slotContentEnd: "slot-content-end",
   slotContentStart: "slot-content-start",
 };
 

--- a/packages/calcite-components/src/components/accordion/accordion.stories.ts
+++ b/packages/calcite-components/src/components/accordion/accordion.stories.ts
@@ -344,3 +344,28 @@ export const slottedItemsStretched = (): string => html`
     </calcite-accordion-item>
   </calcite-accordion>
 `;
+
+export const withContentStartAndEnd = (): string => html`
+  <calcite-accordion scale="m" selection-mode="multiple" appearance="transparent">
+    <calcite-accordion-item heading="Heading" description="Description for item">
+      ${accordionItemContent}
+      <calcite-icon slot="content-start" icon="banana"></calcite-icon>
+      <calcite-icon slot="content-end" icon="banana"></calcite-icon>
+    </calcite-accordion-item>
+    <calcite-accordion-item heading="Heading" description="Description for item">
+      ${accordionItemContent}
+      <calcite-icon slot="content-start" icon="banana"></calcite-icon>
+      <calcite-icon slot="content-end" icon="banana"></calcite-icon>
+    </calcite-accordion-item>
+    <calcite-accordion-item heading="Heading" description="Description for item">
+      ${accordionItemContent}
+      <calcite-icon slot="content-start" icon="banana"></calcite-icon>
+      <calcite-icon slot="content-end" icon="banana"></calcite-icon>
+    </calcite-accordion-item>
+    <calcite-accordion-item heading="Heading" description="Description for item">
+      ${accordionItemContent}
+      <calcite-icon slot="content-start" icon="banana"></calcite-icon>
+      <calcite-icon slot="content-end" icon="banana"></calcite-icon>
+    </calcite-accordion-item>
+  </calcite-accordion>
+`;


### PR DESCRIPTION
**Related Issue:** [#10444](https://github.com/Esri/calcite-design-system/issues/10444)

## Summary
Add `content-start` and `content-end` slots.
