### PR TITLE
ci(deploy): remove the npm token environment variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,8 +61,6 @@ jobs:
       - name: Build Packages and Publish to NPM
         if: steps.release.outputs.releases_created == 'true'
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           npm install
@@ -123,15 +121,12 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Deploy prerelease and storybook
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           # the storybook token needs the the github username appended to the token, see:
           # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
           BRANCH: ${{ github.base_ref || github.ref_name }}
         run: "${{ github.workspace }}/.github/scripts/publishPrerelease.sh"
       - name: notify teams


### PR DESCRIPTION
**Related Issue:** #12991

## Summary

`next` releases are failing with the following error:

> Two-factor authentication is required to publish this package but an automation token was specified

I'm guessing this is because I didn't remove the token environment variables when setting up the repo as trusted publisher. 

If this doesn't fix the issue, I'll revert and do some testing in a different repo.
