### PR TITLE
ci(actions): sync design tokens labels to Monday

### DIFF
--- a/.github/scripts/monday/removeLabel.js
+++ b/.github/scripts/monday/removeLabel.js
@@ -3,7 +3,9 @@ const Monday = require("../support/monday");
 const {
   labels: {
     planning: { spike, spikeComplete },
+    issueType: { designTokens },
   },
+  packages: { tokens }
 } = require("../support/resources");
 const { assertRequired } = require("../support/utils");
 
@@ -16,6 +18,13 @@ module.exports = async ({ context }) => {
   if (isSpike && issue.labels) {
     const isSpikeComplete = issue.labels.some((label) => label.name === spikeComplete);
     assertRequired([isSpikeComplete], "Issue is marked as a spike complete. Skipping label removal.");
+  }
+
+  const tokensLabels = [designTokens, tokens];
+  const isTokens = tokensLabels.includes(labelName);
+  if (isTokens && issue.labels) {
+    const areTokensStillPresent = issue.labels.some((label) => label.name === designTokens);
+    assertRequired([areTokensStillPresent], "Issue is still marked as a design token issue. Skipping label removal.");
   }
 
   const monday = Monday(issue);

--- a/.github/scripts/support/monday.js
+++ b/.github/scripts/support/monday.js
@@ -2,6 +2,7 @@
 const {
   labels: { issueWorkflow, issueType, priority, devEstimate, designEstimate, planning, handoff },
   milestone,
+  packages,
 } = require("./resources");
 const { notReadyForDev, notInLifecycle } = require("./utils");
 
@@ -52,6 +53,7 @@ module.exports = function Monday(issue) {
     blocked: "color_mkv7x1gw",
     a11y: "color_mksw1sfa",
     spike: "color_mkrt20dy",
+    designTokens: "color_mkvyhk10",
     figmaChanges: "color_mkrvmhg7",
     open: "color_mknkrb2n",
   };
@@ -146,6 +148,13 @@ module.exports = function Monday(issue) {
       {
         column: columnIds.designIssue,
         value: "Design",
+      },
+    ],
+    [
+      issueType.designTokens,
+      {
+        column: columnIds.designTokens,
+        value: "Design Tokens",
       },
     ],
     [
@@ -328,6 +337,13 @@ module.exports = function Monday(issue) {
       {
         column: columnIds.stalled,
         value: "Stalled",
+      },
+    ],
+    [
+      packages.tokens,
+      {
+        column: columnIds.designTokens,
+        value: "Design Tokens",
       },
     ],
   ]);

--- a/.github/scripts/support/resources.js
+++ b/.github/scripts/support/resources.js
@@ -18,6 +18,7 @@ const resources = {
       a11y: "a11y",
       newComponent: "new component",
       design: "design",
+      designTokens: "design-tokens",
     },
     issueWorkflow: {
       new: "0 - new",
@@ -77,6 +78,7 @@ const resources = {
     translationReviewers: "calcite-translation-reviewers",
   },
   packages: {
+    tokens: "calcite-design-tokens",
     icons: "calcite-ui-icons",
   },
 };

--- a/.github/workflows/issue-monday-sync.yml
+++ b/.github/workflows/issue-monday-sync.yml
@@ -44,6 +44,8 @@ jobs:
           github.event.action == 'unlabeled' && (
             github.event.label.name == 'blocked' ||
             github.event.label.name == 'design' ||
+            github.event.label.name == 'design-tokens' ||
+            github.event.label.name == 'calcite-design-tokens' ||
             github.event.label.name == 'a11y' ||
             github.event.label.name == 'figma changes' ||
             github.event.label.name == 'spike'


### PR DESCRIPTION
**Related Issue:** #12814

## Summary
- Add `design-tokens` and `calcite-design-tokens` labels to `resources.js`
- Sync these tokens to the "Design Tokens" Monday column, allowing removal but only if neither of them are still present on the issue.
