### PR TITLE
ci(actions): fix Monday sync bugs and trigger sync from `ready for dev` action

### DIFF
--- a/.github/scripts/monday/handleReadyForDev.js
+++ b/.github/scripts/monday/handleReadyForDev.js
@@ -1,0 +1,27 @@
+// @ts-check
+const Monday = require("../support/monday");
+const { assertRequired } = require("../support/utils");
+
+/**
+ * When the "Ready for Dev" automation runs, it fires a trigger for this step.
+ * This script adds the provided "label_name" (should always be "needs milestone"),
+ * clears the milestone through `handleMilestone`, and updates all assignees.
+ */
+/** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+module.exports = async ({ github, context }) => {
+  const [issueNumber, labelName] = assertRequired([
+    context.payload.inputs.issue_number,
+    context.payload.inputs.label_name,
+  ]);
+
+  const { data: issue } = await github.rest.issues.get({
+    ...context.repo,
+    issue_number: issueNumber,
+  });
+
+  const monday = Monday(issue);
+  monday.addLabel(labelName);
+  monday.handleMilestone();
+  monday.addAllAssignees();
+  await monday.commit();
+};

--- a/.github/scripts/monday/updateAssignee.js
+++ b/.github/scripts/monday/updateAssignee.js
@@ -3,7 +3,7 @@ const { notInLifecycle, assertRequired } = require("../support/utils");
 const Monday = require("../support/monday");
 const {
   labels: {
-    issueWorkflow: { new: newLabel, assigned: assignedLabel, needsMilestone },
+    issueWorkflow: { new: newLabel, assigned: assignedLabel, needsTriage, needsMilestone },
   },
 } = require("../support/resources");
 
@@ -16,17 +16,17 @@ module.exports = async ({ context }) => {
   const { assignees: currentAssignees, labels } = issue;
   assertRequired([assignee]);
   const monday = Monday(issue);
+  const skippedLabels = [newLabel, assignedLabel, needsTriage, needsMilestone];
 
   if (
     action === "unassigned" &&
     currentAssignees.length === 0 &&
-    notInLifecycle({ labels }) &&
+    notInLifecycle({ labels, skip: skippedLabels }) &&
     !monday.inMilestoneStatus()
   ) {
     monday.addLabel(newLabel);
     console.info("Set status to unassigned, no assignees updated.");
-  }
-  else if (action === "assigned" && notInLifecycle({ labels, skip: [needsMilestone] }) && !monday.inMilestoneStatus()) {
+  } else if (action === "assigned" && notInLifecycle({ labels, skip: skippedLabels }) && !monday.inMilestoneStatus()) {
     monday.addLabel(assignedLabel);
     monday.addAllAssignees();
     console.info("Update assignees, set status to assigned.");

--- a/.github/scripts/monday/updateLabels.js
+++ b/.github/scripts/monday/updateLabels.js
@@ -1,5 +1,8 @@
 // @ts-check
 const Monday = require("../support/monday");
+const {
+  labels: { planning, issueWorkflow },
+} = require("../support/resources");
 const { assertRequired } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
@@ -8,6 +11,13 @@ module.exports = async ({ context }) => {
   const [labelName] = assertRequired([label?.name]);
 
   const monday = Monday(issue);
+
+  const skippedLabels = [planning.monday, issueWorkflow.new, issueWorkflow.assigned];
+  if (skippedLabels.includes(labelName)) {
+    console.log(`Label "${labelName}" is skipped. Not adding to Monday.com`);
+    return;
+  }
+
   monday.addLabel(labelName);
   await monday.commit();
 };

--- a/.github/scripts/monday/updateState.js
+++ b/.github/scripts/monday/updateState.js
@@ -1,10 +1,5 @@
 // @ts-check
 const Monday = require("../support/monday");
-const {
-  labels: {
-    issueType: { design },
-  },
-} = require("../support/resources");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
@@ -13,18 +8,6 @@ module.exports = async ({ context }) => {
       context.payload
     );
   const monday = Monday(issue);
-
-  if (action === "reopened") {
-    monday.setColumnValue(monday.columnIds.open, "Open");
-  } else {
-    monday.setColumnValue(monday.columnIds.open, "Closed");
-    if (issue.state_reason !== "completed") {
-      monday.setColumnValue(monday.columnIds.status, "Closed");
-    }
-    else if (issue.labels?.every((label) => label.name !== design)) {
-      monday.setColumnValue(monday.columnIds.status, "Done");
-    }
-  }
-
+  monday.handleState(action);
   await monday.commit();
 };

--- a/.github/scripts/notifyWhenReadyForDev.js
+++ b/.github/scripts/notifyWhenReadyForDev.js
@@ -3,12 +3,13 @@
 // 1. Modifies the labels,
 // 2. Updates the assignees and milestone, and
 // 3. Generates a notification to the Calcite project manager(s)
+// 4. Trigger the Monday.com sync workflow
 //
 // The secret is formatted like so: person1, person2, person3
 //
 // Note the script automatically adds the "@" character in to notify the project manager(s)
 const {
-  labels: { issueWorkflow, planning },
+  labels: { issueWorkflow },
 } = require("./support/resources");
 const { removeLabel } = require("./support/utils");
 
@@ -66,6 +67,19 @@ module.exports = async ({ github, context }) => {
     await github.rest.issues.createComment({
       ...issueProps,
       body: `cc ${calcite_managers}`,
+    });
+
+    // Emit event to trigger Monday.com syncing actions
+    await github.rest.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: "issue-monday-sync.yml",
+      ref: "dev",
+      inputs: {
+        issue_number: number.toString(),
+        event_type: "ReadyForDev",
+        label_name: label.name,
+      },
     });
   }
 };

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -359,6 +359,12 @@ module.exports = function Monday(issue) {
     ["Amretasre002762670", { role: columnIds.developers, id: 77031889 }],
   ]);
 
+  /** @type {Record<Exclude<import('@octokit/webhooks-types').Issue["state"], undefined>, string>} */
+  const stateMap = {
+    open: "Open",
+    closed: "Closed",
+  };
+
   /** Private helper functions */
 
   /**
@@ -689,7 +695,11 @@ module.exports = function Monday(issue) {
    * @returns {void}
    */
   function handleState(action = "open") {
-    setColumnValue(columnIds.open, issue.state === "open" ? "Open" : "Closed");
+    if (!issue.state) {
+      console.log("No Issue state provided to handleState.");
+      return;
+    }
+    setColumnValue(columnIds.open, stateMap[issue.state]);
 
     if (action === "closed") {
       if (issue.state_reason !== "completed") {

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -567,7 +567,7 @@ module.exports = function Monday(issue) {
       labels.forEach((label) => addLabel(label.name));
     }
 
-    if (notInLifecycle({ labels, skip: [issueWorkflow.new, issueWorkflow.assigned] })) {
+    if (notInLifecycle({ labels, skip: [issueWorkflow.new] })) {
       addLabel(issueWorkflow.needsTriage);
     }
 
@@ -576,7 +576,12 @@ module.exports = function Monday(issue) {
 
       // Set to "assigned" if no lifecycle labels were applied
       // Overrides the default "needs triage" label
-      if (notInLifecycle({ labels })) {
+      if (
+        notInLifecycle({
+          labels,
+          skip: [issueWorkflow.new, issueWorkflow.needsTriage, issueWorkflow.needsMilestone],
+        })
+      ) {
         addLabel(issueWorkflow.assigned);
       }
     }
@@ -640,7 +645,7 @@ module.exports = function Monday(issue) {
    * Update columnUpdates based on milestone title
    */
   function handleMilestone() {
-    // If removed, reset date and clear stalled label
+    // Null milestone indicates milestone was removed
     if (!issueMilestone) {
       columnUpdates[columnIds.date] = "";
       clearLabel(milestone.stalled);
@@ -654,7 +659,13 @@ module.exports = function Monday(issue) {
       columnUpdates[columnIds.date] = milestoneDate;
       clearLabel(milestone.stalled);
 
-      if (assignee && notInLifecycle({ labels, skip: [issueWorkflow.needsMilestone] })) {
+      if (
+        assignee &&
+        notInLifecycle({
+          labels,
+          skip: [issueWorkflow.new, issueWorkflow.assigned, issueWorkflow.needsTriage, issueWorkflow.needsMilestone],
+        })
+      ) {
         addLabel(issueWorkflow.assigned);
       }
       if (!assignee && notReadyForDev(labels)) {

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -564,7 +564,7 @@ module.exports = function Monday(issue) {
       labels.forEach((label) => addLabel(label.name));
     }
 
-    if (notInLifecycle({ labels })) {
+    if (notInLifecycle({ labels, skip: [issueWorkflow.new, issueWorkflow.assigned] })) {
       addLabel(issueWorkflow.needsTriage);
     }
 

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -422,7 +422,10 @@ module.exports = function Monday(issue) {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error when calling the Monday API: ${JSON.stringify(body)}`);
+        const errorBody = await response.json();
+        throw new Error(
+          `${response.status} (${response.statusText}) HTTP error when calling Monday API: ${JSON.stringify(errorBody)}`,
+        );
       }
       return await response.json();
     } catch (error) {

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -117,7 +117,7 @@ module.exports = function Monday(issue) {
       issueWorkflow.readyForDev,
       {
         column: columnIds.status,
-        value: "Ready for dev",
+        value: "Ready for Dev",
       },
     ],
     [

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -647,7 +647,7 @@ module.exports = function Monday(issue) {
   function handleMilestone() {
     // Null milestone indicates milestone was removed
     if (!issueMilestone) {
-      columnUpdates[columnIds.date] = "";
+      setColumnValue(columnIds.date, "");
       clearLabel(milestone.stalled);
       return;
     }
@@ -656,7 +656,7 @@ module.exports = function Monday(issue) {
     const milestoneDate = milestoneTitle.match(milestoneDateRegex)?.[0];
 
     if (milestoneDate) {
-      columnUpdates[columnIds.date] = milestoneDate;
+      setColumnValue(columnIds.date, milestoneDate);
       clearLabel(milestone.stalled);
 
       if (
@@ -672,12 +672,12 @@ module.exports = function Monday(issue) {
         addLabel(issueWorkflow.new);
       }
     } else {
-      columnUpdates[columnIds.date] = "";
+      setColumnValue(columnIds.date, "");
 
       if (milestoneTitle === milestone.stalled) {
         addLabel(milestone.stalled);
       } else if (inMilestoneStatus()) {
-        columnUpdates[columnIds.status] = milestoneTitle;
+        setColumnValue(columnIds.status, milestoneTitle);
         clearLabel(milestone.stalled);
       }
     }
@@ -735,7 +735,7 @@ module.exports = function Monday(issue) {
       return;
     }
 
-    columnUpdates[info.column] = info.value;
+    setColumnValue(info.column, info.value);
   }
 
   /**
@@ -749,7 +749,7 @@ module.exports = function Monday(issue) {
       console.log(`Label "${label}" not found in Monday Labels map.`);
       return;
     }
-    columnUpdates[labelColumn] = "";
+    setColumnValue(labelColumn, "");
   }
 
   /**

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -340,7 +340,7 @@ module.exports = function Monday(issue) {
   /** @type {Map<string, MondayPerson>} */
   const peopleMap = new Map([
     ["anveshmekala", { role: columnIds.developers, id: 48387134 }],
-    ["aPreciado88", { role: columnIds.developers, id: 6079524 }],
+    ["aPreciado88", { role: columnIds.developers, id: 60795249 }],
     ["ashetland", { role: columnIds.designers, id: 45851619 }],
     ["benelan", { role: columnIds.developers, id: 49704471 }],
     ["chezHarper", { role: columnIds.designers, id: 71157966 }],

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -2,6 +2,14 @@ name: Monday.com Issue Sync
 on:
   issues:
     types: [opened, edited, closed, reopened, labeled, unlabeled, milestoned, demilestoned, assigned, unassigned]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        required: true
+      event_type:
+        required: true
+      label_name:
+        required: true
 env:
   MONDAY_KEY: ${{ secrets.MONDAY_KEY }}
   MONDAY_BOARD: ${{ secrets.MONDAY_BOARD }}
@@ -76,4 +84,12 @@ jobs:
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/monday/updateState.js')
+            await action({github, context})
+
+      - name: "Handle Ready For Dev Automation"
+        if: github.event.inputs.event_type == 'ReadyForDev'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const action = require('${{ github.workspace }}/.github/scripts/monday/handleReadyForDev.js')
             await action({github, context})

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**Related Issue:** #12814

## Summary
After #12820 was merged, a few bugs and logic flaws were discovered. This PR addresses:
- Triggering and handling the Monday.com sync for the "Ready for Dev" automation. Changes made in the automation do not automatically trigger the Monday workflow, so a custom trigger is required.
- Capitalizing "Dev" in the "Ready for Dev" status value to match the Monday board
- Correcting Abraham's Monday ID to properly assign tasks to him
- Properly skipping the "needs triage" label in the logic
- Skipping the "new" and "assigned" labels when syncing to Monday, as they are not needed. These skips will be removed once our labels change.
- Passing HTTP error information instead of the issue body for better error handling
- Abstracting state handling and including the state/title information when doing a full sync of exisitng tasks in Monday
- Minor improvement, using `setColumnValue` method instead of direct mutation for setting column values in Monday

## Changelog
- **ci(actions): capitalize "Dev" in Monday "Ready for Dev" value**
- **ci(actions): fix Abraham's Monday ID**
- **ci(actions): skip new and assigned labels (not needed in Monday)**
- **ci(actions): pass HTTP error info instead of issue body**
- **ci(actions): abstract state handling and add state/title on createTask sync**
- **ci(actions): properly skip `needs triage` in logic, temp skip `new`/`assigned`**
- **ci(actions): use `setColumnValue` instead of direct mutation**
- **ci(actions): trigger and handle Monday.com sync for Ready for Dev automation**
