### PR TITLE
build(deps): tweak dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "patch-package": "8.0.1"
       },
       "devDependencies": {
-        "@arcgis/eslint-config": "^4.34.0-next.155",
+        "@arcgis/eslint-config": ">4.34.0-next.155 <4.35.0",
         "@cspell/dict-gis": "1.0.3",
         "@cspell/dict-pokemon": "1.0.3",
         "@cspell/dict-scientific-terms-us": "3.0.8",
@@ -564,15 +564,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@arcgis/components-utils": {
-      "version": "4.33.24",
-      "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.33.24.tgz",
-      "integrity": "sha512-+7mt88zsibAJyCmCIdV4XYSfsBgBxo48MkfZ0E7aWfXz9Ns3jZ6n7hmRu/kJP5qnBg2X9EXcrDH/RLtAJpQ6Ww==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
     "node_modules/@arcgis/eslint-config": {
       "version": "4.34.0-next.158",
       "resolved": "https://registry.npmjs.org/@arcgis/eslint-config/-/eslint-config-4.34.0-next.158.tgz",
@@ -620,12 +611,12 @@
       }
     },
     "node_modules/@arcgis/lumina": {
-      "version": "4.34.0-next.151",
-      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.34.0-next.151.tgz",
-      "integrity": "sha512-0Tu/Dk5G+p5NvysqMeO9/7PW8MaQpHZ6PMCB2CwbEcx207leL5dCM3GUNjTUdwvPORnxsYMSckOr20SeGtQE4g==",
+      "version": "4.34.0-next.158",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.34.0-next.158.tgz",
+      "integrity": "sha512-xui7M2aqhutM8F0pjQgnQJEIcmT16AXeWgXzI6W6sBm5+5CSnL4Z+IF05Scq96dzeWj9/PgZ1jYr/KjDwb8H3Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@arcgis/toolkit": "~4.34.0-next.151",
+        "@arcgis/toolkit": "~4.34.0-next.158",
         "csstype": "^3.1.3",
         "tslib": "^2.8.1"
       },
@@ -637,6 +628,15 @@
         "@lit/context": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@arcgis/lumina/node_modules/@arcgis/toolkit": {
+      "version": "4.34.0-next.158",
+      "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-4.34.0-next.158.tgz",
+      "integrity": "sha512-sbm215r2rYyi22U0Z4Y9b1brUQH7Qm3vxEtj4+Gnpsi9QyVHI8Q0av3bLnqwLOxBxUqFKi5Zc8cLKON3rP4YXQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@arcgis/toolkit": {
@@ -4121,107 +4121,19 @@
         "node": ">=12"
       }
     },
-    "node_modules/@lit-labs/ssr": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.3.1.tgz",
-      "integrity": "sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-client": "^1.1.7",
-        "@lit-labs/ssr-dom-shim": "^1.3.0",
-        "@lit/reactive-element": "^2.0.4",
-        "@parse5/tools": "^0.3.0",
-        "@types/node": "^16.0.0",
-        "enhanced-resolve": "^5.10.0",
-        "lit": "^3.1.2",
-        "lit-element": "^4.0.4",
-        "lit-html": "^3.1.2",
-        "node-fetch": "^3.2.8",
-        "parse5": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=13.9.0"
-      }
-    },
-    "node_modules/@lit-labs/ssr-client": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
-      "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit": "^3.1.2",
-        "lit-html": "^3.1.2"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
       "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
-    },
-    "node_modules/@lit-labs/ssr/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@lit-labs/ssr/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@lit-labs/ssr/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/@lit/context": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
       "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^1.6.2 || ^2.1.0"
       }
