### PR TITLE
fix(label): set default layout to `block`

### DIFF
--- a/packages/components/.storybook/resources.ts
+++ b/packages/components/.storybook/resources.ts
@@ -360,7 +360,7 @@ export const ATTRIBUTES: CommonAttributes = {
   },
   labelLayout: {
     values: labelLayoutOptions,
-    defaultValue: labelLayoutOptions[0],
+    defaultValue: labelLayoutOptions[1],
   },
   listDisplayMode: {
     values: listDisplayModeOptions,

--- a/packages/components/src/components/inline-editable/inline-editable.stories.ts
+++ b/packages/components/src/components/inline-editable/inline-editable.stories.ts
@@ -60,7 +60,7 @@ export const disabled = (): string => html`
 
 export const darkModeRTL = (): string => html`
   <div dir="rtl" style="width:300px;max-width:100%;">
-    <calcite-label class="calcite-mode-dark" status="idle" scale="m" layout="block">
+    <calcite-label class="calcite-mode-dark" status="idle" scale="m">
       My great label
       <calcite-inline-editable>
         <calcite-input alignment="start" placeholder="Placeholder text"> </calcite-input>

--- a/packages/components/src/components/inline-editable/inline-editable.stories.ts
+++ b/packages/components/src/components/inline-editable/inline-editable.stories.ts
@@ -60,7 +60,7 @@ export const disabled = (): string => html`
 
 export const darkModeRTL = (): string => html`
   <div dir="rtl" style="width:300px;max-width:100%;">
-    <calcite-label class="calcite-mode-dark" status="idle" scale="m" layout="default">
+    <calcite-label class="calcite-mode-dark" status="idle" scale="m" layout="block">
       My great label
       <calcite-inline-editable>
         <calcite-input alignment="start" placeholder="Placeholder text"> </calcite-input>

--- a/packages/components/src/components/label/label.browser.e2e.tsx
+++ b/packages/components/src/components/label/label.browser.e2e.tsx
@@ -1,12 +1,32 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { hidden, renders, themed } from "../../tests/commonTests/browser";
+import { defaults, hidden, renders, themed } from "../../tests/commonTests/browser";
 
 import { CSS } from "./resources";
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-label"));
+});
+
+describe("defaults", () => {
+  defaults(
+    () => mount("calcite-label"),
+    [
+      {
+        propertyName: "alignment",
+        defaultValue: "start",
+      },
+      {
+        propertyName: "layout",
+        defaultValue: "block",
+      },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
+    ],
+  );
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/label/label.e2e.ts
+++ b/packages/components/src/components/label/label.e2e.ts
@@ -3,19 +3,6 @@ import { describe, expect, it } from "vitest";
 import { isElementFocused } from "../../tests/utils/puppeteer";
 import { html } from "../../../support/formatting";
 
-it("renders default props when none are provided", async () => {
-  const page = await newE2EPage();
-  await page.setContent(`
-    <calcite-label>
-    Label text
-    <calcite-input></calcite-input>
-    </calcite-label>
-    `);
-
-  const element = await page.find("calcite-label");
-  expect(element).toEqualAttribute("layout", "block");
-});
-
 it("renders requested props when valid props are provided", async () => {
   const page = await newE2EPage();
   await page.setContent(`

--- a/packages/components/src/components/label/label.e2e.ts
+++ b/packages/components/src/components/label/label.e2e.ts
@@ -13,7 +13,7 @@ it("renders default props when none are provided", async () => {
     `);
 
   const element = await page.find("calcite-label");
-  expect(element).toEqualAttribute("layout", "default");
+  expect(element).toEqualAttribute("layout", "block");
 });
 
 it("renders requested props when valid props are provided", async () => {

--- a/packages/components/src/components/label/label.stories.ts
+++ b/packages/components/src/components/label/label.stories.ts
@@ -11,7 +11,7 @@ export default {
   title: "Components/Label",
   args: {
     alignment: alignment.defaultValue,
-    layout: "default",
+    layout: "block",
     scale: scale.defaultValue,
   },
   argTypes: {

--- a/packages/components/src/components/label/label.tsx
+++ b/packages/components/src/components/label/label.tsx
@@ -37,7 +37,7 @@ export class Label extends LitElement {
    * [Deprecated] The `"default"` value is deprecated in v3.3.0, removal target v6.0.0 - use `"block"` instead.
    */
   @property({ reflect: true }) layout: "block" | "inline" | "inline-space-between" | "default" =
-    "default";
+    "block";
 
   /** Specifies the size of the component. */
   @property({ reflect: true }) scale: Scale = "m";


### PR DESCRIPTION
**Related Issue:** #14713 

## Summary

- update Label's default `layout` to `"block"`
- update tests and storybook to use `layout` of "block" instead of `"default"`
- update tests to use defaults common test helper and test all Label defaults