### PR TITLE
fix(panel): Ensure `content-top` and `action-bar` slots are visible

### DIFF
--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -546,12 +546,12 @@ describe("calcite-panel", () => {
     expect(element).toEqualText("test description");
   });
 
-  it("should not render a header if there are no actions or content", async () => {
+  it("should not render a header container if there are no actions or content", async () => {
     const page = await newE2EPage();
 
     await page.setContent("<calcite-panel>test</calcite-panel>");
 
-    const header = await page.find(`calcite-panel >>> .${CSS.header}`);
+    const header = await page.find(`calcite-panel >>> .${CSS.headerContainer}`);
 
     expect(await header.isVisible()).toBe(false);
   });

--- a/packages/calcite-components/src/components/panel/panel.e2e.ts
+++ b/packages/calcite-components/src/components/panel/panel.e2e.ts
@@ -546,14 +546,24 @@ describe("calcite-panel", () => {
     expect(element).toEqualText("test description");
   });
 
-  it("should not render a header container if there are no actions or content", async () => {
+  it("should not render a header if there are no actions or content", async () => {
     const page = await newE2EPage();
 
     await page.setContent("<calcite-panel>test</calcite-panel>");
 
-    const header = await page.find(`calcite-panel >>> .${CSS.headerContainer}`);
+    const header = await page.find(`calcite-panel >>> .${CSS.header}`);
 
     expect(await header.isVisible()).toBe(false);
+  });
+
+  it("should render a header if slotted content and no header is present", async () => {
+    const page = await newE2EPage();
+
+    await page.setContent("<calcite-panel><div slot='content-top'>test</div></calcite-panel>");
+
+    const header = await page.find(`calcite-panel >>> .${CSS.header}`);
+
+    expect(await header.isVisible()).toBe(true);
   });
 
   it("menuOpen should show/hide when toggled", async () => {

--- a/packages/calcite-components/src/components/panel/panel.stories.ts
+++ b/packages/calcite-components/src/components/panel/panel.stories.ts
@@ -533,6 +533,25 @@ export const footerAndContentTopBottomSlots = (): string => html`
   </div>
 `;
 
+export const contentTopAndActionBarSlotsNoHeader = (): string => html`
+  <div style="height: 350px; width: 400px; display: flex">
+    <calcite-panel height-scale="s">
+      <calcite-action-bar slot="action-bar">
+        <calcite-action-group>
+          <calcite-action text="Add" icon="plus"> </calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+      <div slot="content-top">Slot for a content-top.</div>
+      <p>Slotted content!</p>
+      <p>Hello world!</p>
+      <p>Hello world!</p>
+      <p>Hello world!</p>
+      <div slot="content-bottom">Slot for a content-bottom.</div>
+      <p slot="footer">Footer!</p>
+    </calcite-panel>
+  </div>
+`;
+
 export const footerStartAndEndSlots = (): string => html`
   <calcite-panel style="height: 200px; width: 300px;">
     <div slot="header-content">header-content slot</div>

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -573,6 +573,7 @@ export class Panel extends LitElement implements InteractiveComponent {
       collapsible,
       hasMenuItems,
       hasActionBar,
+      hasContentTop,
     } = this;
 
     const headerContentNode = this.renderHeaderContent();
@@ -584,7 +585,9 @@ export class Panel extends LitElement implements InteractiveComponent {
       hasEndActions ||
       collapsible ||
       closable ||
-      hasMenuItems;
+      hasMenuItems ||
+      hasActionBar ||
+      hasContentTop;
 
     this.showHeaderContent = showHeaderContent;
 

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -592,7 +592,7 @@ export class Panel extends LitElement implements InteractiveComponent {
     this.showHeaderContent = showHeaderContent;
 
     return (
-      <header class={CSS.header} hidden={!(showHeaderContent || hasActionBar)}>
+      <header class={CSS.header}>
         <div
           class={{ [CSS.headerContainer]: true, [CSS.headerContainerBorderEnd]: hasActionBar }}
           hidden={!showHeaderContent}

--- a/packages/calcite-components/src/components/panel/panel.tsx
+++ b/packages/calcite-components/src/components/panel/panel.tsx
@@ -592,7 +592,7 @@ export class Panel extends LitElement implements InteractiveComponent {
     this.showHeaderContent = showHeaderContent;
 
     return (
-      <header class={CSS.header}>
+      <header class={CSS.header} hidden={!(showHeaderContent || hasActionBar || hasContentTop)}>
         <div
           class={{ [CSS.headerContainer]: true, [CSS.headerContainerBorderEnd]: hasActionBar }}
           hidden={!showHeaderContent}

--- a/packages/calcite-components/src/demos/panel.html
+++ b/packages/calcite-components/src/demos/panel.html
@@ -107,6 +107,7 @@
           <calcite-panel scale="l" icon="banana" heading="Large Bananas!"> Hello world! </calcite-panel>
         </div>
       </div>
+      <hr />
 
       <!-- with action bar and content top-->
       <div class="parent">
@@ -132,6 +133,48 @@
           </div>
         </div>
       </div>
+      <hr />
+      <!-- with action bar and content top no heading -->
+      <div class="parent">
+        <div class="child right-aligned-text">Slotted Action Bar Top No Heading</div>
+        <div class="child">
+          <div style="height: 300px; width: 400px; display: flex">
+            <calcite-panel height-scale="s">
+              <calcite-action-bar slot="action-bar">
+                <calcite-action-group>
+                  <calcite-action text="Add" icon="plus"> </calcite-action>
+                  <calcite-action text="Save" icon="save"> </calcite-action>
+                  <calcite-action text="Layers" icon="layers"> </calcite-action>
+                </calcite-action-group>
+              </calcite-action-bar>
+              <div slot="content-top">Slot for a content-top.</div>
+              <p>Slotted content!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p slot="footer">Slotted content!</p>
+            </calcite-panel>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <!-- with action bar and content top no heading -->
+      <div class="parent">
+        <div class="child right-aligned-text">Slotted Slotted Content Top No Heading</div>
+        <div class="child">
+          <div style="height: 300px; width: 400px; display: flex">
+            <calcite-panel height-scale="s">
+              <div slot="content-top">Slot for a content-top.</div>
+              <p>Slotted content!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p style="height: 400px">Hello world!</p>
+              <p slot="footer">Slotted content!</p>
+            </calcite-panel>
+          </div>
+        </div>
+      </div>
+      <hr />
       <!-- with action bar -->
       <div class="parent">
         <div class="child right-aligned-text">Slotted Action Bar action end</div>

--- a/packages/calcite-components/src/demos/panel.html
+++ b/packages/calcite-components/src/demos/panel.html
@@ -158,7 +158,7 @@
         </div>
       </div>
       <hr />
-      <!-- with action bar and content top no heading -->
+      <!-- with content-top and content top no heading -->
       <div class="parent">
         <div class="child right-aligned-text">Slotted Slotted Content Top No Heading</div>
         <div class="child">


### PR DESCRIPTION
**Related Issue:** #12894 

## Summary
Ensures `action-bar` and `content-top` slots display when populated.