### PR TITLE
chore: remove convention references from storybook

### DIFF
--- a/packages/components/src/07-conventions.mdx
+++ b/packages/components/src/07-conventions.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Conventions" />
-
-import CONVENTIONS from "../conventions/README.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/08-testing.mdx
+++ b/packages/components/src/08-testing.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Testing" />
-
-import CONVENTIONS from "../conventions/Testing.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/09-styling.mdx
+++ b/packages/components/src/09-styling.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Styling" />
-
-import CONVENTIONS from "../conventions/Styling.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/10-documentation.mdx
+++ b/packages/components/src/10-documentation.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Documentation" />
-
-import CONVENTIONS from "../conventions/Documentation.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/11-accessibility.mdx
+++ b/packages/components/src/11-accessibility.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Accessibility/General" />
-
-import CONVENTIONS from "../conventions/Accessibility.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/12-accessibilitydesign.mdx
+++ b/packages/components/src/12-accessibilitydesign.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Accessibility/Design Quick Start" />
-
-import CONVENTIONS from "../conventions/Accessibility/AccessibilityDesign.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/13-accessibilitydeveloper.mdx
+++ b/packages/components/src/13-accessibilitydeveloper.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Accessibility/Dev Quick Start" />
-
-import CONVENTIONS from "../conventions/Accessibility/AccessibilityDeveloper.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/14-accessibilityroles.mdx
+++ b/packages/components/src/14-accessibilityroles.mdx
@@ -1,7 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-
-<Meta title="Overview/Accessibility/Roles" />
-
-import CONVENTIONS from "../conventions/Accessibility/AccessibilityRoles.md?raw";
-
-<Markdown>{CONVENTIONS}</Markdown>

--- a/packages/components/src/15-internationalization.mdx
+++ b/packages/components/src/15-internationalization.mdx
@@ -1,6 +1,0 @@
-import { Markdown, Meta } from "@storybook/addon-docs/blocks";
-import CONVENTIONS from "../conventions/Internationalization.md?raw";
-
-<Meta title="Overview/Internationalization" />
-
-<Markdown>{CONVENTIONS}</Markdown>


### PR DESCRIPTION
**Related Issue:** #14863

## Summary

The conventions were removed but storybook was still referencing them.
