### PR TITLE
fix(action-bar): account for nested action-menu items in overflow sizing

### DIFF
--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -305,6 +305,8 @@ describe("selection-mode", () => {
 });
 
 describe("overflowing actions", () => {
+  const collapseToggleLabel = "Collapse action bar";
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -511,6 +513,90 @@ describe("overflowing actions", () => {
     );
 
     expect(overflowedActions.length).toBeGreaterThan(0);
+  });
+
+  it("accounts for action-menus slotted in action-groups when evaluating overflow", async () => {
+    await mount<ActionBar>(
+      <calcite-action-bar
+        expanded
+        messageOverrides={{
+          collapseLabel: collapseToggleLabel,
+          expandLabel: "Expand action bar",
+        }}
+        style={{ height: "160px" }}
+      >
+        <calcite-action-group>
+          <calcite-action icon="plus" text="Add" />
+          <calcite-action icon="save" text="Save" />
+          <calcite-action-menu label="More actions">
+            <calcite-action icon="ellipsis" slot="trigger" text="More" />
+            <calcite-action icon="layers" text="Layers" />
+            <calcite-action icon="layer-basemap" text="Basemaps" />
+          </calcite-action-menu>
+          <calcite-action icon="bookmark" text="Bookmarks" />
+          <calcite-action icon="gear" text="Settings" />
+          <calcite-action icon="information" text="Info" />
+          <calcite-action icon="link" text="Share" />
+          <calcite-action icon="table" text="Table" />
+          <calcite-action icon="measure" text="Measure" />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    vi.advanceTimersByTime(DEBOUNCE.resize);
+
+    const overflowedActions = page.getBySelector(
+      "calcite-action-bar > calcite-action-group calcite-action[slot='menu-actions']",
+    );
+    const collapseToggle = page.getByRole("button", { name: collapseToggleLabel });
+
+    expect(overflowedActions.length).toBeGreaterThan(0);
+    await expect.element(collapseToggle).toBeInViewport();
+  });
+
+  it("increases overflow when constrained and keeps the collapse toggle visible", async () => {
+    const { el } = await mount<ActionBar>(
+      <calcite-action-bar
+        expanded
+        messageOverrides={{
+          collapseLabel: collapseToggleLabel,
+          expandLabel: "Expand action bar",
+        }}
+        style={{ height: "320px" }}
+      >
+        <calcite-action-group>
+          <calcite-action icon="plus" text="Add" />
+          <calcite-action icon="save" text="Save" />
+          <calcite-action-menu label="More actions">
+            <calcite-action icon="ellipsis" slot="trigger" text="More" />
+            <calcite-action icon="layers" text="Layers" />
+            <calcite-action icon="layer-basemap" text="Basemaps" />
+          </calcite-action-menu>
+          <calcite-action icon="bookmark" text="Bookmarks" />
+          <calcite-action icon="gear" text="Settings" />
+          <calcite-action icon="information" text="Info" />
+          <calcite-action icon="link" text="Share" />
+          <calcite-action icon="table" text="Table" />
+          <calcite-action icon="measure" text="Measure" />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    vi.advanceTimersByTime(DEBOUNCE.resize);
+
+    const overflowedActions = page.getBySelector(
+      "calcite-action-bar > calcite-action-group calcite-action[slot='menu-actions']",
+    );
+    const collapseToggle = page.getByRole("button", { name: collapseToggleLabel });
+    const overflowCountAtLargeHeight = overflowedActions.length;
+
+    await expect.element(collapseToggle).toBeInViewport();
+
+    el.style.height = "160px";
+    vi.advanceTimersByTime(DEBOUNCE.resize + 1);
+
+    expect(overflowedActions.length).toBeGreaterThanOrEqual(overflowCountAtLargeHeight);
+    await expect.element(collapseToggle).toBeInViewport();
   });
 
   it("overflows actions from slotted actions-end groups", async () => {

--- a/packages/components/src/components/action-bar/action-bar.stories.ts
+++ b/packages/components/src/components/action-bar/action-bar.stories.ts
@@ -316,6 +316,88 @@ export const horizontalOverflowPerGroupDisabled = (): string => html`
   </div>
 `;
 
+export const nestedActionMenuOverflow = (): string => html`
+  <style>
+    .nested-action-menu-overflow-story {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+
+    .nested-action-menu-overflow-story-column {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      width: 220px;
+    }
+
+    .nested-action-menu-overflow-story-label {
+      font-family: sans-serif;
+      font-size: 0.75rem;
+      margin: 0;
+    }
+
+    .nested-action-menu-overflow-story-holder {
+      border: 1px dashed var(--calcite-ui-border-3, #999);
+      display: flex;
+      height: 160px;
+      overflow: hidden;
+    }
+
+    .nested-action-menu-overflow-story-bar {
+      height: 100%;
+    }
+  </style>
+  <div class="nested-action-menu-overflow-story">
+    <div class="nested-action-menu-overflow-story-column">
+      <p class="nested-action-menu-overflow-story-label">Baseline</p>
+      <div class="nested-action-menu-overflow-story-holder">
+        <calcite-action-bar expanded class="nested-action-menu-overflow-story-bar">
+          <calcite-action-group>
+            <calcite-action icon="plus" text="Add"></calcite-action>
+            <calcite-action icon="save" text="Save"></calcite-action>
+            <calcite-action icon="ellipsis" text="More"></calcite-action>
+            <calcite-action icon="bookmark" text="Bookmarks"></calcite-action>
+            <calcite-action icon="gear" text="Settings"></calcite-action>
+            <calcite-action icon="information" text="Info"></calcite-action>
+            <calcite-action icon="link" text="Share"></calcite-action>
+            <calcite-action icon="table" text="Table"></calcite-action>
+            <calcite-action icon="measure" text="Measure"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>
+    </div>
+    <div class="nested-action-menu-overflow-story-column">
+      <p class="nested-action-menu-overflow-story-label">Nested action-menu in group</p>
+      <div class="nested-action-menu-overflow-story-holder">
+        <calcite-action-bar expanded class="nested-action-menu-overflow-story-bar">
+          <calcite-action-group>
+            <calcite-action icon="plus" text="Add"></calcite-action>
+            <calcite-action icon="save" text="Save"></calcite-action>
+            <calcite-action-menu label="More actions">
+              <calcite-action icon="ellipsis" slot="trigger" text="More"></calcite-action>
+              <calcite-action icon="layers" text="Layers"></calcite-action>
+              <calcite-action icon="layer-basemap" text="Basemaps"></calcite-action>
+            </calcite-action-menu>
+            <calcite-action icon="bookmark" text="Bookmarks"></calcite-action>
+            <calcite-action icon="gear" text="Settings"></calcite-action>
+            <calcite-action icon="information" text="Info"></calcite-action>
+            <calcite-action icon="link" text="Share"></calcite-action>
+            <calcite-action icon="table" text="Table"></calcite-action>
+            <calcite-action icon="measure" text="Measure"></calcite-action>
+          </calcite-action-group>
+        </calcite-action-bar>
+      </div>
+    </div>
+  </div>
+`;
+
+nestedActionMenuOverflow.parameters = {
+  chromatic: {
+    delay: 500,
+  },
+};
+
 export const shadowSlottedHorizontal = (): string => html`
   <script>
     if (!customElements.get("action-bar-shadow-component")) {

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -13,6 +13,7 @@ import {
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
 import {
+  filterDirectChildren,
   focusElementInGroup,
   getSlotAssignedElements,
   getStylePixelValue,
@@ -32,7 +33,7 @@ import { useSetFocus } from "../../controllers/useSetFocus";
 import { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import { isActionGroup, SLOTS as ACTION_GROUP_SLOTS } from "../action-group/resources";
-import { isActionMenu } from "../action-menu/resources";
+import { isActionMenu, SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { getOverflowCount } from "../../utils/overflow";
 import { type ActionMenu } from "../action-menu/action-menu";
 import T9nStrings from "./assets/t9n/messages.en.json";
@@ -170,13 +171,7 @@ export class ActionBar extends LitElement {
       slottedActionGroups.forEach((actionGroup, index) => {
         const actionGroupStyle = getComputedStyle(actionGroup);
         const actionGroupGap = getStylePixelValue(actionGroupStyle.gap);
-        const defaultActionsCount = actionGroup.actions.filter(
-          (action) => action.slot !== ACTION_GROUP_SLOTS.menuActions,
-        ).length;
-        const hasMenuActions = actionGroup.actions.some(
-          (action) => action.slot === ACTION_GROUP_SLOTS.menuActions,
-        );
-        const actionGroupItemCount = defaultActionsCount + (hasMenuActions ? 1 : 0);
+        const actionGroupItemCount = this.getVisibleActionGroupItemCount(actionGroup);
         const actionGroupGapQuantity = Math.max(actionGroupItemCount - 1, 0);
         bufferSize += actionGroupGap * actionGroupGapQuantity;
 
@@ -545,16 +540,46 @@ export class ActionBar extends LitElement {
 
   private getItemSizes(): number[] {
     const { layout, expandToggleEl } = this;
+    const clientSize = layout === "horizontal" ? "clientWidth" : "clientHeight";
 
-    const actions = [...this.actions];
+    const itemSizes = this.actions.map((action) => action[clientSize] || 0);
+    const slottedActionGroupMenus = this.getTrackedActionGroups().flatMap((group) =>
+      filterDirectChildren<ActionMenu["el"]>(group, "calcite-action-menu"),
+    );
+
+    slottedActionGroupMenus.forEach((menu) => {
+      const triggerAction = menu.actions.find(
+        (action) => action.slot === ACTION_MENU_SLOTS.trigger,
+      );
+
+      // Use the host element size when no custom trigger is slotted.
+      itemSizes.push((triggerAction ?? menu)[clientSize] || 0);
+    });
 
     if (expandToggleEl) {
-      actions.push(expandToggleEl);
+      itemSizes.push(expandToggleEl[clientSize] || 0);
     }
 
-    const clientSize = layout === "horizontal" ? "clientWidth" : "clientHeight";
-    const fallbackSize = Math.max(...actions.map((action) => action[clientSize] || 0));
-    return actions.map((action) => action[clientSize] || fallbackSize);
+    const fallbackSize = Math.max(...itemSizes, 0);
+    return itemSizes.map((size) => size || fallbackSize);
+  }
+
+  private getVisibleActionGroupItemCount(actionGroup: ActionGroup["el"]): number {
+    const directActionGroupActions = actionGroup.actions.filter(
+      (action) => action.parentElement === actionGroup,
+    );
+    const directActionMenusCount = filterDirectChildren<ActionMenu["el"]>(
+      actionGroup,
+      "calcite-action-menu",
+    ).length;
+    const defaultActionsCount =
+      directActionGroupActions.filter((action) => action.slot !== ACTION_GROUP_SLOTS.menuActions)
+        .length + directActionMenusCount;
+    const hasMenuActions = directActionGroupActions.some(
+      (action) => action.slot === ACTION_GROUP_SLOTS.menuActions,
+    );
+
+    return defaultActionsCount + (hasMenuActions ? 1 : 0);
   }
 
   private expandedHandler(): void {


### PR DESCRIPTION
**Related Issue:** #14965

## Summary
This update fixes action-bar overflow behavior when a calcite-action-menu is nested inside a calcite-action-group.

It updates overflow sizing logic to:
- Count direct nested action-menu children as visible group items when calculating group gap contribution.
- Include nested action-menu trigger sizing during overflow measurement.
- Keep the expand/collapse toggle visible under constrained heights where clipping previously occurred.

It also adds targeted browser regression coverage for:
- Nested action-menu overflow scenarios.
- Constrained-height behavior to ensure overflow increases as space is reduced.
- Visibility of the collapse toggle using stable, user-facing locators.

A regression introduced after shadow-slot support changes caused under-counting in overflow calculations for grouped nested action-menus. That under-count could leave too many actions visible and push the toggle out of view at smaller container heights.
