### PR TITLE
fix(list-item): fix memory leak caused by focusing before disconnecting

### DIFF
--- a/packages/calcite-components/src/components/list-item/list-item.tsx
+++ b/packages/calcite-components/src/components/list-item/list-item.tsx
@@ -388,6 +388,10 @@ export class ListItem extends LitElement implements InteractiveComponent, Sortab
     this.setSelectionDefaults();
   }
 
+  disconnectedCallback() {
+    focusMap.clear();
+  }
+
   /**
    * TODO: [MIGRATION] Consider inlining some of the watch functions called inside of this method to reduce boilerplate code
    *


### PR DESCRIPTION
**Related Issue:** #12818 

## Summary

This fixes a memory leak caused by `calcite-list-item`'s [`focusMap`](https://github.com/Esri/calcite-design-system/blob/8cc130d4bc496809d53ee4bd31da204ceb9a26b8/packages/calcite-components/src/components/list-item/list-item.tsx#L35) holding on to list elements and not being cleared when removed from the DOM.

Our test environment doesn't cover memory profiling, so no tests were added.