@@ -5700,39 +5612,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parse5/tools": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
-      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      }
-    },
-    "node_modules/@parse5/tools/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@parse5/tools/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -12936,19 +12815,6 @@
         }
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -14350,29 +14216,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -14664,18 +14507,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -22843,26 +22674,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -29353,19 +29164,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -31917,15 +31715,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -32552,7 +32341,7 @@
       "dependencies": {
         "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
         "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
-        "@esri/calcite-ui-icons": ">=4.4.0-next.1 <4.5.0",
+        "@esri/calcite-ui-icons": "^4.4.0-next.1",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
@@ -32568,9 +32357,9 @@
       },
       "devDependencies": {
         "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
-        "@esri/calcite-design-tokens": ">=4.0.0-next.1 <4.1.0",
-        "@esri/calcite-tailwind-preset": ">=1.0.2-next.2 <1.1.0",
-        "@esri/eslint-plugin-calcite-components": ">=2.0.4-next.0 <2.1.0",
+        "@esri/calcite-design-tokens": "^4.0.0-next.1",
+        "@esri/calcite-tailwind-preset": "^1.0.2-next.2",
+        "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
         "@vitest/browser": "3.2.4",
         "playwright": "1.55.1",
         "sass-embedded": "1.92.1",
@@ -32582,29 +32371,14 @@
       "version": "4.0.0-next.20",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/lumina": ">=^4.34.0-next.122 <4.35.0",
-        "@esri/calcite-components": ">=4.0.0-next.20 <5.0.0",
+        "@arcgis/lumina": ">=4.34.0-next.122 <4.35.0",
+        "@esri/calcite-components": "^4.0.0-next.20",
         "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },
       "peerDependencies": {
         "react": ">=18.3",
         "react-dom": ">=18.3"
-      }
-    },
-    "packages/calcite-components-react/node_modules/@arcgis/lumina": {
-      "version": "4.33.24",
-      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.33.24.tgz",
-      "integrity": "sha512-aPmPi+j3bFUI2ZQBy2bQ0vyBMl6CmXVUPRpcOl8+XawVPd21LSNKNmvzz7lkBiFc7H2sYd53rdL8o+eiozeYNw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@arcgis/components-utils": "4.33.24",
-        "@lit-labs/ssr": "^3.2.2",
-        "@lit-labs/ssr-client": "^1.1.7",
-        "@lit/context": "^1.1.5",
-        "csstype": "^3.1.3",
-        "lit": "^3.3.0",
-        "tslib": "^2.8.1"
       }
     },
     "packages/calcite-components/node_modules/@arcgis/lumina-compiler": {
@@ -32742,18 +32516,12 @@
       "version": "1.0.2-next.2",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0"
+        "@esri/calcite-design-tokens": "^4.0.0-next.1"
       },
       "peerDependencies": {
-        "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0",
+        "@esri/calcite-design-tokens": "^4.0.0-next.1",
         "tailwindcss": "^3.0.0 < 4.0.0"
       }
