### PR TITLE
refactor: add component type predicate utils

### DIFF
--- a/packages/components/src/components/accordion-item/resources.ts
+++ b/packages/components/src/components/accordion-item/resources.ts
@@ -1,3 +1,5 @@
+import type { AccordionItem } from "./accordion-item";
+
 import { IconName } from "../icon/types";
 import { Appearance, Position, IconType } from "../types";
 
@@ -42,3 +44,10 @@ export const ICONS: Record<string, IconName> = {
   plus: "plus",
   minus: "minus",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAccordionItem(el: Element | null | EventTarget): el is AccordionItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACCORDION-ITEM";
+}

--- a/packages/components/src/components/accordion-item/resources.ts
+++ b/packages/components/src/components/accordion-item/resources.ts
@@ -1,5 +1,4 @@
-import type { AccordionItem } from "./accordion-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 import { Appearance, Position, IconType } from "../types";
 
@@ -48,6 +47,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAccordionItem(el: Element | null | EventTarget): el is AccordionItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACCORDION-ITEM";
-}
+export const isAccordionItem = isTag("calcite-accordion-item");

--- a/packages/components/src/components/accordion/resources.ts
+++ b/packages/components/src/components/accordion/resources.ts
@@ -1,4 +1,13 @@
+import type { Accordion } from "./accordion";
+
 export const CSS = {
   accordion: "accordion",
   transparent: "accordion--transparent",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAccordion(el: Element | null | EventTarget): el is Accordion["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACCORDION";
+}

--- a/packages/components/src/components/accordion/resources.ts
+++ b/packages/components/src/components/accordion/resources.ts
@@ -1,4 +1,4 @@
-import type { Accordion } from "./accordion";
+import { isTag } from "../resources";
 
 export const CSS = {
   accordion: "accordion",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAccordion(el: Element | null | EventTarget): el is Accordion["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACCORDION";
-}
+export const isAccordion = isTag("calcite-accordion");

--- a/packages/components/src/components/action-bar/resources.ts
+++ b/packages/components/src/components/action-bar/resources.ts
@@ -1,4 +1,4 @@
-import type { ActionBar } from "./action-bar";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -18,6 +18,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isActionBar(el: Element | null | EventTarget): el is ActionBar["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACTION-BAR";
-}
+export const isActionBar = isTag("calcite-action-bar");

--- a/packages/components/src/components/action-bar/resources.ts
+++ b/packages/components/src/components/action-bar/resources.ts
@@ -1,3 +1,5 @@
+import type { ActionBar } from "./action-bar";
+
 export const CSS = {
   container: "container",
   hasActionGroups: "has-action-groups",
@@ -12,3 +14,10 @@ export const SLOTS = {
   actionsStart: "actions-start",
   expandTooltip: "expand-tooltip",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isActionBar(el: Element | null | EventTarget): el is ActionBar["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACTION-BAR";
+}

--- a/packages/components/src/components/action-group/resources.ts
+++ b/packages/components/src/components/action-group/resources.ts
@@ -1,5 +1,5 @@
 import { IconName } from "../icon/types";
-import { ActionGroup } from "./action-group";
+import type { ActionGroup } from "./action-group";
 
 export const SLOTS = {
   menuActions: "menu-actions",
@@ -14,6 +14,9 @@ export const CSS = {
   container: "container",
 };
 
-export function isActionGroup(el: Element | null): el is ActionGroup["el"] {
-  return el?.tagName === "CALCITE-ACTION-GROUP";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isActionGroup(el: Element | null | EventTarget): el is ActionGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACTION-GROUP";
 }

--- a/packages/components/src/components/action-group/resources.ts
+++ b/packages/components/src/components/action-group/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
-import type { ActionGroup } from "./action-group";
-
 export const SLOTS = {
   menuActions: "menu-actions",
   menuTooltip: "menu-tooltip",
@@ -17,6 +16,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isActionGroup(el: Element | null | EventTarget): el is ActionGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACTION-GROUP";
-}
+export const isActionGroup = isTag("calcite-action-group");

--- a/packages/components/src/components/action-menu/resources.ts
+++ b/packages/components/src/components/action-menu/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
-import type { ActionMenu } from "./action-menu";
-
 export const CSS = {
   menu: "menu",
   defaultTrigger: "default-trigger",
@@ -26,6 +25,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isActionMenu(el: Element | null | EventTarget): el is ActionMenu["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACTION-MENU";
-}
+export const isActionMenu = isTag("calcite-action-menu");

--- a/packages/components/src/components/action-menu/resources.ts
+++ b/packages/components/src/components/action-menu/resources.ts
@@ -23,6 +23,9 @@ export const ICONS: Record<string, IconName> = {
   menu: "ellipsis",
 };
 
-export function isActionMenu(el: Element | null): el is ActionMenu["el"] {
-  return el?.tagName === "CALCITE-ACTION-MENU";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isActionMenu(el: Element | null | EventTarget): el is ActionMenu["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACTION-MENU";
 }

--- a/packages/components/src/components/action-pad/resources.ts
+++ b/packages/components/src/components/action-pad/resources.ts
@@ -1,3 +1,5 @@
+import type { ActionPad } from "./action-pad";
+
 export const CSS = {
   actionGroupEnd: "action-group--end",
   container: "container",
@@ -6,3 +8,10 @@ export const CSS = {
 export const SLOTS = {
   expandTooltip: "expand-tooltip",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isActionPad(el: Element | null | EventTarget): el is ActionPad["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACTION-PAD";
+}

--- a/packages/components/src/components/action-pad/resources.ts
+++ b/packages/components/src/components/action-pad/resources.ts
@@ -1,4 +1,4 @@
-import type { ActionPad } from "./action-pad";
+import { isTag } from "../resources";
 
 export const CSS = {
   actionGroupEnd: "action-group--end",
@@ -12,6 +12,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isActionPad(el: Element | null | EventTarget): el is ActionPad["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACTION-PAD";
-}
+export const isActionPad = isTag("calcite-action-pad");

--- a/packages/components/src/components/action/resources.ts
+++ b/packages/components/src/components/action/resources.ts
@@ -1,4 +1,4 @@
-import { Action } from "./action";
+import type { Action } from "./action";
 
 export const CSS = {
   button: "button",
@@ -21,6 +21,9 @@ export const IDS = {
   indicator: (id: string) => `${prefixId}-${id}-indicator`,
 } as const;
 
-export function isAction(el: Element | null): el is Action["el"] {
-  return el?.tagName === "CALCITE-ACTION";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAction(el: Element | null | EventTarget): el is Action["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ACTION";
 }

--- a/packages/components/src/components/action/resources.ts
+++ b/packages/components/src/components/action/resources.ts
@@ -1,4 +1,4 @@
-import type { Action } from "./action";
+import { isTag } from "../resources";
 
 export const CSS = {
   button: "button",
@@ -24,6 +24,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAction(el: Element | null | EventTarget): el is Action["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ACTION";
-}
+export const isAction = isTag("calcite-action");

--- a/packages/components/src/components/alert/resources.ts
+++ b/packages/components/src/components/alert/resources.ts
@@ -1,4 +1,4 @@
-import type { Alert } from "./alert";
+import { isTag } from "../resources";
 
 export const DURATIONS = {
   slow: 14000,
@@ -39,6 +39,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAlert(el: Element | null | EventTarget): el is Alert["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ALERT";
-}
+export const isAlert = isTag("calcite-alert");

--- a/packages/components/src/components/alert/resources.ts
+++ b/packages/components/src/components/alert/resources.ts
@@ -1,3 +1,5 @@
+import type { Alert } from "./alert";
+
 export const DURATIONS = {
   slow: 14000,
   medium: 10000,
@@ -33,3 +35,10 @@ export const CSS = {
   textContainer: "text-container",
   focused: "focused",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAlert(el: Element | null | EventTarget): el is Alert["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ALERT";
+}

--- a/packages/components/src/components/autocomplete-item-group/resources.ts
+++ b/packages/components/src/components/autocomplete-item-group/resources.ts
@@ -1,3 +1,5 @@
+import type { AutocompleteItemGroup } from "./autocomplete-item-group";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -8,3 +10,10 @@ export const CSS = {
   scale: (scale: Scale) => `scale--${scale}` as const,
   separator: "separator",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAutocompleteItemGroup(el: Element | null | EventTarget): el is AutocompleteItemGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE-ITEM-GROUP";
+}

--- a/packages/components/src/components/autocomplete-item-group/resources.ts
+++ b/packages/components/src/components/autocomplete-item-group/resources.ts
@@ -1,5 +1,4 @@
-import type { AutocompleteItemGroup } from "./autocomplete-item-group";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -14,6 +13,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAutocompleteItemGroup(el: Element | null | EventTarget): el is AutocompleteItemGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE-ITEM-GROUP";
-}
+export const isAutocompleteItemGroup = isTag("calcite-autocomplete-item-group");

--- a/packages/components/src/components/autocomplete-item/resources.ts
+++ b/packages/components/src/components/autocomplete-item/resources.ts
@@ -1,5 +1,4 @@
-import type { AutocompleteItem } from "./autocomplete-item";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -27,6 +26,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAutocompleteItem(el: Element | null | EventTarget): el is AutocompleteItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE-ITEM";
-}
+export const isAutocompleteItem = isTag("calcite-autocomplete-item");

--- a/packages/components/src/components/autocomplete-item/resources.ts
+++ b/packages/components/src/components/autocomplete-item/resources.ts
@@ -1,3 +1,5 @@
+import type { AutocompleteItem } from "./autocomplete-item";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -21,3 +23,10 @@ const idPrefix = "autocomplete-item";
 export const IDS = {
   host: (id: string) => `${idPrefix}-${id}`,
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAutocompleteItem(el: Element | null | EventTarget): el is AutocompleteItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE-ITEM";
+}

--- a/packages/components/src/components/autocomplete/resources.ts
+++ b/packages/components/src/components/autocomplete/resources.ts
@@ -1,3 +1,5 @@
+import type { Autocomplete } from "./autocomplete";
+
 export const SLOTS = {
   contentBottom: "content-bottom",
   contentTop: "content-top",
@@ -22,3 +24,10 @@ export const IDS = {
   input: (id: string) => `${idPrefix}-input-${id}`,
   list: (id: string) => `${idPrefix}-list-${id}`,
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAutocomplete(el: Element | null | EventTarget): el is Autocomplete["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE";
+}

--- a/packages/components/src/components/autocomplete/resources.ts
+++ b/packages/components/src/components/autocomplete/resources.ts
@@ -1,4 +1,4 @@
-import type { Autocomplete } from "./autocomplete";
+import { isTag } from "../resources";
 
 export const SLOTS = {
   contentBottom: "content-bottom",
@@ -28,6 +28,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAutocomplete(el: Element | null | EventTarget): el is Autocomplete["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-AUTOCOMPLETE";
-}
+export const isAutocomplete = isTag("calcite-autocomplete");

--- a/packages/components/src/components/avatar/resources.ts
+++ b/packages/components/src/components/avatar/resources.ts
@@ -1,4 +1,4 @@
-import type { Avatar } from "./avatar";
+import { isTag } from "../resources";
 
 export const CSS = {
   thumbnail: "thumbnail",
@@ -10,6 +10,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isAvatar(el: Element | null | EventTarget): el is Avatar["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-AVATAR";
-}
+export const isAvatar = isTag("calcite-avatar");

--- a/packages/components/src/components/avatar/resources.ts
+++ b/packages/components/src/components/avatar/resources.ts
@@ -1,6 +1,15 @@
+import type { Avatar } from "./avatar";
+
 export const CSS = {
   thumbnail: "thumbnail",
   background: "background",
   initials: "initials",
   icon: "icon",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isAvatar(el: Element | null | EventTarget): el is Avatar["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-AVATAR";
+}

--- a/packages/components/src/components/block-group/resources.ts
+++ b/packages/components/src/components/block-group/resources.ts
@@ -1,3 +1,5 @@
+import type { BlockGroup } from "./block-group";
+
 export const CSS = {
   container: "container",
   groupContainer: "group-container",
@@ -8,3 +10,10 @@ export const CSS = {
 export const blockGroupSelector = "calcite-block-group";
 
 export const blockSelector = "calcite-block";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isBlockGroup(el: Element | null | EventTarget): el is BlockGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-BLOCK-GROUP";
+}

--- a/packages/components/src/components/block-group/resources.ts
+++ b/packages/components/src/components/block-group/resources.ts
@@ -1,4 +1,4 @@
-import type { BlockGroup } from "./block-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -14,6 +14,4 @@ export const blockSelector = "calcite-block";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isBlockGroup(el: Element | null | EventTarget): el is BlockGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-BLOCK-GROUP";
-}
+export const isBlockGroup = isTag("calcite-block-group");

--- a/packages/components/src/components/block-section/resources.ts
+++ b/packages/components/src/components/block-section/resources.ts
@@ -1,3 +1,5 @@
+import type { BlockSection } from "./block-section";
+
 import { IconName } from "../icon/types";
 
 export const IDS = {
@@ -27,3 +29,10 @@ export const ICONS: Record<string, IconName> = {
   valid: "check-circle",
   invalid: "exclamation-mark-triangle",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isBlockSection(el: Element | null | EventTarget): el is BlockSection["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-BLOCK-SECTION";
+}

--- a/packages/components/src/components/block-section/resources.ts
+++ b/packages/components/src/components/block-section/resources.ts
@@ -1,5 +1,4 @@
-import type { BlockSection } from "./block-section";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const IDS = {
@@ -33,6 +32,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isBlockSection(el: Element | null | EventTarget): el is BlockSection["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-BLOCK-SECTION";
-}
+export const isBlockSection = isTag("calcite-block-section");

--- a/packages/components/src/components/block/resources.ts
+++ b/packages/components/src/components/block/resources.ts
@@ -49,6 +49,9 @@ export const ICONS: Record<string, IconName> = {
   invalid: "exclamation-mark-triangle",
 };
 
-export function isBlock(el?: Element | null): el is Block["el"] {
-  return el?.tagName === "CALCITE-BLOCK";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isBlock(el: Element | null | EventTarget): el is Block["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-BLOCK";
 }

--- a/packages/components/src/components/block/resources.ts
+++ b/packages/components/src/components/block/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import type { IconName } from "../icon/types";
-import type { Block } from "./block";
-
 export const IDS = {
   content: "content",
   toggle: "toggle",
@@ -52,6 +51,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isBlock(el: Element | null | EventTarget): el is Block["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-BLOCK";
-}
+export const isBlock = isTag("calcite-block");

--- a/packages/components/src/components/button/resources.ts
+++ b/packages/components/src/components/button/resources.ts
@@ -1,3 +1,5 @@
+import type { Button } from "./button";
+
 export const CSS = {
   buttonLoader: "calcite-button--loader",
   content: "content",
@@ -12,3 +14,10 @@ export const CSS = {
   buttonPadding: "button-padding",
   buttonPaddingShrunk: "button-padding--shrunk",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isButton(el: Element | null | EventTarget): el is Button["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-BUTTON";
+}

--- a/packages/components/src/components/button/resources.ts
+++ b/packages/components/src/components/button/resources.ts
@@ -1,4 +1,4 @@
-import type { Button } from "./button";
+import { isTag } from "../resources";
 
 export const CSS = {
   buttonLoader: "calcite-button--loader",
@@ -18,6 +18,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isButton(el: Element | null | EventTarget): el is Button["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-BUTTON";
-}
+export const isButton = isTag("calcite-button");

--- a/packages/components/src/components/card-group/resources.ts
+++ b/packages/components/src/components/card-group/resources.ts
@@ -1,4 +1,4 @@
-import type { CardGroup } from "./card-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCardGroup(el: Element | null | EventTarget): el is CardGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CARD-GROUP";
-}
+export const isCardGroup = isTag("calcite-card-group");

--- a/packages/components/src/components/card-group/resources.ts
+++ b/packages/components/src/components/card-group/resources.ts
@@ -1,4 +1,13 @@
+import type { CardGroup } from "./card-group";
+
 export const CSS = {
   container: "container",
   checkboxWrapper: "checkbox-wrapper",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCardGroup(el: Element | null | EventTarget): el is CardGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CARD-GROUP";
+}

--- a/packages/components/src/components/card/resources.ts
+++ b/packages/components/src/components/card/resources.ts
@@ -1,5 +1,4 @@
-import type { Card } from "./card";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -35,6 +34,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCard(el: Element | null | EventTarget): el is Card["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CARD";
-}
+export const isCard = isTag("calcite-card");

--- a/packages/components/src/components/card/resources.ts
+++ b/packages/components/src/components/card/resources.ts
@@ -1,3 +1,5 @@
+import type { Card } from "./card";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -29,3 +31,10 @@ export const ICONS: Record<string, IconName> = {
   selectedSingle: "circle-f",
   unselectedSingle: "circle",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCard(el: Element | null | EventTarget): el is Card["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CARD";
+}

--- a/packages/components/src/components/carousel-item/resources.ts
+++ b/packages/components/src/components/carousel-item/resources.ts
@@ -1,3 +1,5 @@
+import type { CarouselItem } from "./carousel-item";
+
 export const CSS = {
   container: "container",
   selected: "selected",
@@ -8,3 +10,10 @@ const idPrefix = "calcite-carousel-item";
 export const IDS = {
   host: (id: string) => `${idPrefix}-${id}` as const,
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCarouselItem(el: Element | null | EventTarget): el is CarouselItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CAROUSEL-ITEM";
+}

--- a/packages/components/src/components/carousel-item/resources.ts
+++ b/packages/components/src/components/carousel-item/resources.ts
@@ -1,4 +1,4 @@
-import type { CarouselItem } from "./carousel-item";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -14,6 +14,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCarouselItem(el: Element | null | EventTarget): el is CarouselItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CAROUSEL-ITEM";
-}
+export const isCarouselItem = isTag("calcite-carousel-item");

--- a/packages/components/src/components/carousel/resources.ts
+++ b/packages/components/src/components/carousel/resources.ts
@@ -1,5 +1,4 @@
-import type { Carousel } from "./carousel";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const DURATION = 6000;
@@ -51,6 +50,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCarousel(el: Element | null | EventTarget): el is Carousel["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CAROUSEL";
-}
+export const isCarousel = isTag("calcite-carousel");

--- a/packages/components/src/components/carousel/resources.ts
+++ b/packages/components/src/components/carousel/resources.ts
@@ -1,3 +1,5 @@
+import type { Carousel } from "./carousel";
+
 import { IconName } from "../icon/types";
 
 export const DURATION = 6000;
@@ -45,3 +47,10 @@ const idPrefix = "calcite-carousel-container";
 export const IDS = {
   host: (id: string) => `${idPrefix}-${id}` as const,
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCarousel(el: Element | null | EventTarget): el is Carousel["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CAROUSEL";
+}

--- a/packages/components/src/components/checkbox/resources.ts
+++ b/packages/components/src/components/checkbox/resources.ts
@@ -1,4 +1,13 @@
+import type { Checkbox } from "./checkbox";
+
 export const CSS = {
   toggle: "toggle",
   check: "check-svg",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCheckbox(el: Element | null | EventTarget): el is Checkbox["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CHECKBOX";
+}

--- a/packages/components/src/components/checkbox/resources.ts
+++ b/packages/components/src/components/checkbox/resources.ts
@@ -1,4 +1,4 @@
-import type { Checkbox } from "./checkbox";
+import { isTag } from "../resources";
 
 export const CSS = {
   toggle: "toggle",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCheckbox(el: Element | null | EventTarget): el is Checkbox["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CHECKBOX";
-}
+export const isCheckbox = isTag("calcite-checkbox");

--- a/packages/components/src/components/chip-group/resources.ts
+++ b/packages/components/src/components/chip-group/resources.ts
@@ -1,0 +1,8 @@
+import type { ChipGroup } from "./chip-group";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isChipGroup(el: Element | null | EventTarget): el is ChipGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-CHIP-GROUP";
+}

--- a/packages/components/src/components/chip-group/resources.ts
+++ b/packages/components/src/components/chip-group/resources.ts
@@ -1,8 +1,5 @@
-import type { ChipGroup } from "./chip-group";
-
+import { isTag } from "../resources";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isChipGroup(el: Element | null | EventTarget): el is ChipGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CHIP-GROUP";
-}
+export const isChipGroup = isTag("calcite-chip-group");

--- a/packages/components/src/components/chip/resources.ts
+++ b/packages/components/src/components/chip/resources.ts
@@ -31,6 +31,9 @@ export const ICONS: Record<string, IconName> = {
   checkedMultiple: "check-square-f",
 };
 
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
 export function isChip(el: Element | null | EventTarget): el is Chip["el"] {
-  return (el as Element)?.tagName === "CALCITE-CHIP";
+  return (el as Element | null)?.tagName === "CALCITE-CHIP";
 }

--- a/packages/components/src/components/chip/resources.ts
+++ b/packages/components/src/components/chip/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
-import type { Chip } from "./chip";
-
 export const CSS = {
   title: "title",
   close: "close",
@@ -34,6 +33,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isChip(el: Element | null | EventTarget): el is Chip["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-CHIP";
-}
+export const isChip = isTag("calcite-chip");

--- a/packages/components/src/components/color-picker-hex-input/resources.ts
+++ b/packages/components/src/components/color-picker-hex-input/resources.ts
@@ -1,5 +1,14 @@
+import type { ColorPickerHexInput } from "./color-picker-hex-input";
+
 export const CSS = {
   container: "container",
   hexInput: "hex-input",
   opacityInput: "opacity-input",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isColorPickerHexInput(el: Element | null | EventTarget): el is ColorPickerHexInput["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER-HEX-INPUT";
+}

--- a/packages/components/src/components/color-picker-hex-input/resources.ts
+++ b/packages/components/src/components/color-picker-hex-input/resources.ts
@@ -1,4 +1,4 @@
-import type { ColorPickerHexInput } from "./color-picker-hex-input";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isColorPickerHexInput(el: Element | null | EventTarget): el is ColorPickerHexInput["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER-HEX-INPUT";
-}
+export const isColorPickerHexInput = isTag("calcite-color-picker-hex-input");

--- a/packages/components/src/components/color-picker-swatch/resources.ts
+++ b/packages/components/src/components/color-picker-swatch/resources.ts
@@ -1,4 +1,4 @@
-import type { ColorPickerSwatch } from "./color-picker-swatch";
+import { isTag } from "../resources";
 
 export const CSS = {
   swatch: "swatch",
@@ -26,6 +26,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isColorPickerSwatch(el: Element | null | EventTarget): el is ColorPickerSwatch["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER-SWATCH";
-}
+export const isColorPickerSwatch = isTag("calcite-color-picker-swatch");

--- a/packages/components/src/components/color-picker-swatch/resources.ts
+++ b/packages/components/src/components/color-picker-swatch/resources.ts
@@ -1,3 +1,5 @@
+import type { ColorPickerSwatch } from "./color-picker-swatch";
+
 export const CSS = {
   swatch: "swatch",
   noColorSwatch: "swatch--no-color",
@@ -20,3 +22,10 @@ export const IDS = {
   checker: "checker",
   shape: "shape",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isColorPickerSwatch(el: Element | null | EventTarget): el is ColorPickerSwatch["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER-SWATCH";
+}

--- a/packages/components/src/components/color-picker/resources.ts
+++ b/packages/components/src/components/color-picker/resources.ts
@@ -1,3 +1,5 @@
+import type { ColorPicker } from "./color-picker";
+
 import Color from "color";
 import {
   calciteSpacingFixedSm,
@@ -110,3 +112,10 @@ export const ICONS: Record<string, IconName> = {
   minus: "minus",
   plus: "plus",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isColorPicker(el: Element | null | EventTarget): el is ColorPicker["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER";
+}

--- a/packages/components/src/components/color-picker/resources.ts
+++ b/packages/components/src/components/color-picker/resources.ts
@@ -1,5 +1,4 @@
-import type { ColorPicker } from "./color-picker";
-
+import { isTag } from "../resources";
 import Color from "color";
 import {
   calciteSpacingFixedSm,
@@ -116,6 +115,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isColorPicker(el: Element | null | EventTarget): el is ColorPicker["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COLOR-PICKER";
-}
+export const isColorPicker = isTag("calcite-color-picker");

--- a/packages/components/src/components/combobox-item-group/resources.ts
+++ b/packages/components/src/components/combobox-item-group/resources.ts
@@ -1,5 +1,4 @@
-import type { ComboboxItemGroup } from "./combobox-item-group";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -16,6 +15,4 @@ export const itemSpacingMultiplier = "--calcite-combobox-item-spacing-indent-mul
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isComboboxItemGroup(el: Element | null | EventTarget): el is ComboboxItemGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX-ITEM-GROUP";
-}
+export const isComboboxItemGroup = isTag("calcite-combobox-item-group");

--- a/packages/components/src/components/combobox-item-group/resources.ts
+++ b/packages/components/src/components/combobox-item-group/resources.ts
@@ -1,3 +1,5 @@
+import type { ComboboxItemGroup } from "./combobox-item-group";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -10,3 +12,10 @@ export const CSS = {
 };
 
 export const itemSpacingMultiplier = "--calcite-combobox-item-spacing-indent-multiplier";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isComboboxItemGroup(el: Element | null | EventTarget): el is ComboboxItemGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX-ITEM-GROUP";
+}

--- a/packages/components/src/components/combobox-item/resources.ts
+++ b/packages/components/src/components/combobox-item/resources.ts
@@ -1,5 +1,4 @@
-import type { ComboboxItem } from "./combobox-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 import { Scale } from "../types";
 
@@ -37,6 +36,4 @@ export const itemSpacingMultiplier = "--calcite-combobox-item-spacing-indent-mul
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isComboboxItem(el: Element | null | EventTarget): el is ComboboxItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX-ITEM";
-}
+export const isComboboxItem = isTag("calcite-combobox-item");

--- a/packages/components/src/components/combobox-item/resources.ts
+++ b/packages/components/src/components/combobox-item/resources.ts
@@ -1,3 +1,5 @@
+import type { ComboboxItem } from "./combobox-item";
+
 import { IconName } from "../icon/types";
 import { Scale } from "../types";
 
@@ -31,3 +33,10 @@ export const SLOTS = {
 };
 
 export const itemSpacingMultiplier = "--calcite-combobox-item-spacing-indent-multiplier";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isComboboxItem(el: Element | null | EventTarget): el is ComboboxItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX-ITEM";
+}

--- a/packages/components/src/components/combobox/resources.ts
+++ b/packages/components/src/components/combobox/resources.ts
@@ -1,3 +1,5 @@
+import type { Combobox } from "./combobox";
+
 import { IconName } from "../icon/types";
 
 export const ComboboxItemSelector = "CALCITE-COMBOBOX-ITEM";
@@ -57,3 +59,10 @@ export const ICONS: Record<string, IconName> = {
 export const SLOTS = {
   labelContent: "label-content",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isCombobox(el: Element | null | EventTarget): el is Combobox["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX";
+}

--- a/packages/components/src/components/combobox/resources.ts
+++ b/packages/components/src/components/combobox/resources.ts
@@ -1,5 +1,4 @@
-import type { Combobox } from "./combobox";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const ComboboxItemSelector = "CALCITE-COMBOBOX-ITEM";
@@ -63,6 +62,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isCombobox(el: Element | null | EventTarget): el is Combobox["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-COMBOBOX";
-}
+export const isCombobox = isTag("calcite-combobox");

--- a/packages/components/src/components/date-picker-day/resources.ts
+++ b/packages/components/src/components/date-picker-day/resources.ts
@@ -1,6 +1,15 @@
+import type { DatePickerDay } from "./date-picker-day";
+
 export const CSS = {
   dayWrapper: "day-wrapper",
   day: "day",
   text: "text",
   currentDay: "current-day",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDatePickerDay(el: Element | null | EventTarget): el is DatePickerDay["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-DAY";
+}

--- a/packages/components/src/components/date-picker-day/resources.ts
+++ b/packages/components/src/components/date-picker-day/resources.ts
@@ -1,4 +1,4 @@
-import type { DatePickerDay } from "./date-picker-day";
+import { isTag } from "../resources";
 
 export const CSS = {
   dayWrapper: "day-wrapper",
@@ -10,6 +10,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDatePickerDay(el: Element | null | EventTarget): el is DatePickerDay["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-DAY";
-}
+export const isDatePickerDay = isTag("calcite-date-picker-day");

--- a/packages/components/src/components/date-picker-month-header/resources.ts
+++ b/packages/components/src/components/date-picker-month-header/resources.ts
@@ -1,3 +1,5 @@
+import type { DatePickerMonthHeader } from "./date-picker-month-header";
+
 export const CSS = {
   header: "header",
   chevron: "chevron",
@@ -18,3 +20,10 @@ export const ICON = {
 } as const;
 
 export const ICON_WIDTH_M = 16;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDatePickerMonthHeader(el: Element | null | EventTarget): el is DatePickerMonthHeader["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-MONTH-HEADER";
+}

--- a/packages/components/src/components/date-picker-month-header/resources.ts
+++ b/packages/components/src/components/date-picker-month-header/resources.ts
@@ -1,4 +1,4 @@
-import type { DatePickerMonthHeader } from "./date-picker-month-header";
+import { isTag } from "../resources";
 
 export const CSS = {
   header: "header",
@@ -24,6 +24,4 @@ export const ICON_WIDTH_M = 16;
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDatePickerMonthHeader(el: Element | null | EventTarget): el is DatePickerMonthHeader["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-MONTH-HEADER";
-}
+export const isDatePickerMonthHeader = isTag("calcite-date-picker-month-header");

--- a/packages/components/src/components/date-picker-month/resources.ts
+++ b/packages/components/src/components/date-picker-month/resources.ts
@@ -1,4 +1,4 @@
-import type { DatePickerMonth } from "./date-picker-month";
+import { isTag } from "../resources";
 
 export const CSS = {
   calendar: "calendar",
@@ -16,6 +16,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDatePickerMonth(el: Element | null | EventTarget): el is DatePickerMonth["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-MONTH";
-}
+export const isDatePickerMonth = isTag("calcite-date-picker-month");

--- a/packages/components/src/components/date-picker-month/resources.ts
+++ b/packages/components/src/components/date-picker-month/resources.ts
@@ -1,3 +1,5 @@
+import type { DatePickerMonth } from "./date-picker-month";
+
 export const CSS = {
   calendar: "calendar",
   calendarContainer: "calendar-container",
@@ -10,3 +12,10 @@ export const CSS = {
   weekHeader: "week-header",
   weekHeaderContainer: "week-header-container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDatePickerMonth(el: Element | null | EventTarget): el is DatePickerMonth["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER-MONTH";
+}

--- a/packages/components/src/components/date-picker/resources.ts
+++ b/packages/components/src/components/date-picker/resources.ts
@@ -1,3 +1,5 @@
+import type { DatePicker } from "./date-picker";
+
 export const HEADING_LEVEL = 2;
 
 export const DATE_PICKER_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = { dateStyle: "full" };
@@ -5,3 +7,10 @@ export const DATE_PICKER_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = { dateStyl
 export const CSS = {
   container: "container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDatePicker(el: Element | null | EventTarget): el is DatePicker["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER";
+}

--- a/packages/components/src/components/date-picker/resources.ts
+++ b/packages/components/src/components/date-picker/resources.ts
@@ -1,4 +1,4 @@
-import type { DatePicker } from "./date-picker";
+import { isTag } from "../resources";
 
 export const HEADING_LEVEL = 2;
 
@@ -11,6 +11,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDatePicker(el: Element | null | EventTarget): el is DatePicker["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DATE-PICKER";
-}
+export const isDatePicker = isTag("calcite-date-picker");

--- a/packages/components/src/components/dialog/resources.ts
+++ b/packages/components/src/components/dialog/resources.ts
@@ -1,5 +1,4 @@
-import type { Dialog } from "./dialog";
-
+import { isTag } from "../resources";
 import { DialogDragPosition, DialogPlacement, DialogResizePosition } from "./types";
 
 export const CSS = {
@@ -47,6 +46,4 @@ export const initialResizePosition: DialogResizePosition = { top: 0, right: 0, b
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDialog(el: Element | null | EventTarget): el is Dialog["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DIALOG";
-}
+export const isDialog = isTag("calcite-dialog");

--- a/packages/components/src/components/dialog/resources.ts
+++ b/packages/components/src/components/dialog/resources.ts
@@ -1,3 +1,5 @@
+import type { Dialog } from "./dialog";
+
 import { DialogDragPosition, DialogPlacement, DialogResizePosition } from "./types";
 
 export const CSS = {
@@ -41,3 +43,10 @@ export const dialogPlacements: DialogPlacement[] = [
 
 export const initialDragPosition: DialogDragPosition = { x: 0, y: 0 };
 export const initialResizePosition: DialogResizePosition = { top: 0, right: 0, bottom: 0, left: 0 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDialog(el: Element | null | EventTarget): el is Dialog["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DIALOG";
+}

--- a/packages/components/src/components/dropdown-group/resources.ts
+++ b/packages/components/src/components/dropdown-group/resources.ts
@@ -1,4 +1,4 @@
-import type { DropdownGroup } from "./dropdown-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   title: "title",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDropdownGroup(el: Element | null | EventTarget): el is DropdownGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN-GROUP";
-}
+export const isDropdownGroup = isTag("calcite-dropdown-group");

--- a/packages/components/src/components/dropdown-group/resources.ts
+++ b/packages/components/src/components/dropdown-group/resources.ts
@@ -1,5 +1,14 @@
+import type { DropdownGroup } from "./dropdown-group";
+
 export const CSS = {
   title: "title",
   firstTitle: "first-title",
   separator: "separator",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDropdownGroup(el: Element | null | EventTarget): el is DropdownGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN-GROUP";
+}

--- a/packages/components/src/components/dropdown-item/resources.ts
+++ b/packages/components/src/components/dropdown-item/resources.ts
@@ -1,5 +1,4 @@
-import type { DropdownItem } from "./dropdown-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -19,6 +18,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDropdownItem(el: Element | null | EventTarget): el is DropdownItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN-ITEM";
-}
+export const isDropdownItem = isTag("calcite-dropdown-item");

--- a/packages/components/src/components/dropdown-item/resources.ts
+++ b/packages/components/src/components/dropdown-item/resources.ts
@@ -1,3 +1,5 @@
+import type { DropdownItem } from "./dropdown-item";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -13,3 +15,10 @@ export const CSS = {
 export const ICONS: Record<string, IconName> = {
   check: "check",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDropdownItem(el: Element | null | EventTarget): el is DropdownItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN-ITEM";
+}

--- a/packages/components/src/components/dropdown/resources.ts
+++ b/packages/components/src/components/dropdown/resources.ts
@@ -1,4 +1,4 @@
-import type { Dropdown } from "./dropdown";
+import { isTag } from "../resources";
 
 export const SLOTS = {
   trigger: "trigger",
@@ -13,6 +13,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isDropdown(el: Element | null | EventTarget): el is Dropdown["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN";
-}
+export const isDropdown = isTag("calcite-dropdown");

--- a/packages/components/src/components/dropdown/resources.ts
+++ b/packages/components/src/components/dropdown/resources.ts
@@ -1,3 +1,5 @@
+import type { Dropdown } from "./dropdown";
+
 export const SLOTS = {
   trigger: "trigger",
 };
@@ -7,3 +9,10 @@ export const CSS = {
   wrapper: "wrapper",
   triggerContainer: "trigger-container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isDropdown(el: Element | null | EventTarget): el is Dropdown["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-DROPDOWN";
+}

--- a/packages/components/src/components/fab/resources.ts
+++ b/packages/components/src/components/fab/resources.ts
@@ -1,5 +1,4 @@
-import type { Fab } from "./fab";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -13,6 +12,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isFab(el: Element | null | EventTarget): el is Fab["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-FAB";
-}
+export const isFab = isTag("calcite-fab");

--- a/packages/components/src/components/fab/resources.ts
+++ b/packages/components/src/components/fab/resources.ts
@@ -1,3 +1,5 @@
+import type { Fab } from "./fab";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -7,3 +9,10 @@ export const CSS = {
 export const ICONS: Record<string, IconName> = {
   plus: "plus",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isFab(el: Element | null | EventTarget): el is Fab["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-FAB";
+}

--- a/packages/components/src/components/filter/resources.ts
+++ b/packages/components/src/components/filter/resources.ts
@@ -1,3 +1,5 @@
+import type { Filter } from "./filter";
+
 export const CSS = {
   container: "container",
 };
@@ -6,3 +8,10 @@ export const ICONS = {
   search: "search",
   close: "x",
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isFilter(el: Element | null | EventTarget): el is Filter["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-FILTER";
+}

--- a/packages/components/src/components/filter/resources.ts
+++ b/packages/components/src/components/filter/resources.ts
@@ -1,4 +1,4 @@
-import type { Filter } from "./filter";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -12,6 +12,4 @@ export const ICONS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isFilter(el: Element | null | EventTarget): el is Filter["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-FILTER";
-}
+export const isFilter = isTag("calcite-filter");

--- a/packages/components/src/components/flow-item/resources.ts
+++ b/packages/components/src/components/flow-item/resources.ts
@@ -1,5 +1,4 @@
-import type { FlowItem } from "./flow-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -31,6 +30,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isFlowItem(el: Element | null | EventTarget): el is FlowItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-FLOW-ITEM";
-}
+export const isFlowItem = isTag("calcite-flow-item");

--- a/packages/components/src/components/flow-item/resources.ts
+++ b/packages/components/src/components/flow-item/resources.ts
@@ -1,3 +1,5 @@
+import type { FlowItem } from "./flow-item";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -25,3 +27,10 @@ export const SLOTS = {
   footerEnd: "footer-end",
   footerStart: "footer-start",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isFlowItem(el: Element | null | EventTarget): el is FlowItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-FLOW-ITEM";
+}

--- a/packages/components/src/components/flow/resources.ts
+++ b/packages/components/src/components/flow/resources.ts
@@ -1,4 +1,4 @@
-import type { Flow } from "./flow";
+import { isTag } from "../resources";
 
 export const CSS = {
   frame: "frame",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isFlow(el: Element | null | EventTarget): el is Flow["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-FLOW";
-}
+export const isFlow = isTag("calcite-flow");

--- a/packages/components/src/components/flow/resources.ts
+++ b/packages/components/src/components/flow/resources.ts
@@ -1,5 +1,14 @@
+import type { Flow } from "./flow";
+
 export const CSS = {
   frame: "frame",
   frameAdvancing: "frame--advancing",
   frameRetreating: "frame--retreating",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isFlow(el: Element | null | EventTarget): el is Flow["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-FLOW";
+}

--- a/packages/components/src/components/graph/resources.ts
+++ b/packages/components/src/components/graph/resources.ts
@@ -1,3 +1,5 @@
+import type { Graph } from "./graph";
+
 export const CSS = {
   svg: "svg",
   graphPath: "graph-path",
@@ -11,3 +13,10 @@ export const IDS = {
   linearGradient: (id: string) => `linear-gradient-${idPrefix}-${id}`,
   mask: (id: string, maskId: number) => `${idPrefix}-${id}${maskId}`,
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isGraph(el: Element | null | EventTarget): el is Graph["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-GRAPH";
+}

--- a/packages/components/src/components/graph/resources.ts
+++ b/packages/components/src/components/graph/resources.ts
@@ -1,4 +1,4 @@
-import type { Graph } from "./graph";
+import { isTag } from "../resources";
 
 export const CSS = {
   svg: "svg",
@@ -17,6 +17,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isGraph(el: Element | null | EventTarget): el is Graph["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-GRAPH";
-}
+export const isGraph = isTag("calcite-graph");

--- a/packages/components/src/components/handle/resources.ts
+++ b/packages/components/src/components/handle/resources.ts
@@ -1,4 +1,4 @@
-import type { Handle } from "./handle";
+import { isTag } from "../resources";
 
 export const CSS = {
   handle: "handle",
@@ -18,6 +18,4 @@ export const SUBSTITUTIONS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isHandle(el: Element | null | EventTarget): el is Handle["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-HANDLE";
-}
+export const isHandle = isTag("calcite-handle");

--- a/packages/components/src/components/handle/resources.ts
+++ b/packages/components/src/components/handle/resources.ts
@@ -1,3 +1,5 @@
+import type { Handle } from "./handle";
+
 export const CSS = {
   handle: "handle",
   handleSelected: "handle--selected",
@@ -12,3 +14,10 @@ export const SUBSTITUTIONS = {
   position: "{position}",
   total: "{total}",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isHandle(el: Element | null | EventTarget): el is Handle["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-HANDLE";
+}

--- a/packages/components/src/components/icon/resources.ts
+++ b/packages/components/src/components/icon/resources.ts
@@ -1,5 +1,14 @@
+import type { Icon } from "./icon";
+
 export const CSS = {
   icon: "icon",
   flipRtl: "flip-rtl",
   svg: "svg",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isIcon(el: Element | null | EventTarget): el is Icon["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-ICON";
+}

--- a/packages/components/src/components/icon/resources.ts
+++ b/packages/components/src/components/icon/resources.ts
@@ -1,4 +1,4 @@
-import type { Icon } from "./icon";
+import { isTag } from "../resources";
 
 export const CSS = {
   icon: "icon",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isIcon(el: Element | null | EventTarget): el is Icon["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-ICON";
-}
+export const isIcon = isTag("calcite-icon");

--- a/packages/components/src/components/inline-editable/resources.ts
+++ b/packages/components/src/components/inline-editable/resources.ts
@@ -1,5 +1,4 @@
-import type { InlineEditable } from "./inline-editable";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -22,6 +21,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInlineEditable(el: Element | null | EventTarget): el is InlineEditable["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INLINE-EDITABLE";
-}
+export const isInlineEditable = isTag("calcite-inline-editable");

--- a/packages/components/src/components/inline-editable/resources.ts
+++ b/packages/components/src/components/inline-editable/resources.ts
@@ -1,3 +1,5 @@
+import type { InlineEditable } from "./inline-editable";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -16,3 +18,10 @@ export const ICONS: Record<string, IconName> = {
   close: "x",
   pencil: "pencil",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInlineEditable(el: Element | null | EventTarget): el is InlineEditable["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INLINE-EDITABLE";
+}

--- a/packages/components/src/components/input-date-picker/resources.ts
+++ b/packages/components/src/components/input-date-picker/resources.ts
@@ -1,3 +1,5 @@
+import type { InputDatePicker } from "./input-date-picker";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -38,3 +40,10 @@ export const ICONS: Record<string, IconName> = {
   chevronDown: "chevron-down",
   chevronUp: "chevron-up",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputDatePicker(el: Element | null | EventTarget): el is InputDatePicker["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-DATE-PICKER";
+}

--- a/packages/components/src/components/input-date-picker/resources.ts
+++ b/packages/components/src/components/input-date-picker/resources.ts
@@ -1,5 +1,4 @@
-import type { InputDatePicker } from "./input-date-picker";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -44,6 +43,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputDatePicker(el: Element | null | EventTarget): el is InputDatePicker["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-DATE-PICKER";
-}
+export const isInputDatePicker = isTag("calcite-input-date-picker");

--- a/packages/components/src/components/input-message/resources.ts
+++ b/packages/components/src/components/input-message/resources.ts
@@ -1,3 +1,5 @@
+import type { InputMessage } from "./input-message";
+
 export const CSS = {
   inputMessageIcon: "calcite-input-message-icon",
 };
@@ -7,3 +9,10 @@ export const StatusIconDefaults = {
   invalid: "exclamation-mark-triangle",
   idle: "information",
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputMessage(el: Element | null | EventTarget): el is InputMessage["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-MESSAGE";
+}

--- a/packages/components/src/components/input-message/resources.ts
+++ b/packages/components/src/components/input-message/resources.ts
@@ -1,4 +1,4 @@
-import type { InputMessage } from "./input-message";
+import { isTag } from "../resources";
 
 export const CSS = {
   inputMessageIcon: "calcite-input-message-icon",
@@ -13,6 +13,4 @@ export const StatusIconDefaults = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputMessage(el: Element | null | EventTarget): el is InputMessage["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-MESSAGE";
-}
+export const isInputMessage = isTag("calcite-input-message");

--- a/packages/components/src/components/input-number/resources.ts
+++ b/packages/components/src/components/input-number/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import type { IconName } from "../icon/types";
-import type { InputNumber } from "./input-number";
-
 export const CSS = {
   loader: "loader",
   clearButton: "clear-button",
@@ -47,6 +46,4 @@ export const NUDGE_DELAY_IN_MS = 150;
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputNumber(el: Element | null | EventTarget): el is InputNumber["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-NUMBER";
-}
+export const isInputNumber = isTag("calcite-input-number");

--- a/packages/components/src/components/input-number/resources.ts
+++ b/packages/components/src/components/input-number/resources.ts
@@ -44,6 +44,9 @@ export const DIRECTION = {
 
 export const NUDGE_DELAY_IN_MS = 150;
 
-export function isInputNumber(el: Element | null): el is InputNumber["el"] {
-  return el?.tagName === "CALCITE-INPUT-NUMBER";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputNumber(el: Element | null | EventTarget): el is InputNumber["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-NUMBER";
 }

--- a/packages/components/src/components/input-text/resources.ts
+++ b/packages/components/src/components/input-text/resources.ts
@@ -1,4 +1,4 @@
-import type { InputText } from "./input-text";
+import { isTag } from "../resources";
 
 export const CSS = {
   loader: "loader",
@@ -30,6 +30,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputText(el: Element | null | EventTarget): el is InputText["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-TEXT";
-}
+export const isInputText = isTag("calcite-input-text");

--- a/packages/components/src/components/input-text/resources.ts
+++ b/packages/components/src/components/input-text/resources.ts
@@ -1,3 +1,5 @@
+import type { InputText } from "./input-text";
+
 export const CSS = {
   loader: "loader",
   clearable: "clearable",
@@ -24,3 +26,10 @@ export const IDS = {
 export const SLOTS = {
   action: "action",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputText(el: Element | null | EventTarget): el is InputText["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-TEXT";
+}

--- a/packages/components/src/components/input-time-picker/resources.ts
+++ b/packages/components/src/components/input-time-picker/resources.ts
@@ -1,5 +1,4 @@
-import type { InputTimePicker } from "./input-time-picker";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -40,6 +39,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputTimePicker(el: Element | null | EventTarget): el is InputTimePicker["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-TIME-PICKER";
-}
+export const isInputTimePicker = isTag("calcite-input-time-picker");

--- a/packages/components/src/components/input-time-picker/resources.ts
+++ b/packages/components/src/components/input-time-picker/resources.ts
@@ -1,3 +1,5 @@
+import type { InputTimePicker } from "./input-time-picker";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -34,3 +36,10 @@ export const ICONS: Record<string, IconName> = {
   chevronUp: "chevron-up",
   chevronDown: "chevron-down",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputTimePicker(el: Element | null | EventTarget): el is InputTimePicker["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-TIME-PICKER";
+}

--- a/packages/components/src/components/input-time-zone/resources.ts
+++ b/packages/components/src/components/input-time-zone/resources.ts
@@ -1,4 +1,4 @@
-import type { InputTimeZone } from "./input-time-zone";
+import { isTag } from "../resources";
 
 export const CSS = {
   offset: "offset",
@@ -11,6 +11,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInputTimeZone(el: Element | null | EventTarget): el is InputTimeZone["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT-TIME-ZONE";
-}
+export const isInputTimeZone = isTag("calcite-input-time-zone");

--- a/packages/components/src/components/input-time-zone/resources.ts
+++ b/packages/components/src/components/input-time-zone/resources.ts
@@ -1,3 +1,5 @@
+import type { InputTimeZone } from "./input-time-zone";
+
 export const CSS = {
   offset: "offset",
 };
@@ -5,3 +7,10 @@ export const CSS = {
 export const SLOTS = {
   labelContent: "label-content",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInputTimeZone(el: Element | null | EventTarget): el is InputTimeZone["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT-TIME-ZONE";
+}

--- a/packages/components/src/components/input/resources.ts
+++ b/packages/components/src/components/input/resources.ts
@@ -1,3 +1,5 @@
+import type { Input } from "./input";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -49,3 +51,10 @@ export const ICONS: Record<string, IconName> = {
 };
 
 export const NUDGE_DELAY_IN_MS = 150;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isInput(el: Element | null | EventTarget): el is Input["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-INPUT";
+}

--- a/packages/components/src/components/input/resources.ts
+++ b/packages/components/src/components/input/resources.ts
@@ -1,5 +1,4 @@
-import type { Input } from "./input";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -55,6 +54,4 @@ export const NUDGE_DELAY_IN_MS = 150;
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isInput(el: Element | null | EventTarget): el is Input["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-INPUT";
-}
+export const isInput = isTag("calcite-input");

--- a/packages/components/src/components/label/resources.ts
+++ b/packages/components/src/components/label/resources.ts
@@ -1,4 +1,4 @@
-import type { Label } from "./label";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -7,6 +7,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isLabel(el: Element | null | EventTarget): el is Label["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LABEL";
-}
+export const isLabel = isTag("calcite-label");

--- a/packages/components/src/components/label/resources.ts
+++ b/packages/components/src/components/label/resources.ts
@@ -1,3 +1,12 @@
+import type { Label } from "./label";
+
 export const CSS = {
   container: "container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isLabel(el: Element | null | EventTarget): el is Label["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LABEL";
+}

--- a/packages/components/src/components/link/resources.ts
+++ b/packages/components/src/components/link/resources.ts
@@ -1,4 +1,4 @@
-import type { Link } from "./link";
+import { isTag } from "../resources";
 
 export const CSS = {
   calciteLinkIcon: "calcite-link--icon",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isLink(el: Element | null | EventTarget): el is Link["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LINK";
-}
+export const isLink = isTag("calcite-link");

--- a/packages/components/src/components/link/resources.ts
+++ b/packages/components/src/components/link/resources.ts
@@ -1,5 +1,14 @@
+import type { Link } from "./link";
+
 export const CSS = {
   calciteLinkIcon: "calcite-link--icon",
   iconStart: "icon-start",
   iconEnd: "icon-end",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isLink(el: Element | null | EventTarget): el is Link["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LINK";
+}

--- a/packages/components/src/components/list-item-group/resources.ts
+++ b/packages/components/src/components/list-item-group/resources.ts
@@ -1,4 +1,4 @@
-import type { ListItemGroup } from "./list-item-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isListItemGroup(el: Element | null | EventTarget): el is ListItemGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LIST-ITEM-GROUP";
-}
+export const isListItemGroup = isTag("calcite-list-item-group");

--- a/packages/components/src/components/list-item-group/resources.ts
+++ b/packages/components/src/components/list-item-group/resources.ts
@@ -1,4 +1,13 @@
+import type { ListItemGroup } from "./list-item-group";
+
 export const CSS = {
   container: "container",
   heading: "heading",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isListItemGroup(el: Element | null | EventTarget): el is ListItemGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LIST-ITEM-GROUP";
+}

--- a/packages/components/src/components/list-item/resources.ts
+++ b/packages/components/src/components/list-item/resources.ts
@@ -1,5 +1,4 @@
-import type { ListItem } from "./list-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -67,6 +66,4 @@ export const activeCellTestAttribute = "data-test-active";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isListItem(el: Element | null | EventTarget): el is ListItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LIST-ITEM";
-}
+export const isListItem = isTag("calcite-list-item");

--- a/packages/components/src/components/list-item/resources.ts
+++ b/packages/components/src/components/list-item/resources.ts
@@ -1,3 +1,5 @@
+import type { ListItem } from "./list-item";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -61,3 +63,10 @@ export const ICONS: Record<string, IconName> = {
 };
 
 export const activeCellTestAttribute = "data-test-active";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isListItem(el: Element | null | EventTarget): el is ListItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LIST-ITEM";
+}

--- a/packages/components/src/components/list-item/utils.ts
+++ b/packages/components/src/components/list-item/utils.ts
@@ -66,7 +66,3 @@ export function getDepth(element: HTMLElement, includeGroup = false): number {
 
   return result.snapshotLength;
 }
-
-export function isListItem(element: Element): element is ListItem["el"] {
-  return element.tagName === "CALCITE-LIST-ITEM";
-}

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -16,7 +16,6 @@ import { InteractionMode, Scale, SelectionMode } from "../types";
 import { ItemData } from "../list-item/types";
 import {
   expandedAncestors,
-  isListItem,
   listItemGroupSelector,
   listItemSelector,
   listSelector,
@@ -46,6 +45,7 @@ import { ListDisplayMode, ListDragDetail, ListElement } from "./types";
 import { styles } from "./list.scss";
 import type { SortHandle } from "../sort-handle/sort-handle";
 import { logger } from "../../utils/logger";
+import { isListItem } from "../list-item/resources";
 
 declare global {
   interface DeclareElements {

--- a/packages/components/src/components/list/resources.ts
+++ b/packages/components/src/components/list/resources.ts
@@ -1,3 +1,5 @@
+import type { List } from "./list";
+
 export const CSS = {
   container: "container",
   table: "table",
@@ -17,3 +19,10 @@ export const SLOTS = {
   filterActionsStart: "filter-actions-start",
   filterActionsEnd: "filter-actions-end",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isList(el: Element | null | EventTarget): el is List["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LIST";
+}

--- a/packages/components/src/components/list/resources.ts
+++ b/packages/components/src/components/list/resources.ts
@@ -1,4 +1,4 @@
-import type { List } from "./list";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -23,6 +23,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isList(el: Element | null | EventTarget): el is List["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LIST";
-}
+export const isList = isTag("calcite-list");

--- a/packages/components/src/components/loader/resources.ts
+++ b/packages/components/src/components/loader/resources.ts
@@ -1,4 +1,4 @@
-import type { Loader } from "./loader";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -14,6 +14,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isLoader(el: Element | null | EventTarget): el is Loader["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-LOADER";
-}
+export const isLoader = isTag("calcite-loader");

--- a/packages/components/src/components/loader/resources.ts
+++ b/packages/components/src/components/loader/resources.ts
@@ -1,3 +1,5 @@
+import type { Loader } from "./loader";
+
 export const CSS = {
   container: "container",
   loader: "loader",
@@ -8,3 +10,10 @@ export const CSS = {
   text: "text",
   trackRing: "ring--track",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isLoader(el: Element | null | EventTarget): el is Loader["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-LOADER";
+}

--- a/packages/components/src/components/menu-item/resources.ts
+++ b/packages/components/src/components/menu-item/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
-import type { MenuItem } from "./menu-item";
-
 export const CSS = {
   container: "container",
   content: "content",
@@ -37,6 +36,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isMenuItem(el: Element | null | EventTarget): el is MenuItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-MENU-ITEM";
-}
+export const isMenuItem = isTag("calcite-menu-item");

--- a/packages/components/src/components/menu-item/resources.ts
+++ b/packages/components/src/components/menu-item/resources.ts
@@ -34,6 +34,9 @@ export const ICONS: Record<string, IconName> = {
   chevronDown: "chevron-down",
 };
 
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
 export function isMenuItem(el: Element | null | EventTarget): el is MenuItem["el"] {
-  return (el as Element)?.tagName === "CALCITE-MENU-ITEM";
+  return (el as Element | null)?.tagName === "CALCITE-MENU-ITEM";
 }

--- a/packages/components/src/components/menu/resources.ts
+++ b/packages/components/src/components/menu/resources.ts
@@ -1,0 +1,8 @@
+import type { Menu } from "./menu";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isMenu(el: Element | null | EventTarget): el is Menu["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-MENU";
+}

--- a/packages/components/src/components/menu/resources.ts
+++ b/packages/components/src/components/menu/resources.ts
@@ -1,8 +1,5 @@
-import type { Menu } from "./menu";
-
+import { isTag } from "../resources";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isMenu(el: Element | null | EventTarget): el is Menu["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-MENU";
-}
+export const isMenu = isTag("calcite-menu");

--- a/packages/components/src/components/meter/resources.ts
+++ b/packages/components/src/components/meter/resources.ts
@@ -1,3 +1,5 @@
+import type { Meter } from "./meter";
+
 export const CSS = {
   container: "container",
   fill: "fill",
@@ -13,3 +15,10 @@ export const CSS = {
   warning: "fill-warning",
   danger: "fill-danger",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isMeter(el: Element | null | EventTarget): el is Meter["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-METER";
+}

--- a/packages/components/src/components/meter/resources.ts
+++ b/packages/components/src/components/meter/resources.ts
@@ -1,4 +1,4 @@
-import type { Meter } from "./meter";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -19,6 +19,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isMeter(el: Element | null | EventTarget): el is Meter["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-METER";
-}
+export const isMeter = isTag("calcite-meter");

--- a/packages/components/src/components/navigation-logo/resources.ts
+++ b/packages/components/src/components/navigation-logo/resources.ts
@@ -1,4 +1,4 @@
-import type { NavigationLogo } from "./navigation-logo";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -14,6 +14,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isNavigationLogo(el: Element | null | EventTarget): el is NavigationLogo["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION-LOGO";
-}
+export const isNavigationLogo = isTag("calcite-navigation-logo");

--- a/packages/components/src/components/navigation-logo/resources.ts
+++ b/packages/components/src/components/navigation-logo/resources.ts
@@ -1,3 +1,5 @@
+import type { NavigationLogo } from "./navigation-logo";
+
 export const CSS = {
   container: "container",
   containerLink: "container--link",
@@ -8,3 +10,10 @@ export const CSS = {
   standalone: "standalone",
   icon: "icon",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isNavigationLogo(el: Element | null | EventTarget): el is NavigationLogo["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION-LOGO";
+}

--- a/packages/components/src/components/navigation-user/resources.ts
+++ b/packages/components/src/components/navigation-user/resources.ts
@@ -1,4 +1,4 @@
-import type { NavigationUser } from "./navigation-user";
+import { isTag } from "../resources";
 
 export const CSS = {
   button: "button",
@@ -11,6 +11,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isNavigationUser(el: Element | null | EventTarget): el is NavigationUser["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION-USER";
-}
+export const isNavigationUser = isTag("calcite-navigation-user");

--- a/packages/components/src/components/navigation-user/resources.ts
+++ b/packages/components/src/components/navigation-user/resources.ts
@@ -1,3 +1,5 @@
+import type { NavigationUser } from "./navigation-user";
+
 export const CSS = {
   button: "button",
   fullName: "full-name",
@@ -5,3 +7,10 @@ export const CSS = {
   textContainer: "text-container",
   username: "username",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isNavigationUser(el: Element | null | EventTarget): el is NavigationUser["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION-USER";
+}

--- a/packages/components/src/components/navigation/resources.ts
+++ b/packages/components/src/components/navigation/resources.ts
@@ -1,3 +1,5 @@
+import type { Navigation } from "./navigation";
+
 export const CSS = {
   container: "container",
   containerContent: "container-content",
@@ -23,3 +25,10 @@ export const SLOTS = {
 export const ICONS = {
   hamburger: "hamburger",
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isNavigation(el: Element | null | EventTarget): el is Navigation["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION";
+}

--- a/packages/components/src/components/navigation/resources.ts
+++ b/packages/components/src/components/navigation/resources.ts
@@ -1,4 +1,4 @@
-import type { Navigation } from "./navigation";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -29,6 +29,4 @@ export const ICONS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isNavigation(el: Element | null | EventTarget): el is Navigation["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-NAVIGATION";
-}
+export const isNavigation = isTag("calcite-navigation");

--- a/packages/components/src/components/notice/resources.ts
+++ b/packages/components/src/components/notice/resources.ts
@@ -1,4 +1,4 @@
-import type { Notice } from "./notice";
+import { isTag } from "../resources";
 
 export const SLOTS = {
   title: "title",
@@ -18,6 +18,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isNotice(el: Element | null | EventTarget): el is Notice["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-NOTICE";
-}
+export const isNotice = isTag("calcite-notice");

--- a/packages/components/src/components/notice/resources.ts
+++ b/packages/components/src/components/notice/resources.ts
@@ -1,3 +1,5 @@
+import type { Notice } from "./notice";
+
 export const SLOTS = {
   title: "title",
   message: "message",
@@ -12,3 +14,10 @@ export const CSS = {
   content: "notice-content",
   icon: "notice-icon",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isNotice(el: Element | null | EventTarget): el is Notice["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-NOTICE";
+}

--- a/packages/components/src/components/option-group/resources.ts
+++ b/packages/components/src/components/option-group/resources.ts
@@ -1,8 +1,5 @@
-import type { OptionGroup } from "./option-group";
-
+import { isTag } from "../resources";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isOptionGroup(el: Element | null | EventTarget): el is OptionGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-OPTION-GROUP";
-}
+export const isOptionGroup = isTag("calcite-option-group");

--- a/packages/components/src/components/option-group/resources.ts
+++ b/packages/components/src/components/option-group/resources.ts
@@ -1,0 +1,8 @@
+import type { OptionGroup } from "./option-group";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isOptionGroup(el: Element | null | EventTarget): el is OptionGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-OPTION-GROUP";
+}

--- a/packages/components/src/components/option/resources.ts
+++ b/packages/components/src/components/option/resources.ts
@@ -1,8 +1,5 @@
-import type { Option } from "./option";
-
+import { isTag } from "../resources";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isOption(el: Element | null | EventTarget): el is Option["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-OPTION";
-}
+export const isOption = isTag("calcite-option");

--- a/packages/components/src/components/option/resources.ts
+++ b/packages/components/src/components/option/resources.ts
@@ -1,0 +1,8 @@
+import type { Option } from "./option";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isOption(el: Element | null | EventTarget): el is Option["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-OPTION";
+}

--- a/packages/components/src/components/pagination/resources.ts
+++ b/packages/components/src/components/pagination/resources.ts
@@ -1,3 +1,5 @@
+import type { Pagination } from "./pagination";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -17,3 +19,10 @@ export const ICONS: Record<string, IconName> = {
   first: "chevron-start",
   last: "chevron-end",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isPagination(el: Element | null | EventTarget): el is Pagination["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-PAGINATION";
+}

--- a/packages/components/src/components/pagination/resources.ts
+++ b/packages/components/src/components/pagination/resources.ts
@@ -1,5 +1,4 @@
-import type { Pagination } from "./pagination";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -23,6 +22,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isPagination(el: Element | null | EventTarget): el is Pagination["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-PAGINATION";
-}
+export const isPagination = isTag("calcite-pagination");

--- a/packages/components/src/components/panel/resources.ts
+++ b/packages/components/src/components/panel/resources.ts
@@ -1,5 +1,4 @@
-import type { Panel } from "./panel";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -66,6 +65,4 @@ export const HEADING_LEVEL = 3;
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isPanel(el: Element | null | EventTarget): el is Panel["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-PANEL";
-}
+export const isPanel = isTag("calcite-panel");

--- a/packages/components/src/components/panel/resources.ts
+++ b/packages/components/src/components/panel/resources.ts
@@ -1,3 +1,5 @@
+import type { Panel } from "./panel";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -60,3 +62,10 @@ export const SLOTS = {
 };
 
 export const HEADING_LEVEL = 3;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isPanel(el: Element | null | EventTarget): el is Panel["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-PANEL";
+}

--- a/packages/components/src/components/popover/resources.ts
+++ b/packages/components/src/components/popover/resources.ts
@@ -1,4 +1,4 @@
-import type { Popover } from "./popover";
+import { isTag } from "../resources";
 
 export const CSS = {
   positionContainer: "position-container",
@@ -19,6 +19,4 @@ export const defaultPopoverPlacement = "auto";
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isPopover(el: Element | null | EventTarget): el is Popover["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-POPOVER";
-}
+export const isPopover = isTag("calcite-popover");

--- a/packages/components/src/components/popover/resources.ts
+++ b/packages/components/src/components/popover/resources.ts
@@ -1,3 +1,5 @@
+import type { Popover } from "./popover";
+
 export const CSS = {
   positionContainer: "position-container",
   container: "container",
@@ -13,3 +15,10 @@ export const CSS = {
 };
 
 export const defaultPopoverPlacement = "auto";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isPopover(el: Element | null | EventTarget): el is Popover["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-POPOVER";
+}

--- a/packages/components/src/components/progress/resources.ts
+++ b/packages/components/src/components/progress/resources.ts
@@ -1,4 +1,4 @@
-import type { Progress } from "./progress";
+import { isTag } from "../resources";
 
 export const CSS = {
   track: "track",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isProgress(el: Element | null | EventTarget): el is Progress["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-PROGRESS";
-}
+export const isProgress = isTag("calcite-progress");

--- a/packages/components/src/components/progress/resources.ts
+++ b/packages/components/src/components/progress/resources.ts
@@ -1,5 +1,14 @@
+import type { Progress } from "./progress";
+
 export const CSS = {
   track: "track",
   bar: "bar",
   text: "text",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isProgress(el: Element | null | EventTarget): el is Progress["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-PROGRESS";
+}

--- a/packages/components/src/components/radio-button-group/resources.ts
+++ b/packages/components/src/components/radio-button-group/resources.ts
@@ -1,3 +1,5 @@
+import type { RadioButtonGroup } from "./radio-button-group";
+
 export const CSS = {
   itemWrapper: "item-wrapper",
 };
@@ -5,3 +7,10 @@ export const CSS = {
 export const IDS = {
   validationMessage: "radioButtonGroupValidationMessage",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isRadioButtonGroup(el: Element | null | EventTarget): el is RadioButtonGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-RADIO-BUTTON-GROUP";
+}

--- a/packages/components/src/components/radio-button-group/resources.ts
+++ b/packages/components/src/components/radio-button-group/resources.ts
@@ -1,4 +1,4 @@
-import type { RadioButtonGroup } from "./radio-button-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   itemWrapper: "item-wrapper",
@@ -11,6 +11,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isRadioButtonGroup(el: Element | null | EventTarget): el is RadioButtonGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-RADIO-BUTTON-GROUP";
-}
+export const isRadioButtonGroup = isTag("calcite-radio-button-group");

--- a/packages/components/src/components/radio-button/resources.ts
+++ b/packages/components/src/components/radio-button/resources.ts
@@ -1,4 +1,13 @@
+import type { RadioButton } from "./radio-button";
+
 export const CSS = {
   container: "container",
   radio: "radio",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isRadioButton(el: Element | null | EventTarget): el is RadioButton["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-RADIO-BUTTON";
+}

--- a/packages/components/src/components/radio-button/resources.ts
+++ b/packages/components/src/components/radio-button/resources.ts
@@ -1,4 +1,4 @@
-import type { RadioButton } from "./radio-button";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isRadioButton(el: Element | null | EventTarget): el is RadioButton["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-RADIO-BUTTON";
-}
+export const isRadioButton = isTag("calcite-radio-button");

--- a/packages/components/src/components/rating/resources.ts
+++ b/packages/components/src/components/rating/resources.ts
@@ -1,3 +1,5 @@
+import type { Rating } from "./rating";
+
 export const CSS = {
   fieldSet: "fieldset",
   star: "star",
@@ -18,3 +20,10 @@ export const IDS = {
   validationMessage: "validationMessage",
   host: (id: any) => `${idPrefix}-${id}` as const,
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isRating(el: Element | null | EventTarget): el is Rating["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-RATING";
+}

--- a/packages/components/src/components/rating/resources.ts
+++ b/packages/components/src/components/rating/resources.ts
@@ -1,4 +1,4 @@
-import type { Rating } from "./rating";
+import { isTag } from "../resources";
 
 export const CSS = {
   fieldSet: "fieldset",
@@ -24,6 +24,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isRating(el: Element | null | EventTarget): el is Rating["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-RATING";
-}
+export const isRating = isTag("calcite-rating");

--- a/packages/components/src/components/resources.ts
+++ b/packages/components/src/components/resources.ts
@@ -12,3 +12,12 @@ export const KindIconsFilled = {
   success: "checkCircleF",
   warning: "exclamationMarkTriangleF",
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+/*#__NO_SIDE_EFFECTS__*/
+export function isTag<K extends keyof HTMLElementTagNameMap>(tagName: K) {
+  return (element: Element | EventTarget | null | undefined): element is HTMLElementTagNameMap[K] =>
+    (element as Element)?.localName === tagName;
+}

--- a/packages/components/src/components/resources.ts
+++ b/packages/components/src/components/resources.ts
@@ -14,7 +14,7 @@ export const KindIconsFilled = {
 } as const;
 
 /**
- * Use this type guard to narrow an element or event target to this component's element type.
+ * Generates a type guard to narrow an element or event target to the element type for the given Calcite component tag name.
  */
 /*#__NO_SIDE_EFFECTS__*/
 export function isTag<K extends keyof HTMLElementTagNameMap>(tagName: K) {

--- a/packages/components/src/components/scrim/resources.ts
+++ b/packages/components/src/components/scrim/resources.ts
@@ -1,4 +1,4 @@
-import type { Scrim } from "./scrim";
+import { isTag } from "../resources";
 
 export const CSS = {
   scrim: "scrim",
@@ -14,6 +14,4 @@ export const BREAKPOINTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isScrim(el: Element | null | EventTarget): el is Scrim["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SCRIM";
-}
+export const isScrim = isTag("calcite-scrim");

--- a/packages/components/src/components/scrim/resources.ts
+++ b/packages/components/src/components/scrim/resources.ts
@@ -1,3 +1,5 @@
+import type { Scrim } from "./scrim";
+
 export const CSS = {
   scrim: "scrim",
   content: "content",
@@ -8,3 +10,10 @@ export const BREAKPOINTS = {
   // medium is assumed default.
   l: 480, // Greater than or equal to 480px.
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isScrim(el: Element | null | EventTarget): el is Scrim["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SCRIM";
+}

--- a/packages/components/src/components/segmented-control-item/resources.ts
+++ b/packages/components/src/components/segmented-control-item/resources.ts
@@ -1,5 +1,4 @@
-import type { SegmentedControlItem } from "./segmented-control-item";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const SLOTS = {
@@ -19,6 +18,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSegmentedControlItem(el: Element | null | EventTarget): el is SegmentedControlItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SEGMENTED-CONTROL-ITEM";
-}
+export const isSegmentedControlItem = isTag("calcite-segmented-control-item");

--- a/packages/components/src/components/segmented-control-item/resources.ts
+++ b/packages/components/src/components/segmented-control-item/resources.ts
@@ -1,3 +1,5 @@
+import type { SegmentedControlItem } from "./segmented-control-item";
+
 import { Scale } from "../types";
 
 export const SLOTS = {
@@ -13,3 +15,10 @@ export const CSS = {
   icon: "icon",
   iconSolo: "icon--solo",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSegmentedControlItem(el: Element | null | EventTarget): el is SegmentedControlItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SEGMENTED-CONTROL-ITEM";
+}

--- a/packages/components/src/components/segmented-control/resources.ts
+++ b/packages/components/src/components/segmented-control/resources.ts
@@ -1,4 +1,4 @@
-import type { SegmentedControl } from "./segmented-control";
+import { isTag } from "../resources";
 
 export const CSS = {
   itemWrapper: "item-wrapper",
@@ -11,6 +11,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSegmentedControl(el: Element | null | EventTarget): el is SegmentedControl["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SEGMENTED-CONTROL";
-}
+export const isSegmentedControl = isTag("calcite-segmented-control");

--- a/packages/components/src/components/segmented-control/resources.ts
+++ b/packages/components/src/components/segmented-control/resources.ts
@@ -1,3 +1,5 @@
+import type { SegmentedControl } from "./segmented-control";
+
 export const CSS = {
   itemWrapper: "item-wrapper",
 };
@@ -5,3 +7,10 @@ export const CSS = {
 export const IDS = {
   validationMessage: "segmentedControlValidationMessage",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSegmentedControl(el: Element | null | EventTarget): el is SegmentedControl["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SEGMENTED-CONTROL";
+}

--- a/packages/components/src/components/select/resources.ts
+++ b/packages/components/src/components/select/resources.ts
@@ -1,3 +1,5 @@
+import type { Select } from "./select";
+
 export const CSS = {
   icon: "icon",
   iconContainer: "icon-container",
@@ -8,3 +10,10 @@ export const CSS = {
 export const IDS = {
   validationMessage: "selectValidationMessage",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSelect(el: Element | null | EventTarget): el is Select["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SELECT";
+}

--- a/packages/components/src/components/select/resources.ts
+++ b/packages/components/src/components/select/resources.ts
@@ -1,4 +1,4 @@
-import type { Select } from "./select";
+import { isTag } from "../resources";
 
 export const CSS = {
   icon: "icon",
@@ -14,6 +14,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSelect(el: Element | null | EventTarget): el is Select["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SELECT";
-}
+export const isSelect = isTag("calcite-select");

--- a/packages/components/src/components/sheet/resources.ts
+++ b/packages/components/src/components/sheet/resources.ts
@@ -1,5 +1,4 @@
-import type { Sheet } from "./sheet";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -27,6 +26,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSheet(el: Element | null | EventTarget): el is Sheet["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SHEET";
-}
+export const isSheet = isTag("calcite-sheet");

--- a/packages/components/src/components/sheet/resources.ts
+++ b/packages/components/src/components/sheet/resources.ts
@@ -1,3 +1,5 @@
+import type { Sheet } from "./sheet";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -21,3 +23,10 @@ export const ICONS: Record<string, IconName> = {
   dragVertical: "drag-resize-vertical",
   dragHorizontal: "drag-resize-horizontal",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSheet(el: Element | null | EventTarget): el is Sheet["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SHEET";
+}

--- a/packages/components/src/components/shell-panel/resources.ts
+++ b/packages/components/src/components/shell-panel/resources.ts
@@ -1,3 +1,5 @@
+import type { ShellPanel } from "./shell-panel";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -26,3 +28,10 @@ export const ICONS: Record<string, IconName> = {
   dragVertical: "drag-resize-vertical",
   dragHorizontal: "drag-resize-horizontal",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isShellPanel(el: Element | null | EventTarget): el is ShellPanel["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SHELL-PANEL";
+}

--- a/packages/components/src/components/shell-panel/resources.ts
+++ b/packages/components/src/components/shell-panel/resources.ts
@@ -1,5 +1,4 @@
-import type { ShellPanel } from "./shell-panel";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -32,6 +31,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isShellPanel(el: Element | null | EventTarget): el is ShellPanel["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SHELL-PANEL";
-}
+export const isShellPanel = isTag("calcite-shell-panel");

--- a/packages/components/src/components/shell/resources.ts
+++ b/packages/components/src/components/shell/resources.ts
@@ -1,4 +1,4 @@
-import type { Shell } from "./shell";
+import { isTag } from "../resources";
 
 export const CSS = {
   main: "main",
@@ -30,6 +30,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isShell(el: Element | null | EventTarget): el is Shell["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SHELL";
-}
+export const isShell = isTag("calcite-shell");

--- a/packages/components/src/components/shell/resources.ts
+++ b/packages/components/src/components/shell/resources.ts
@@ -1,3 +1,5 @@
+import type { Shell } from "./shell";
+
 export const CSS = {
   main: "main",
   content: "content",
@@ -24,3 +26,10 @@ export const SLOTS = {
   sheets: "sheets",
   dialogs: "dialogs",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isShell(el: Element | null | EventTarget): el is Shell["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SHELL";
+}

--- a/packages/components/src/components/slider/resources.ts
+++ b/packages/components/src/components/slider/resources.ts
@@ -1,3 +1,5 @@
+import type { Slider } from "./slider";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -38,3 +40,10 @@ export const IDS = {
 } as const;
 
 export const maxTickElementThreshold = 250;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSlider(el: Element | null | EventTarget): el is Slider["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SLIDER";
+}

--- a/packages/components/src/components/slider/resources.ts
+++ b/packages/components/src/components/slider/resources.ts
@@ -1,5 +1,4 @@
-import type { Slider } from "./slider";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -44,6 +43,4 @@ export const maxTickElementThreshold = 250;
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSlider(el: Element | null | EventTarget): el is Slider["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SLIDER";
-}
+export const isSlider = isTag("calcite-slider");

--- a/packages/components/src/components/sort-handle/resources.ts
+++ b/packages/components/src/components/sort-handle/resources.ts
@@ -1,5 +1,4 @@
-import type { SortHandle } from "./sort-handle";
-
+import { isTag } from "../resources";
 import { Reorder } from "./types";
 
 export const CSS = {
@@ -33,6 +32,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSortHandle(el: Element | null | EventTarget): el is SortHandle["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SORT-HANDLE";
-}
+export const isSortHandle = isTag("calcite-sort-handle");

--- a/packages/components/src/components/sort-handle/resources.ts
+++ b/packages/components/src/components/sort-handle/resources.ts
@@ -1,3 +1,5 @@
+import type { SortHandle } from "./sort-handle";
+
 import { Reorder } from "./types";
 
 export const CSS = {
@@ -27,3 +29,10 @@ export const IDS = {
   move: "move",
   reorder: "reorder",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSortHandle(el: Element | null | EventTarget): el is SortHandle["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SORT-HANDLE";
+}

--- a/packages/components/src/components/sortable-list/resources.ts
+++ b/packages/components/src/components/sortable-list/resources.ts
@@ -1,4 +1,4 @@
-import type { SortableList } from "./sortable-list";
+import { isTag } from "../resources";
 
 export const CSS = {
   sortItem: "sort-item",
@@ -10,6 +10,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSortableList(el: Element | null | EventTarget): el is SortableList["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SORTABLE-LIST";
-}
+export const isSortableList = isTag("calcite-sortable-list");

--- a/packages/components/src/components/sortable-list/resources.ts
+++ b/packages/components/src/components/sortable-list/resources.ts
@@ -1,6 +1,15 @@
+import type { SortableList } from "./sortable-list";
+
 export const CSS = {
   sortItem: "sort-item",
   container: "container",
   containerHorizontal: "container--horizontal",
   containerVertical: "container--vertical",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSortableList(el: Element | null | EventTarget): el is SortableList["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SORTABLE-LIST";
+}

--- a/packages/components/src/components/split-button/resources.ts
+++ b/packages/components/src/components/split-button/resources.ts
@@ -1,5 +1,4 @@
-import type { SplitButton } from "./split-button";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -25,6 +24,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSplitButton(el: Element | null | EventTarget): el is SplitButton["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SPLIT-BUTTON";
-}
+export const isSplitButton = isTag("calcite-split-button");

--- a/packages/components/src/components/split-button/resources.ts
+++ b/packages/components/src/components/split-button/resources.ts
@@ -1,3 +1,5 @@
+import type { SplitButton } from "./split-button";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -19,3 +21,10 @@ export const ICONS: Record<string, IconName> = {
   ellipsis: "ellipsis",
   handleVertical: "handle-vertical",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSplitButton(el: Element | null | EventTarget): el is SplitButton["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SPLIT-BUTTON";
+}

--- a/packages/components/src/components/stack/resources.ts
+++ b/packages/components/src/components/stack/resources.ts
@@ -1,4 +1,4 @@
-import type { Stack } from "./stack";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -19,6 +19,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isStack(el: Element | null | EventTarget): el is Stack["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-STACK";
-}
+export const isStack = isTag("calcite-stack");

--- a/packages/components/src/components/stack/resources.ts
+++ b/packages/components/src/components/stack/resources.ts
@@ -1,3 +1,5 @@
+import type { Stack } from "./stack";
+
 export const CSS = {
   container: "container",
   actionsStart: "actions-start",
@@ -13,3 +15,10 @@ export const SLOTS = {
   contentEnd: "content-end",
   actionsEnd: "actions-end",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isStack(el: Element | null | EventTarget): el is Stack["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-STACK";
+}

--- a/packages/components/src/components/stepper-item/resources.ts
+++ b/packages/components/src/components/stepper-item/resources.ts
@@ -1,6 +1,5 @@
+import { isTag } from "../resources";
 import type { IconName } from "../icon/types";
-import type { StepperItem } from "./stepper-item";
-
 export const CSS = {
   container: "container",
   hasSlottedContent: "has-slotted-content",
@@ -24,6 +23,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isStepperItem(el: Element | null | EventTarget): el is StepperItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-STEPPER-ITEM";
-}
+export const isStepperItem = isTag("calcite-stepper-item");

--- a/packages/components/src/components/stepper-item/resources.ts
+++ b/packages/components/src/components/stepper-item/resources.ts
@@ -21,6 +21,9 @@ export const ICONS: Record<string, IconName> = {
   checkCircleF: "checkCircleF",
 };
 
-export function isStepperItem(el?: Element | null): el is StepperItem["el"] {
-  return el?.tagName === "CALCITE-STEPPER-ITEM";
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isStepperItem(el: Element | null | EventTarget): el is StepperItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-STEPPER-ITEM";
 }

--- a/packages/components/src/components/stepper/resources.ts
+++ b/packages/components/src/components/stepper/resources.ts
@@ -1,5 +1,4 @@
-import type { Stepper } from "./stepper";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -30,6 +29,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isStepper(el: Element | null | EventTarget): el is Stepper["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-STEPPER";
-}
+export const isStepper = isTag("calcite-stepper");

--- a/packages/components/src/components/stepper/resources.ts
+++ b/packages/components/src/components/stepper/resources.ts
@@ -1,3 +1,5 @@
+import type { Stepper } from "./stepper";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -24,3 +26,10 @@ const idPrefix = "calcite-stepper-action";
 export const IDS = {
   position: (id: any, isPositionStart: boolean) => `${idPrefix}-${id}-${isPositionStart ? "start" : "end"}`,
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isStepper(el: Element | null | EventTarget): el is Stepper["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-STEPPER";
+}

--- a/packages/components/src/components/swatch-group/resources.ts
+++ b/packages/components/src/components/swatch-group/resources.ts
@@ -1,3 +1,12 @@
+import type { SwatchGroup } from "./swatch-group";
+
 export const CSS = {
   container: "container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSwatchGroup(el: Element | null | EventTarget): el is SwatchGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SWATCH-GROUP";
+}

--- a/packages/components/src/components/swatch-group/resources.ts
+++ b/packages/components/src/components/swatch-group/resources.ts
@@ -1,4 +1,4 @@
-import type { SwatchGroup } from "./swatch-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -7,6 +7,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSwatchGroup(el: Element | null | EventTarget): el is SwatchGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SWATCH-GROUP";
-}
+export const isSwatchGroup = isTag("calcite-swatch-group");

--- a/packages/components/src/components/swatch/resources.ts
+++ b/packages/components/src/components/swatch/resources.ts
@@ -34,6 +34,9 @@ export const IDS = {
   swatchTransparent: "swatch-transparent",
 };
 
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
 export function isSwatch(el: Element | null | EventTarget): el is Swatch["el"] {
-  return (el as Element)?.tagName === "CALCITE-SWATCH";
+  return (el as Element | null)?.tagName === "CALCITE-SWATCH";
 }

--- a/packages/components/src/components/swatch/resources.ts
+++ b/packages/components/src/components/swatch/resources.ts
@@ -1,4 +1,4 @@
-import type { Swatch } from "./swatch";
+import { isTag } from "../resources";
 
 export const CSS = {
   imageContainer: "image-container",
@@ -37,6 +37,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSwatch(el: Element | null | EventTarget): el is Swatch["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SWATCH";
-}
+export const isSwatch = isTag("calcite-swatch");

--- a/packages/components/src/components/switch/resources.ts
+++ b/packages/components/src/components/switch/resources.ts
@@ -1,5 +1,14 @@
+import type { Switch } from "./switch";
+
 export const CSS = {
   container: "container",
   track: "track",
   handle: "handle",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isSwitch(el: Element | null | EventTarget): el is Switch["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-SWITCH";
+}

--- a/packages/components/src/components/switch/resources.ts
+++ b/packages/components/src/components/switch/resources.ts
@@ -1,4 +1,4 @@
-import type { Switch } from "./switch";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -9,6 +9,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isSwitch(el: Element | null | EventTarget): el is Switch["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-SWITCH";
-}
+export const isSwitch = isTag("calcite-switch");

--- a/packages/components/src/components/tab-nav/resources.ts
+++ b/packages/components/src/components/tab-nav/resources.ts
@@ -1,3 +1,5 @@
+import type { TabNav } from "./tab-nav";
+
 import { TabPosition } from "../tabs/types";
 import { Scale } from "../types";
 
@@ -16,3 +18,10 @@ export const CSS = {
   scale: (scale: Scale) => `scale-${scale}` as const,
   position: (position: TabPosition) => `position-${position}` as const,
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTabNav(el: Element | null | EventTarget): el is TabNav["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TAB-NAV";
+}

--- a/packages/components/src/components/tab-nav/resources.ts
+++ b/packages/components/src/components/tab-nav/resources.ts
@@ -1,5 +1,4 @@
-import type { TabNav } from "./tab-nav";
-
+import { isTag } from "../resources";
 import { TabPosition } from "../tabs/types";
 import { Scale } from "../types";
 
@@ -22,6 +21,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTabNav(el: Element | null | EventTarget): el is TabNav["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TAB-NAV";
-}
+export const isTabNav = isTag("calcite-tab-nav");

--- a/packages/components/src/components/tab-title/resources.ts
+++ b/packages/components/src/components/tab-title/resources.ts
@@ -1,3 +1,5 @@
+import type { TabTitle } from "./tab-title";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -19,3 +21,10 @@ const idPrefix = "calcite-tab-title";
 export const IDS = {
   host: (id: any) => `${idPrefix}-${id}`,
 } as const;
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTabTitle(el: Element | null | EventTarget): el is TabTitle["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TAB-TITLE";
+}

--- a/packages/components/src/components/tab-title/resources.ts
+++ b/packages/components/src/components/tab-title/resources.ts
@@ -1,5 +1,4 @@
-import type { TabTitle } from "./tab-title";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -25,6 +24,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTabTitle(el: Element | null | EventTarget): el is TabTitle["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TAB-TITLE";
-}
+export const isTabTitle = isTag("calcite-tab-title");

--- a/packages/components/src/components/tab/resources.ts
+++ b/packages/components/src/components/tab/resources.ts
@@ -1,5 +1,4 @@
-import type { Tab } from "./tab";
-
+import { isTag } from "../resources";
 import { Scale } from "../types";
 
 export const CSS = {
@@ -15,6 +14,4 @@ export const IDS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTab(el: Element | null | EventTarget): el is Tab["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TAB";
-}
+export const isTab = isTag("calcite-tab");

--- a/packages/components/src/components/tab/resources.ts
+++ b/packages/components/src/components/tab/resources.ts
@@ -1,3 +1,5 @@
+import type { Tab } from "./tab";
+
 import { Scale } from "../types";
 
 export const CSS = {
@@ -9,3 +11,10 @@ export const CSS = {
 export const IDS = {
   tabTitleId: (id: any) => `calcite-tab-title-${id}` as const,
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTab(el: Element | null | EventTarget): el is Tab["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TAB";
+}

--- a/packages/components/src/components/table-cell/resources.ts
+++ b/packages/components/src/components/table-cell/resources.ts
@@ -1,4 +1,4 @@
-import type { TableCell } from "./table-cell";
+import { isTag } from "../resources";
 
 export const CSS = {
   contentCell: "content-cell",
@@ -14,6 +14,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTableCell(el: Element | null | EventTarget): el is TableCell["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TABLE-CELL";
-}
+export const isTableCell = isTag("calcite-table-cell");

--- a/packages/components/src/components/table-cell/resources.ts
+++ b/packages/components/src/components/table-cell/resources.ts
@@ -1,3 +1,5 @@
+import type { TableCell } from "./table-cell";
+
 export const CSS = {
   contentCell: "content-cell",
   numberCell: "number-cell",
@@ -8,3 +10,10 @@ export const CSS = {
   lastCell: "last-cell",
   staticCell: "static-cell",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTableCell(el: Element | null | EventTarget): el is TableCell["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TABLE-CELL";
+}

--- a/packages/components/src/components/table-header/resources.ts
+++ b/packages/components/src/components/table-header/resources.ts
@@ -1,3 +1,5 @@
+import type { TableHeader } from "./table-header";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -21,3 +23,10 @@ export const ICONS: Record<string, IconName> = {
   indeterminate: "minus-square-f",
   unchecked: "square",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTableHeader(el: Element | null | EventTarget): el is TableHeader["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TABLE-HEADER";
+}

--- a/packages/components/src/components/table-header/resources.ts
+++ b/packages/components/src/components/table-header/resources.ts
@@ -1,5 +1,4 @@
-import type { TableHeader } from "./table-header";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -27,6 +26,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTableHeader(el: Element | null | EventTarget): el is TableHeader["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TABLE-HEADER";
-}
+export const isTableHeader = isTag("calcite-table-header");

--- a/packages/components/src/components/table-row/resources.ts
+++ b/packages/components/src/components/table-row/resources.ts
@@ -1,5 +1,4 @@
-import type { TableRow } from "./table-row";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -16,6 +15,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTableRow(el: Element | null | EventTarget): el is TableRow["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TABLE-ROW";
-}
+export const isTableRow = isTag("calcite-table-row");

--- a/packages/components/src/components/table-row/resources.ts
+++ b/packages/components/src/components/table-row/resources.ts
@@ -1,3 +1,5 @@
+import type { TableRow } from "./table-row";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -10,3 +12,10 @@ export const ICONS: Record<string, IconName> = {
   circleF: "circle-f",
   circle: "circle",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTableRow(el: Element | null | EventTarget): el is TableRow["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TABLE-ROW";
+}

--- a/packages/components/src/components/table/resources.ts
+++ b/packages/components/src/components/table/resources.ts
@@ -1,3 +1,5 @@
+import type { Table } from "./table";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -27,3 +29,10 @@ export const ICONS: Record<string, IconName> = {
   hideEmpty: "hide-empty",
   clear: "x",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTable(el: Element | null | EventTarget): el is Table["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TABLE";
+}

--- a/packages/components/src/components/table/resources.ts
+++ b/packages/components/src/components/table/resources.ts
@@ -1,5 +1,4 @@
-import type { Table } from "./table";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -33,6 +32,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTable(el: Element | null | EventTarget): el is Table["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TABLE";
-}
+export const isTable = isTag("calcite-table");

--- a/packages/components/src/components/tabs/resources.ts
+++ b/packages/components/src/components/tabs/resources.ts
@@ -1,3 +1,5 @@
+import type { Tabs } from "./tabs";
+
 export const CSS = {
   section: "section",
 };
@@ -5,3 +7,10 @@ export const CSS = {
 export const SLOTS = {
   titleGroup: "title-group",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTabs(el: Element | null | EventTarget): el is Tabs["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TABS";
+}

--- a/packages/components/src/components/tabs/resources.ts
+++ b/packages/components/src/components/tabs/resources.ts
@@ -1,4 +1,4 @@
-import type { Tabs } from "./tabs";
+import { isTag } from "../resources";
 
 export const CSS = {
   section: "section",
@@ -11,6 +11,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTabs(el: Element | null | EventTarget): el is Tabs["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TABS";
-}
+export const isTabs = isTag("calcite-tabs");

--- a/packages/components/src/components/text-area/resources.ts
+++ b/packages/components/src/components/text-area/resources.ts
@@ -1,3 +1,5 @@
+import type { TextArea } from "./text-area";
+
 export const CSS = {
   assistiveText: "assistive-text",
   characterLimit: "character-limit",
@@ -32,3 +34,10 @@ export const SLOTS = {
 export const RESIZE_TIMEOUT = 100;
 
 export const NO_DIMENSIONS = Object.freeze({ height: 0, width: 0 });
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTextArea(el: Element | null | EventTarget): el is TextArea["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TEXT-AREA";
+}

--- a/packages/components/src/components/text-area/resources.ts
+++ b/packages/components/src/components/text-area/resources.ts
@@ -1,4 +1,4 @@
-import type { TextArea } from "./text-area";
+import { isTag } from "../resources";
 
 export const CSS = {
   assistiveText: "assistive-text",
@@ -38,6 +38,4 @@ export const NO_DIMENSIONS = Object.freeze({ height: 0, width: 0 });
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTextArea(el: Element | null | EventTarget): el is TextArea["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TEXT-AREA";
-}
+export const isTextArea = isTag("calcite-text-area");

--- a/packages/components/src/components/tile-group/resources.ts
+++ b/packages/components/src/components/tile-group/resources.ts
@@ -1,4 +1,4 @@
-import type { TileGroup } from "./tile-group";
+import { isTag } from "../resources";
 
 export const CSS = {
   container: "container",
@@ -7,6 +7,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTileGroup(el: Element | null | EventTarget): el is TileGroup["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TILE-GROUP";
-}
+export const isTileGroup = isTag("calcite-tile-group");

--- a/packages/components/src/components/tile-group/resources.ts
+++ b/packages/components/src/components/tile-group/resources.ts
@@ -1,3 +1,12 @@
+import type { TileGroup } from "./tile-group";
+
 export const CSS = {
   container: "container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTileGroup(el: Element | null | EventTarget): el is TileGroup["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TILE-GROUP";
+}

--- a/packages/components/src/components/tile/resources.ts
+++ b/packages/components/src/components/tile/resources.ts
@@ -1,5 +1,4 @@
-import type { Tile } from "./tile";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -34,6 +33,4 @@ export const SLOTS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTile(el: Element | null | EventTarget): el is Tile["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TILE";
-}
+export const isTile = isTag("calcite-tile");

--- a/packages/components/src/components/tile/resources.ts
+++ b/packages/components/src/components/tile/resources.ts
@@ -1,3 +1,5 @@
+import type { Tile } from "./tile";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -28,3 +30,10 @@ export const SLOTS = {
   contentBottom: "content-bottom",
   contentTop: "content-top",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTile(el: Element | null | EventTarget): el is Tile["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TILE";
+}

--- a/packages/components/src/components/time-picker/resources.ts
+++ b/packages/components/src/components/time-picker/resources.ts
@@ -1,3 +1,5 @@
+import type { TimePicker } from "./time-picker";
+
 import { IconName } from "../icon/types";
 import { Scale } from "../types";
 
@@ -41,3 +43,10 @@ export const ICONS: Record<string, IconName> = {
   chevronUp: "chevron-up",
   chevronDown: "chevron-down",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTimePicker(el: Element | null | EventTarget): el is TimePicker["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TIME-PICKER";
+}

--- a/packages/components/src/components/time-picker/resources.ts
+++ b/packages/components/src/components/time-picker/resources.ts
@@ -1,5 +1,4 @@
-import type { TimePicker } from "./time-picker";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 import { Scale } from "../types";
 
@@ -47,6 +46,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTimePicker(el: Element | null | EventTarget): el is TimePicker["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TIME-PICKER";
-}
+export const isTimePicker = isTag("calcite-time-picker");

--- a/packages/components/src/components/tooltip/resources.ts
+++ b/packages/components/src/components/tooltip/resources.ts
@@ -1,4 +1,4 @@
-import type { Tooltip } from "./tooltip";
+import { isTag } from "../resources";
 
 export const CSS = {
   positionContainer: "position-container",
@@ -8,6 +8,4 @@ export const CSS = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTooltip(el: Element | null | EventTarget): el is Tooltip["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TOOLTIP";
-}
+export const isTooltip = isTag("calcite-tooltip");

--- a/packages/components/src/components/tooltip/resources.ts
+++ b/packages/components/src/components/tooltip/resources.ts
@@ -1,4 +1,13 @@
+import type { Tooltip } from "./tooltip";
+
 export const CSS = {
   positionContainer: "position-container",
   container: "container",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTooltip(el: Element | null | EventTarget): el is Tooltip["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TOOLTIP";
+}

--- a/packages/components/src/components/tree-item/resources.ts
+++ b/packages/components/src/components/tree-item/resources.ts
@@ -1,5 +1,4 @@
-import type { TreeItem } from "./tree-item";
-
+import { isTag } from "../resources";
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -34,6 +33,4 @@ export const ICONS: Record<string, IconName> = {
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTreeItem(el: Element | null | EventTarget): el is TreeItem["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TREE-ITEM";
-}
+export const isTreeItem = isTag("calcite-tree-item");

--- a/packages/components/src/components/tree-item/resources.ts
+++ b/packages/components/src/components/tree-item/resources.ts
@@ -1,3 +1,5 @@
+import type { TreeItem } from "./tree-item";
+
 import { IconName } from "../icon/types";
 
 export const CSS = {
@@ -28,3 +30,10 @@ export const ICONS: Record<string, IconName> = {
   minusSquareF: "minus-square-f",
   square: "square",
 };
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTreeItem(el: Element | null | EventTarget): el is TreeItem["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TREE-ITEM";
+}

--- a/packages/components/src/components/tree/resources.ts
+++ b/packages/components/src/components/tree/resources.ts
@@ -1,0 +1,8 @@
+import type { Tree } from "./tree";
+
+/**
+ * Use this type guard to narrow an element or event target to this component's element type.
+ */
+export function isTree(el: Element | null | EventTarget): el is Tree["el"] {
+  return (el as Element | null)?.tagName === "CALCITE-TREE";
+}

--- a/packages/components/src/components/tree/resources.ts
+++ b/packages/components/src/components/tree/resources.ts
@@ -1,8 +1,6 @@
-import type { Tree } from "./tree";
+import { isTag } from "../resources";
 
 /**
  * Use this type guard to narrow an element or event target to this component's element type.
  */
-export function isTree(el: Element | null | EventTarget): el is Tree["el"] {
-  return (el as Element | null)?.tagName === "CALCITE-TREE";
-}
+export const isTree = isTag("calcite-tree");

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -13,8 +13,9 @@ import { toAriaBoolean } from "../../utils/aria";
 import { Scale, SelectionMode } from "../types";
 import { TreeItemSelectDetail } from "../tree-item/types";
 import type { TreeItem } from "../tree-item/tree-item";
-import { getTraversableItems, isTreeItem } from "./utils";
+import { getTraversableItems } from "./utils";
 import { styles } from "./tree.scss";
+import { isTreeItem } from "../tree-item/resources";
 
 declare global {
   interface DeclareElements {

--- a/packages/components/src/components/tree/utils.ts
+++ b/packages/components/src/components/tree/utils.ts
@@ -1,9 +1,6 @@
 import type { TreeItem } from "../tree-item/tree-item";
 import type { Tree } from "./tree";
-
-export function isTreeItem(element: Element | undefined): element is TreeItem["el"] {
-  return element?.tagName === "CALCITE-TREE-ITEM";
-}
+import { isTreeItem } from "../tree-item/resources";
 
 export function getTraversableItems(root: Tree["el"]): TreeItem["el"][] {
   return Array.from(root.querySelectorAll<TreeItem["el"]>("calcite-tree-item:not([disabled])")).filter(
@@ -11,7 +8,7 @@ export function getTraversableItems(root: Tree["el"]): TreeItem["el"][] {
       let currentItem: HTMLElement | null = item;
 
       while (currentItem !== root && currentItem !== null) {
-        const parent = currentItem.parentElement ?? undefined;
+        const parent = currentItem.parentElement;
         const traversable = !isTreeItem(parent) || !parent.hasChildren || parent.expanded;
 
         if (!traversable) {


### PR DESCRIPTION
**Related Issue:** #13524 

## Summary

Adds `is<ComponentName>` type guards for all components, standardizing flexible element/event-target inputs.
