### PR TITLE
ci(actions): fix extension-less import path after TS changes

### DIFF
--- a/.github/scripts/addCalcitePackageLabel.cjs
+++ b/.github/scripts/addCalcitePackageLabel.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { createLabelIfMissing } = require("./support/utils");
+const { createLabelIfMissing } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/addComponentLabel.cjs
+++ b/.github/scripts/addComponentLabel.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { createLabelIfMissing } = require("./support/utils");
+const { createLabelIfMissing } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/addEsriProductLabel.cjs
+++ b/.github/scripts/addEsriProductLabel.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { createLabelIfMissing } = require("./support/utils");
+const { createLabelIfMissing } = require("./support/utils.cjs");
 const {
   labels: { productColor },
 } = require("./support/resources.cjs");

--- a/.github/scripts/addPriorityLabel.cjs
+++ b/.github/scripts/addPriorityLabel.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const { createLabelIfMissing } = require("./support/utils");
+const { createLabelIfMissing } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/createRefactorTask.cjs
+++ b/.github/scripts/monday/createRefactorTask.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { createBodyUpdater } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/createRefactorTask.cjs
+++ b/.github/scripts/monday/createRefactorTask.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/createTask.cjs
+++ b/.github/scripts/monday/createTask.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { createBodyUpdater } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/createTask.cjs
+++ b/.github/scripts/monday/createTask.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/removeLabel.cjs
+++ b/.github/scripts/monday/removeLabel.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { assertRequired, includesLabel, createBodyUpdater } = require("../support/utils");
 const {
   labels: {

--- a/.github/scripts/monday/removeLabel.cjs
+++ b/.github/scripts/monday/removeLabel.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { assertRequired, includesLabel, createBodyUpdater } = require("../support/utils");
+const { assertRequired, includesLabel, createBodyUpdater } = require("../support/utils.cjs");
 const {
   labels: {
     planning: { spike, spikeComplete },

--- a/.github/scripts/monday/syncActionChanges.cjs
+++ b/.github/scripts/monday/syncActionChanges.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /**

--- a/.github/scripts/monday/syncActionChanges.cjs
+++ b/.github/scripts/monday/syncActionChanges.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { assertRequired, createBodyUpdater } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils.cjs");
 
 /**
  * @typedef {object} SyncActionChangesInputs

--- a/.github/scripts/monday/updateAssignee.cjs
+++ b/.github/scripts/monday/updateAssignee.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { createBodyUpdater } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/updateAssignee.cjs
+++ b/.github/scripts/monday/updateAssignee.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/updateLabels.cjs
+++ b/.github/scripts/monday/updateLabels.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { assertRequired, createBodyUpdater } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/updateLabels.cjs
+++ b/.github/scripts/monday/updateLabels.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/updateMilestone.cjs
+++ b/.github/scripts/monday/updateMilestone.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { createBodyUpdater } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/updateMilestone.cjs
+++ b/.github/scripts/monday/updateMilestone.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/updateState.cjs
+++ b/.github/scripts/monday/updateState.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { createBodyUpdater } = require("../support/utils");
+const { createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/updateState.cjs
+++ b/.github/scripts/monday/updateState.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/monday/updateTitle.cjs
+++ b/.github/scripts/monday/updateTitle.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 const Monday = require("../support/monday.cjs");
-const { assertRequired, createBodyUpdater } = require("../support/utils");
+const { assertRequired, createBodyUpdater } = require("../support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {

--- a/.github/scripts/monday/updateTitle.cjs
+++ b/.github/scripts/monday/updateTitle.cjs
@@ -1,5 +1,5 @@
 // @ts-check
-const Monday = require("../support/monday");
+const Monday = require("../support/monday.cjs");
 const { assertRequired, createBodyUpdater } = require("../support/utils");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */

--- a/.github/scripts/notifyWhenInstalled.cjs
+++ b/.github/scripts/notifyWhenInstalled.cjs
@@ -2,7 +2,7 @@
 const {
   labels: { issueWorkflow },
 } = require("./support/resources.cjs");
-const { removeLabel } = require("./support/utils");
+const { removeLabel } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context }) => {

--- a/.github/scripts/notifyWhenReadyForDev.cjs
+++ b/.github/scripts/notifyWhenReadyForDev.cjs
@@ -12,7 +12,7 @@ const {
   labels: { issueWorkflow },
   milestones,
 } = require("./support/resources.cjs");
-const { removeLabel } = require("./support/utils");
+const { removeLabel } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context }) => {

--- a/.github/scripts/notifyWhenSpikeComplete.cjs
+++ b/.github/scripts/notifyWhenSpikeComplete.cjs
@@ -12,7 +12,7 @@ const {
   labels: { issueWorkflow, planning },
   milestones,
 } = require("./support/resources.cjs");
-const { removeLabel } = require("./support/utils");
+const { removeLabel } = require("./support/utils.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context }) => {


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

After #14975, the require paths without file extensions used in Monday.com sync files caused errors with the Monday sync actions.

This PR adds the file extensions to correctly resolve the paths.
