### PR TITLE
fix(table-row): add deprecated background token as fallback

### DIFF
--- a/packages/calcite-components/src/components/table-row/table-row.scss
+++ b/packages/calcite-components/src/components/table-row/table-row.scss
@@ -34,7 +34,7 @@
 calcite-table-cell {
   --calcite-internal-table-cell-background-color: var(
     --calcite-table-row-background-color,
-    var(--calcite-color-foreground-1)
+    var(--calcite-table-row-background, var(--calcite-color-foreground-1))
   );
 }
 
@@ -47,7 +47,10 @@ calcite-table-cell {
 
 tr {
   border-block-end: var(--calcite-border-width-sm) solid var(--calcite-table-row-border-color, transparent);
-  background-color: var(--calcite-table-row-background-color, var(--calcite-color-foreground-1));
+  background-color: var(
+    --calcite-table-row-background-color,
+    var(--calcite-table-row-background, var(--calcite-color-foreground-1))
+  );
 }
 
 tr.last-visible-row {


### PR DESCRIPTION
**Related Issue:** #13024

## Summary
Adds back the deprecated `--calcite-table-row-background` token as a fallback until it is removed in a breaking change release.
