### PR TITLE
feat(cli): add `notify-teams` command and utils

### DIFF
--- a/.github/actions/notify-new-icon/action.yml
+++ b/.github/actions/notify-new-icon/action.yml
@@ -1,0 +1,28 @@
+name: Notify Icon Team of new icon request
+description: Notifies the Icon Team via Microsoft Teams when a new icon request is created in the repository.
+
+inputs:
+  webhook:
+    description: The Microsoft Teams incoming webhook URI to notify.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: ./package.json
+
+    - name: Install CLI dependencies
+      shell: bash
+      run: npm ci --workspace=@esri/monorepo-cli
+
+    - name: Send notification
+      shell: bash
+      env:
+        TEAMS_WEBHOOK: ${{ inputs.webhook }}
+        TEAMS_TITLE: "Icon Request - #${{ github.event.issue.number }}"
+        TEAMS_MESSAGE: ${{ github.event.issue.title }}
+        TEAMS_ACTION_TEXT: "View issue"
+        TEAMS_ACTION_URL: ${{ github.event.issue.html_url }}
+      run: node cli notify-teams

--- a/.github/scripts/addCalcitePackageLabel.cjs
+++ b/.github/scripts/addCalcitePackageLabel.cjs
@@ -1,5 +1,8 @@
 // @ts-check
