### PR TITLE
feat(dropdown-group): update design for 4.0

### DIFF
--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
@@ -97,11 +97,6 @@ describe("calcite-dropdown-group", () => {
     const tokens: ComponentTestTokens = {
       "--calcite-dropdown-group-border-color": [
         {
-          targetProp: "borderColor",
-          shadowSelector: `.${CSS.title}`,
-          selector: `calcite-dropdown-group`,
-        },
-        {
           targetProp: "backgroundColor",
           shadowSelector: `.${CSS.separator}`,
           selector: `calcite-dropdown-group.two`,

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.e2e.ts
@@ -95,13 +95,11 @@ describe("calcite-dropdown-group", () => {
 
   describe("theme", () => {
     const tokens: ComponentTestTokens = {
-      "--calcite-dropdown-group-border-color": [
-        {
-          targetProp: "backgroundColor",
-          shadowSelector: `.${CSS.separator}`,
-          selector: `calcite-dropdown-group.two`,
-        },
-      ],
+      "--calcite-dropdown-group-border-color": {
+        targetProp: "backgroundColor",
+        shadowSelector: `.${CSS.separator}`,
+        selector: `calcite-dropdown-group.two`,
+      },
       "--calcite-dropdown-group-title-text-color": {
         targetProp: "color",
         shadowSelector: `.${CSS.title}`,

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -34,7 +34,11 @@
 :host([scale="s"]) {
   @apply text-n2h;
   .dropdown-title {
-    @apply p-2;
+    padding-block: var(--calcite-spacing-xxs);
+    padding-inline: var(--calcite-spacing-sm);
+  }
+  .dropdown-first-title {
+    padding-block-start: var(--calcite-spacing-sm);
   }
   .dropdown-separator {
     margin-block: var(--calcite-spacing-xxs);
@@ -45,7 +49,11 @@
 :host([scale="m"]) {
   @apply text-n1h;
   .dropdown-title {
-    @apply p-3;
+    padding-block: var(--calcite-spacing-sm);
+    padding-inline: var(--calcite-spacing-md);
+  }
+  .dropdown-first-title {
+    padding-block-start: var(--calcite-spacing-lg);
   }
   .dropdown-separator {
     margin-block: var(--calcite-spacing-sm);
@@ -56,7 +64,11 @@
 :host([scale="l"]) {
   @apply text-0h;
   .dropdown-title {
-    @apply p-4;
+    padding-block: var(--calcite-spacing-sm-plus);
+    padding-inline: var(--calcite-spacing-lg);
+  }
+  .dropdown-first-title {
+    padding-block-start: var(--calcite-spacing-xl);
   }
   .dropdown-separator {
     margin-block: var(--calcite-spacing-sm-plus);

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -21,12 +21,9 @@
   cursor-default
   break-words
   border-0
-  border-b
-  border-solid
   font-bold;
 
-  border-color: var(--calcite-dropdown-group-border-color, var(--calcite-color-border-3));
-  color: var(--calcite-dropdown-group-title-text-color, var(--calcite-color-text-2));
+  color: var(--calcite-dropdown-group-title-text-color, var(--calcite-color-text-1));
 }
 
 .dropdown-separator {
@@ -39,6 +36,10 @@
   .dropdown-title {
     @apply p-2;
   }
+  .dropdown-separator {
+    margin-block: var(--calcite-spacing-xxs);
+    margin-inline: var(--calcite-spacing-sm);
+  }
 }
 
 :host([scale="m"]) {
@@ -46,12 +47,20 @@
   .dropdown-title {
     @apply p-3;
   }
+  .dropdown-separator {
+    margin-block: var(--calcite-spacing-sm);
+    margin-inline: var(--calcite-spacing-md);
+  }
 }
 
 :host([scale="l"]) {
   @apply text-0h;
   .dropdown-title {
     @apply p-4;
+  }
+  .dropdown-separator {
+    margin-block: var(--calcite-spacing-sm-plus);
+    margin-inline: var(--calcite-spacing-lg);
   }
 }
 

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.scss
@@ -15,7 +15,7 @@
   @apply text-start;
 }
 
-.dropdown-title {
+.title {
   @apply -mb-px
   block
   cursor-default
@@ -26,21 +26,21 @@
   color: var(--calcite-dropdown-group-title-text-color, var(--calcite-color-text-1));
 }
 
-.dropdown-separator {
+.separator {
   @apply block h-px;
   background-color: var(--calcite-dropdown-group-border-color, var(--calcite-color-border-3));
 }
 
 :host([scale="s"]) {
   @apply text-n2h;
-  .dropdown-title {
+  .title {
     padding-block: var(--calcite-spacing-xxs);
     padding-inline: var(--calcite-spacing-sm);
   }
-  .dropdown-first-title {
+  .first-title {
     padding-block-start: var(--calcite-spacing-sm);
   }
-  .dropdown-separator {
+  .separator {
     margin-block: var(--calcite-spacing-xxs);
     margin-inline: var(--calcite-spacing-sm);
   }
@@ -48,14 +48,14 @@
 
 :host([scale="m"]) {
   @apply text-n1h;
-  .dropdown-title {
+  .title {
     padding-block: var(--calcite-spacing-sm);
     padding-inline: var(--calcite-spacing-md);
   }
-  .dropdown-first-title {
+  .first-title {
     padding-block-start: var(--calcite-spacing-lg);
   }
-  .dropdown-separator {
+  .separator {
     margin-block: var(--calcite-spacing-sm);
     margin-inline: var(--calcite-spacing-md);
   }
@@ -63,14 +63,14 @@
 
 :host([scale="l"]) {
   @apply text-0h;
-  .dropdown-title {
+  .title {
     padding-block: var(--calcite-spacing-sm-plus);
     padding-inline: var(--calcite-spacing-lg);
   }
-  .dropdown-first-title {
+  .first-title {
     padding-block-start: var(--calcite-spacing-xl);
   }
-  .dropdown-separator {
+  .separator {
     margin-block: var(--calcite-spacing-sm-plus);
     margin-inline: var(--calcite-spacing-lg);
   }

--- a/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/calcite-components/src/components/dropdown-group/dropdown-group.tsx
@@ -129,7 +129,7 @@ export class DropdownGroup extends LitElement {
 
   override render(): JsxNode {
     const groupTitle = this.groupTitle ? (
-      <span ariaHidden="true" class={CSS.title}>
+      <span ariaHidden="true" class={{ [CSS.title]: true, [CSS.firstTitle]: this.position === 0 }}>
         {this.groupTitle}
       </span>
     ) : null;

--- a/packages/calcite-components/src/components/dropdown-group/resources.ts
+++ b/packages/calcite-components/src/components/dropdown-group/resources.ts
@@ -1,5 +1,5 @@
 export const CSS = {
-  title: "dropdown-title",
-  firstTitle: "dropdown-first-title",
-  separator: "dropdown-separator",
+  title: "title",
+  firstTitle: "first-title",
+  separator: "separator",
 };

--- a/packages/calcite-components/src/components/dropdown-group/resources.ts
+++ b/packages/calcite-components/src/components/dropdown-group/resources.ts
@@ -1,4 +1,5 @@
 export const CSS = {
   title: "dropdown-title",
+  firstTitle: "dropdown-first-title",
   separator: "dropdown-separator",
 };

--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -225,8 +225,8 @@ describe("calcite-dropdown", () => {
       </calcite-dropdown>`,
     );
 
-    const group1Title = await page.find("calcite-dropdown-group[id='group-1'] >>> .dropdown-title");
-    const group2Title = await page.find("calcite-dropdown-group[id='group-2'] >>> .dropdown-title");
+    const group1Title = await page.find("calcite-dropdown-group[id='group-1'] >>> .title");
+    const group2Title = await page.find("calcite-dropdown-group[id='group-2'] >>> .title");
     expect(group1Title).not.toBeNull();
     expect(group2Title).toBeNull();
   });


### PR DESCRIPTION
**Related Issue:** [#10783](https://github.com/Esri/calcite-design-system/issues/10783)

## Summary

Update group-title color to `--calcite-color-text-1`.
Update padding-block of group-title at each scale. padding-inline matches that of Dropdown Item at each scale.
Use a single divider between groups.