### PR TITLE
fix(tree): only emit calciteTreeSelect when selection changes

### DIFF
--- a/packages/components/src/components/tree/tree.browser.e2e.tsx
+++ b/packages/components/src/components/tree/tree.browser.e2e.tsx
@@ -1,9 +1,10 @@
 import { h } from "@arcgis/lumina";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { accessible, defaults, hidden, renders } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { page, userEvent } from "vitest/browser";
+import type { Tree } from "./tree";
 
 mockConsole();
 
@@ -64,6 +65,108 @@ describe("renders", () => {
       ),
     { display: "block" },
   );
+});
+
+describe("selection events", () => {
+  const selectionModesThatSelectParentItems = [
+    { selectionMode: "ancestors", selectsChildren: true },
+    { selectionMode: "children", selectsChildren: false },
+    { selectionMode: "multichildren", selectsChildren: false },
+  ] as const;
+  const selectionModesThatToggleParentItems = [
+    "multiple",
+    "none",
+    "single",
+    "single-persist",
+  ] as const;
+  const selectionModesThatSelectChildItems = [
+    "ancestors",
+    "children",
+    "multichildren",
+    "multiple",
+    "single",
+    "single-persist",
+  ] as const;
+
+  async function mountTreeWithExpandableParent(
+    selectionMode: Tree["selectionMode"],
+    expanded = false,
+  ): Promise<Tree["el"]> {
+    const { el } = await mount<Tree>(
+      <calcite-tree selection-mode={selectionMode}>
+        <calcite-tree-item expanded={expanded} id="parent-item">
+          Parent item
+          <calcite-tree slot="children">
+            <calcite-tree-item id="child-item">Child item</calcite-tree-item>
+          </calcite-tree>
+        </calcite-tree-item>
+      </calcite-tree>,
+    );
+
+    return el;
+  }
+
+  selectionModesThatSelectParentItems.forEach(({ selectionMode, selectsChildren }) => {
+    it(`emits calciteTreeSelect when a parent item is selected in ${selectionMode} mode`, async () => {
+      const el = await mountTreeWithExpandableParent(selectionMode);
+      const parentItem = page.getBySelector("#parent-item");
+      const childItem = page.getBySelector("#child-item");
+      const selectionChangeHandler = vi.fn();
+
+      el.addEventListener("calciteTreeSelect", selectionChangeHandler);
+
+      await userEvent.click(parentItem);
+
+      expect(selectionChangeHandler).toHaveBeenCalledTimes(1);
+      await expect.element(parentItem).toHaveProperty("selected", true);
+      await expect.element(childItem).toHaveProperty("selected", selectsChildren);
+    });
+  });
+
+  selectionModesThatToggleParentItems.forEach((selectionMode) => {
+    it(`does not emit calciteTreeSelect when a parent item only expands or collapses in ${selectionMode} mode`, async () => {
+      const el = await mountTreeWithExpandableParent(selectionMode);
+      const parentItem = page.getBySelector("#parent-item");
+      const childItem = page.getBySelector("#child-item");
+      const selectionChangeHandler = vi.fn();
+
+      el.addEventListener("calciteTreeSelect", selectionChangeHandler);
+
+      await userEvent.click(parentItem);
+
+      expect(selectionChangeHandler).not.toHaveBeenCalled();
+      await expect.element(parentItem).toHaveProperty("selected", false);
+      await expect.element(childItem).toHaveProperty("selected", false);
+    });
+  });
+
+  selectionModesThatSelectChildItems.forEach((selectionMode) => {
+    it(`emits calciteTreeSelect when a child item is selected in ${selectionMode} mode`, async () => {
+      const el = await mountTreeWithExpandableParent(selectionMode, true);
+      const childItem = page.getBySelector("#child-item");
+      const selectionChangeHandler = vi.fn();
+
+      el.addEventListener("calciteTreeSelect", selectionChangeHandler);
+
+      await userEvent.click(childItem);
+
+      expect(selectionChangeHandler).toHaveBeenCalledTimes(1);
+      await expect.element(childItem).toHaveProperty("selected", true);
+    });
+  });
+
+  it("does not emit calciteTreeSelect when a child item is clicked in none mode", async () => {
+    const el = await mountTreeWithExpandableParent("none", true);
+    const childItem = page.getBySelector("#child-item");
+    const selectionChangeHandler = vi.fn();
+
+    el.addEventListener("calciteTreeSelect", selectionChangeHandler);
+
+    await userEvent.click(childItem);
+
+    expect(selectionChangeHandler).not.toHaveBeenCalled();
+    await expect.element(childItem).toHaveProperty("selected", false);
+  });
 });
 
 it("is focusable after making a selection across trees with slotted items", async () => {

--- a/packages/components/src/components/tree/tree.e2e.ts
+++ b/packages/components/src/components/tree/tree.e2e.ts
@@ -393,32 +393,6 @@ describe("item selection", () => {
     });
   });
 