-    },
-    "packages/calcite-tailwind-preset/node_modules/@esri/calcite-design-tokens": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-design-tokens/-/calcite-design-tokens-3.2.1.tgz",
-      "integrity": "sha512-rTdJA4gH6nYpO1KDZWXpbYRTfvApgrZcAo+Lg29mZ47C9JECKejZCj5NU3373DSW9XWpAGvDNNwWNax3Iw/SXA==",
-      "license": "SEE LICENSE.md"
     },
     "packages/calcite-ui-icons": {
       "name": "@esri/calcite-ui-icons",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32341,7 +32341,7 @@
       "dependencies": {
         "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
         "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
-        "@esri/calcite-ui-icons": "^4.4.0-next.1",
+        "@esri/calcite-ui-icons": "4.4.0-next.1",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
@@ -32357,8 +32357,8 @@
       },
       "devDependencies": {
         "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
-        "@esri/calcite-design-tokens": "^4.0.0-next.1",
-        "@esri/calcite-tailwind-preset": "^1.0.2-next.2",
+        "@esri/calcite-design-tokens": "4.0.0-next.1",
+        "@esri/calcite-tailwind-preset": "1.0.2-next.2",
         "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
         "@vitest/browser": "3.2.4",
         "playwright": "1.55.1",
@@ -32372,7 +32372,7 @@
       "license": "SEE LICENSE.md",
       "dependencies": {
         "@arcgis/lumina": ">=4.34.0-next.122 <4.35.0",
-        "@esri/calcite-components": "^4.0.0-next.20",
+        "@esri/calcite-components": "4.0.0-next.20",
         "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },
@@ -32516,7 +32516,7 @@
       "version": "1.0.2-next.2",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-design-tokens": "^4.0.0-next.1"
+        "@esri/calcite-design-tokens": "4.0.0-next.1"
       },
       "peerDependencies": {
         "@esri/calcite-design-tokens": "^4.0.0-next.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,6 +564,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@arcgis/components-utils": {
+      "version": "4.33.24",
+      "resolved": "https://registry.npmjs.org/@arcgis/components-utils/-/components-utils-4.33.24.tgz",
+      "integrity": "sha512-+7mt88zsibAJyCmCIdV4XYSfsBgBxo48MkfZ0E7aWfXz9Ns3jZ6n7hmRu/kJP5qnBg2X9EXcrDH/RLtAJpQ6Ww==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@arcgis/eslint-config": {
       "version": "4.34.0-next.158",
       "resolved": "https://registry.npmjs.org/@arcgis/eslint-config/-/eslint-config-4.34.0-next.158.tgz",
@@ -4112,11 +4121,110 @@
         "node": ">=12"
       }
     },
+    "node_modules/@lit-labs/ssr": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.3.1.tgz",
+      "integrity": "sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
+      "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
       "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "license": "MIT"
+    },
+    "node_modules/@lit-labs/ssr/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@lit-labs/ssr/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.6.tgz",
+      "integrity": "sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.1.0"
+      }
     },
     "node_modules/@lit/react": {
       "version": "1.0.8",
@@ -5592,6 +5700,39 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@parse5/tools/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@parse5/tools/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -12795,6 +12936,19 @@
         }
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -14196,6 +14350,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -14487,6 +14664,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -22654,6 +22843,26 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -29144,6 +29353,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -31695,6 +31917,15 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -32319,9 +32550,9 @@
       "version": "4.0.0-next.20",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/lumina": "^4.34.0-next.151",
-        "@arcgis/toolkit": "^4.34.0-next.151",
-        "@esri/calcite-ui-icons": "4.4.0-next.1",
+        "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
+        "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
+        "@esri/calcite-ui-icons": ">=4.4.0-next.1 <4.5.0",
         "@floating-ui/dom": "^1.6.12",
         "@floating-ui/utils": "^0.2.8",
         "@types/sortablejs": "^1.15.8",
