### PR TITLE
fix(sheet): allow Sheet focus trap to be disabled for modal sheets

### DIFF
--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -249,6 +249,28 @@ describe("modalDisabled", () => {
 
     await expect.element(outsideButton).toHaveFocus();
   });
+
+  it("allows focus to leave when focusTrapDisabled is true for a modal sheet", async () => {
+    const openEvent = waitForEvent(document, "calciteSheetOpen");
+    const { el } = await mount<Sheet>(
+      <>
+        <calcite-sheet focusTrapDisabled label="Modal sheet" open>
+          <button type="button">inside</button>
+        </calcite-sheet>
+        <button type="button">outside</button>
+      </>,
+    );
+    await openEvent;
+
+    expect(el.ariaModal).toBe("true");
+    const insideButton = page.getByRole("button", { name: "inside" });
+    const outsideButton = page.getByRole("button", { name: "outside" });
+    await userEvent.click(insideButton);
+
+    await userEvent.tab();
+
+    await expect.element(outsideButton).toHaveFocus();
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/sheet/sheet.browser.e2e.tsx
+++ b/packages/components/src/components/sheet/sheet.browser.e2e.tsx
@@ -233,7 +233,7 @@ describe("modalDisabled", () => {
     const openEvent = waitForEvent(document, "calciteSheetOpen");
     await mount<Sheet>(
       <>
-        <calcite-sheet focusTrapDisabled label="Non-modal sheet" modalDisabled open>
+        <calcite-sheet focus-trap-disabled label="Non-modal sheet" modalDisabled open>
           <button type="button">inside</button>
         </calcite-sheet>
         <button type="button">outside</button>
@@ -254,7 +254,7 @@ describe("modalDisabled", () => {
     const openEvent = waitForEvent(document, "calciteSheetOpen");
     const { el } = await mount<Sheet>(
       <>
-        <calcite-sheet focusTrapDisabled label="Modal sheet" open>
+        <calcite-sheet focus-trap-disabled label="Modal sheet" open>
           <button type="button">inside</button>
         </calcite-sheet>
         <button type="button">outside</button>

--- a/packages/components/src/components/sheet/sheet.tsx
+++ b/packages/components/src/components/sheet/sheet.tsx
@@ -164,7 +164,7 @@ export class Sheet extends LitElement {
   /** When `true`, disables the default close on escape behavior. */
   @property({ reflect: true }) escapeDisabled = false;
 
-  /** When `true` and `modalDisabled` is `true`, prevents focus trapping. */
+  /** When `true`, prevents focus trapping. */
   @property({ reflect: true }) focusTrapDisabled = false;
 
   /**
@@ -362,11 +362,6 @@ export class Sheet extends LitElement {
   //#endregion
 
   //#region Private Methods
-
-  /** When defined, provides a condition to disable focus trapping. When `true`, prevents focus trapping. */
-  focusTrapDisabledOverride(): boolean {
-    return this.modalDisabled && this.focusTrapDisabled;
-  }
 
   private async setOpenState(value: boolean): Promise<void> {
     if (this.beforeClose && !value) {


### PR DESCRIPTION
**Related Issue:** #12114

## Summary

- Update `focusTrapDisabled` documentation to apply to all sheets.
- Remove the modal-only focus-trap override.
- Add browser coverage for modal sheets allowing focus to move outside.

## Why

Focus trapping worked on modal sheets previously so this restores that before we introduce a breaking change


BEGIN_COMMIT_OVERRIDE
omitted from changelog
END_COMMIT_OVERRIDE