### PR TITLE
feat(action, action-bar, action-pad): add new selectionAppearance property for 4.0

### DIFF
--- a/packages/calcite-components/.storybook/resources.ts
+++ b/packages/calcite-components/.storybook/resources.ts
@@ -122,7 +122,7 @@ const textTypeOptions: TextType[] = [
   "date",
 ];
 const modeOptions: TimeZoneMode[] = ["offset", "name"];
-const selectionAppearanceOptions: SelectionAppearance[] = ["icon", "border"];
+const selectionAppearanceOptions: SelectionAppearance[] = ["icon", "border", "highlight", "neutral"];
 const overlayPositioningOptions: OverlayPositioning[] = ["absolute", "fixed"];
 const shellDisplayModeOptions: ShellDisplayMode[] = ["dock", "float", "overlay"];
 

--- a/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
+++ b/packages/calcite-components/src/components/action-bar/action-bar.e2e.ts
@@ -58,6 +58,10 @@ describe("calcite-action-bar", () => {
         propertyName: "overlayPositioning",
         defaultValue: "absolute",
       },
+      {
+        propertyName: "selectionAppearance",
+        defaultValue: "neutral",
+      },
     ]);
   });
 
@@ -78,6 +82,10 @@ describe("calcite-action-bar", () => {
       {
         propertyName: "overlayPositioning",
         value: "fixed",
+      },
+      {
+        propertyName: "selectionAppearance",
+        value: "neutral",
       },
     ]);
   });

--- a/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
+++ b/packages/calcite-components/src/components/action-pad/action-pad.e2e.ts
@@ -50,6 +50,10 @@ describe("calcite-action-pad", () => {
         propertyName: "scale",
         defaultValue: "m",
       },
+      {
+        propertyName: "selectionAppearance",
+        defaultValue: "neutral",
+      },
     ]);
   });
 
@@ -70,6 +74,10 @@ describe("calcite-action-pad", () => {
       {
         propertyName: "overlayPositioning",
         value: "fixed",
+      },
+      {
+        propertyName: "selectionAppearance",
+        value: "neutral",
       },
     ]);
   });

--- a/packages/calcite-components/src/components/action/action.e2e.ts
+++ b/packages/calcite-components/src/components/action/action.e2e.ts
@@ -63,6 +63,10 @@ describe("calcite-action", () => {
         propertyName: "type",
         defaultValue: "button",
       },
+      {
+        propertyName: "selectionAppearance",
+        defaultValue: undefined,
+      },
     ]);
   });
 
@@ -119,6 +123,10 @@ describe("calcite-action", () => {
       {
         propertyName: "type",
         value: "button",
+      },
+      {
+        propertyName: "selectionAppearance",
+        value: "neutral",
       },
     ]);
   });

--- a/packages/calcite-components/src/components/action/action.scss
+++ b/packages/calcite-components/src/components/action/action.scss
@@ -204,6 +204,15 @@
   }
 }
 
+:host([selection-appearance="highlight"]) {
+  .button {
+    &:active {
+      background-color: var(--calcite-color-surface-highlight);
+      color: var(--calcite-color-text-highlight);
+    }
+  }
+}
+
 :host([active-descendant]) .button {
   @apply focus-inset;
 }

