### PR TITLE
feat(shell-panel): allow programmatic updates of `--calcite-shell-panel-height/width` after user resize

### DIFF
--- a/packages/calcite-components/src/components/shell-panel/shell-panel.scss
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.scss
@@ -20,6 +20,21 @@
  *
  */
 
+// AUTO-GENERATED — do not modify. Changes will be overwritten.
+//
+// Internal CSS custom properties for component use only. Overwriting is not recommended.
+//
+// --calcite-internal-shell-panel-max-height
+// --calcite-internal-shell-panel-max-width
+// --calcite-internal-shell-panel-min-height
+// --calcite-internal-shell-panel-min-width
+// --calcite-internal-shell-panel-resize-handle-offset
+// --calcite-internal-shell-panel-shadow-block-end
+// --calcite-internal-shell-panel-shadow-block-start
+// --calcite-internal-shell-panel-shadow-inline-end
+// --calcite-internal-shell-panel-shadow-inline-start
+// --calcite-internal-shell-panel-width
+
 :host {
   @apply relative
     pointer-events-none
@@ -315,18 +330,18 @@
 }
 
 :host([layout="vertical"]:not([display-mode="float-all"])) .content {
-  inline-size: var(--calcite-internal-shell-panel-width);
+  inline-size: var(--calcite-shell-panel-width);
   max-inline-size: var(--calcite-internal-shell-panel-max-width);
   min-inline-size: var(--calcite-internal-shell-panel-min-width);
 }
 
 :host([layout="vertical"][display-mode="float-all"]) .content {
-  inline-size: var(--calcite-internal-shell-panel-width);
+  inline-size: var(--calcite-shell-panel-width);
   min-inline-size: var(--calcite-internal-shell-panel-min-width);
 }
 
 :host([layout="horizontal"]) .content {
-  block-size: var(--calcite-internal-shell-panel-height);
+  block-size: var(--calcite-shell-panel-height);
   max-block-size: var(--calcite-internal-shell-panel-max-height);
   min-block-size: var(--calcite-internal-shell-panel-min-height);
 }

--- a/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/calcite-components/src/components/shell-panel/shell-panel.tsx
@@ -277,7 +277,14 @@ export class ShellPanel extends LitElement {
       [type]: rounded,
     };
 
-    contentEl.style[type] = size !== null ? `${rounded}px` : null;
+    if (type === "blockSize") {
+      this.el.style.setProperty(
+        "--calcite-shell-panel-height",
+        size !== null ? `${rounded}px` : "",
+      );
+    } else {
+      this.el.style.setProperty("--calcite-shell-panel-width", size !== null ? `${rounded}px` : "");
+    }
   }
 
   private cleanupInteractions(): void {

--- a/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
+++ b/packages/calcite-components/src/components/tree-item/tree-item.e2e.ts
@@ -450,6 +450,35 @@ describe("calcite-tree-item", () => {
     expect(collapseSpy).toHaveReceivedEventTimes(1);
   });
 
+  describe("selection event", () => {
+    it("emits calciteTreeItemSelect when selected or deselected", async () => {
+      const page = await newE2EPage();
+      await page.setContent(html`
+        <calcite-tree>
+          <calcite-tree-item id="item-1">Item 1</calcite-tree-item>
+        </calcite-tree>
+      `);
+
+      const treeItem = await page.find("#item-1");
+
+      await page.$eval("#item-1", (treeItem: HTMLElement) => {
+        treeItem.addEventListener("calciteTreeItemSelect", (event: CustomEvent) => {
+          (window as any).selectionEvent = event.detail;
+        });
+      });
+
+      await treeItem.click();
+      let selectionEvent = await page.evaluate(() => (window as any).selectionEvent);
+      expect(selectionEvent).toBeDefined();
+      expect(selectionEvent.selected).toBe(true);
+
+      await treeItem.click();
+      selectionEvent = await page.evaluate(() => (window as any).selectionEvent);
+      expect(selectionEvent).toBeDefined();
+      expect(selectionEvent.selected).toBe(false);
+    });
+  });
+
   describe("themed", () => {
     describe(`selection-mode="none"`, () => {
       themed(

--- a/packages/calcite-components/src/components/tree-item/tree-item.tsx
+++ b/packages/calcite-components/src/components/tree-item/tree-item.tsx
@@ -129,6 +129,9 @@ export class TreeItem extends LitElement implements InteractiveComponent {
   /** Fires when the component's content area is expanded. */
   calciteTreeItemExpand = createEvent({ cancelable: false });
 
+  /** Fires when the component is selected or deselected. */
+  calciteTreeItemSelect = createEvent<{ selected: boolean }>({ cancelable: false });
+
   //#endregion
 
   //#region Lifecycle
@@ -197,6 +200,7 @@ export class TreeItem extends LitElement implements InteractiveComponent {
         updateItem: false,
       });
     }
+    this.calciteTreeItemSelect.emit({ selected: value });
   }
 
   private getSelectionMode(): void {


### PR DESCRIPTION
**Related Issue:** #

## Summary
Expand `--calcite-shell-panel-height` and `--calcite-shell-panel-width` tokens to support programmatic dimension updates after the user's manual resize.