### PR TITLE
fix(navigation-logo, navigation-user): remove transitions

### DIFF
--- a/packages/components/src/components/navigation-logo/navigation-logo.scss
+++ b/packages/components/src/components/navigation-logo/navigation-logo.scss
@@ -69,7 +69,6 @@
     var(--calcite-internal-navigation-logo-background-color, var(--calcite-color-foreground-1))
   );
   border-block-end: 2px solid var(--calcite-color-transparent);
-  @include includes.transition-default($target-props: "background-color");
 }
 
 .container--link {

--- a/packages/components/src/components/navigation-user/navigation-user.scss
+++ b/packages/components/src/components/navigation-user/navigation-user.scss
@@ -57,7 +57,6 @@
       items-center
       justify-center
       cursor-pointer
-      transition-default
       focus-base
       text-0h;
     font-family: inherit;


### PR DESCRIPTION
**Related Issue:** #11706

## Summary

- Removed the background-color transition from `calcite-navigation-logo`.
- Removed the shared transition utility from `calcite-navigation-user`.

## Why

Transitions caused the navigation components to update noticeably slower when switching between light and dark themes.