### PR TITLE
fix(dropdown): auto-close when another dropdown opens

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -537,7 +537,7 @@ describe("referenceElement keydown", () => {
 
 describe("autoClose", () => {
   it("closes an open dropdown when another reference element dropdown opens", async () => {
-    const { el: dropdownOne } = await mount<Dropdown>(
+    await mount<Dropdown>(
       <>
         <calcite-dropdown id="dropdown-1" reference-element="trigger-1">
           <calcite-dropdown-group>
@@ -545,22 +545,21 @@ describe("autoClose", () => {
           </calcite-dropdown-group>
         </calcite-dropdown>
         <calcite-button id="trigger-1">Open dropdown 1</calcite-button>
-      </>,
-    );
-
-    const { el: dropdownTwo } = await mount<Dropdown>(
-      <>
         <calcite-dropdown id="dropdown-2" reference-element="trigger-2">
           <calcite-dropdown-group>
             <calcite-dropdown-item>Item 2</calcite-dropdown-item>
           </calcite-dropdown-group>
         </calcite-dropdown>
         <calcite-button id="trigger-2">Open dropdown 2</calcite-button>
+        <calcite-button id="outside">Outside</calcite-button>
       </>,
     );
 
+    const dropdownOne = page.getBySelector("#dropdown-1").element() as Dropdown;
+    const dropdownTwo = page.getBySelector("#dropdown-2").element() as Dropdown;
     const triggerOne = page.getByRole("button", { name: "Open dropdown 1" });
     const triggerTwo = page.getByRole("button", { name: "Open dropdown 2" });
+    const outside = page.getByRole("button", { name: "Outside" });
 
     expect(dropdownOne.open).toBe(false);
     expect(dropdownTwo.open).toBe(false);
@@ -573,6 +572,10 @@ describe("autoClose", () => {
     await userEvent.click(triggerTwo);
 
     expect(dropdownOne.open).toBe(false);
+    expect(dropdownTwo.open).toBe(true);
+
+    await userEvent.click(outside);
+
     expect(dropdownTwo.open).toBe(true);
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -576,7 +576,7 @@ describe("autoClose", () => {
 
     await userEvent.click(outside);
 
-    expect(dropdownTwo.open).toBe(true);
+    expect(dropdownTwo.open).toBe(false);
   });
 });
 

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -535,6 +535,48 @@ describe("referenceElement keydown", () => {
   });
 });
 
+describe("autoClose", () => {
+  it("closes an open dropdown when another reference element dropdown opens", async () => {
+    const { el: dropdownOne } = await mount<Dropdown>(
+      <>
+        <calcite-dropdown id="dropdown-1" reference-element="trigger-1">
+          <calcite-dropdown-group>
+            <calcite-dropdown-item>Item 1</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <calcite-button id="trigger-1">Open dropdown 1</calcite-button>
+      </>,
+    );
+
+    const { el: dropdownTwo } = await mount<Dropdown>(
+      <>
+        <calcite-dropdown id="dropdown-2" reference-element="trigger-2">
+          <calcite-dropdown-group>
+            <calcite-dropdown-item>Item 2</calcite-dropdown-item>
+          </calcite-dropdown-group>
+        </calcite-dropdown>
+        <calcite-button id="trigger-2">Open dropdown 2</calcite-button>
+      </>,
+    );
+
+    const triggerOne = page.getByRole("button", { name: "Open dropdown 1" });
+    const triggerTwo = page.getByRole("button", { name: "Open dropdown 2" });
+
+    expect(dropdownOne.open).toBe(false);
+    expect(dropdownTwo.open).toBe(false);
+
+    await userEvent.click(triggerOne);
+
+    expect(dropdownOne.open).toBe(true);
+    expect(dropdownTwo.open).toBe(false);
+
+    await userEvent.click(triggerTwo);
+
+    expect(dropdownOne.open).toBe(false);
+    expect(dropdownTwo.open).toBe(true);
+  });
+});
+
 describe("virtual referenceElement", () => {
   function renderVirtualReferenceElementDropdownHTML(): JsxNode {
     return (

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -85,9 +85,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   private focusLastDropdownItem = false;
 
   /** @internal */
-  get autoClose(): true {
-    return true;
-  }
+  @property({ attribute: false }) autoClose = true;
 
   private activeItemIndex = -1;
 

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -84,6 +84,11 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   private focusLastDropdownItem = false;
 
+  /** @internal */
+  get autoClose(): true {
+    return true;
+  }
+
   private activeItemIndex = -1;
 
   private groups: DropdownGroup["el"][] = [];

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -85,7 +85,9 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   private focusLastDropdownItem = false;
 
   /** @internal */
-  @property({ attribute: false }) autoClose = true;
+  get autoClose(): true {
+    return true;
+  }
 
   private activeItemIndex = -1;
 

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -84,7 +84,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   private focusLastDropdownItem = false;
 
-  /** @internal */
   get autoClose(): true {
     return true;
   }


### PR DESCRIPTION
**Related Issue:** #14392

## Summary

- Mark `calcite-dropdown` as auto-closing through the shared reference-element manager.
- Add browser coverage verifying that opening a second reference-element dropdown closes the first.

Reference-element dropdowns should behave as a mutually exclusive set, preventing multiple menus from remaining open at once.