### PR TITLE
feat(autocomplete-item-group): update design for 4.0

### DIFF
--- a/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.e2e.ts
+++ b/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.e2e.ts
@@ -1,4 +1,5 @@
 import { describe } from "vitest";
+import { html } from "../../../support/formatting";
 import { defaults, hidden, renders, themed } from "../../tests/commonTests";
 import { CSS } from "./resources";
 
@@ -26,14 +27,30 @@ describe("calcite-autocomplete-item-group", () => {
         shadowSelector: `.${CSS.container}`,
         targetProp: "backgroundColor",
       },
-      "--calcite-autocomplete-border-color": {
-        shadowSelector: `.${CSS.heading}`,
-        targetProp: "borderBlockEndColor",
-      },
       "--calcite-autocomplete-text-color": {
         shadowSelector: `.${CSS.heading}`,
         targetProp: "color",
       },
+    });
+
+    describe("groups", () => {
+      themed(
+        html`<calcite-autocomplete>
+          <calcite-autocomplete-item-group heading="Group 1">
+            <calcite-autocomplete-item value="1" heading="Item 1"></calcite-autocomplete-item>
+          </calcite-autocomplete-item-group>
+          <calcite-autocomplete-item-group heading="Group 2" position="1">
+            <calcite-autocomplete-Item value="2" heading="Item 2"></calcite-autocomplete-Item>
+          </calcite-autocomplete-item-group>
+        </calcite-autocomplete>`,
+        {
+          "--calcite-autocomplete-border-color": {
+            selector: "calcite-autocomplete-item-group[position='1']",
+            shadowSelector: `.${CSS.separator}`,
+            targetProp: "backgroundColor",
+          },
+        },
+      );
     });
   });
 });

--- a/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.scss
+++ b/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.scss
@@ -12,23 +12,54 @@
 //
 // Internal CSS custom properties for component use only. Overwriting is not recommended.
 //
-// --calcite-internal-autocomplete-item-group-spacing-unit
+// --calcite-internal-autocomplete-item-group-horizontal-spacing-unit
+// --calcite-internal-autocomplete-item-group-vertical-spacing-unit
 
 @use "../../assets/styles/includes";
 
 .scale--s {
   @apply text-n2h;
-  --calcite-internal-autocomplete-item-group-spacing-unit: theme("spacing.2");
+  --calcite-internal-autocomplete-item-group-horizontal-spacing-unit: var(--calcite-spacing-sm);
+  --calcite-internal-autocomplete-item-group-vertical-spacing-unit: var(--calcite-spacing-xxs);
+
+  .first-title {
+    padding-block-start: var(--calcite-spacing-sm);
+  }
+
+  .separator {
+    margin-block: var(--calcite-internal-autocomplete-item-group-vertical-spacing-unit);
+    margin-inline: var(--calcite-internal-autocomplete-item-group-horizontal-spacing-unit);
+  }
 }
 
 .scale--m {
   @apply text-n1h;
-  --calcite-internal-autocomplete-item-group-spacing-unit: theme("spacing.3");
+  --calcite-internal-autocomplete-item-group-horizontal-spacing-unit: var(--calcite-spacing-md);
+  --calcite-internal-autocomplete-item-group-vertical-spacing-unit: var(--calcite-spacing-xs);
+
+  .first-title {
+    padding-block-start: var(--calcite-spacing-md);
+  }
+
+  .separator {
+    margin-block: var(--calcite-internal-autocomplete-item-group-vertical-spacing-unit);
+    margin-inline: var(--calcite-internal-autocomplete-item-group-horizontal-spacing-unit);
+  }
 }
 
 .scale--l {
   @apply text-0h;
-  --calcite-internal-autocomplete-item-group-spacing-unit: theme("spacing.4");
+  --calcite-internal-autocomplete-item-group-horizontal-spacing-unit: var(--calcite-spacing-lg);
+  --calcite-internal-autocomplete-item-group-vertical-spacing-unit: var(--calcite-spacing-sm-plus);
+
+  .first-title {
+    padding-block-start: var(--calcite-spacing-xl);
+  }
+
+  .separator {
+    margin-block: var(--calcite-internal-autocomplete-item-group-vertical-spacing-unit);
+    margin-inline: var(--calcite-internal-autocomplete-item-group-horizontal-spacing-unit);
+  }
 }
 
 :host {
@@ -41,26 +72,27 @@
   @apply flex
     flex-col;
   background-color: var(--calcite-autocomplete-background-color, var(--calcite-color-foreground-1));
-  padding-block-start: var(--calcite-internal-autocomplete-item-group-spacing-unit);
 }
 
 .container--no-spacing {
   padding-block-start: 0;
 }
 