-const { createLabelIfMissing } = require("./support/utils.cjs");
+const { createLabelIfMissing, includesLabel } = require("./support/utils.cjs");
+const {
+  packages: { icons: iconsPackage },
+} = require("./support/resources.cjs");
 
 /** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({ github, context, core }) => {
@@ -8,7 +11,7 @@ module.exports = async ({ github, context, core }) => {
 
   const payload = /** @type {import('@octokit/webhooks-types').IssuesEvent} */ (context.payload);
   const {
-    issue: { body, number: issue_number },
+    issue: { body, number: issue_number, labels: issue_labels },
   } = payload;
 
   if (!body) {
@@ -20,22 +23,31 @@ module.exports = async ({ github, context, core }) => {
   const packageRegex = /(?<=\[X\]\s@esri\/)[\w-]*$/gim;
   const packages = body.match(packageRegex) || [];
 
-  for (const package of packages) {
+  for (const packageLabel of packages) {
+    if (includesLabel(issue_labels, packageLabel)) {
+      core.notice(`Skipping: issue #${issue_number} already has the label '${packageLabel}'`, logParams);
+      continue;
+    }
+
     await createLabelIfMissing({
       github,
       context,
-      label: package,
+      label: packageLabel,
       // eslint-disable-next-line @cspell/spellchecker -- hex color
       color: "BFBEAF",
-      description: `Issues specific to the @esri/${package} package.`,
+      description: `Issues specific to the @esri/${packageLabel} package.`,
     });
 
     await github.rest.issues.addLabels({
       issue_number,
       owner,
       repo,
-      labels: [package],
+      labels: [packageLabel],
     });
+
+    if (packageLabel === iconsPackage) {
+      core.setOutput("icon-label-added", "true");
+    }
 
     await github.rest.actions.createWorkflowDispatch({
       owner,
@@ -45,7 +57,7 @@ module.exports = async ({ github, context, core }) => {
       inputs: {
         issue_number: issue_number.toString(),
         event_type: "SyncActionChanges",
-        label_name: package,
+        label_name: packageLabel,
         label_action: "added",
       },
     });

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -53,10 +53,6 @@ jobs:
 
       - name: "Icon request notification"
         if: github.event.label.name == 'calcite-ui-icons'
-        uses: actions/github-script@v9
-        env:
-          ICONS_TEAM: ${{secrets.ICON_LEADS}}
+        uses: ./.github/actions/notify-new-icon
         with:
-          script: |
-            const action = require('${{ github.workspace }}/.github/scripts/notifyAboutIconRequest.cjs')
-            await action({github, context, core})
+          webhook: ${{ secrets.TEAMS_ICON_WEBHOOK_URI }}

--- a/.github/workflows/issue-update-metadata.yml
+++ b/.github/workflows/issue-update-metadata.yml
@@ -19,11 +19,19 @@ jobs:
             await action({github, context, core})
 
       - name: Add Calcite Package Label
+        id: calcite-package-label
         uses: actions/github-script@v9
         with:
           script: |
             const action = require('${{ github.workspace }}/.github/scripts/addCalcitePackageLabel.cjs')
             await action({github, context, core})
+
+      - name: Notify icon team
+        if: steps.calcite-package-label.outputs.icon-label-added == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/notify-new-icon
+        with:
+          webhook: ${{ secrets.TEAMS_ICON_WEBHOOK_URI }}
 
       - name: Add Priority Label
         uses: actions/github-script@v9

--- a/package-lock.json
+++ b/package-lock.json
@@ -30828,6 +30828,7 @@
         "@commander-js/extra-typings": "15.0.0",
         "@types/node": "24.10.0",
         "commander": "15.0.0",
+        "dedent": "1.7.2",
         "typescript": "6.0.3",
         "vitest": "4.1.10"
       }

--- a/packages/monorepo-cli/package.json
+++ b/packages/monorepo-cli/package.json
@@ -30,6 +30,7 @@
     "@commander-js/extra-typings": "15.0.0",
     "@types/node": "24.10.0",
     "commander": "15.0.0",
+    "dedent": "1.7.2",
     "typescript": "6.0.3",
     "vitest": "4.1.10"
   }

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -68,24 +68,21 @@ async function run({ webhook, title, message, action_text, action_url }: Partial
   const validatedWebhook = assertRequiredOption(webhook || TEAMS_WEBHOOK, webhookUsage);
   const validatedTitle = assertRequiredOption(title || TEAMS_TITLE, titleUsage);
 
-  const { error } = await notifyTeams({
-    webhook: validatedWebhook,
-    title: validatedTitle,
-    message: message || TEAMS_MESSAGE,
-    action_text: action_text || TEAMS_ACTION_TEXT,
-    action_url: action_url || TEAMS_ACTION_URL,
-  });
-
-  if (error) {
-    errorAndExit(error);
+  try {
+    await notifyTeams({
+      webhook: validatedWebhook,
+      title: validatedTitle,
+      message: message || TEAMS_MESSAGE,
+      action_text: action_text || TEAMS_ACTION_TEXT,
+      action_url: action_url || TEAMS_ACTION_URL,
+    });
+  } catch (error) {
+    errorAndExit(`Failed to send Teams notification. ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
 /**
  * Sends an `AdaptiveCard` message to a specified Microsoft Teams channel via webhook.
- *
- * @returns An object with an error message if the request failed, or null if it
- * succeeded.
  */
 export async function notifyTeams({
   webhook,
@@ -93,33 +90,25 @@ export async function notifyTeams({
   message,
   action_text,
   action_url,
-}: NotifyTeamsOptions): Promise<{ error: string | null }> {
-  const teamsCard = {
-    type: "message",
-    attachments: [
+}: NotifyTeamsOptions): Promise<void> {
+  const cardContent: CardContent = {
+    type: "AdaptiveCard",
+    $schema: "https://adaptivecards.io/schemas/adaptive-card.json",
+    version: "1.2",
+    body: [
       {
-        contentType: "application/vnd.microsoft.card.adaptive",
-        content: {
-          type: "AdaptiveCard",
-          $schema: "https://adaptivecards.io/schemas/adaptive-card.json",
-          version: "1.2",
-          body: [
-            {
-              type: "TextBlock",
-              text: title,
-              size: "Large",
-              weight: "Bolder",
-              color: "Accent",
-              wrap: true,
-            },
-          ],
-        } as CardContent,
+        type: "TextBlock",
+        text: title,
+        size: "Large",
+        weight: "Bolder",
+        color: "Accent",
+        wrap: true,
       },
     ],
   };
 
   if (message) {
-    teamsCard.attachments[0].content.body.push({
+    cardContent.body.push({
       type: "TextBlock",
       text: message,
       wrap: true,
@@ -127,7 +116,7 @@ export async function notifyTeams({
   }
 
   if (action_text && action_url) {
-    teamsCard.attachments[0].content.actions = [
+    cardContent.actions = [
       {
         type: "Action.OpenUrl",
         title: action_text,
@@ -136,17 +125,23 @@ export async function notifyTeams({
     ];
   }
 
-  return fetch(webhook, {
+  const response = await fetch(webhook, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(teamsCard),
-  })
-    .then(async (response) => {
-      return { error: !response.ok ? `${response.status}: ${await response.text()}` : null };
-    })
-    .catch((error) => {
-      return { error: `Failed to send Teams notification. ${error}` };
-    });
+    body: JSON.stringify({
+      type: "message",
+      attachments: [
+        {
+          contentType: "application/vnd.microsoft.card.adaptive",
+          content: cardContent,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${await response.text()}`);
+  }
 }

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -1,0 +1,145 @@
+import { Command } from "@commander-js/extra-typings";
+import { assertRequiredOption, errorAndExit, formatDescription, getSummary } from "./utils/commands.ts";
+
+type NotifyTeamsOptions = {
+  /** The Microsoft Teams incoming webhook URI to notify. */
+  webhook: string;
+  /** The title. */
+  title: string;
+  /** The message. Supports simple Markdown formatting. */
+  message?: string;
+  /** The text for a clickable link action on the message card. Requires `action_url` to also be provided. */
+  action_text?: string;
+  /** The URL for the clickable link action on the message card. Requires `action_text` to also be provided. */
+  action_url?: string;
+};
+
+type CardContent = {
+  type: "AdaptiveCard";
+  $schema: string;
+  version: string;
+  body: {
+    type: string;
+    text?: string;
+    size?: "Large";
+    weight?: "Bolder";
+    color?: "Accent";
+    wrap?: boolean;
+  }[];
+  actions: {
+    type: "Action.OpenUrl";
+    title: string;
+    url: string;
+  }[];
+};
+
+const description = formatDescription(`
+  Notify Teams via webhook.
+
+  Sends a notification to a Microsoft Teams channel using an Adaptive Card.
+`);
+const webhookUsage = "-w, --webhook <WEBHOOK URI>";
+const titleUsage = "-t, --title <TITLE>";
+
+export const registerCommand = (command: Command) =>
+  void command
+    .command("notify-teams")
+    .summary(getSummary(description))
+    .description(description)
+    .option(webhookUsage, "The Microsoft Teams incoming webhook URI to notify. (env: TEAMS_WEBHOOK)")
+    .option(titleUsage, "The title. (env: TEAMS_TITLE)")
+    .option("-m, --message <MESSAGE>", "The message. Supports basic Markdown formatting. (env: TEAMS_MESSAGE)")
+    .option(
+      "--at, --action-text <TEXT>",
+      "The text for a clickable link action on the message card. Requires `action-url` to also be provided. (env: TEAMS_ACTION_TEXT)",
+    )
+    .option(
+      "--au, --action-url <URL>",
+      "The URL for the clickable link action on the message card. Requires `action-text` to also be provided. (env: TEAMS_ACTION_URL)",
+    )
+    .action(run);
+
+/**
+ * Runs the `notify-teams` command using the provided options or environment variables.
+ */
+async function run({ webhook, title, message, action_text, action_url }: Partial<NotifyTeamsOptions>) {
+  const { TEAMS_WEBHOOK, TEAMS_TITLE, TEAMS_MESSAGE, TEAMS_ACTION_TEXT, TEAMS_ACTION_URL } = process.env;
+
+  const validatedWebhook = assertRequiredOption(webhook || TEAMS_WEBHOOK, webhookUsage);
+  const validatedTitle = assertRequiredOption(title || TEAMS_TITLE, titleUsage);
+
+  const { error } = await notifyTeams({
+    webhook: validatedWebhook,
+    title: validatedTitle,
+    message: message || TEAMS_MESSAGE,
+    action_text: action_text || TEAMS_ACTION_TEXT,
+    action_url: action_url || TEAMS_ACTION_URL,
+  });
+
+  if (error) {
+    errorAndExit(error);
+  }
+}
+
+/**
+ * Sends an `AdaptiveCard` message to a specifed Microsoft Teams channel via webhook.
+ * @returns An object with an error message if the request failed, or null if it
+ * succeeded.
+ */
+export async function notifyTeams({ webhook, title, message, action_text, action_url }: NotifyTeamsOptions) {
+  const teamsCard = {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "https://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.2",
+          body: [
+            {
+              type: "TextBlock",
+              text: title,
+              size: "Large",
+              weight: "Bolder",
+              color: "Accent",
+              wrap: true,
+            },
+          ],
+        } as CardContent,
+      },
+    ],
+  };
+
+  if (message) {
+    teamsCard.attachments[0].content.body.push({
+      type: "TextBlock",
+      text: message,
+      wrap: true,
+    });
+  }
+
+  if (action_text && action_url) {
+    teamsCard.attachments[0].content.actions = [
+      {
+        type: "Action.OpenUrl",
+        title: action_text,
+        url: action_url,
+      },
+    ];
+  }
+
+  return fetch(webhook, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(teamsCard),
+  })
+    .then(async (response) => {
+      return { error: !response.ok ? `${response.status}: ${await response.text()}` : null };
+    })
+    .catch((error) => {
+      return { error: `Failed to send Teams notification. ${error}` };
+    });
+}

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -26,7 +26,7 @@ type CardContent = {
     color?: "Accent";
     wrap?: boolean;
   }[];
