### PR TITLE
fix(input): remove Microsoft Edge `type="password"` reveal icon

### DIFF
--- a/packages/components/src/components/input/input.scss
+++ b/packages/components/src/components/input/input.scss
@@ -346,13 +346,12 @@ input[readonly]:focus {
   }
 }
 
-// hide browser default clear
-
-input[type="text"]::-ms-clear,
-input[type="text"]::-ms-reveal {
-  @apply hidden
-    h-0
-    w-0;
+// hide browser default icons/buttons
+input:is([type="text"], [type="password"])::-ms-clear,
+input:is([type="text"], [type="password"])::-ms-reveal {
+  display: none;
+  inline-size: 0;
+  block-size: 0;
 }
 input[type="search"]::-webkit-search-decoration,
 input[type="search"]::-webkit-search-cancel-button,


### PR DESCRIPTION
**Related Issue:** #13973

## Summary

Removes the Microsoft Edge reveal icon button from Input when `type="password"`, by adding `type="password"` to the CSS rule.

Replaces the `@apply` Tailwind usage with the equivalent CSS to help with #12080.