+.separator {
+  block-size: var(--calcite-spacing-px);
+  background-color: var(--calcite-autocomplete-border-color, var(--calcite-color-border-3));
+}
+
 .heading {
-  border: 0 solid;
   @apply box-border
     w-full
     min-w-0
     max-w-full
     word-break
-    border-b
     font-bold;
-  color: var(--calcite-autocomplete-text-color, var(--calcite-color-text-2));
-  border-block-end-color: var(--calcite-autocomplete-border-color, var(--calcite-color-border-3));
-  padding-block: var(--calcite-internal-autocomplete-item-group-spacing-unit);
-  padding-inline: var(--calcite-internal-autocomplete-item-group-spacing-unit);
+  color: var(--calcite-autocomplete-text-color, var(--calcite-color-text-1));
+  padding-block: var(--calcite-internal-autocomplete-item-group-vertical-spacing-unit);
+  padding-inline: var(--calcite-internal-autocomplete-item-group-horizontal-spacing-unit);
 }
 
 @include includes.base-component();

--- a/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/calcite-components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -38,6 +38,13 @@ export class AutocompleteItemGroup extends LitElement {
   @property() label: any;
 
   /**
+   * Specifies the position of the group in the autocomplete menu.
+   *
+   * @internal
+   */
+  @property() position: number = 0;
+
+  /**
    * Specifies the size of the component inherited from the `calcite-autocomplete`, defaults to `m`.
    *
    * @private
@@ -50,6 +57,8 @@ export class AutocompleteItemGroup extends LitElement {
 
   override render(): JsxNode {
     const { scale } = this;
+    const autocompleteSeparator =
+      this.position > 0 ? <div class={CSS.separator} role="separator" /> : null;
     return (
       <div
         aria-label={this.label ?? this.heading}
@@ -60,7 +69,11 @@ export class AutocompleteItemGroup extends LitElement {
         }}
         role="group"
       >
-        <div class={CSS.heading} role="presentation">
+        {autocompleteSeparator}
+        <div
+          class={{ [CSS.heading]: true, [CSS.firstTitle]: this.position === 0 }}
+          role="presentation"
+        >
           {this.heading}
         </div>
         <slot />

--- a/packages/calcite-components/src/components/autocomplete-item-group/resources.ts
+++ b/packages/calcite-components/src/components/autocomplete-item-group/resources.ts
@@ -3,6 +3,8 @@ import { Scale } from "../interfaces";
 export const CSS = {
   container: "container",
   containerNoSpacing: "container--no-spacing",
+  firstTitle: "first-title",
   heading: "heading",
   scale: (scale: Scale) => `scale--${scale}` as const,
+  separator: "separator",
 };

--- a/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/calcite-components/src/components/autocomplete/autocomplete.tsx
@@ -597,6 +597,7 @@ export class Autocomplete
   private updateGroups(): void {
     this.groups.forEach((group, index, items) => {
       group.scale = this.scale;
+      group.position = index;
 
       if (index === 0) {
         group.disableSpacing = true;


### PR DESCRIPTION
**Related Issue:** [#12177](https://github.com/Esri/calcite-design-system/issues/12177)

## Summary

Update heading color to `--calcite-color-text-1`.
Update padding-block of heading.
Remove border underneath heading.
Add inset border between groups.
Remove padding between groups.
