### PR TITLE
feat: add non-modal behavior to Sheet

### DIFF
--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -219,9 +219,8 @@ describe("modalDisabled", () => {
     expect(el.shadowRoot.querySelector("calcite-scrim")).toBeNull();
     expect(document.documentElement.style.overflow).not.toBe("hidden");
     expect(getComputedStyle(el).pointerEvents).toBe("none");
-    expect(getComputedStyle(el.shadowRoot.querySelector(`.${CSS.content}`)).pointerEvents).toBe(
-      "auto",
-    );
+    const content = el.shadowRoot.querySelector<HTMLElement>(`.${CSS.content}`)!;
+    expect(getComputedStyle(content).pointerEvents).toBe("auto");
 
     const outsideButton = page.getByRole("button", { name: "outside" });
     await userEvent.click(outsideButton);

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { h } from "@arcgis/lumina";
+import { Fragment, h } from "@arcgis/lumina";
 import { page, userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { commands } from "../../tests/browser/commands";
@@ -88,6 +88,10 @@ describe("defaults", () => {
         defaultValue: false,
       },
       {
+        propertyName: "modalDisabled",
+        defaultValue: false,
+      },
+      {
         propertyName: "outsideCloseDisabled",
         defaultValue: false,
       },
@@ -127,7 +131,9 @@ describe("is focusable", () => {
       () =>
         mount(
           <calcite-sheet open>
-            <button class={focusableContentTargetClass}>test</button>
+            <button class={focusableContentTargetClass} type="button">
+              test
+            </button>
           </calcite-sheet>,
         ),
       {
@@ -152,6 +158,80 @@ describe("focus-trap", () => {
   );
 });
 
+describe("modalDisabled", () => {
+  it("updates modal behavior when toggled while open", async () => {
+    const openEvent = waitForEvent(document, "calciteSheetOpen");
+    const { el } = await mount<Sheet>(<calcite-sheet label="Sheet" open />);
+    await openEvent;
+
+    expect(document.documentElement.style.overflow).toBe("hidden");
+    expect(el.ariaModal).toBe("true");
+    expect(el.shadowRoot.querySelector("calcite-scrim")).not.toBeNull();
+
+    el.modalDisabled = true;
+
+    await expect.poll(() => document.documentElement.style.overflow).not.toBe("hidden");
+    expect(el.ariaModal).toBe("false");
+    expect(el.shadowRoot.querySelector("calcite-scrim")).toBeNull();
+
+    el.modalDisabled = false;
+
+    await expect.poll(() => document.documentElement.style.overflow).toBe("hidden");
+    expect(el.ariaModal).toBe("true");
+    expect(el.shadowRoot.querySelector("calcite-scrim")).not.toBeNull();
+
+    el.open = false;
+
+    await expect.poll(() => document.documentElement.style.overflow).not.toBe("hidden");
+  });
+
+  it("allows interaction outside without rendering a scrim or blocking document scroll", async () => {
+    const openEvent = waitForEvent(document, "calciteSheetOpen");
+    const { el } = await mount<Sheet>(
+      <>
+        <calcite-sheet label="Non-modal sheet" modalDisabled open>
+          <button type="button">inside</button>
+        </calcite-sheet>
+        <button style={{ insetInlineEnd: 0, position: "fixed" }} type="button">
+          outside
+        </button>
+      </>,
+    );
+    await openEvent;
+
+    expect(el.ariaModal).toBe("false");
+    expect(el.shadowRoot.querySelector("calcite-scrim")).toBeNull();
+    expect(document.documentElement.style.overflow).not.toBe("hidden");
+
+    const outsideButton = page.getByRole("button", { name: "outside" });
+    await userEvent.click(outsideButton);
+
+    await expect.element(outsideButton).toHaveFocus();
+    expect(el.open).toBe(true);
+  });
+
+  it("allows focus to leave when focusTrapDisabled is true", async () => {
+    const openEvent = waitForEvent(document, "calciteSheetOpen");
+    await mount<Sheet>(
+      <>
+        <calcite-sheet focusTrapDisabled label="Non-modal sheet" modalDisabled open>
+          <button type="button">inside</button>
+        </calcite-sheet>
+        <button type="button">outside</button>
+      </>,
+    );
+    await openEvent;
+
+    const insideButton = page.getByRole("button", { name: "inside" });
+    const outsideButton = page.getByRole("button", { name: "outside" });
+    await userEvent.click(insideButton);
+
+    await userEvent.tab();
+
+    await expect.element(outsideButton).toHaveFocus();
+  });
+});
+
 describe("reflects", () => {
   reflects(
     () => mount("calcite-sheet"),
@@ -163,6 +243,10 @@ describe("reflects", () => {
       {
         propertyName: "heightScale",
         value: "m",
+      },
+      {
+        propertyName: "modalDisabled",
+        value: true,
       },
       {
         propertyName: "resizable",

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -218,6 +218,10 @@ describe("modalDisabled", () => {
     expect(el.ariaModal).toBe("false");
     expect(el.shadowRoot.querySelector("calcite-scrim")).toBeNull();
     expect(document.documentElement.style.overflow).not.toBe("hidden");
+    expect(getComputedStyle(el).pointerEvents).toBe("none");
+    expect(getComputedStyle(el.shadowRoot.querySelector(`.${CSS.content}`)).pointerEvents).toBe(
+      "auto",
+    );
 
     const outsideButton = page.getByRole("button", { name: "outside" });
     await userEvent.click(outsideButton);

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -65,6 +65,22 @@ describe("accessible", () => {
       return renderResult;
     });
   });
+
+  describe("with modalDisabled", () => {
+    accessible(async () => {
+      const openEvent = waitForEvent(document, "calciteSheetOpen");
+      const renderResult = await mount(
+        <>
+          <calcite-sheet label="Non-modal sheet" modalDisabled open>
+            <button type="button">inside</button>
+          </calcite-sheet>
+          <button type="button">outside</button>
+        </>,
+      );
+      await openEvent;
+      return renderResult;
+    });
+  });
 });
 
 describe("defaults", () => {

--- a/packages/components/src/components/sheet/sheet.scss
+++ b/packages/components/src/components/sheet/sheet.scss
@@ -72,6 +72,10 @@
   z-index: var(--calcite-z-index-overlay);
 }
 
+:host([modal-disabled]) .container {
+  @apply pointer-events-none;
+}
+
 :host([position="inline-start"]) .container {
   @apply justify-start;
   inset-block: 0;

--- a/packages/components/src/components/sheet/sheet.scss
+++ b/packages/components/src/components/sheet/sheet.scss
@@ -72,6 +72,7 @@
   z-index: var(--calcite-z-index-overlay);
 }
 
+:host([modal-disabled]),
 :host([modal-disabled]) .container {
   @apply pointer-events-none;
 }

--- a/packages/components/src/components/sheet/sheet.stories.ts
+++ b/packages/components/src/components/sheet/sheet.stories.ts
@@ -5,11 +5,15 @@ import { Sheet } from "./sheet";
 
 const { logicalFlowPosition, displayMode, scale } = ATTRIBUTES;
 
-type SheetStoryArgs = Pick<Sheet, "displayMode" | "heightScale" | "open" | "position" | "resizable" | "width">;
+type SheetStoryArgs = Pick<
+  Sheet,
+  "displayMode" | "heightScale" | "modalDisabled" | "open" | "position" | "resizable" | "width"
+>;
 
 export default {
   title: "Components/Sheet",
   args: {
+    modalDisabled: false,
     open: true,
     resizable: false,
     position: logicalFlowPosition.values[0],
@@ -53,9 +57,35 @@ const panelHTML = html`<calcite-panel heading="Ultrices neque"
   <calcite-button slot="footer" width="half" appearance="outline">amet porttitor</calcite-button>
 </calcite-panel>`;
 
+const nonModalPageContent = html`
+  <style>
+    .non-modal-page-content {
+      box-sizing: border-box;
+      display: grid;
+      gap: var(--calcite-spacing-md);
+      min-block-size: 100vh;
+      padding: var(--calcite-spacing-xl);
+    }
+
+    .non-modal-page-content__actions {
+      display: flex;
+      gap: var(--calcite-spacing-sm);
+    }
+  </style>
+  <main class="non-modal-page-content">
+    <h1>Page content remains available</h1>
+    <p>The controls and content outside the Sheet remain visible and interactive.</p>
+    <div class="non-modal-page-content__actions">
+      <calcite-button>Primary action</calcite-button>
+      <calcite-button appearance="outline">Secondary action</calcite-button>
+    </div>
+  </main>
+`;
+
 export const simple = (args: SheetStoryArgs): string => html`
   <calcite-sheet
     label="libero nunc"
+    ${boolean("modal-disabled", args.modalDisabled)}
     ${boolean("open", args.open)}
     ${boolean("resizable", args.resizable)}
     position="${args.position}"
@@ -76,6 +106,16 @@ export const simpleDarkMode = (args: SheetStoryArgs): string => html`
   >
 `;
 simpleDarkMode.parameters = { themes: modesDarkDefault };
+
+export const modalDisabledInlineEnd = (): string => html`
+  ${nonModalPageContent}
+  <calcite-sheet label="Non-modal inline sheet" modal-disabled open position="inline-end">${panelHTML}</calcite-sheet>
+`;
+
+export const modalDisabledBlockEnd = (): string => html`
+  ${nonModalPageContent}
+  <calcite-sheet label="Non-modal block sheet" modal-disabled open position="block-end">${panelHTML}</calcite-sheet>
+`;
 
 export const resizable = (): string =>
   html`<calcite-sheet resizable label="libero nunc" open position="inline-start">${panelHTML}</calcite-sheet>`;

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -56,7 +56,7 @@ export class Sheet extends LitElement {
     triggerProp: "open",
     focusTrapOptions: {
       // scrim closes on click, so we let it take over
-      clickOutsideDeactivates: () => this.embedded,
+      clickOutsideDeactivates: () => this.modalDisabled || this.embedded,
       escapeDeactivates: (event) => {
         if (!event.defaultPrevented && !this.escapeDisabled) {
           this.open = false;
@@ -75,6 +75,8 @@ export class Sheet extends LitElement {
   messages = useT9n<typeof T9nStrings>();
 
   private mutationObserver = createObserver("mutation", () => this.handleMutationObserver());
+
+  private _modalDisabled = false;
 
   private _open = false;
 
@@ -133,7 +135,7 @@ export class Sheet extends LitElement {
   };
 
   get preventDocumentScroll(): boolean {
-    return !this.embedded;
+    return !this.embedded && !this.modalDisabled;
   }
 
   //#endregion
@@ -162,7 +164,7 @@ export class Sheet extends LitElement {
   /** When `true`, disables the default close on escape behavior. */
   @property({ reflect: true }) escapeDisabled = false;
 
-  /** When `true`, prevents focus trapping. */
+  /** When `true` and `modalDisabled` is `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
@@ -195,6 +197,21 @@ export class Sheet extends LitElement {
   /** @copyDoc */
   @property() messageOverrides?: typeof this.messages._overrides;
 
+  /** When `true`, disables the default modal behavior, allowing interaction with content outside the component. */
+  @property({ reflect: true })
+  get modalDisabled(): boolean {
+    return this._modalDisabled;
+  }
+  set modalDisabled(value: boolean) {
+    if (value === this._modalDisabled) {
+      return;
+    }
+
+    const oldPreventDocumentScroll = this.preventDocumentScroll;
+    this._modalDisabled = value;
+    this.requestUpdate("preventDocumentScroll", oldPreventDocumentScroll);
+  }
+
   /** When `true`, displays and positions the component. */
   @property({ reflect: true })
   get open(): boolean {
@@ -214,7 +231,7 @@ export class Sheet extends LitElement {
    */
   @property({ reflect: true }) opened = false;
 
-  /** When `true`, disables closing the component when the area outside of the component is clicked. */
+  /** When `true` and `modalDisabled` is `false`, disables the closing of the component when clicked outside. */
   @property({ reflect: true }) outsideCloseDisabled = false;
 
   /** Determines where the component will be positioned. */
@@ -345,6 +362,11 @@ export class Sheet extends LitElement {
   //#endregion
 
   //#region Private Methods
+
+  /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */
+  focusTrapDisabledOverride(): boolean {
+    return this.modalDisabled && this.focusTrapDisabled;
+  }
 
   private async setOpenState(value: boolean): Promise<void> {
     if (this.beforeClose && !value) {
@@ -567,7 +589,7 @@ export class Sheet extends LitElement {
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.ariaLabel = this.label;
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
-    this.el.ariaModal = "true";
+    this.el.ariaModal = this.modalDisabled ? "false" : "true";
     /* TODO: [MIGRATION] This used <Host> before. In Stencil, <Host> props overwrite user-provided props. If you don't wish to overwrite user-values, replace "=" here with "??=" */
     this.el.role = "dialog";
 
@@ -588,7 +610,9 @@ export class Sheet extends LitElement {
         popover={!this.embedded ? "manual" : undefined}
         ref={this.transitionRef}
       >
-        <calcite-scrim class={CSS.scrim} onClick={this.handleOutsideClose} />
+        {this.modalDisabled ? null : (
+          <calcite-scrim class={CSS.scrim} onClick={this.handleOutsideClose} />
+        )}
         <div class={CSS.content} id={IDS.sheetContent} ref={this.contentRef}>
           <div class={CSS.contentContainer}>
             <slot />


### PR DESCRIPTION
**Related Issue:** #12114

## Summary

Adds a `modalDisabled` property to allow Sheet to operate without blocking interaction with the surrounding page while preserving modal behavior by default.

- Removes the scrim and document scroll lock in non-modal mode.
- Allows pointer and focus interaction outside the Sheet.
- Reflects the correct `aria-modal` state.
- Aligns focus trapping and related property documentation with Dialog.
- Adds Storybook controls and Chromatic stories for inline and block positions.
- Adds browser coverage for defaults, reflection, outside interaction, focus behavior, and runtime mode changes.

The opt-out property preserves the existing default behavior and avoids a breaking API change. Follow-up work for computed scroll-prevention dependencies is tracked in #15011.