### PR TITLE
fix: use fully specified `calcite-design-tokens` imports

### DIFF
--- a/packages/components/src/components/color-picker/resources.ts
+++ b/packages/components/src/components/color-picker/resources.ts
@@ -3,7 +3,7 @@ import {
   calciteSpacingFixedSm,
   calciteSpacingFixedMd,
   calciteSpacingFixedXl,
-} from "@esri/calcite-design-tokens/dist/es6/global";
+} from "@esri/calcite-design-tokens/dist/es6/global.js";
 import { IconName } from "../icon/interfaces";
 
 export const CSS = {

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -2,7 +2,7 @@ import {
   calciteSize24,
   calciteSize32,
   calciteSize44,
-} from "@esri/calcite-design-tokens/dist/es6/core";
+} from "@esri/calcite-design-tokens/dist/es6/core.js";
 import { PropertyValues } from "lit";
 import { LitElement, property, createEvent, h, state, JsxNode, ToEvents } from "@arcgis/lumina";
 import { useDirection } from "@arcgis/lumina/controllers";

--- a/packages/components/src/utils/responsive.ts
+++ b/packages/components/src/utils/responsive.ts
@@ -4,7 +4,7 @@ import {
   calciteContainerSizeWidthSm,
   calciteContainerSizeWidthXs,
   calciteContainerSizeWidthXxs,
-} from "@esri/calcite-design-tokens/dist/es6/global";
+} from "@esri/calcite-design-tokens/dist/es6/global.js";
 
 export interface Breakpoints {
   width: {


### PR DESCRIPTION
**Related Issue:** #14998

## Summary

Fix token imports to be fully specified so [the recently externalized `@esri/calcite-design-tokens`](https://github.com/Esri/calcite-design-system/pull/14929) modules resolve reliably across strict ESM consumers.