-  actions: {
+  actions?: {
     type: "Action.OpenUrl";
     title: string;
     url: string;
@@ -38,7 +38,7 @@ const description = formatDescription(`
 
   Sends a notification to a Microsoft Teams channel using an Adaptive Card.
 `);
-const webhookUsage = "-w, --webhook <WEBHOOK URI>";
+const webhookUsage = "-w, --webhook <WEBHOOK_URI>";
 const titleUsage = "-t, --title <TITLE>";
 
 export const registerCommand = (command: Command) =>
@@ -82,7 +82,7 @@ async function run({ webhook, title, message, action_text, action_url }: Partial
 }
 
 /**
- * Sends an `AdaptiveCard` message to a specifed Microsoft Teams channel via webhook.
+ * Sends an `AdaptiveCard` message to a specified Microsoft Teams channel via webhook.
  * @returns An object with an error message if the request failed, or null if it
  * succeeded.
  */

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -1,5 +1,6 @@
 import { Command } from "@commander-js/extra-typings";
-import { assertRequiredOption, errorAndExit, formatDescription, getSummary } from "./utils/commands.ts";
+import { assertRequiredOption, errorAndExit, getSummary } from "./utils/commands.ts";
+import dedent from "dedent";
 
 type NotifyTeamsOptions = {
   /** The Microsoft Teams incoming webhook URI to notify. */
@@ -33,11 +34,11 @@ type CardContent = {
   }[];
 };
 
-const description = formatDescription(`
+const description = dedent`
   Notify Teams via webhook.
 
   Sends a notification to a Microsoft Teams channel using an Adaptive Card.
-`);
+`;
 const webhookUsage = "-w, --webhook <WEBHOOK_URI>";
 const titleUsage = "-t, --title <TITLE>";
 

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -41,7 +41,7 @@ const description = formatDescription(`
 const webhookUsage = "-w, --webhook <WEBHOOK_URI>";
 const titleUsage = "-t, --title <TITLE>";
 
-export const registerCommand = (command: Command) =>
+export const registerCommand = (command: Command): void =>
   void command
     .command("notify-teams")
     .summary(getSummary(description))
@@ -83,10 +83,17 @@ async function run({ webhook, title, message, action_text, action_url }: Partial
 
 /**
  * Sends an `AdaptiveCard` message to a specified Microsoft Teams channel via webhook.
+ *
  * @returns An object with an error message if the request failed, or null if it
  * succeeded.
  */
-export async function notifyTeams({ webhook, title, message, action_text, action_url }: NotifyTeamsOptions) {
+export async function notifyTeams({
+  webhook,
+  title,
+  message,
+  action_text,
+  action_url,
+}: NotifyTeamsOptions): Promise<{ error: string | null }> {
   const teamsCard = {
     type: "message",
     attachments: [

--- a/packages/monorepo-cli/src/notify-teams.ts
+++ b/packages/monorepo-cli/src/notify-teams.ts
@@ -10,9 +10,9 @@ type NotifyTeamsOptions = {
   /** The message. Supports simple Markdown formatting. */
   message?: string;
   /** The text for a clickable link action on the message card. Requires `action_url` to also be provided. */
-  action_text?: string;
+  actionText?: string;
   /** The URL for the clickable link action on the message card. Requires `action_text` to also be provided. */
-  action_url?: string;
+  actionUrl?: string;
 };
 
 type CardContent = {
@@ -63,7 +63,7 @@ export const registerCommand = (command: Command): void =>
 /**
  * Runs the `notify-teams` command using the provided options or environment variables.
  */
-async function run({ webhook, title, message, action_text, action_url }: Partial<NotifyTeamsOptions>) {
+async function run({ webhook, title, message, actionText, actionUrl }: Partial<NotifyTeamsOptions>) {
   const { TEAMS_WEBHOOK, TEAMS_TITLE, TEAMS_MESSAGE, TEAMS_ACTION_TEXT, TEAMS_ACTION_URL } = process.env;
 
   const validatedWebhook = assertRequiredOption(webhook || TEAMS_WEBHOOK, webhookUsage);
@@ -74,8 +74,8 @@ async function run({ webhook, title, message, action_text, action_url }: Partial
       webhook: validatedWebhook,
       title: validatedTitle,
       message: message || TEAMS_MESSAGE,
-      action_text: action_text || TEAMS_ACTION_TEXT,
-      action_url: action_url || TEAMS_ACTION_URL,
+      actionText: actionText || TEAMS_ACTION_TEXT,
+      actionUrl: actionUrl || TEAMS_ACTION_URL,
     });
   } catch (error) {
     errorAndExit(`Failed to send Teams notification. ${error instanceof Error ? error.message : String(error)}`);
@@ -89,8 +89,8 @@ export async function notifyTeams({
   webhook,
   title,
   message,
-  action_text,
-  action_url,
+  actionText,
+  actionUrl,
 }: NotifyTeamsOptions): Promise<void> {
   const cardContent: CardContent = {
     type: "AdaptiveCard",
@@ -116,12 +116,12 @@ export async function notifyTeams({
     });
   }
 
-  if (action_text && action_url) {
+  if (actionText && actionUrl) {
     cardContent.actions = [
       {
         type: "Action.OpenUrl",
-        title: action_text,
-        url: action_url,
+        title: actionText,
+        url: actionUrl,
       },
     ];
   }

--- a/packages/monorepo-cli/src/utils/commands.ts
+++ b/packages/monorepo-cli/src/utils/commands.ts
@@ -1,0 +1,69 @@
+import { setGithubError } from "./github-actions.ts";
+
+/**
+ * Returns first non-empty line from command description.
+ */
+export function getSummary(description: string): string {
+  const newLineIndex = description.indexOf("\n");
+  if (newLineIndex === -1) {
+    return description.trim();
+  } else {
+    return description.slice(0, newLineIndex);
+  }
+}
+
+/**
+ * Normalizes multiline command descriptions by removing leading/trailing blank lines
+ * and stripping shared indentation while preserving internal formatting.
+ */
+export function formatDescription(text: string): string {
+  const normalized = text.replace(/\r\n/gu, "\n");
+  const lines = normalized.split("\n");
+
+  while (lines.length > 0 && lines[0]?.trim() === "") {
+    lines.shift();
+  }
+
+  while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
+    lines.pop();
+  }
+
+  const indents = lines
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const match = line.match(/^[\t ]*/u);
+      return match ? match[0].length : 0;
+    });
+
+  const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(minIndent)).join("\n");
+}
+
+/**
+ * Asserts that the provided option is not undefined or null, otherwise exits with an error message.
+ * @param option The option to check.
+ * @param name The name of the option. Used to generate a useful error message.
+ * @param errorMessage Optional custom error message to display if the option is not specified.
+ * @returns The non-nullable value of the option.
+ */
+export function assertRequiredOption<T extends unknown>(
+  option: T,
+  name: string,
+  errorMessage?: string,
+): NonNullable<T> {
+  if (option === undefined || option === null) {
+    errorAndExit(errorMessage || `error: required option ${name} not specified`);
+  }
+
+  return option as NonNullable<T>;
+}
+
+/**
+ * Logs the error message and exits the process with the provided exit code.
+ * @param message The error message to log.
+ * @param code The process exit code (default: 1).
+ */
+export function errorAndExit(message: string, code: number = 1): never {
+  setGithubError(message);
+  process.exit(code);
+}

--- a/packages/monorepo-cli/src/utils/commands.ts
+++ b/packages/monorepo-cli/src/utils/commands.ts
@@ -5,11 +5,7 @@ import { setGithubError } from "./github-actions.ts";
  */
 export function getSummary(description: string): string {
   const newLineIndex = description.indexOf("\n");
-  if (newLineIndex === -1) {
-    return description.trim();
-  } else {
-    return description.slice(0, newLineIndex);
-  }
+  return newLineIndex === -1 ? description.trim() : description.slice(0, newLineIndex);
 }
 
 /**
@@ -41,25 +37,23 @@ export function formatDescription(text: string): string {
 
 /**
  * Asserts that the provided option is not undefined or null, otherwise exits with an error message.
+ *
  * @param option The option to check.
  * @param name The name of the option. Used to generate a useful error message.
  * @param errorMessage Optional custom error message to display if the option is not specified.
  * @returns The non-nullable value of the option.
  */
-export function assertRequiredOption<T extends unknown>(
-  option: T,
-  name: string,
-  errorMessage?: string,
-): NonNullable<T> {
+export function assertRequiredOption<T>(option: T, name: string, errorMessage?: string): NonNullable<T> {
   if (option === undefined || option === null) {
     errorAndExit(errorMessage || `error: required option ${name} not specified`);
   }
 
-  return option as NonNullable<T>;
+  return option;
 }
 
 /**
  * Logs the error message and exits the process with the provided exit code.
+ *
  * @param message The error message to log.
  * @param code The process exit code (default: 1).
  */

--- a/packages/monorepo-cli/src/utils/commands.ts
+++ b/packages/monorepo-cli/src/utils/commands.ts
@@ -44,11 +44,7 @@ export function formatDescription(text: string): string {
  * @returns The non-nullable value of the option.
  */
 export function assertRequiredOption<T>(option: T, name: string, errorMessage?: string): NonNullable<T> {
-  if (option === undefined || option === null) {
-    errorAndExit(errorMessage || `error: required option ${name} not specified`);
-  }
-
-  return option;
+  return option ?? errorAndExit(errorMessage || `error: required option ${name} not specified`);
 }
 
 /**

--- a/packages/monorepo-cli/src/utils/commands.ts
+++ b/packages/monorepo-cli/src/utils/commands.ts
@@ -9,33 +9,6 @@ export function getSummary(description: string): string {
 }
 
 /**
- * Normalizes multiline command descriptions by removing leading/trailing blank lines
- * and stripping shared indentation while preserving internal formatting.
- */
-export function formatDescription(text: string): string {
-  const normalized = text.replace(/\r\n/gu, "\n");
-  const lines = normalized.split("\n");
-
-  while (lines.length > 0 && lines[0]?.trim() === "") {
-    lines.shift();
-  }
-
-  while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
-    lines.pop();
-  }
-
-  const indents = lines
-    .filter((line) => line.trim() !== "")
-    .map((line) => {
-      const match = line.match(/^[\t ]*/u);
-      return match ? match[0].length : 0;
-    });
-
-  const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
-  return lines.map((line) => line.slice(minIndent)).join("\n");
-}
-
-/**
  * Asserts that the provided option is not undefined or null, otherwise exits with an error message.
  *
  * @param option The option to check.

--- a/packages/monorepo-cli/src/utils/github-actions.ts
+++ b/packages/monorepo-cli/src/utils/github-actions.ts
@@ -1,9 +1,6 @@
 import * as githubCore from "@actions/core";
 import { styleText } from "node:util";
 
-/**
- * Check if the current environment is running under GitHub Actions.
- */
 export const isUnderGitHubActions = process.env.GITHUB_ACTIONS === "true";
 
 /**

--- a/packages/monorepo-cli/src/utils/github-actions.ts
+++ b/packages/monorepo-cli/src/utils/github-actions.ts
@@ -1,0 +1,20 @@
+import * as githubCore from "@actions/core";
+import { styleText } from "node:util";
+
+/**
+ * Check if the current environment is running under GitHub Actions.
+ */
+export const isUnderGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
+/**
+ * Set a GitHub Actions error annotation.
+ */
+export function setGithubError(text: string, properties?: githubCore.AnnotationProperties): void {
+  if (isUnderGitHubActions) {
+    githubCore.error(text, properties);
+  }
+  if (properties?.file) {
+    console.error(styleText("red", `In ${properties.file}:`));
+  }
+  console.error(styleText("red", text));
+}

--- a/packages/monorepo-cli/src/utils/github-actions.ts
+++ b/packages/monorepo-cli/src/utils/github-actions.ts
@@ -14,7 +14,9 @@ export function setGithubError(text: string, properties?: githubCore.AnnotationP
     githubCore.error(text, properties);
   }
   if (properties?.file) {
+    // eslint-disable-next-line no-console
     console.error(styleText("red", `In ${properties.file}:`));
   }
+  // eslint-disable-next-line no-console
   console.error(styleText("red", text));
 }

--- a/packages/monorepo-cli/src/utils/github-actions.ts
+++ b/packages/monorepo-cli/src/utils/github-actions.ts
@@ -14,9 +14,9 @@ export function setGithubError(text: string, properties?: githubCore.AnnotationP
     githubCore.error(text, properties);
   }
   if (properties?.file) {
-    // eslint-disable-next-line no-console
+    /* eslint-disable-next-line no-console -- Required for CLI output outside of GitHub. */
     console.error(styleText("red", `In ${properties.file}:`));
   }
-  // eslint-disable-next-line no-console
+  /* eslint-disable-next-line no-console -- Required for CLI output outside of GitHub. */
   console.error(styleText("red", text));
 }


### PR DESCRIPTION
**Related Issue:** #14992, #15005

## Summary

Adds:
- A new `notify-teams` CLI command to the `monorepo-cli` package. This can be used/modified for future Teams notifications needs.
- A composite GH Action that calls the `notify-teams` command to notify the Icons Team when new icon-related issues are created/updated, using the `calcite-ui-icons` label as a trigger.

We had an Icons workflow to add a GH comment, but it was broken. This replaces it with a notification via Teams, which the Icons Teams uses more frequently.

I have tested the notification in the Build Notification channel, and will have to setup the webhook for the Icons channel before merging.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>