@@ -32336,10 +32567,10 @@
         "type-fest": "^4.30.1"
       },
       "devDependencies": {
-        "@arcgis/lumina-compiler": "^4.34.0-next.151",
-        "@esri/calcite-design-tokens": "4.0.0-next.1",
-        "@esri/calcite-tailwind-preset": "1.0.2-next.2",
-        "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
+        "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
+        "@esri/calcite-design-tokens": ">=4.0.0-next.1 <4.1.0",
+        "@esri/calcite-tailwind-preset": ">=1.0.2-next.2 <1.1.0",
+        "@esri/eslint-plugin-calcite-components": ">=2.0.4-next.0 <2.1.0",
         "@vitest/browser": "3.2.4",
         "playwright": "1.55.1",
         "sass-embedded": "1.92.1",
@@ -32351,14 +32582,29 @@
       "version": "4.0.0-next.20",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@arcgis/lumina": "^4.34.0-next.122",
-        "@esri/calcite-components": "4.0.0-next.20",
+        "@arcgis/lumina": ">=^4.34.0-next.122 <4.35.0",
+        "@esri/calcite-components": ">=4.0.0-next.20 <5.0.0",
         "@lit/react": "^1.0.8",
         "lit": "^3.3.0"
       },
       "peerDependencies": {
         "react": ">=18.3",
         "react-dom": ">=18.3"
+      }
+    },
+    "packages/calcite-components-react/node_modules/@arcgis/lumina": {
+      "version": "4.33.24",
+      "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.33.24.tgz",
+      "integrity": "sha512-aPmPi+j3bFUI2ZQBy2bQ0vyBMl6CmXVUPRpcOl8+XawVPd21LSNKNmvzz7lkBiFc7H2sYd53rdL8o+eiozeYNw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@arcgis/components-utils": "4.33.24",
+        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit/context": "^1.1.5",
+        "csstype": "^3.1.3",
+        "lit": "^3.3.0",
+        "tslib": "^2.8.1"
       }
     },
     "packages/calcite-components/node_modules/@arcgis/lumina-compiler": {
@@ -32496,12 +32742,18 @@
       "version": "1.0.2-next.2",
       "license": "SEE LICENSE.md",
       "dependencies": {
-        "@esri/calcite-design-tokens": "4.0.0-next.1"
+        "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0"
       },
       "peerDependencies": {
-        "@esri/calcite-design-tokens": "^3.0.2-next.8",
+        "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0",
         "tailwindcss": "^3.0.0 < 4.0.0"
       }
+    },
+    "packages/calcite-tailwind-preset/node_modules/@esri/calcite-design-tokens": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-design-tokens/-/calcite-design-tokens-3.2.1.tgz",
+      "integrity": "sha512-rTdJA4gH6nYpO1KDZWXpbYRTfvApgrZcAo+Lg29mZ47C9JECKejZCj5NU3373DSW9XWpAGvDNNwWNax3Iw/SXA==",
+      "license": "SEE LICENSE.md"
     },
     "packages/calcite-ui-icons": {
       "name": "@esri/calcite-ui-icons",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "util:update-3rd-party-licenses": "turbo run util:update-3rd-party-licenses --log-order=stream"
   },
   "devDependencies": {
-    "@arcgis/eslint-config": "^4.34.0-next.155",
+    "@arcgis/eslint-config": ">4.34.0-next.155 <4.35.0",
     "@cspell/dict-gis": "1.0.3",
     "@cspell/dict-pokemon": "1.0.3",
     "@cspell/dict-scientific-terms-us": "3.0.8",

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@arcgis/lumina": ">=4.34.0-next.122 <4.35.0",
-    "@esri/calcite-components": "^4.0.0-next.20",
+    "@esri/calcite-components": "4.0.0-next.20",
     "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -28,8 +28,8 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@arcgis/lumina": ">=^4.34.0-next.122 <4.35.0",
-    "@esri/calcite-components": ">=4.0.0-next.20 <5.0.0",
+    "@arcgis/lumina": ">=4.34.0-next.122 <4.35.0",
+    "@esri/calcite-components": "^4.0.0-next.20",
     "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },

--- a/packages/calcite-components-react/package.json
+++ b/packages/calcite-components-react/package.json
@@ -28,8 +28,8 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@arcgis/lumina": "^4.34.0-next.122",
-    "@esri/calcite-components": "4.0.0-next.20",
+    "@arcgis/lumina": ">=^4.34.0-next.122 <4.35.0",
+    "@esri/calcite-components": ">=4.0.0-next.20 <5.0.0",
     "@lit/react": "^1.0.8",
     "lit": "^3.3.0"
   },

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
     "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
