### PR TITLE
fix(button): add backward compatibility for `--calcite-ui-icon-color` token

### DIFF
--- a/packages/calcite-components/src/components/button/button.e2e.ts
+++ b/packages/calcite-components/src/components/button/button.e2e.ts
@@ -709,5 +709,19 @@ describe("calcite-button", () => {
         ],
       });
     });
+    describe("deprecated", () => {
+      themed(html`<calcite-button icon-start="layer" icon-end="layer"></calcite-button>`, {
+        "--calcite-ui-icon-color": [
+          {
+            shadowSelector: `.${CSS.iconStart}`,
+            targetProp: "color",
+          },
+          {
+            shadowSelector: `.${CSS.iconEnd}`,
+            targetProp: "color",
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/calcite-components/src/components/button/button.scss
+++ b/packages/calcite-components/src/components/button/button.scss
@@ -228,7 +228,7 @@
 
 .icon--start,
 .icon--end {
-  color: var(--calcite-button-icon-color, var(--calcite-icon-color));
+  color: var(--calcite-button-icon-color, var(--calcite-icon-color, var(--calcite-ui-icon-color)));
 }
 @include includes.disabled();
 


### PR DESCRIPTION
**Related Issue:** #13038 

## Summary

Add back support for `--calcite-ui-icon-color`.

##### Side note:

Issue is resolved by this [update](https://devtopia.esri.com/WebGIS/arcgis-js-api/pull/74895#issuecomment-5829349) to use `--calcite-icon-color` instead of `--calcite-ui-icon-color`. This fix will help resolve similar use cases.