### PR TITLE
fix(autocomplete): synchronize item selection with value

### DIFF
--- a/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
@@ -76,7 +76,7 @@ describe("disabled", () => {
 });
 
 describe("toggleSelection", () => {
-  it("toggles selected and emits calciteAutocompleteItemSelect", async () => {
+  it("emits calciteAutocompleteItemSelect without changing selected", async () => {
     const { el, reRender } = await mount("calcite-autocomplete-item");
     const selectSpy = vi.fn();
     el.addEventListener("calciteAutocompleteItemSelect", selectSpy);
@@ -87,7 +87,7 @@ describe("toggleSelection", () => {
     (el as any).toggleSelection();
     await reRender();
 
-    expect(el.selected).toBe(true);
+    expect(el.selected).toBe(false);
     expect(selectSpy).toHaveBeenCalledTimes(1);
 
     (el as any).toggleSelection();

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.browser.e2e.tsx
@@ -75,7 +75,7 @@ describe("disabled", () => {
   });
 });
 
-describe("toggleSelection", () => {
+describe("requestSelection", () => {
   it("emits calciteAutocompleteItemSelect without changing selected", async () => {
     const { el, reRender } = await mount("calcite-autocomplete-item");
     const selectSpy = vi.fn();
@@ -84,13 +84,13 @@ describe("toggleSelection", () => {
     expect(el.selected).toBe(false);
     expect(typeof (el as any).emitSelectEvent).toBe("undefined");
 
-    (el as any).toggleSelection();
+    (el as any).requestSelection();
     await reRender();
 
     expect(el.selected).toBe(false);
     expect(selectSpy).toHaveBeenCalledTimes(1);
 
-    (el as any).toggleSelection();
+    (el as any).requestSelection();
     await reRender();
 
     expect(el.selected).toBe(false);

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -86,7 +86,7 @@ export class AutocompleteItem extends LitElement {
    */
   @property() scale: Scale = "m";
 
-  /** When `true`, the component is selected. The parent `calcite-autocomplete` synchronizes this property with its non-empty `value`; when no value is provided, declarative selection is preserved. */
+  /** When `true`, the component is selected. The parent `calcite-autocomplete` synchronizes this property with its non-empty `value`; declarative selection is preserved when no initial value is provided, but is cleared when a controlled value is explicitly reset. */
   @property({ reflect: true }) selected = false;
 
   /** Specifies the component's value. */

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -86,7 +86,7 @@ export class AutocompleteItem extends LitElement {
    */
   @property() scale: Scale = "m";
 
-  /** When `true`, the component is selected. */
+  /** When `true`, the component is selected. The parent `calcite-autocomplete` synchronizes this property with its `value`. */
   @property({ reflect: true }) selected = false;
 
   /** Specifies the component's value. */
@@ -97,13 +97,12 @@ export class AutocompleteItem extends LitElement {
   //#region Public Methods
 
   /**
-   * Toggles selection and emits the `calciteAutocompleteItemSelect` event.
+   * Requests selection by emitting the `calciteAutocompleteItemSelect` event. Selection state is managed by the parent `calcite-autocomplete`.
    *
    * @private
    */
   @method()
   toggleSelection(): void {
-    this.selected = !this.selected;
     this.calciteAutocompleteItemSelect.emit();
   }
 
@@ -134,7 +133,8 @@ export class AutocompleteItem extends LitElement {
         changes.has("disabled") ||
         changes.has("heading") ||
         changes.has("label") ||
-        changes.has("selected"))
+        changes.has("selected") ||
+        changes.has("value"))
     ) {
       this.calciteInternalAutocompleteItemChange.emit();
     }

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -86,7 +86,7 @@ export class AutocompleteItem extends LitElement {
    */
   @property() scale: Scale = "m";
 
-  /** When `true`, the component is selected. The parent `calcite-autocomplete` synchronizes this property with its `value`. */
+  /** When `true`, the component is selected. The parent `calcite-autocomplete` synchronizes this property with its non-empty `value`; when no value is provided, declarative selection is preserved. */
   @property({ reflect: true }) selected = false;
 
   /** Specifies the component's value. */
@@ -102,7 +102,7 @@ export class AutocompleteItem extends LitElement {
    * @private
    */
   @method()
-  toggleSelection(): void {
+  requestSelection(): void {
     this.calciteAutocompleteItemSelect.emit();
   }
 
@@ -111,7 +111,7 @@ export class AutocompleteItem extends LitElement {
   //#region Events
 
   /**
-   * Fires when the item has been selected.
+   * Fires when selection is requested.
    */
   calciteAutocompleteItemSelect = createEvent({ cancelable: false });
 
@@ -151,7 +151,7 @@ export class AutocompleteItem extends LitElement {
       return;
     }
 
-    this.toggleSelection();
+    this.requestSelection();
   }
 
   //#endregion

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -375,6 +375,65 @@ describe("keyboard selection", () => {
     expect(itemSelectSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("updates item selection when value changes", async () => {
+    const { component, reRender } = await mount<Autocomplete>(renderAutocomplete);
+    const firstItem = component.items[0];
+    const secondItem = component.items[1];
+
+    component.value = secondItem.value;
+    await reRender();
+
+    expect(firstItem.selected).toBe(false);
+    expect(secondItem.selected).toBe(true);
+  });
+
+  it("applies initial value to item selection", async () => {
+    const { component } = await mount<Autocomplete>(
+      <calcite-autocomplete label="Item list" open value="two">
+        <calcite-autocomplete-item heading="Item one" label="Item one" value="one" />
+        <calcite-autocomplete-item heading="Item two" label="Item two" value="two" />
+      </calcite-autocomplete>,
+    );
+
+    expect(component.items[0].selected).toBe(false);
+    expect(component.items[1].selected).toBe(true);
+    await expect
+      .element(page.getByRole("listbox").getByRole("option").nth(1))
+      .toHaveAttribute("aria-selected", "true");
+  });
+
+  it("applies value to items added after initialization", async () => {
+    const { component, el, reRender } = await mount<Autocomplete>(
+      <calcite-autocomplete label="Item list" value="two">
+        <calcite-autocomplete-item heading="Item one" label="Item one" value="one" />
+      </calcite-autocomplete>,
+    );
+
+    const item = document.createElement("calcite-autocomplete-item");
+    item.heading = "Item two";
+    item.label = "Item two";
+    item.value = "two";
+    el.append(item);
+    await reRender();
+
+    expect(component.items[1].selected).toBe(true);
+  });
+
+  it("updates selection when an item value changes", async () => {
+    const { component, reRender } = await mount<Autocomplete>(
+      <calcite-autocomplete label="Item list" value="two">
+        <calcite-autocomplete-item heading="Item one" label="Item one" value="one" />
+        <calcite-autocomplete-item heading="Item two" label="Item two" value="two" />
+      </calcite-autocomplete>,
+    );
+
+    const selectedItem = component.items[1];
+    selectedItem.value = "three";
+    await reRender();
+
+    expect(selectedItem.selected).toBe(false);
+  });
+
   it("updates listbox option aria-selected from programmatic item selection without emitting change", async () => {
     const changeSpy = vi.fn();
     const { component, reRender } = await mount<Autocomplete>(

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -351,7 +351,7 @@ describe("keyboard selection", () => {
     }
   }
 
-  it("toggles active item selection on Enter and emits calciteAutocompleteItemSelect", async () => {
+  it("selects active item on Enter and emits calciteAutocompleteItemSelect", async () => {
     const { el, reRender } = await mount<Autocomplete>(renderAutocomplete);
     const firstItem = el.querySelector("calcite-autocomplete-item")!;
     const itemSelectSpy = vi.fn();
@@ -371,7 +371,7 @@ describe("keyboard selection", () => {
     await userEvent.keyboard("{ArrowDown}{Enter}");
     await reRender();
 
-    expect(firstItem.selected).toBe(false);
+    expect(firstItem.selected).toBe(true);
     expect(itemSelectSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -388,10 +388,10 @@ describe("keyboard selection", () => {
   });
 
   it("updates item selection before emitting change", async () => {
-    const { component, reRender } = await mount<Autocomplete>(renderAutocomplete);
+    const { component, el, reRender } = await mount<Autocomplete>(renderAutocomplete);
     let selectedItemsAtChange: boolean[] | undefined;
 
-    component.addEventListener("calciteAutocompleteChange", () => {
+    el.addEventListener("calciteAutocompleteChange", () => {
       selectedItemsAtChange = component.items.map((item) => item.selected);
     });
 

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -387,6 +387,21 @@ describe("keyboard selection", () => {
     expect(secondItem.selected).toBe(true);
   });
 
+  it("updates item selection before emitting change", async () => {
+    const { component, reRender } = await mount<Autocomplete>(renderAutocomplete);
+    let selectedItemsAtChange: boolean[] | undefined;
+
+    component.addEventListener("calciteAutocompleteChange", () => {
+      selectedItemsAtChange = component.items.map((item) => item.selected);
+    });
+
+    await component.setFocus();
+    await userEvent.keyboard("{ArrowDown}{Enter}");
+    await reRender();
+
+    expect(selectedItemsAtChange).toEqual([true, false]);
+  });
+
   it("applies initial value to item selection", async () => {
     const { component } = await mount<Autocomplete>(
       <calcite-autocomplete label="Item list" open value="two">

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -399,7 +399,7 @@ describe("keyboard selection", () => {
     await userEvent.keyboard("{ArrowDown}{Enter}");
     await reRender();
 
-    expect(selectedItemsAtChange).toEqual([true, false]);
+    expect(selectedItemsAtChange).toEqual([true, false, false, false, false]);
   });
 
   it("applies initial value to item selection", async () => {

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -402,6 +402,37 @@ describe("keyboard selection", () => {
       .toHaveAttribute("aria-selected", "true");
   });
 
+  it("preserves declarative selection without an initial value", async () => {
+    const { component } = await mount<Autocomplete>(
+      <calcite-autocomplete label="Item list" open>
+        <calcite-autocomplete-item heading="Item one" label="Item one" selected value="one" />
+        <calcite-autocomplete-item heading="Item two" label="Item two" value="two" />
+      </calcite-autocomplete>,
+    );
+
+    expect(component.items[0].selected).toBe(true);
+    await expect
+      .element(page.getByRole("listbox").getByRole("option").nth(0))
+      .toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clears selection when a controlled value is reset", async () => {
+    const { component, reRender } = await mount<Autocomplete>(
+      <calcite-autocomplete label="Item list" open value="one">
+        <calcite-autocomplete-item heading="Item one" label="Item one" value="one" />
+        <calcite-autocomplete-item heading="Item two" label="Item two" value="two" />
+      </calcite-autocomplete>,
+    );
+
+    component.value = "";
+    await reRender();
+
+    expect(component.items[0].selected).toBe(false);
+    await expect
+      .element(page.getByRole("listbox").getByRole("option").nth(0))
+      .toHaveAttribute("aria-selected", "false");
+  });
+
   it("applies value to items added after initialization", async () => {
     const { component, el, reRender } = await mount<Autocomplete>(
       <calcite-autocomplete label="Item list" value="two">

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -690,7 +690,6 @@ export class Autocomplete
         break;
       case "Enter":
         if (open && activeItem) {
-          this.value = activeItem.value;
           activeItem.toggleSelection();
           this.open = false;
           event.preventDefault();

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -690,7 +690,7 @@ export class Autocomplete
         break;
       case "Enter":
         if (open && activeItem) {
-          activeItem.toggleSelection();
+          activeItem.requestSelection();
           this.open = false;
           event.preventDefault();
         } else if (!event.defaultPrevented && this.formSupport.active) {

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -525,6 +525,7 @@ export class Autocomplete
 
   private async handleAutocompleteItemSelect(event: Event): Promise<void> {
     this.value = (event.target as AutocompleteItem["el"]).value;
+    this.selectedItemsHandler();
     this.emitChange();
     await this.setFocus();
     this.open = false;

--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -302,7 +302,7 @@ export class Autocomplete
    */
   @property({ readOnly: true }) validity!: ValidityState;
 
-  /** Specifies the selected `autocomplete-item`. When the component resides in a form, the `value` is submitted with the form. */
+  /** Specifies the value of the selected `autocomplete-item`. When the component resides in a form, the `value` is submitted with the form. */
   @property() value = "";
 
   //#endregion
@@ -423,6 +423,10 @@ export class Autocomplete
       this.openHandler();
     }
 
+    if (changes.has("value") && this.hasUpdated) {
+      this.selectedItemsHandler();
+    }
+
     if (
       changes.has("flipPlacements") ||
       (changes.has("overlayPositioning") &&
@@ -490,6 +494,10 @@ export class Autocomplete
     if (!value) {
       this.open = false;
     }
+  }
+
+  private selectedItemsHandler(): void {
+    this.items.forEach((item) => (item.selected = item.value === this.value));
   }
 
   private openHandler(): void {
@@ -578,6 +586,10 @@ export class Autocomplete
 
   private updateItems(): void {
     let activeDescendant = "";
+
+    if (this.value) {
+      this.selectedItemsHandler();
+    }
 
     this.items.forEach((item) => {
       item.scale = this.scale;


### PR DESCRIPTION
**Related Issue:** #14907

## Summary

- Make `calcite-autocomplete` the source of truth for item selection when `value` is set.
- Keep `calcite-autocomplete-item` selection state unchanged when its private selection request emits.
- Synchronize selection for initial values, dynamically added items, and item value changes.
- Add browser coverage for selection state and `aria-selected`.

Selection state was not consistently synchronized when the autocomplete value or item values changed. This could leave the selected item and listbox accessibility metadata out of sync.

Declarative item selection remains supported when the autocomplete has no value. This is because the `selected` property is public API on the item.