### PR TITLE
chore: add `monorepo-cli` package

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,1 @@
+import "./packages/monorepo-cli/src/run.ts";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3070,6 +3070,10 @@
       "resolved": "packages/eslint-plugin-components",
       "link": true
     },
+    "node_modules/@esri/monorepo-cli": {
+      "resolved": "packages/monorepo-cli",
+      "link": true
+    },
     "node_modules/@esri/stylelint-plugin-calcite-components": {
       "resolved": "packages/stylelint-plugin-components",
       "link": true
@@ -30811,6 +30815,100 @@
         "@typescript-eslint/utils": ">=8.0.0",
         "eslint": ">=10"
       }
+    },
+    "packages/monorepo-cli": {
+      "name": "@esri/monorepo-cli",
+      "version": "1.0.0",
+      "license": "SEE LICENSE.md",
+      "bin": {
+        "cli": "src/run.ts"
+      },
+      "devDependencies": {
+        "@actions/core": "3.0.1",
+        "@actions/github": "9.1.1",
+        "@commander-js/extra-typings": "15.0.0",
+        "@types/node": "26.2.0",
+        "commander": "15.0.0",
+        "typescript": "6.0.3",
+        "vitest": "4.1.10"
+      }
+    },
+    "packages/monorepo-cli/node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "packages/monorepo-cli/node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "packages/monorepo-cli/node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "packages/monorepo-cli/node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/monorepo-cli/node_modules/@commander-js/extra-typings": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~15.0.0"
+      }
+    },
+    "packages/monorepo-cli/node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "packages/monorepo-cli/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "packages/monorepo-cli/node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/stylelint-plugin-components": {
       "name": "@esri/stylelint-plugin-calcite-components",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30827,7 +30827,7 @@
         "@actions/core": "3.0.1",
         "@actions/github": "9.1.1",
         "@commander-js/extra-typings": "15.0.0",
-        "@types/node": "26.2.0",
+        "@types/node": "24.10.0",
         "commander": "15.0.0",
         "typescript": "6.0.3",
         "vitest": "4.1.10"

--- a/packages/monorepo-cli/README.md
+++ b/packages/monorepo-cli/README.md
@@ -1,0 +1,12 @@
+# Monorepo CLI
+
+This package is under `@esri` scope and will never be published to npm or our registry.
+It is only intended to be used via `node cli <command>` from the monorepo root, and should not be imported by other packages.
+
+It has only value to this monorepo as a central place to put CLI commands related to development and maintenance of the monorepo itself.
+
+To get the list of available commands, run:
+
+```sh
+node cli
+```

--- a/packages/monorepo-cli/eslint.config.mjs
+++ b/packages/monorepo-cli/eslint.config.mjs
@@ -10,8 +10,4 @@ export default tseslint.config({
       project: ["tsconfig.eslint.json"],
     },
   },
-
-  rules: {
-    "no-console": "off",
-  },
 });

--- a/packages/monorepo-cli/eslint.config.mjs
+++ b/packages/monorepo-cli/eslint.config.mjs
@@ -1,0 +1,17 @@
+import calciteCoreConfig from "@esri/eslint-config-calcite/core.js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config({
+  extends: [calciteCoreConfig],
+
+  languageOptions: {
+    parserOptions: {
+      tsconfigRootDir: import.meta.dirname,
+      project: ["tsconfig.eslint.json"],
+    },
+  },
+
+  rules: {
+    "no-console": "off",
+  },
+});

