### PR TITLE
feat(date-picker, table-cell): update to use color-surface-highlight token

### DIFF
--- a/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
+++ b/packages/calcite-components/src/components/date-picker-day/date-picker-day.scss
@@ -118,8 +118,8 @@
 :host([highlighted]:not([selected])),
 :host(:hover[highlighted]:not([selected])) {
   .day {
-    color: var(--calcite-date-picker-day-range-text-color, var(--calcite-color-brand));
-    background-color: var(--calcite-date-picker-day-range-background-color, var(--calcite-color-foreground-current));
+    color: var(--calcite-date-picker-day-range-text-color, var(--calcite-color-text-highlight));
+    background-color: var(--calcite-date-picker-day-range-background-color, var(--calcite-color-surface-highlight));
   }
 }
 

--- a/packages/calcite-components/src/components/table-cell/table-cell.scss
+++ b/packages/calcite-components/src/components/table-cell/table-cell.scss
@@ -118,7 +118,7 @@ td.last-cell {
 .selected-cell:not(.number-cell):not(.footer-cell) {
   background-color: var(
     --calcite-table-cell-background-color-selected,
-    var(--calcite-table-row-background-color-selected, var(--calcite-color-foreground-current))
+    var(--calcite-table-row-background-color-selected, var(--calcite-color-surface-highlight))
   );
 }
 


### PR DESCRIPTION

**Related Issue:** [#12482](https://github.com/Esri/calcite-design-system/issues/12482)

## Summary
Replaced deprecated `color-foreground-current` with `color-surface-highlight` token.

