### PR TITLE
revert: use a granular npm token for deployment

### DIFF
--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -1,10 +1,9 @@
-name: Deploy to NPM
+name: Deploy Latest
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev]
+    branches: [main]
 permissions:
-  id-token: write # Required for OIDC
   contents: write
   pull-requests: write
 jobs:
@@ -35,8 +34,8 @@ jobs:
           npm test
           git push origin main
 
-  release-latest:
-    if: github.event_name != 'workflow_dispatch' && github.ref_name == 'main'
+  release-please:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -107,39 +106,3 @@ jobs:
           git push -u origin HEAD
           gh pr create --fill --head "ci/cherry-pick-release-commit" --base "dev" \
             --label "skip visual snapshots"
-
-  release-next:
-    if: github.event_name != 'workflow_dispatch' && github.ref_name == 'dev'
-    runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.ADMIN_TOKEN }}
-          ref: ${{ github.base_ref || github.ref_name }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: package.json
-          registry-url: "https://registry.npmjs.org"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Deploy prerelease and storybook
-        env:
-          NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
-          # the storybook token needs the the github username appended to the token, see:
-          # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
-          GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          BRANCH: ${{ github.base_ref || github.ref_name }}
-        run: "${{ github.workspace }}/.github/scripts/publishPrerelease.sh"
-      - name: notify teams
-        uses: toko-bifrost/ms-teams-deploy-card@3.1.2
-        if: ${{ !cancelled() && github.event_name == 'push' }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          webhook-uri: ${{ secrets.TEAMS_WEBHOOK_URI_BUILD }}
-          show-on-start: false
-          card-layout-exit: complete
-          timezone: America/Los_Angeles

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -1,0 +1,45 @@
+name: Deploy Prerelease
+concurrency:
+  group: deploy_prerelease
+  cancel-in-progress: true
+on:
+  # `next` versions are automatically released when deployabled commits are pushed to dev
+  push:
+    branches: [dev]
+  # `rc` versions must be manually released:
+  # https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.ADMIN_TOKEN }}
+          ref: ${{ github.base_ref || github.ref_name }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          registry-url: "https://registry.npmjs.org"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Deploy prerelease and storybook
+        env:
+          NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
+          # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
+          GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+          BRANCH: ${{ github.base_ref || github.ref_name }}
+        run: "${{ github.workspace }}/.github/scripts/publishPrerelease.sh"
+      - name: notify teams
+        uses: toko-bifrost/ms-teams-deploy-card@3.1.2
+        if: ${{ !cancelled() && github.event_name == 'push' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          webhook-uri: ${{ secrets.TEAMS_WEBHOOK_URI_BUILD }}
+          show-on-start: false
+          card-layout-exit: complete
+          timezone: America/Los_Angeles

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Build Packages and Publish to NPM
         if: steps.release.outputs.releases_created == 'true'
         env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           npm install
@@ -121,12 +123,15 @@ jobs:
         with:
           node-version-file: package.json
           registry-url: "https://registry.npmjs.org"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Deploy prerelease and storybook
         env:
           NEXT_RELEASE_ENABLED: ${{ secrets.NEXT_RELEASE_ENABLED }}
           # the storybook token needs the the github username appended to the token, see:
           # https://github.com/storybookjs/storybook-deployer/issues/77#issuecomment-618560481
           GH_TOKEN_FOR_STORYBOOK: ${{ github.actor }}:${{ secrets.ADMIN_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
           BRANCH: ${{ github.base_ref || github.ref_name }}
         run: "${{ github.workspace }}/.github/scripts/publishPrerelease.sh"
       - name: notify teams


### PR DESCRIPTION
**Related Issue:** #12998 #12991

## Summary

Revert the changes to the deployment workflows due to `next` failures. There is a new error:

> lerna WARN notice Package failed to publish: @esri/calcite-components
> lerna ERR! E404 Not found
> lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1