--- a/packages/monorepo-cli/package.json
+++ b/packages/monorepo-cli/package.json
@@ -15,15 +15,20 @@
   },
   "scripts": {
     "build": "tsc",
+    "lint": "concurrently npm:lint:*",
+    "lint:json": "prettier --ignore-path \"../../.prettierignore\" --write \"**/*.json\" >/dev/null",
+    "lint:md": "prettier --ignore-path \"../../.prettierignore\" --write \"**/*.md\" >/dev/null && markdownlint-cli2 \"**/*.md\" --fix --config \"../../.markdownlint-cli2.jsonc\"",
+    "lint:ts": "eslint --fix && prettier --ignore-path \"../../.prettierignore\" --write \"**/*.{ts,mjs}\" >/dev/null",
     "test": "vitest run",
-    "test-watch": "vitest",
-    "test-related": "vitest related --run --passWithNoTests"
+    "test:ci": "npm test -- --passWithNoTests",
+    "test:related": "vitest related --run --passWithNoTests",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@actions/core": "3.0.1",
     "@actions/github": "9.1.1",
     "@commander-js/extra-typings": "15.0.0",
-    "@types/node": "26.2.0",
+    "@types/node": "24.10.0",
     "commander": "15.0.0",
     "typescript": "6.0.3",
     "vitest": "4.1.10"

--- a/packages/monorepo-cli/package.json
+++ b/packages/monorepo-cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@esri/monorepo-cli",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Set of commands to manage the monorepo and support CI/CD workflows",
+  "license": "SEE LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Esri/calcite-design-system.git",
+    "directory": "packages/monorepo-cli"
+  },
+  "bin": {
+    "cli": "src/run.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test-watch": "vitest",
+    "test-related": "vitest related --run --passWithNoTests"
+  },
+  "devDependencies": {
+    "@actions/core": "3.0.1",
+    "@actions/github": "9.1.1",
+    "@commander-js/extra-typings": "15.0.0",
+    "@types/node": "26.2.0",
+    "commander": "15.0.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/monorepo-cli/package.json
+++ b/packages/monorepo-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@esri/monorepo-cli",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "Set of commands to manage the monorepo and support CI/CD workflows",

--- a/packages/monorepo-cli/src/run.ts
+++ b/packages/monorepo-cli/src/run.ts
@@ -41,7 +41,7 @@ Promise.all(
         "url" in error &&
         typeof error.url === "string" &&
         // It is not a command not found error if the error reports for a file
-        // that was imported by the command file, rathe than the command file itself.
+        // that was imported by the command file, rather than the command file itself.
         error.url.endsWith(file);
       /* eslint-disable-next-line no-console -- Required for CLI output. */
       console.error(isCommandNotFound ? `error: unknown command: ${file.slice(0, -".ts".length)}` : error);

--- a/packages/monorepo-cli/src/run.ts
+++ b/packages/monorepo-cli/src/run.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import { Command } from "@commander-js/extra-typings";
+import fs from "node:fs";
+
+interface CommandModule {
+  registerCommand: (program: Command) => void;
+}
+
+const program = new Command();
+
+program
+  .name("node cli")
+  .description(`CLI for managing monorepo tasks. Use node cli <command> --help to see more details about a command.`);
+
+const commandsDirectory = import.meta.dirname;
+
+/**
+ * If CLI is called with a specific command, only load that command.
+ * Otherwise, load all.
+ */
+const commandName = process.argv[2];
+const commandsToLoad =
+  commandName !== undefined && commandName !== "help" && !commandName.startsWith("-")
+    ? [`${commandName}.ts`]
+    : fs.readdirSync(commandsDirectory);
+
+// Load all commands in the ./commands directory
+Promise.all(
+  commandsToLoad.map(async (file) => {
+    if (!file.endsWith(".ts")) {
+      return;
+    }
+    let command: CommandModule;
+    try {
+      command = (await import(`./${file}`)) as CommandModule;
+    } catch (error) {
+      const isCommandNotFound =
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_MODULE_NOT_FOUND" &&
+        "url" in error &&
+        typeof error.url === "string" &&
+        // It is not a command not found error if the error reports for a file
+        // that was imported by the command file, rathe than the command file itself.
+        error.url.endsWith(file);
+      if (isCommandNotFound) {
+        console.error(`error: unknown command: ${file.slice(0, -".ts".length)}`);
+      } else {
+        console.error(error);
+      }
+      process.exit(1);
+    }
+    if (typeof command.registerCommand === "function") {
+      command.registerCommand(program);
+    }
+  }),
+)
+  .then(() => {
+    const commands = program.commands as Command[];
+    commands.sort((left, right) => left.name().localeCompare(right.name()));
+    program.parse();
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/monorepo-cli/src/run.ts
+++ b/packages/monorepo-cli/src/run.ts
@@ -43,11 +43,8 @@ Promise.all(
         // It is not a command not found error if the error reports for a file
         // that was imported by the command file, rathe than the command file itself.
         error.url.endsWith(file);
-      if (isCommandNotFound) {
-        console.error(`error: unknown command: ${file.slice(0, -".ts".length)}`);
-      } else {
-        console.error(error);
-      }
+      // eslint-disable-next-line no-console
+      console.error(isCommandNotFound ? `error: unknown command: ${file.slice(0, -".ts".length)}` : error);
       process.exit(1);
     }
     if (typeof command.registerCommand === "function") {
@@ -61,6 +58,7 @@ Promise.all(
     program.parse();
   })
   .catch((error) => {
+    // eslint-disable-next-line no-console
     console.error(error);
     process.exit(1);
   });

--- a/packages/monorepo-cli/src/run.ts
+++ b/packages/monorepo-cli/src/run.ts
@@ -43,7 +43,7 @@ Promise.all(
         // It is not a command not found error if the error reports for a file
         // that was imported by the command file, rathe than the command file itself.
         error.url.endsWith(file);
-      // eslint-disable-next-line no-console
+      /* eslint-disable-next-line no-console -- Required for CLI output. */
       console.error(isCommandNotFound ? `error: unknown command: ${file.slice(0, -".ts".length)}` : error);
       process.exit(1);
     }
@@ -58,7 +58,7 @@ Promise.all(
     program.parse();
   })
   .catch((error) => {
-    // eslint-disable-next-line no-console
+    /* eslint-disable-next-line no-console -- Required for CLI output. */
     console.error(error);
     process.exit(1);
   });

--- a/packages/monorepo-cli/tsconfig.eslint.json
+++ b/packages/monorepo-cli/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@esri/calcite-typescript-config/tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "include": ["**/*", "*.config.mjs"]
+}

--- a/packages/monorepo-cli/tsconfig.json
+++ b/packages/monorepo-cli/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@esri/calcite-typescript-config/tsconfig.node.json",
+  "include": ["src", "*.ts"]
+}

--- a/packages/monorepo-cli/vitest.config.ts
+++ b/packages/monorepo-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
**Related Issue:** #15005

## Summary

Initializes a new package in the monorepo, `monorepo-cli`, which provides the structure for a CLI tool to manage the monorepo. This is the location that all CI/CD scripts would be moved to and then referenced in GH Workflows/Actions.

The package name, setup, and installed packages mirrors the setup of the CLI used by the Maps SDK for JS monorepo. A lot of the code is copied directly from that repo.

This does require installation of Node and deps for GH actions runs, but provides the ability to run scripts locally, use TS/linting, and support easier testing. An example of what a command would look like can be seen the PR #15015 stacked on top of this.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>