### PR TITLE
docs(conventions): revert boolean guidelines to "When `true`, xxx"

### DIFF
--- a/packages/calcite-components/conventions/Documentation.md
+++ b/packages/calcite-components/conventions/Documentation.md
@@ -13,7 +13,7 @@ Follow these conventions when adding or editing API reference:
 - Only use single quotes (`'`) as apostrophes.
 - No links or URLs allowed in descriptions. If a link is necessary, a custom JSDoc tag should be added and parsed in the SDK site.
 - Refrain from using "e.g." or "i.e." references. Leverage "such as" (or similar) where examples are referenced.
-- For boolean attributes, refrain from using `true` or `false` as values. Instead, use "When present", "When not present", or similar.
+- For boolean attributes, use "When `true`, xxx" or "When `false`, xxx" to communicate behavior in the different states.
 - Use "Accessible" instead of "Aria" or "a11y" language.
 - Verify slots and properties/attributes don't use the text "optional" in their descriptions.
 


### PR DESCRIPTION
**Related Issue:** #12711

## Summary
Reverts the Style Guide recommendatations for boolean properties to use "When `true`, xxx" wording instead of "When present, xxx."
