### PR TITLE
feat(color-picker, date-picker): adjust outline color for 4.0

### DIFF
--- a/packages/calcite-components/src/components/color-picker/color-picker.scss
+++ b/packages/calcite-components/src/components/color-picker/color-picker.scss
@@ -127,7 +127,7 @@ calcite-swatch {
   display: flex;
   flex-direction: column;
   block-size: min-content;
-  border: 1px solid var(--calcite-color-picker-border-color, var(--calcite-color-border-1));
+  border: 1px solid var(--calcite-color-picker-border-color, var(--calcite-color-border-3));
   background-color: var(--calcite-color-picker-background-color, var(--calcite-color-foreground-1));
   border-radius: var(--calcite-color-picker-corner-radius, var(--calcite-corner-radius-none));
   box-shadow: var(--calcite-color-picker-shadow, var(--calcite-shadow-none));

--- a/packages/calcite-components/src/components/date-picker/date-picker.scss
+++ b/packages/calcite-components/src/components/date-picker/date-picker.scss
@@ -36,7 +36,7 @@
 :host {
   @extend %component-host;
   @apply align-top inline-block overflow-visible w-full border-solid border;
-  border-color: var(--calcite-date-picker-border-color, var(--calcite-color-border-1));
+  border-color: var(--calcite-date-picker-border-color, var(--calcite-color-border-3));
   border-radius: var(--calcite-date-picker-corner-radius, 0);
 }
 


### PR DESCRIPTION
**Related Issue:** [#10768](https://github.com/Esri/calcite-design-system/issues/10768)

## Summary

Update `border-color` to `--calcite-color-border-3`.