--- a/packages/calcite-components/src/components/action/action.tsx
+++ b/packages/calcite-components/src/components/action/action.tsx
@@ -9,7 +9,14 @@ import {
 } from "../../utils/interactive";
 import { createObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
-import { Alignment, Appearance, AriaAttributesCamelCased, Scale, Width } from "../interfaces";
+import {
+  Alignment,
+  Appearance,
+  AriaAttributesCamelCased,
+  Scale,
+  SelectionAppearance,
+  Width,
+} from "../interfaces";
 import { IconName } from "../icon/interfaces";
 import { useT9n } from "../../controllers/useT9n";
 import type { Tooltip } from "../tooltip/tooltip";
@@ -164,6 +171,16 @@ export class Action extends LitElement implements InteractiveComponent, FormOwne
    * @mdn [type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)
    */
   @property({ reflect: true }) type: HTMLButtonElement["type"] = "button";
+
+  /**
+   * Specifies the selection appearance of the component. Inherited from `calcite-action-bar`.
+   *
+   * @private
+   */
+  @property({ reflect: true }) selectionAppearance: Extract<
+    "highlight" | "neutral",
+    SelectionAppearance
+  >;
 
   //#endregion
 

--- a/packages/calcite-components/src/components/interfaces.ts
+++ b/packages/calcite-components/src/components/interfaces.ts
@@ -24,7 +24,7 @@ export type LogicalFlowPosition = "inline-start" | "inline-end" | "block-start" 
 export type ModeClass = "calcite-mode-light" | "calcite-mode-dark" | "calcite-mode-auto";
 export type ModeName = "light" | "dark" | "auto";
 export type Position = "start" | "end" | "top" | "bottom";
-export type SelectionAppearance = "icon" | "border";
+export type SelectionAppearance = "icon" | "border" | "highlight" | "neutral";
 export type SelectionMode =
   | "single"
   | "none"

--- a/packages/calcite-components/src/components/list/list.stories.ts
+++ b/packages/calcite-components/src/components/list/list.stories.ts
@@ -65,7 +65,7 @@ export default {
       control: { type: "select" },
     },
     selectionAppearance: {
-      options: selectionAppearance.values,
+      options: selectionAppearance.values.filter((option) => option !== "highlight" && option !== "neutral"),
       control: { type: "select" },
     },
     iconStart: {

--- a/packages/calcite-components/src/components/list/list.tsx
+++ b/packages/calcite-components/src/components/list/list.tsx
@@ -266,7 +266,10 @@ export class List extends LitElement implements InteractiveComponent, SortableCo
   @property() selectedItems: ListItem["el"][] = [];
 
   /** Specifies the selection appearance - `"icon"` (displays a checkmark or dot) or `"border"` (displays a border). */
-  @property({ reflect: true }) selectionAppearance: SelectionAppearance = "icon";
+  @property({ reflect: true }) selectionAppearance: Extract<
+    "icon" | "border",
+    SelectionAppearance
+  > = "icon";
 
   /**
    * Specifies the selection mode of the component, where:

--- a/packages/calcite-components/src/components/tile-group/tile-group.tsx
+++ b/packages/calcite-components/src/components/tile-group/tile-group.tsx
@@ -79,7 +79,10 @@ export class TileGroup
    * - `"icon"` (displays a checkmark or dot), or
    * - `"border"` (displays a border).
    */
-  @property({ reflect: true }) selectionAppearance: SelectionAppearance = "icon";
+  @property({ reflect: true }) selectionAppearance: Extract<
+    "icon" | "border",
+    SelectionAppearance
+  > = "icon";
 
   /**
    * Specifies the selection mode, where:

--- a/packages/calcite-components/src/components/tile/tile.tsx
+++ b/packages/calcite-components/src/components/tile/tile.tsx
@@ -127,7 +127,10 @@ export class Tile extends LitElement implements InteractiveComponent, Selectable
    *
    * @private
    */
-  @property({ reflect: true }) selectionAppearance: SelectionAppearance = "icon";
+  @property({ reflect: true }) selectionAppearance: Extract<
+    "icon" | "border",
+    SelectionAppearance
+  > = "icon";
 
   /**
    * Specifies the selection mode, where:


### PR DESCRIPTION
**Related Issue:** [#10758](https://github.com/Esri/calcite-design-system/issues/10758)

## Summary

- Add new prop `selection-appearance="highlight" | "neutral" (default)` to `action`, `action-bar` and `action-pad`.
- When `selection-appearance="highlight"`:
    - Update `background-color` to `--calcite-color-surface-highlight`.
    - Update icon and text `color` to `--calcite-color-text-highlight`.
- When `selection-appearance="neutral"`:
    - Use current `active` state colors.