### PR TITLE
refactor(dropdown): drop multi-trigger handling logic

### DIFF
--- a/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/calcite-components/src/components/dropdown/dropdown.e2e.ts
@@ -1056,36 +1056,6 @@ describe("calcite-dropdown", () => {
     expect(await page.evaluate(() => document.activeElement.id)).toEqual("trigger");
   });
 
-  it("accepts multiple triggers", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-dropdown>
-        <calcite-button class="trigger" slot="trigger">Open dropdown</calcite-button>
-        <calcite-icon class="trigger" icon="caretDown" scale="s" slot="trigger"></calcite-icon>
-        <calcite-dropdown-group id="group-1" selection-mode="single">
-          <calcite-dropdown-item id="item-1"> Dropdown Item Content </calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2" selected> Dropdown Item Content </calcite-dropdown-item>
-          <calcite-dropdown-item id="item-3"> Dropdown Item Content </calcite-dropdown-item>
-        </calcite-dropdown-group>
-      </calcite-dropdown>
-    `);
-
-    const element = await page.find("calcite-dropdown");
-    const trigger = await findAll(element, ".trigger");
-    const dropdownWrapper = await page.find("calcite-dropdown >>> .wrapper");
-    await trigger[0].click();
-    expect(await dropdownWrapper.isVisible()).toBe(true);
-    await trigger[0].click();
-    await page.waitForChanges();
-    expect(await dropdownWrapper.isVisible()).toBe(false);
-    await page.waitForChanges();
-    await trigger[1].click();
-    expect(await dropdownWrapper.isVisible()).toBe(true);
-    await trigger[1].click();
-    await page.waitForChanges();
-    expect(await dropdownWrapper.isVisible()).toBe(false);
-  });
-
   describe("accessible", () => {
     accessible(html`${dropdownSelectionModeContent}`);
   });

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -27,7 +27,7 @@ import { createObserver, updateRefObserver } from "../../utils/observers";
 import { OpenCloseComponent, toggleOpenClose } from "../../utils/openCloseComponent";
 import { getDimensionClass } from "../../utils/dynamicClasses";
 import { RequestedItem } from "../dropdown-group/interfaces";
-import { Scale, Width } from "../interfaces";
+import { Scale, SingleItemSlotArray, Width } from "../interfaces";
 import type { DropdownItem } from "../dropdown-item/dropdown-item";
 import type { DropdownGroup } from "../dropdown-group/dropdown-group";
 import { useSetFocus } from "../../controllers/useSetFocus";
@@ -85,11 +85,8 @@ export class Dropdown
 
   transitionEl: HTMLDivElement;
 
-  /**
-   * Typed as single-element array due to queryAssignedElements always returning an array.
-   */
   @queryAssignedElements({ slot: SLOTS.trigger })
-  private triggerEl: [HTMLElement];
+  private triggerEls: SingleItemSlotArray<HTMLElement>;
 
   private focusSetter = useSetFocus<this>()(this);
 
@@ -571,7 +568,7 @@ export class Dropdown
     this.open = false;
 
     if (focusTrigger) {
-      focusElement(this.triggerEl[0]);
+      focusElement(this.triggerEls[0]);
     }
   }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 import { PropertyValues } from "lit";
 import { createEvent, h, JsxNode, LitElement, method, property } from "@arcgis/lumina";
+import { queryAssignedElements } from "lit/decorators.js";
 import { focusElement, focusElementInGroup } from "../../utils/dom";
 import {
   connectFloatingUI,
@@ -84,8 +85,11 @@ export class Dropdown
 
   transitionEl: HTMLDivElement;
 
-  /** trigger elements */
-  private triggers: HTMLElement[];
+  /**
+   * Typed as single-element array due to queryAssignedElements always returning an array.
+   */
+  @queryAssignedElements({ slot: SLOTS.trigger })
+  private triggerEl: [HTMLElement];
 
   private focusSetter = useSetFocus<this>()(this);
 
@@ -420,14 +424,6 @@ export class Dropdown
       : null;
   }
 
-  private updateTriggers(event: Event): void {
-    this.triggers = (event.target as HTMLSlotElement).assignedElements({
-      flatten: true,
-    }) as HTMLElement[];
-
-    this.reposition(true);
-  }
-
   private updateItems(): void {
     this.items = this.groups
       .map((group) => Array.from(group?.querySelectorAll("calcite-dropdown-item")))
@@ -575,7 +571,7 @@ export class Dropdown
     this.open = false;
 
     if (focusTrigger) {
-      focusElement(this.triggers[0]);
+      focusElement(this.triggerEl[0]);
     }
   }
 

--- a/packages/calcite-components/src/components/dropdown/dropdown.tsx
+++ b/packages/calcite-components/src/components/dropdown/dropdown.tsx
@@ -620,7 +620,6 @@ export class Dropdown
             ariaExpanded={open}
             ariaHasPopup="menu"
             name={SLOTS.trigger}
-            onSlotChange={this.updateTriggers}
           />
         </div>
         <div

--- a/packages/calcite-components/src/components/interfaces.ts
+++ b/packages/calcite-components/src/components/interfaces.ts
@@ -1,5 +1,5 @@
 import { LuminaJsx } from "@arcgis/lumina";
-import { CamelCase } from "type-fest/source/camel-case";
+import { CamelCase, ReadonlyTuple } from "type-fest";
 
 export type Alignment = "start" | "center" | "end";
 export type Appearance = "solid" | "outline" | "outline-fill" | "transparent";
@@ -40,6 +40,12 @@ export type IconType = "chevron" | "caret" | "ellipsis" | "overflow" | "plus-min
 export type CollapseDirection = "down" | "up";
 export type Dir = "ltr" | "rtl";
 export type InteractionMode = "interactive" | "static";
+
+/**
+ * Helper type for properties decorated with @queryAssignedElements or @queryAssignedNodes
+ * that are intended to support exactly one slotted element or node.
+ */
+export type SingleItemSlotArray<T extends HTMLElement | Node> = ReadonlyTuple<T, 1>;
 
 type RemoveAriaPrefix<K extends string> = K extends `aria-${infer Rest}`
   ? Rest


### PR DESCRIPTION
**Related Issue:** #12947  

## Summary  

Cleans up code related to supporting multiple triggers.  

**Note:** The component now uses Lit’s [`queryAssignedElements`](https://lit.dev/docs/api/decorators/#queryAssignedElements) decorator. Since this API always returns an array, the property is typed as a single-element array to both simplify the code and help catch improper usage. The property name remains singular, but we can update it if a plural form feels more accurate.  