### PR TITLE
fix(inline-editable): prevent interaction with start-editing button when hidden

### DIFF
--- a/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.e2e.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { accessible, disabled, focusable, hidden, labelable, renders, t9n, themed } from "../../tests/commonTests";
 import { html } from "../../../support/formatting";
 import type { Input } from "../input/input";
-import { findAll } from "../../tests/utils/puppeteer";
+import { findAll, getElementRect, toElementHandle } from "../../tests/utils/puppeteer";
 import { createControlledPromise } from "../../tests/utils/promises";
 import { CSS } from "./resources";
 import type { InlineEditable } from "./inline-editable";
@@ -147,6 +147,15 @@ describe("calcite-inline-editable", () => {
       await enableEditingButton.click();
       expect(element).toHaveAttribute("editing-enabled");
       expect(calciteInternalInlineEditableEnableEditingChange).toHaveReceivedEventTimes(1);
+
+      const enableEditingButtonRect = await getElementRect(
+        page,
+        `calcite-inline-editable`,
+        `.${CSS.enableEditingButton}`,
+      );
+      await page.mouse.move(enableEditingButtonRect.x, enableEditingButtonRect.y);
+      const elementHandle = await toElementHandle(enableEditingButton);
+      expect(await elementHandle.evaluate((el) => el.matches(":hover"))).toBe(false);
     });
 
     it("enables editing when the child input is clicked", async () => {

--- a/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/calcite-components/src/components/inline-editable/inline-editable.tsx
@@ -313,6 +313,7 @@ export class InlineEditable extends LitElement implements InteractiveComponent, 
               ref={this.enableEditingButtonRef}
               scale={this.scale}
               style={{
+                "pointer-events": this.editingEnabled ? "none" : "auto",
                 opacity: this.editingEnabled ? "0" : "1",
                 width: this.editingEnabled ? "0" : "inherit",
               }}


### PR DESCRIPTION
**Related Issue:** #12858 

## Summary

This prevents tooltips from appearing when the start editing button is hidden during an active edit session.
