### PR TITLE
perf(table): improve performance

### DIFF
--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -134,13 +134,27 @@ export class TableCell extends LitElement {
   //#region Lifecycle
 
   async load(): Promise<void> {
-    this.updateScreenReaderContentsText();
-    this.updateScreenReaderSelectionText();
+    if (this.readCellContentsToAT) {
+      this.updateScreenReaderContentsText();
+    }
+
+    if (this.selectionCell) {
+      this.updateScreenReaderSelectionText();
+    }
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
-    if (changes.has("parentRowIsSelected")) {
+    if (
+      this.selectionCell &&
+      (changes.has("parentRowIsSelected") ||
+        changes.has("parentRowPositionLocalized") ||
+        changes.has("selectionCell"))
+    ) {
       this.updateScreenReaderSelectionText();
+    }
+
+    if (this.readCellContentsToAT && changes.has("readCellContentsToAT")) {
+      this.updateScreenReaderContentsText();
     }
   }
 
@@ -164,6 +178,12 @@ export class TableCell extends LitElement {
 
   private onContainerFocus(): void {
     this.focused = true;
+  }
+
+  private onSlotChange(): void {
+    if (this.readCellContentsToAT) {
+      this.updateScreenReaderContentsText();
+    }
   }
 
   //#endregion
@@ -206,7 +226,7 @@ export class TableCell extends LitElement {
               {this.readCellContentsToAT && !this.selectionCell && this.contentsText}
             </span>
           )}
-          <slot onSlotChange={this.updateScreenReaderContentsText} />
+          <slot onSlotChange={this.onSlotChange} />
         </td>
       </this.interactiveContainer>
     );

--- a/packages/components/src/components/table-header/table-header.tsx
+++ b/packages/components/src/components/table-header/table-header.tsx
@@ -126,11 +126,21 @@ export class TableHeader extends LitElement {
   //#region Lifecycle
 
   async load(): Promise<void> {
-    this.updateScreenReaderText();
+    if (this.selectionCell || this.numberCell) {
+      this.updateScreenReaderText();
+    }
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
-    if (changes.has("selectedRowCount") || changes.has("selectedRowCountLocalized")) {
+    if (
+      (this.selectionCell || this.numberCell) &&
+      (changes.has("bodyRowCount") ||
+        changes.has("numberCell") ||
+        changes.has("selectedRowCount") ||
+        changes.has("selectedRowCountLocalized") ||
+        changes.has("selectionCell") ||
+        changes.has("selectionMode"))
+    ) {
       this.updateScreenReaderText();
     }
   }

--- a/packages/components/src/components/table-row/table-row.tsx
+++ b/packages/components/src/components/table-row/table-row.tsx
@@ -47,6 +47,10 @@ export class TableRow extends LitElement {
 
   private selectionHeaderRef = createRef<TableHeader["el"]>();
 
+  private deferSelectedCellSync = false;
+
+  private suppressSelectedChangeEvent = false;
+
   private userTriggered = false;
 
   private _selected = false;
@@ -133,7 +137,9 @@ export class TableRow extends LitElement {
     const oldValue = this._selected;
     if (value !== oldValue) {
       this._selected = value;
-      this.handleCellChanges();
+      if (!this.deferSelectedCellSync) {
+        this.handleCellChanges();
+      }
     }
   }
 
@@ -201,15 +207,21 @@ export class TableRow extends LitElement {
     if (
       changes.has("selected") &&
       (this.hasUpdated || this.selected !== false) &&
-      !this.userTriggered
+      !this.userTriggered &&
+      !this.suppressSelectedChangeEvent
     ) {
       this.calciteInternalTableRowSelect.emit();
     }
   }
 
   loaded(): void {
-    if (this.rowCells.length > 0) {
-      this.updateCells();
+    this.refreshCells();
+    this.syncCells();
+  }
+
+  override updated(changes: PropertyValues<this>): void {
+    if (changes.has("selected")) {
+      this.suppressSelectedChangeEvent = false;
     }
   }
 
@@ -218,19 +230,21 @@ export class TableRow extends LitElement {
   //#region Private Methods
 
   private handleSlotChange(): void {
-    this.updateCells();
+    this.refreshCells();
+    this.syncCells();
   }
 
   private handleCellChanges(): void {
     if (this.rowCells.length > 0) {
-      this.updateCells();
+      this.syncCells();
     }
   }
 
   private handleDelayedCellChanges(): void {
-    if (this.rowCells.length > 0) {
-      requestAnimationFrame(() => this.updateCells());
-    }
+    requestAnimationFrame(() => {
+      this.refreshCells();
+      this.syncCells();
+    });
   }
 
   private calciteInternalTableRowFocusChangeHandler(event: CustomEvent): void {
@@ -328,12 +342,7 @@ export class TableRow extends LitElement {
     });
   }
 
-  private updateCells(): void {
-    const alignment = this.alignment
-      ? this.alignment
-      : this.rowType !== "head"
-        ? "center"
-        : "start";
+  private refreshCells(): void {
     const slottedCells = this.rowSlotRef.value
       ? getSlotAssignedElements<TableCell["el"] | TableHeader["el"]>(
           this.rowSlotRef.value,
@@ -348,32 +357,60 @@ export class TableRow extends LitElement {
     ].filter((cell) => cell != null);
     const cells = renderedCells.concat(slottedCells);
 
-    if (cells.length > 0) {
-      cells?.forEach((cell, index) => {
-        cell.interactionMode = this.interactionMode;
-        cell.lastCell = index === cells.length - 1;
-        cell.parentRowAlignment = alignment;
-        cell.parentRowIsSelected = this.selected;
-        cell.parentRowType = this.rowType;
-        cell.positionInRow = index + 1;
-        cell.scale = this.scale;
+    this.rowCells = cells;
+    this.cellCount = cells.length;
+  }
 
-        if (cell.nodeName === "CALCITE-TABLE-CELL") {
-          const rowSpan = cell.rowSpan || 1;
-          const reachesBodyEnd =
-            this.rowType === "body" &&
-            rowSpan > 1 &&
-            this.positionSection + rowSpan >= this.bodyRowCount;
+  private syncCells(): void {
+    const alignment = this.alignment
+      ? this.alignment
+      : this.rowType !== "head"
+        ? "center"
+        : "start";
+    const cells = this.rowCells;
 
-          (cell as TableCell["el"]).readCellContentsToAT = this.readCellContentsToAT;
-          (cell as TableCell["el"]).disabled = this.disabled;
-          (cell as TableCell["el"]).reachesBodyEnd = reachesBodyEnd;
-        }
-      });
+    if (cells.length === 0) {
+      return;
     }
 
-    this.rowCells = cells || [];
-    this.cellCount = cells?.length;
+    cells.forEach((cell, index) => {
+      cell.interactionMode = this.interactionMode;
+      cell.lastCell = index === cells.length - 1;
+      cell.parentRowAlignment = alignment;
+      cell.parentRowIsSelected = this.selected;
+      cell.parentRowType = this.rowType;
+      cell.positionInRow = index + 1;
+      cell.scale = this.scale;
+
+      if (cell.nodeName === "CALCITE-TABLE-CELL") {
+        const rowSpan = cell.rowSpan || 1;
+        const reachesBodyEnd =
+          this.rowType === "body" &&
+          rowSpan > 1 &&
+          this.positionSection + rowSpan >= this.bodyRowCount;
+
+        (cell as TableCell["el"]).readCellContentsToAT = this.readCellContentsToAT;
+        (cell as TableCell["el"]).disabled = this.disabled;
+        (cell as TableCell["el"]).reachesBodyEnd = reachesBodyEnd;
+      }
+    });
+  }
+
+  setSelectedFromTable(value: boolean): boolean {
+    if (value === this.selected) {
+      return false;
+    }
+
+    this.deferSelectedCellSync = true;
+    this.suppressSelectedChangeEvent = true;
+    this.selected = value;
+    this.deferSelectedCellSync = false;
+
+    return true;
+  }
+
+  syncSelectionCells(): void {
+    this.handleCellChanges();
   }
 
   private async handleRowSelection(): Promise<void> {

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -45,9 +45,17 @@ export class Table extends LitElement {
 
   private bodyRows: TableRow["el"][] = [];
 
+  private firstVisibleBodyRowPosition: number | undefined;
+
   private footRows: TableRow["el"][] = [];
 
   private headRows: TableRow["el"][] = [];
+
+  private lastHeadRowPosition: number | undefined;
+
+  private lastVisibleBodyRowPosition: number | undefined;
+
+  private lastVisibleTableRowPosition: number | undefined;
 
   private paginationRef = createRef<Pagination["el"]>();
 
@@ -214,24 +222,30 @@ export class Table extends LitElement {
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://webgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
+    if (changes.has("groupSeparator") || changes.has("numberingSystem")) {
+      this.updateLocalizedRowData();
+      this.updateSelectedItems();
+    }
+
     if (
-      (changes.has("groupSeparator") && (this.hasUpdated || this.groupSeparator !== false)) ||
       (changes.has("interactionMode") &&
         (this.hasUpdated || this.interactionMode !== "interactive")) ||
       (changes.has("numbered") && (this.hasUpdated || this.numbered !== false)) ||
-      changes.has("numberingSystem") ||
-      (changes.has("pageSize") && (this.hasUpdated || this.pageSize !== 0)) ||
       (changes.has("scale") && (this.hasUpdated || this.scale !== "m")) ||
-      (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) ||
+      (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none"))
+    ) {
+      this.updateRowsState();
+    }
+
+    if (
+      (changes.has("pageSize") && (this.hasUpdated || this.pageSize !== 0)) ||
       (changes.has("currentPage") && (this.hasUpdated || this.currentPage > 1) && this.pageSize > 0)
     ) {
-      this.updateRows();
+      this.handleCurrentPageRange();
     }
 
     if (changes.has("stickyHeader") && (this.hasUpdated || this.stickyHeader !== false)) {
-      this.allRows?.forEach((row) => {
-        row.stickyHeaderEnabled = this.stickyHeader;
-      });
+      this.updateStickyHeaderEnabled();
 
       if (this.stickyHeader) {
         this.applyHeaderRowPositionStyles();
@@ -246,7 +260,7 @@ export class Table extends LitElement {
   //#region Private Methods
 
   private handleSlotChange(): void {
-    this.updateRows();
+    this.refreshRows();
   }
 
   private clearStickyHeaderRowStyles(): void {
@@ -282,21 +296,18 @@ export class Table extends LitElement {
     const destination = event.detail.destination;
     const lastCell = event.detail.lastCell;
 
-    const visibleBody = this.bodyRows?.filter((row) => !isHidden(row));
-    const visibleAll = this.allRows?.filter((row) => !isHidden(row));
-
-    const lastHeadRow = this.headRows[this.headRows.length - 1]?.positionAll;
-    const firstBodyRow = visibleBody[0]?.positionAll;
-    const lastBodyRow = visibleBody[visibleBody.length - 1]?.positionAll;
+    const firstBodyRow = this.firstVisibleBodyRowPosition;
+    const lastBodyRow = this.lastVisibleBodyRowPosition;
+    const lastHeadRow = this.lastHeadRowPosition;
     const firstFootRow = this.footRows[0]?.positionAll;
-    const lastTableRow = visibleAll[visibleAll.length - 1]?.positionAll;
+    const lastTableRow = this.lastVisibleTableRowPosition;
 
     const leavingHeader = destination === "next" && rowPos === lastHeadRow;
     const leavingFooter = destination === "previous" && rowPos === firstFootRow;
     const enteringHeader = destination === "previous" && rowPos === firstBodyRow;
     const enteringFooter = destination === "next" && rowPos === lastBodyRow;
 
-    let rowPosition: number;
+    let rowPosition: number | undefined;
 
     switch (destination) {
       case "first":
@@ -313,7 +324,8 @@ export class Table extends LitElement {
         break;
     }
 
-    const destinationCount = this.allRows.find((row) => row.positionAll === rowPosition)?.cellCount;
+    const destinationCount =
+      rowPosition !== undefined ? this.allRows[rowPosition]?.cellCount : undefined;
 
     const adjustedPos =
       destinationCount && cellPosition > destinationCount ? destinationCount : cellPosition;
@@ -388,51 +400,97 @@ export class Table extends LitElement {
         tableContainer.scrollWidth > tableContainer.clientWidth);
   }
 
-  private updateRows(): void {
+  private updateStickyHeaderEnabled(): void {
+    this.allRows.forEach((row) => {
+      row.stickyHeaderEnabled = this.stickyHeader;
+    });
+  }
+
+  private updateLocalizedSectionPositions(
+    rows: TableRow["el"][],
+    rowType: TableRow["el"]["rowType"],
+  ): void {
+    rows.forEach((row, index) => {
+      row.rowType = rowType;
+      row.positionSection = index;
+      row.positionSectionLocalized = this.localizeNumber((index + 1).toString());
+    });
+  }
+
+  private updateLocalizedRowData(): void {
+    this.updateLocalizedSectionPositions(this.headRows, "head");
+    this.updateLocalizedSectionPositions(this.bodyRows, "body");
+    this.updateLocalizedSectionPositions(this.footRows, "foot");
+  }
+
+  private updateVisibleRowPositions(): void {
+    this.firstVisibleBodyRowPosition = undefined;
+    this.lastVisibleBodyRowPosition = undefined;
+    this.lastVisibleTableRowPosition = undefined;
+    this.lastHeadRowPosition = this.headRows[this.headRows.length - 1]?.positionAll;
+
+    for (let index = 0; index < this.bodyRows.length; index++) {
+      const row = this.bodyRows[index];
+
+      if (!isHidden(row)) {
+        this.firstVisibleBodyRowPosition ??= row.positionAll;
+        this.lastVisibleBodyRowPosition = row.positionAll;
+      }
+    }
+
+    for (let index = this.allRows.length - 1; index >= 0; index--) {
+      const row = this.allRows[index];
+
+      if (!isHidden(row)) {
+        this.lastVisibleTableRowPosition = row.positionAll;
+        break;
+      }
+    }
+  }
+
+  private updateRowsState(): void {
+    const bodyRowCount = this.bodyRows.length;
+    let lastVisibleBodyRow: TableRow["el"] | undefined;
+
+    for (let index = this.bodyRows.length - 1; index >= 0; index--) {
+      const row = this.bodyRows[index];
+
+      if (!row.itemHidden) {
+        lastVisibleBodyRow = row;
+        break;
+      }
+    }
+
+    this.allRows.forEach((row, index) => {
+      row.interactionMode = this.interactionMode;
+      row.selectionMode = this.selectionMode;
+      row.bodyRowCount = bodyRowCount;
+      row.positionAll = index;
+      row.numbered = this.numbered;
+      row.scale = this.scale;
+      row.readCellContentsToAT = this.readCellContentsToAT;
+      row.lastVisibleRow =
+        row.rowType === "body" ? row === lastVisibleBodyRow : index === this.allRows.length - 1;
+    });
+
+    this.updateStickyHeaderEnabled();
+  }
+
+  private refreshRows(): void {
     const headRows = this.getSlottedRows(this.tableHeadSlotRef.value);
     const bodyRows = this.getSlottedRows(this.tableBodySlotRef.value);
     const footRows = this.getSlottedRows(this.tableFootSlotRef.value);
     const allRows = [...headRows, ...bodyRows, ...footRows];
 
-    headRows.forEach((row) => {
-      const position = headRows.indexOf(row);
-      row.rowType = "head";
-      row.positionSection = position;
-      row.positionSectionLocalized = this.localizeNumber((position + 1).toString());
-    });
-
-    bodyRows.forEach((row) => {
-      const position = bodyRows.indexOf(row);
-      row.rowType = "body";
-      row.positionSection = position;
-      row.positionSectionLocalized = this.localizeNumber((position + 1).toString());
-    });
-
-    footRows.forEach((row) => {
-      const position = footRows.indexOf(row);
-      row.rowType = "foot";
-      row.positionSection = position;
-      row.positionSectionLocalized = this.localizeNumber((position + 1).toString());
-    });
-
-    allRows.forEach((row) => {
-      row.interactionMode = this.interactionMode;
-      row.selectionMode = this.selectionMode;
-      row.bodyRowCount = bodyRows?.length;
-      row.positionAll = allRows?.indexOf(row);
-      row.numbered = this.numbered;
-      row.scale = this.scale;
-      row.readCellContentsToAT = this.readCellContentsToAT;
-      row.lastVisibleRow = allRows?.indexOf(row) === allRows.length - 1;
-    });
-
-    const colCount = headRows[0]?.cellCount || 0;
-
-    this.colCount = colCount;
     this.headRows = headRows;
     this.bodyRows = bodyRows;
     this.footRows = footRows;
     this.allRows = allRows;
+
+    this.updateLocalizedRowData();
+    this.updateRowsState();
+
+    this.colCount = headRows[0]?.cellCount || 0;
 
     this.applyHeaderRowPositionStyles();
 
@@ -454,6 +512,7 @@ export class Table extends LitElement {
       this.pageStartRow = (page - 1) * this.pageSize + 1;
     }
     this.paginateRows();
+    this.scheduleTableContainerOverflowUpdate();
   }
 
   private handlePaginationChange(): void {
@@ -461,7 +520,8 @@ export class Table extends LitElement {
     this.pageStartRow = requestedItem || 1;
     this.currentPage = Math.ceil(this.pageStartRow / this.pageSize);
     this.calciteTablePageChange.emit();
-    this.updateRows();
+    this.paginateRows();
+    this.scheduleTableContainerOverflowUpdate();
   }
 
   private paginateRows(): void {
@@ -472,6 +532,8 @@ export class Table extends LitElement {
       row.lastVisibleRow =
         rowPos === this.pageStartRow + this.pageSize - 1 || rowPos === this.bodyRows.length;
     });
+
+    this.updateVisibleRowPositions();
   }
 
   private async updateSelectedItems(emit?: boolean): Promise<void> {
@@ -488,20 +550,26 @@ export class Table extends LitElement {
   }
 
   private handleDeselectAllRows(): void {
-    this.bodyRows?.forEach((row) => {
-      row.selected = false;
-    });
+    const changedRows = this.bodyRows.filter((row) => row.setSelectedFromTable(false));
+
+    changedRows.forEach((row) => row.syncSelectionCells());
     this.updateSelectedItems(true);
   }
 
   private setSelectedItems(elToMatch?: TableRow["el"]): void {
-    this.bodyRows?.forEach((el) => {
+    const nextHeadSelectionState = this.selectedCount !== this.bodyRows.length;
+    const changedRows = this.bodyRows.filter((row) => {
       if (elToMatch?.rowType === "head") {
-        el.selected = this.selectedCount !== this.bodyRows?.length;
-      } else {
-        el.selected = this.selectionMode === "multiple" || elToMatch === el ? el.selected : false;
+        return row.setSelectedFromTable(nextHeadSelectionState);
       }
+
+      return this.selectionMode === "multiple" || elToMatch === row
+        ? false
+        : row.setSelectedFromTable(false);
     });
+
+    changedRows.forEach((row) => row.syncSelectionCells());
+
     this.updateSelectedItems(true);
   }
 

--- a/packages/components/src/components/table/table.tsx
+++ b/packages/components/src/components/table/table.tsx
@@ -549,10 +549,36 @@ export class Table extends LitElement {
     }
   }
 
-  private handleDeselectAllRows(): void {
-    const changedRows = this.bodyRows.filter((row) => row.setSelectedFromTable(false));
+  private setRowSelectedFromTable(row: TableRow["el"], value: boolean): boolean {
+    const tableRow = row as TableRow["el"] & {
+      setSelectedFromTable?: (value: boolean) => boolean;
+    };
 
-    changedRows.forEach((row) => row.syncSelectionCells());
+    if (typeof tableRow.setSelectedFromTable === "function") {
+      return tableRow.setSelectedFromTable(value);
+    }
+
+    if (row.selected === value) {
+      return false;
+    }
+
+    row.selected = value;
+
+    return true;
+  }
+
+  private syncRowSelectionCells(row: TableRow["el"]): void {
+    const tableRow = row as TableRow["el"] & {
+      syncSelectionCells?: () => void;
+    };
+
+    tableRow.syncSelectionCells?.();
+  }
+
+  private handleDeselectAllRows(): void {
+    const changedRows = this.bodyRows.filter((row) => this.setRowSelectedFromTable(row, false));
+
+    changedRows.forEach((row) => this.syncRowSelectionCells(row));
     this.updateSelectedItems(true);
   }
 
@@ -560,15 +586,15 @@ export class Table extends LitElement {
     const nextHeadSelectionState = this.selectedCount !== this.bodyRows.length;
     const changedRows = this.bodyRows.filter((row) => {
       if (elToMatch?.rowType === "head") {
-        return row.setSelectedFromTable(nextHeadSelectionState);
+        return this.setRowSelectedFromTable(row, nextHeadSelectionState);
       }
 
       return this.selectionMode === "multiple" || elToMatch === row
         ? false
-        : row.setSelectedFromTable(false);
+        : this.setRowSelectedFromTable(row, false);
     });
 
-    changedRows.forEach((row) => row.syncSelectionCells());
+    changedRows.forEach((row) => this.syncRowSelectionCells(row));
 
     this.updateSelectedItems(true);
   }


### PR DESCRIPTION
**Related Issue:** #14766 

## Summary

Improves `calcite-table` performance by:

* Reducing redundant row scans, indexing, localization, and property propagation.
* Limiting selection updates to affected cells and header summaries.
* Separating structural row discovery from property-only synchronization.
* Replaces per-row document-level focus listeners with direct table-owned routing, reducing global event overhead.