### PR TITLE
docs(button, split-button): reword `icon-color` token docs to avoid forward slash

### DIFF
--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -6,7 +6,7 @@
  * @prop --calcite-button-background-color: Specifies the component's background color.
  * @prop --calcite-button-border-color: Specifies the component's border color.
  * @prop --calcite-button-corner-radius: Specifies the component's corner radius.
- * @prop --calcite-button-icon-color: Specifies the component's `iconStart` and/or `iconEnd` color.
+ * @prop --calcite-button-icon-color: Specifies the component's `iconStart` and `iconEnd` color.
  * @prop --calcite-button-loader-color: Specifies the component's loader color.
  * @prop --calcite-button-shadow-color: [Deprecated] Use `--calcite-button-shadow`. Specifies the component's box-shadow color.
  * @prop --calcite-button-text-color: Specifies the component's text color.

--- a/packages/calcite-components/src/components/split-button/split-button.scss
+++ b/packages/calcite-components/src/components/split-button/split-button.scss
@@ -6,7 +6,7 @@
  * @prop --calcite-split-button-background-color: Specifies the component's background color.
  * @prop --calcite-split-button-border-color: Specifies the component's border color.
  * @prop --calcite-split-button-corner-radius: Specifies the component's corner radius.
- * @prop --calcite-split-button-icon-color: Specifies the component's `iconStart` and/or `iconEnd` color.
+ * @prop --calcite-split-button-icon-color: Specifies the component's `iconStart` and `iconEnd` color.
  * @prop --calcite-split-button-loader-color: Specifies the component's loader color.
  * @prop --calcite-split-button-text-color: Specifies the component's text color.
  * @prop --calcite-split-button-shadow: Specifies the component's shadow.


### PR DESCRIPTION
**Related Issue:** #13039

## Summary
Removes the `/or` wording from `button` and `split-button` `xxx-icon-color` token docs to avoid the Lumina API generator from cuttin the strings short.