-  describe(`when tree-item selection-mode is "none"`, () => {
-    it("emits selection event without updating selection", async () => {
-      const page = await newE2EPage();
-      await page.setContent(html`
-        <calcite-tree selection-mode="none">
-          <calcite-tree-item id="1">1</calcite-tree-item>
-          <calcite-tree-item id="2">2</calcite-tree-item>
-        </calcite-tree>
-      `);
-
-      const tree = await page.find(`calcite-tree`);
-      const selectEventSpy = await tree.spyOnEvent("calciteTreeSelect");
-      const [item1, item2] = await findAll(page, `calcite-tree-item`);
-
-      await item1.click();
-      expect(selectEventSpy).toHaveReceivedEventTimes(1);
-      expect(await tree.getProperty("selectedItems")).toHaveLength(0);
-      expect(await findAll(page, "calcite-tree-item[selected]", { allowEmpty: true })).toHaveLength(0);
-
-      await item2.click();
-      expect(selectEventSpy).toHaveReceivedEventTimes(2);
-      expect(await tree.getProperty("selectedItems")).toHaveLength(0);
-      expect(await findAll(page, "calcite-tree-item[selected]", { allowEmpty: true })).toHaveLength(0);
-    });
-  });
-
   describe("selection changes programmatically in ancestors selection-mode", () => {
     const pageContent = html`<calcite-tree selection-mode="ancestors">
       <calcite-tree-item id="grandparent">

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -149,12 +149,13 @@ export class Tree extends LitElement {
 
     const target = event.target as TreeItem["el"];
     const childItems = nodeListToArray(target.querySelectorAll("calcite-tree-item"));
+    const previouslySelectedItems = this.getSelectedItems();
 
     event.preventDefault();
     event.stopPropagation();
 
     if (this.selectionMode === "ancestors") {
-      this.updateAncestorTree(event);
+      this.updateAncestorTree(event, previouslySelectedItems);
       return;
     }
 
@@ -237,11 +238,11 @@ export class Tree extends LitElement {
       });
     }
 
-    this.selectedItems = isNoneSelectionMode
-      ? []
-      : nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter((i) => i.selected);
+    this.selectedItems = isNoneSelectionMode ? [] : this.getSelectedItems();
 
-    this.calciteTreeSelect.emit();
+    if (this.selectionChanged(previouslySelectedItems)) {
+      this.calciteTreeSelect.emit();
+    }
 
     event.stopPropagation();
   }
@@ -335,7 +336,10 @@ export class Tree extends LitElement {
     }
   }
 
-  private updateAncestorTree(event: CustomEvent<TreeItemSelectDetail>): void {
+  private updateAncestorTree(
+    event: CustomEvent<TreeItemSelectDetail>,
+    previouslySelectedItems: TreeItem["el"][],
+  ): void {
     const item = event.target as TreeItem["el"];
     const updateItem = event.detail.updateItem;
 
@@ -407,13 +411,24 @@ export class Tree extends LitElement {
       ancestor.selected = !indeterminate;
     });
 
-    this.selectedItems = nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter(
-      (i) => i.selected,
-    );
+    this.selectedItems = this.getSelectedItems();
 
-    if (updateItem) {
+    if (updateItem && this.selectionChanged(previouslySelectedItems)) {
       this.calciteTreeSelect.emit();
     }
+  }
+
+  private getSelectedItems(): TreeItem["el"][] {
+    return nodeListToArray(this.el.querySelectorAll("calcite-tree-item")).filter(
+      (item) => item.selected,
+    );
+  }
+
+  private selectionChanged(previouslySelectedItems: TreeItem["el"][]): boolean {
+    return (
+      previouslySelectedItems.length !== this.selectedItems.length ||
+      this.selectedItems.some((item) => !previouslySelectedItems.includes(item))
+    );
   }
 
   private updateItems(): void {

--- a/packages/components/src/components/tree/tree.tsx
+++ b/packages/components/src/components/tree/tree.tsx
@@ -149,7 +149,8 @@ export class Tree extends LitElement {
 
     const target = event.target as TreeItem["el"];
     const childItems = nodeListToArray(target.querySelectorAll("calcite-tree-item"));
-    const previouslySelectedItems = this.getSelectedItems();
+    const isNoneSelectionMode = this.selectionMode === "none";
+    const previouslySelectedItems = isNoneSelectionMode ? [] : this.getSelectedItems();
 
     event.preventDefault();
     event.stopPropagation();
@@ -158,8 +159,6 @@ export class Tree extends LitElement {
       this.updateAncestorTree(event, previouslySelectedItems);
       return;
     }
-
-    const isNoneSelectionMode = this.selectionMode === "none";
 
     const shouldSelect =
       this.selectionMode !== null &&


### PR DESCRIPTION
**Related Issue:** #14413

## Summary
Updates `calciteTreeSelect` so it emits only when a Tree interaction changes the selected-item set. Parent-item clicks now emit in `ancestors`, `children` , and `multichildren` modes when they change selection, while `multiple`, `none`, `single` and `single-persist` parent clicks only expand or collapse without emitting. Adds browser coverage for parent and child interactions across selection modes, including their resulting selected states.