### PR TITLE
ci(actions): set status to "Done" only if issue is not labeled "design"

### DIFF
--- a/.github/scripts/monday/updateLabels.js
+++ b/.github/scripts/monday/updateLabels.js
@@ -1,9 +1,13 @@
 // @ts-check
 const Monday = require("../support/monday");
 const {
-  labels: { planning, issueWorkflow },
+  labels: {
+    planning,
+    issueWorkflow,
+    issueType: { design },
+  },
 } = require("../support/resources");
-const { assertRequired } = require("../support/utils");
+const { assertRequired, includesLabel } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ context }) => {
@@ -19,8 +23,8 @@ module.exports = async ({ context }) => {
   }
 
   const isVerified = labelName === issueWorkflow.verified;
-  if (isVerified && issue.state === "closed") {
-    monday.handleState("closed");
+  if (isVerified && issue.state === "closed" && !includesLabel(issue.labels, design)) {
+    monday.setColumnValue(monday.columnIds.status, "Done");
   } else {
     monday.addLabel(labelName);
   }

--- a/.github/scripts/support/utils.js
+++ b/.github/scripts/support/utils.js
@@ -79,16 +79,13 @@ module.exports = {
     return labels.every((label) => !lifecycleLabels.includes(label.name));
   },
   /**
-   * Checks if the labels do not include the "Ready for Dev" label
-   * @param {import('@octokit/webhooks-types').Label[] | undefined} labels - The list of labels for the issue
-   * @return {boolean} `true` if "Ready for Dev" label is not present, `false` otherwise
+   * Check if an issues' labels includes a specified label
+   * @param {import('@octokit/webhooks-types').Label[] | undefined} issueLabels - The list of labels for the issue
+   * @param {string} label - The label to check for
+   * @return {boolean} `true` if the label is present, `false` otherwise
    */
-  notReadyForDev: (labels) => {
-    if (!labels) {
-      return true;
-    }
-
-    return labels.every((label) => label.name !== issueWorkflow.readyForDev);
+  includesLabel: (issueLabels, label) => {
+    return issueLabels?.some((issueLabel) => issueLabel.name === label) ?? false;
   },
   /**
    * Validates that no values in an array are undefined or null. If any are,


### PR DESCRIPTION
**Related Issue:** #13053

## Summary
Fixes Monday logic when a closed issue is labeled with "4 - verified". The Monday status will only be set to "Done" if the issue is not a "design" issue.

Additionally refactors the `notReadyForDev` util function into a more generic `includesLabel` function, cleaning up re-used code.
