### PR TITLE
fix(text-area): prevent height growth in flex layouts

### DIFF
--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -325,6 +325,30 @@ it("reconciles textarea height when resize is none and host height is constraine
   }
 });
 
+it("reconciles textarea height when resize is none and host has fixed height", async () => {
+  const { el } = await mount<TextArea>(
+    <calcite-text-area
+      label-text="Description"
+      max-length="600"
+      resize="none"
+      style={{ height: "200px" }}
+    />,
+  );
+
+  const componentLocator = page.elementLocator(el);
+  const loader = componentLocator.getBySelector(`.${CSS.loaderContainer}`).element();
+  const textArea = componentLocator.getByRole("textbox").first().element();
+  const footer = componentLocator.getByRole("contentinfo").element();
+
+  await afterNextFrame();
+
+  const loaderHeight = loader.getBoundingClientRect().height;
+  const textAreaHeight = textArea.getBoundingClientRect().height;
+  const footerHeight = footer.getBoundingClientRect().height;
+
+  expect(Math.abs(loaderHeight - (textAreaHeight + footerHeight))).toBeLessThanOrEqual(1);
+});
+
 it("allocates a fixed height between the textarea, footer, and validation message", async () => {
   const { el } = await mount<TextArea>(
     <calcite-text-area

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -247,8 +247,8 @@ it("does not grow textarea height on repeated key presses", async () => {
   expect(el.value).toBe("aaaaaaaaaa");
 });
 
-it("does not grow textarea height on repeated input when resize is none", async () => {
-  const { el } = await mount<TextArea>(
+it("does not grow textarea height on non-value updates when resize is none", async () => {
+  const { component, el } = await mount<TextArea>(
     <calcite-text-area label-text="text" limit-text max-length="500" resize="none" rows={2} />,
   );
 
@@ -256,6 +256,11 @@ it("does not grow textarea height on repeated input when resize is none", async 
   await userEvent.click(textArea);
 
   const initialHeight = textArea.element().getBoundingClientRect().height;
+  expect(textArea.element().style.height).toBe("");
+
+  el.status = "valid";
+  await component.updateComplete;
+  expect(textArea.element().style.height).toBe("");
 
   await userEvent.keyboard("aaaaaaaaaa");
   await afterNextFrame();
@@ -369,12 +374,12 @@ it("reconciles textarea height when value and max length change together", async
   const componentLocator = page.elementLocator(el);
   const loader = componentLocator.getBySelector(`.${CSS.loaderContainer}`).element();
   const textArea = componentLocator.getByRole("textbox").first().element();
-  const footer = componentLocator.getByRole("contentinfo").element();
 
   el.value = "a";
   el.maxLength = 600;
   await component.updateComplete;
 
+  const footer = componentLocator.getByRole("contentinfo").element();
   const loaderHeight = loader.getBoundingClientRect().height;
   const textAreaHeight = textArea.getBoundingClientRect().height;
   const footerHeight = footer.getBoundingClientRect().height;

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -237,6 +237,7 @@ it("does not grow textarea height on repeated key presses", async () => {
   await userEvent.click(textArea);
 
   const initialHeight = textArea.element().getBoundingClientRect().height;
+  expect(textArea.element().style.height).toBe("");
 
   await userEvent.keyboard("aaaaaaaaaa");
   await afterNextFrame();

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -360,6 +360,27 @@ it("reconciles textarea height when resize is none and host has fixed height", a
   ).toBeLessThanOrEqual(1);
 });
 
+it("reconciles textarea height when value and max length change together", async () => {
+  const { component, el } = await mount<TextArea>(
+    <calcite-text-area label-text="Description" resize="none" style={{ height: "200px" }} />,
+  );
+
+  const componentLocator = page.elementLocator(el);
+  const loader = componentLocator.getBySelector(`.${CSS.loaderContainer}`).element();
+  const textArea = componentLocator.getByRole("textbox").first().element();
+  const footer = componentLocator.getByRole("contentinfo").element();
+
+  el.value = "a";
+  el.maxLength = 600;
+  await component.updateComplete;
+
+  const loaderHeight = loader.getBoundingClientRect().height;
+  const textAreaHeight = textArea.getBoundingClientRect().height;
+  const footerHeight = footer.getBoundingClientRect().height;
+
+  expect(Math.abs(loaderHeight - (textAreaHeight + footerHeight))).toBeLessThanOrEqual(1);
+});
+
 it("allocates a fixed height between the textarea, footer, and validation message", async () => {
   const { el } = await mount<TextArea>(
     <calcite-text-area

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -245,3 +245,75 @@ it("does not grow textarea height on repeated key presses", async () => {
   expect(Math.abs(finalHeight - initialHeight)).toBeLessThanOrEqual(1);
   expect(el.value).toBe("aaaaaaaaaa");
 });
+
+it("does not grow textarea height in a zero-height flex container", async () => {
+  const { el: component } = await mount<TextArea>(
+    <calcite-text-area label-text="Description" max-length="600" />,
+  );
+  component.parentElement!.style.display = "flex";
+  component.parentElement!.style.height = "0";
+  const textArea = page.elementLocator(component).getByRole("textbox").first();
+  const initialHeight = textArea.element().getBoundingClientRect().height;
+
+  component.loading = true;
+  component.placeholder = "Add a description";
+  component.readOnly = true;
+  component.status = "valid";
+  await component.updateComplete;
+
+  const heightAfterPropertyUpdates = textArea.element().getBoundingClientRect().height;
+  expect(Math.abs(heightAfterPropertyUpdates - initialHeight)).toBeLessThanOrEqual(1);
+
+  component.readOnly = false;
+  await component.updateComplete;
+  await userEvent.click(textArea);
+
+  await userEvent.keyboard("aaaaaaaaaa");
+  await afterNextFrame();
+
+  const finalHeight = textArea.element().getBoundingClientRect().height;
+  expect(Math.abs(finalHeight - heightAfterPropertyUpdates)).toBeLessThanOrEqual(1);
+  expect(component.value).toBe("aaaaaaaaaa");
+});
+
+it("allocates a fixed height between the textarea, footer, and validation message", async () => {
+  const { el: component } = await mount<TextArea>(
+    <calcite-text-area
+      label-text="Description"
+      max-length="600"
+      status="invalid"
+      style={{ height: "200px" }}
+      validation-message="Enter a description"
+    />,
+  );
+  const componentLocator = page.elementLocator(component);
+  const loader = componentLocator.locator(`.${CSS.loaderContainer}`).element();
+  const textArea = componentLocator.getByRole("textbox").first().element();
+  const footer = componentLocator.getByRole("contentinfo").element();
+  const validation = componentLocator.getByText("Enter a description").element();
+
+  await afterNextFrame();
+
+  const componentRect = component.getBoundingClientRect();
+  const loaderRect = loader.getBoundingClientRect();
+  const textAreaRect = textArea.getBoundingClientRect();
+  const footerRect = footer.getBoundingClientRect();
+  const validationRect = validation.getBoundingClientRect();
+
+  expect(componentRect.height).toBe(200);
+  expect(textAreaRect.bottom).toBeLessThanOrEqual(footerRect.top + 1);
+  expect(footerRect.bottom).toBeLessThanOrEqual(loaderRect.bottom + 1);
+  expect(loaderRect.bottom).toBeLessThanOrEqual(validationRect.top + 1);
+  expect(validationRect.bottom).toBeLessThanOrEqual(componentRect.bottom + 1);
+});
+
+it("releases a fixed host height when the textarea is resized", async () => {
+  const { el: component } = await mount<TextArea>(
+    <calcite-text-area max-length="600" style={{ height: "200px" }} />,
+  );
+  const textArea = page.elementLocator(component).getByRole("textbox").first().element();
+
+  textArea.style.height = "220px";
+
+  await expect.poll(() => component.style.height).toBe("auto");
+});

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -299,12 +299,13 @@ it("allocates a fixed height between the textarea, footer, and validation messag
   const textAreaRect = textArea.getBoundingClientRect();
   const footerRect = footer.getBoundingClientRect();
   const validationRect = validation.getBoundingClientRect();
+  const tolerance = 2;
 
   expect(componentRect.height).toBe(200);
-  expect(textAreaRect.bottom).toBeLessThanOrEqual(footerRect.top + 1);
-  expect(footerRect.bottom).toBeLessThanOrEqual(loaderRect.bottom + 1);
-  expect(loaderRect.bottom).toBeLessThanOrEqual(validationRect.top + 1);
-  expect(validationRect.bottom).toBeLessThanOrEqual(componentRect.bottom + 1);
+  expect(textAreaRect.bottom).toBeLessThanOrEqual(footerRect.top + tolerance);
+  expect(footerRect.bottom).toBeLessThanOrEqual(loaderRect.bottom + tolerance);
+  expect(loaderRect.bottom).toBeLessThanOrEqual(validationRect.top + tolerance);
+  expect(validationRect.bottom).toBeLessThanOrEqual(componentRect.bottom + tolerance);
 });
 
 it("releases a fixed host height when the textarea is resized", async () => {

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -246,6 +246,23 @@ it("does not grow textarea height on repeated key presses", async () => {
   expect(el.value).toBe("aaaaaaaaaa");
 });
 
+it("does not grow textarea height on first input when resize is none", async () => {
+  const { el } = await mount<TextArea>(
+    <calcite-text-area label-text="text" limit-text max-length="500" resize="none" rows="2" />,
+  );
+
+  const textArea = page.elementLocator(el).getByRole("textbox").first();
+  await userEvent.click(textArea);
+
+  const initialHeight = textArea.element().getBoundingClientRect().height;
+
+  await userEvent.keyboard("a");
+  await afterNextFrame();
+
+  const finalHeight = textArea.element().getBoundingClientRect().height;
+  expect(Math.abs(finalHeight - initialHeight)).toBeLessThanOrEqual(1);
+});
+
 it("does not grow textarea height in a zero-height flex container", async () => {
   const { component, el } = await mount<TextArea>(
     <calcite-text-area label-text="Description" max-length="600" />,
@@ -274,6 +291,38 @@ it("does not grow textarea height in a zero-height flex container", async () => 
   const finalHeight = textArea.element().getBoundingClientRect().height;
   expect(Math.abs(finalHeight - heightAfterPropertyUpdates)).toBeLessThanOrEqual(1);
   expect(el.value).toBe("aaaaaaaaaa");
+});
+
+it("reconciles textarea height when resize is none and host height is constrained by stylesheet", async () => {
+  const styleEl = document.createElement("style");
+  styleEl.textContent = `.resize-none-constrained { display: block; height: 80px; }`;
+  document.head.append(styleEl);
+
+  try {
+    const { el } = await mount<TextArea>(
+      <calcite-text-area
+        class="resize-none-constrained"
+        label-text="Description"
+        max-length="600"
+        resize="none"
+      />,
+    );
+
+    const componentLocator = page.elementLocator(el);
+    const loader = componentLocator.getBySelector(`.${CSS.loaderContainer}`).element();
+    const textArea = componentLocator.getByRole("textbox").first().element();
+    const footer = componentLocator.getByRole("contentinfo").element();
+
+    await afterNextFrame();
+
+    const loaderHeight = loader.getBoundingClientRect().height;
+    const textAreaHeight = textArea.getBoundingClientRect().height;
+    const footerHeight = footer.getBoundingClientRect().height;
+
+    expect(Math.abs(loaderHeight - (textAreaHeight + footerHeight))).toBeLessThanOrEqual(1);
+  } finally {
+    styleEl.remove();
+  }
 });
 
 it("allocates a fixed height between the textarea, footer, and validation message", async () => {

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -247,24 +247,24 @@ it("does not grow textarea height on repeated key presses", async () => {
 });
 
 it("does not grow textarea height in a zero-height flex container", async () => {
-  const { el: component } = await mount<TextArea>(
+  const { component, el } = await mount<TextArea>(
     <calcite-text-area label-text="Description" max-length="600" />,
   );
-  component.parentElement!.style.display = "flex";
-  component.parentElement!.style.height = "0";
-  const textArea = page.elementLocator(component).getByRole("textbox").first();
+  el.parentElement!.style.display = "flex";
+  el.parentElement!.style.height = "0";
+  const textArea = page.elementLocator(el).getByRole("textbox").first();
   const initialHeight = textArea.element().getBoundingClientRect().height;
 
-  component.loading = true;
-  component.placeholder = "Add a description";
-  component.readOnly = true;
-  component.status = "valid";
+  el.loading = true;
+  el.placeholder = "Add a description";
+  el.readOnly = true;
+  el.status = "valid";
   await component.updateComplete;
 
   const heightAfterPropertyUpdates = textArea.element().getBoundingClientRect().height;
   expect(Math.abs(heightAfterPropertyUpdates - initialHeight)).toBeLessThanOrEqual(1);
 
-  component.readOnly = false;
+  el.readOnly = false;
   await component.updateComplete;
   await userEvent.click(textArea);
 
@@ -273,11 +273,11 @@ it("does not grow textarea height in a zero-height flex container", async () => 
 
   const finalHeight = textArea.element().getBoundingClientRect().height;
   expect(Math.abs(finalHeight - heightAfterPropertyUpdates)).toBeLessThanOrEqual(1);
-  expect(component.value).toBe("aaaaaaaaaa");
+  expect(el.value).toBe("aaaaaaaaaa");
 });
 
 it("allocates a fixed height between the textarea, footer, and validation message", async () => {
-  const { el: component } = await mount<TextArea>(
+  const { el } = await mount<TextArea>(
     <calcite-text-area
       label-text="Description"
       max-length="600"
@@ -286,15 +286,15 @@ it("allocates a fixed height between the textarea, footer, and validation messag
       validation-message="Enter a description"
     />,
   );
-  const componentLocator = page.elementLocator(component);
-  const loader = componentLocator.locator(`.${CSS.loaderContainer}`).element();
+  const componentLocator = page.elementLocator(el);
+  const loader = componentLocator.getBySelector(`.${CSS.loaderContainer}`).element();
   const textArea = componentLocator.getByRole("textbox").first().element();
   const footer = componentLocator.getByRole("contentinfo").element();
   const validation = componentLocator.getByText("Enter a description").element();
 
   await afterNextFrame();
 
-  const componentRect = component.getBoundingClientRect();
+  const componentRect = el.getBoundingClientRect();
   const loaderRect = loader.getBoundingClientRect();
   const textAreaRect = textArea.getBoundingClientRect();
   const footerRect = footer.getBoundingClientRect();
@@ -308,12 +308,12 @@ it("allocates a fixed height between the textarea, footer, and validation messag
 });
 
 it("releases a fixed host height when the textarea is resized", async () => {
-  const { el: component } = await mount<TextArea>(
+  const { el } = await mount<TextArea>(
     <calcite-text-area max-length="600" style={{ height: "200px" }} />,
   );
-  const textArea = page.elementLocator(component).getByRole("textbox").first().element();
+  const textArea = page.elementLocator(el).getByRole("textbox").first().element();
 
   textArea.style.height = "220px";
 
-  await expect.poll(() => component.style.height).toBe("auto");
+  await expect.poll(() => el.style.height).toBe("auto");
 });

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -248,7 +248,7 @@ it("does not grow textarea height on repeated key presses", async () => {
 
 it("does not grow textarea height on first input when resize is none", async () => {
   const { el } = await mount<TextArea>(
-    <calcite-text-area label-text="text" limit-text max-length="500" resize="none" rows="2" />,
+    <calcite-text-area label-text="text" limit-text max-length="500" resize="none" rows={2} />,
   );
 
   const textArea = page.elementLocator(el).getByRole("textbox").first();

--- a/packages/components/src/components/text-area/text-area.browser.e2e.tsx
+++ b/packages/components/src/components/text-area/text-area.browser.e2e.tsx
@@ -246,7 +246,7 @@ it("does not grow textarea height on repeated key presses", async () => {
   expect(el.value).toBe("aaaaaaaaaa");
 });
 
-it("does not grow textarea height on first input when resize is none", async () => {
+it("does not grow textarea height on repeated input when resize is none", async () => {
   const { el } = await mount<TextArea>(
     <calcite-text-area label-text="text" limit-text max-length="500" resize="none" rows={2} />,
   );
@@ -256,11 +256,13 @@ it("does not grow textarea height on first input when resize is none", async () 
 
   const initialHeight = textArea.element().getBoundingClientRect().height;
 
-  await userEvent.keyboard("a");
+  await userEvent.keyboard("aaaaaaaaaa");
   await afterNextFrame();
 
   const finalHeight = textArea.element().getBoundingClientRect().height;
   expect(Math.abs(finalHeight - initialHeight)).toBeLessThanOrEqual(1);
+  expect(textArea.element().style.height).toBe("");
+  expect(el.value).toBe("aaaaaaaaaa");
 });
 
 it("does not grow textarea height in a zero-height flex container", async () => {
@@ -347,6 +349,15 @@ it("reconciles textarea height when resize is none and host has fixed height", a
   const footerHeight = footer.getBoundingClientRect().height;
 
   expect(Math.abs(loaderHeight - (textAreaHeight + footerHeight))).toBeLessThanOrEqual(1);
+
+  await userEvent.click(textArea);
+  const initialInputHeight = textArea.getBoundingClientRect().height;
+  await userEvent.keyboard("aaaaaaaaaa");
+  await afterNextFrame();
+
+  expect(
+    Math.abs(textArea.getBoundingClientRect().height - initialInputHeight),
+  ).toBeLessThanOrEqual(1);
 });
 
 it("allocates a fixed height between the textarea, footer, and validation message", async () => {

--- a/packages/components/src/components/text-area/text-area.scss
+++ b/packages/components/src/components/text-area/text-area.scss
@@ -61,7 +61,7 @@
 }
 
 .wrapper {
-  @apply h-full w-full box-border;
+  @apply flex h-full w-full flex-col box-border;
   box-shadow: var(--calcite-internal-text-area-shadow);
   border-radius: var(--calcite-internal-text-area-corner-radius);
 }
@@ -131,8 +131,9 @@
 }
 
 .loader-container {
+  @apply flex-auto;
   position: relative;
-  block-size: inherit;
+  min-block-size: 0;
 }
 
 .loader {

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -333,8 +333,10 @@ export class TextArea
     }
   }
 
-  override updated(): void {
-    this.setTextAreaHeight();
+  override updated(changes: PropertyValues<this>): void {
+    if (!(this.resize === "none" && changes.has("value"))) {
+      this.setTextAreaHeight();
+    }
   }
 
   override disconnectedCallback(): void {
@@ -415,7 +417,7 @@ export class TextArea
     const { height: elStyleHeight } = getComputedStyle(this.el);
     const hostHeightIsConstrained = elStyleHeight !== "auto";
 
-    if (this.resize === "none" && loaderHeight >= contentHeight && !hostHeightIsConstrained) {
+    if (this.resize === "none" && !hostHeightIsConstrained) {
       return;
     }
 

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -414,8 +414,7 @@ export class TextArea
     }
 
     const contentHeight = textAreaHeight + footerHeight;
-    const { height: elStyleHeight } = getComputedStyle(this.el);
-    const hostHeightIsConstrained = elStyleHeight !== "auto";
+    const hostHeightIsConstrained = this.dimensionsDiffer(contentHeight, loaderHeight);
 
     if (this.resize === "none" && !hostHeightIsConstrained) {
       return;

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -334,7 +334,7 @@ export class TextArea
   }
 
   override updated(changes: PropertyValues<this>): void {
-    if (!(this.resize === "none" && changes.has("value"))) {
+    if (!(this.resize === "none" && changes.size === 1 && changes.has("value"))) {
       this.setTextAreaHeight();
     }
   }

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -411,7 +411,13 @@ export class TextArea
       return;
     }
 
-    if (this.dimensionsDiffer(textAreaHeight + footerHeight, loaderHeight)) {
+    const contentHeight = textAreaHeight + footerHeight;
+
+    if (this.resize === "none" && loaderHeight >= contentHeight) {
+      return;
+    }
+
+    if (this.dimensionsDiffer(contentHeight, loaderHeight)) {
       this.textAreaEl!.style.height = `${loaderHeight - footerHeight}px`;
     }
   }

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -412,8 +412,10 @@ export class TextArea
     }
 
     const contentHeight = textAreaHeight + footerHeight;
+    const { height: elStyleHeight } = getComputedStyle(this.el);
+    const hostHeightIsConstrained = elStyleHeight !== "auto";
 
-    if (this.resize === "none" && loaderHeight >= contentHeight) {
+    if (this.resize === "none" && loaderHeight >= contentHeight && !hostHeightIsConstrained) {
       return;
     }
 

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -422,7 +422,10 @@ export class TextArea
     }
 
     if (this.dimensionsDiffer(contentHeight, loaderHeight)) {
-      this.textAreaEl!.style.height = `${loaderHeight - footerHeight}px`;
+      const height = `${loaderHeight - footerHeight}px`;
+      if (this.textAreaEl!.style.height !== height) {
+        this.textAreaEl!.style.height = height;
+      }
     }
   }
 


### PR DESCRIPTION
**Related Issue:** #11868

## Summary

- Use column flex layout to correctly allocate the text area’s available height.
- Prevent repeated height growth when rendered in zero-height flex containers, such as dialogs.
- Preserve fixed-height, footer, validation-message, and resize behavior.
- Add focused browser regression coverage.

## Background

The loader container previously inherited the host height, which could include the label and other surrounding content. Reactive updates then applied that oversized measurement to the native textarea, creating a height feedback loop.

The loader container now flexes within the wrapper’s remaining space, providing a stable measurement for textarea sizing.