-    "@esri/calcite-ui-icons": "^4.4.0-next.1",
+    "@esri/calcite-ui-icons": "4.4.0-next.1",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
@@ -94,8 +94,8 @@
   },
   "devDependencies": {
     "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
-    "@esri/calcite-design-tokens": "^4.0.0-next.1",
-    "@esri/calcite-tailwind-preset": "^1.0.2-next.2",
+    "@esri/calcite-design-tokens": "4.0.0-next.1",
+    "@esri/calcite-tailwind-preset": "1.0.2-next.2",
     "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
     "@vitest/browser": "3.2.4",
     "playwright": "1.55.1",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
     "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
-    "@esri/calcite-ui-icons": ">=4.4.0-next.1 <4.5.0",
+    "@esri/calcite-ui-icons": "^4.4.0-next.1",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
@@ -94,9 +94,9 @@
   },
   "devDependencies": {
     "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
-    "@esri/calcite-design-tokens": ">=4.0.0-next.1 <4.1.0",
-    "@esri/calcite-tailwind-preset": ">=1.0.2-next.2 <1.1.0",
-    "@esri/eslint-plugin-calcite-components": ">=2.0.4-next.0 <2.1.0",
+    "@esri/calcite-design-tokens": "^4.0.0-next.1",
+    "@esri/calcite-tailwind-preset": "^1.0.2-next.2",
+    "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
     "@vitest/browser": "3.2.4",
     "playwright": "1.55.1",
     "sass-embedded": "1.92.1",

--- a/packages/calcite-components/package.json
+++ b/packages/calcite-components/package.json
@@ -76,9 +76,9 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@arcgis/lumina": "^4.34.0-next.151",
-    "@arcgis/toolkit": "^4.34.0-next.151",
-    "@esri/calcite-ui-icons": "4.4.0-next.1",
+    "@arcgis/lumina": ">=4.34.0-next.151 <4.35.0",
+    "@arcgis/toolkit": ">=4.34.0-next.151 <4.35.0",
+    "@esri/calcite-ui-icons": ">=4.4.0-next.1 <4.5.0",
     "@floating-ui/dom": "^1.6.12",
     "@floating-ui/utils": "^0.2.8",
     "@types/sortablejs": "^1.15.8",
@@ -93,10 +93,10 @@
     "type-fest": "^4.30.1"
   },
   "devDependencies": {
-    "@arcgis/lumina-compiler": "^4.34.0-next.151",
-    "@esri/calcite-design-tokens": "4.0.0-next.1",
-    "@esri/calcite-tailwind-preset": "1.0.2-next.2",
-    "@esri/eslint-plugin-calcite-components": "2.0.4-next.0",
+    "@arcgis/lumina-compiler": ">=4.34.0-next.151 <4.35.0",
+    "@esri/calcite-design-tokens": ">=4.0.0-next.1 <4.1.0",
+    "@esri/calcite-tailwind-preset": ">=1.0.2-next.2 <1.1.0",
+    "@esri/eslint-plugin-calcite-components": ">=2.0.4-next.0 <2.1.0",
     "@vitest/browser": "3.2.4",
     "playwright": "1.55.1",
     "sass-embedded": "1.92.1",

--- a/packages/calcite-tailwind-preset/package.json
+++ b/packages/calcite-tailwind-preset/package.json
@@ -23,10 +23,10 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@esri/calcite-design-tokens": "4.0.0-next.1"
+    "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0"
   },
   "peerDependencies": {
-    "@esri/calcite-design-tokens": "^3.0.2-next.8",
+    "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0",
     "tailwindcss": "^3.0.0 < 4.0.0"
   },
   "volta": {

--- a/packages/calcite-tailwind-preset/package.json
+++ b/packages/calcite-tailwind-preset/package.json
@@ -23,7 +23,7 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@esri/calcite-design-tokens": "^4.0.0-next.1"
+    "@esri/calcite-design-tokens": "4.0.0-next.1"
   },
   "peerDependencies": {
     "@esri/calcite-design-tokens": "^4.0.0-next.1",

--- a/packages/calcite-tailwind-preset/package.json
+++ b/packages/calcite-tailwind-preset/package.json
@@ -23,10 +23,10 @@
     "util:update-3rd-party-licenses": "tsx ../../support/createThirdPartyLicenses.ts"
   },
   "dependencies": {
-    "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0"
+    "@esri/calcite-design-tokens": "^4.0.0-next.1"
   },
   "peerDependencies": {
-    "@esri/calcite-design-tokens": ">=^4.0.0-next.1 <5.0.0",
+    "@esri/calcite-design-tokens": "^4.0.0-next.1",
     "tailwindcss": "^3.0.0 < 4.0.0"
   },
   "volta": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -88,7 +88,8 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "merge": false
+      "merge": false,
+      "updatePeerDependencies": true
     },
     {
       "type": "linked-versions",


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

* Keeps `@arcgis` dependencies within supported range
* Updates `@esri/calcite-tailwind-preset`'s peer dep
* Enables [`release-please` peer dep bumps](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#linking-peer-dependencies)