### PR TITLE
test(checkbox, inline-editable, radio-button, text-area): drop out-of-scope a11y coverage

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
+++ b/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
@@ -18,16 +18,6 @@ import { CSS } from "./resources";
 
 describe("accessible", () => {
   accessible(() =>
-    mount(
-      <calcite-label>
-        <calcite-checkbox id="example" name="example" value="one" /> label
-      </calcite-label>,
-    ),
-  );
-});
-
-describe("accessible without calcite-label", () => {
-  accessible(() =>
     mount(<calcite-checkbox id="example" label="label" name="example" value="one" />),
   );
 });

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -22,12 +22,9 @@ describe("accessible", () => {
   describe("default", () => {
     accessible(() =>
       mount(
-        <calcite-label>
-          Label
-          <calcite-inline-editable>
-            <calcite-input value="John Doe" />
-          </calcite-inline-editable>
-        </calcite-label>,
+        <calcite-inline-editable>
+          <calcite-input label="test-label" value="John Doe" />
+        </calcite-inline-editable>,
       ),
     );
   });
@@ -35,12 +32,9 @@ describe("accessible", () => {
   describe("editing enabled", () => {
     accessible(() =>
       mount(
-        <calcite-label>
-          Label
-          <calcite-inline-editable editing-enabled>
-            <calcite-input value="John Doe" />
-          </calcite-inline-editable>
-        </calcite-label>,
+        <calcite-inline-editable editing-enabled>
+          <calcite-input label="test-label" value="John Doe" />
+        </calcite-inline-editable>,
       ),
     );
   });
@@ -48,12 +42,9 @@ describe("accessible", () => {
   describe("with controls", () => {
     accessible(() =>
       mount(
-        <calcite-label>
-          Label
-          <calcite-inline-editable controls>
-            <calcite-input value="John Doe" />
-          </calcite-inline-editable>
-        </calcite-label>,
+        <calcite-inline-editable controls>
+          <calcite-input label="test-label" value="John Doe" />
+        </calcite-inline-editable>,
       ),
     );
   });
@@ -61,12 +52,9 @@ describe("accessible", () => {
   describe("with controls + editing enabled", () => {
     accessible(() =>
       mount(
-        <calcite-label>
-          Label
-          <calcite-inline-editable controls editing-enabled>
-            <calcite-input value="John Doe" />
-          </calcite-inline-editable>
-        </calcite-label>,
+        <calcite-inline-editable controls editing-enabled>
+          <calcite-input label="test-label" value="John Doe" />
+        </calcite-inline-editable>,
       ),
     );
   });

--- a/packages/components/src/components/radio-button/radio-button.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button/radio-button.browser.e2e.tsx
@@ -19,18 +19,7 @@ import { CSS } from "./resources";
 
 describe("accessible", () => {
   accessible(() =>
-    mount(
-      <calcite-label>
-        <calcite-radio-button id="example" name="example" value="one" />
-        label
-      </calcite-label>,
-    ),
-  );
-});
-
-describe("accessible without calcite-label", () => {
-  accessible(() =>
-    mount(<calcite-radio-button id="example" label="label" name="example" value="one" />),
+    mount(<calcite-radio-button id="example" label="test-label" name="example" value="one" />),
   );
 });
 

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -27,12 +27,7 @@ describe("cancelable", () => {
 
 describe("accessible", () => {
   accessible(() =>
-    mount(
-      <calcite-label>
-        add notes
-        <calcite-text-area max-length="50" name="something" required />
-      </calcite-label>,
-    ),
+    mount(<calcite-text-area label="test-label" max-length="50" name="something" required />),
   );
 });
 


### PR DESCRIPTION
**Related Issue:** #12013

## Summary

Removes a11y-related tests that require a wrapping `calcite-label`. Coverage for that use case is provided by the `labelable` common test helper and the `useLabel` spec test.