### PR TITLE
docs: add `@parent` relationships

### DIFF
--- a/packages/components/src/components/accordion-item/accordion-item.tsx
+++ b/packages/components/src/components/accordion-item/accordion-item.tsx
@@ -23,6 +23,7 @@ declare global {
 
 /**
  * @deprecated in v5.2.0, removal target v7.0.0 - Use the `calcite-block` component instead.
+ * @parent calcite-accordion
  * @slot - A slot for adding custom content, including nested `calcite-accordion-item`s.
  * @slot actions-end - A slot for adding `calcite-action`s or content to the end side of the component's header.
  * @slot actions-start - A slot for adding `calcite-action`s or content to the start side of the component's header.

--- a/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
+++ b/packages/components/src/components/autocomplete-item-group/autocomplete-item-group.tsx
@@ -14,7 +14,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-autocomplete-item`s. */
+/**
+ * @parent calcite-autocomplete
+ * @slot - A slot for adding `calcite-autocomplete-item`s.
+ */
 export class AutocompleteItemGroup extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
+++ b/packages/components/src/components/autocomplete-item/autocomplete-item.tsx
@@ -16,6 +16,7 @@ declare global {
 }
 
 /**
+ * @parent calcite-autocomplete
  * @slot content-end - A slot for adding non-actionable elements after content of the component.
  * @slot content-start - A slot for adding non-actionable elements before content of the component.
  */

--- a/packages/components/src/components/block-section/block-section.tsx
+++ b/packages/components/src/components/block-section/block-section.tsx
@@ -30,6 +30,7 @@ declare global {
 
 /**
  * @deprecated in v5.2.0, removal target v7.0.0 - Use the `calcite-block` component instead.
+ * @parent calcite-block
  * @slot - A slot for adding custom content.
  */
 export class BlockSection extends LitElement {

--- a/packages/components/src/components/carousel-item/carousel-item.tsx
+++ b/packages/components/src/components/carousel-item/carousel-item.tsx
@@ -9,7 +9,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding content. */
+/**
+ * @parent calcite-carousel
+ * @slot - A slot for adding content.
+ */
 export class CarouselItem extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.tsx
@@ -12,7 +12,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-combobox-item`s. */
+/**
+ * @parent calcite-combobox
+ * @slot - A slot for adding `calcite-combobox-item`s.
+ */
 export class ComboboxItemGroup extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/combobox-item/combobox-item.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.tsx
@@ -19,6 +19,7 @@ declare global {
 }
 
 /**
+ * @parent calcite-combobox
  * @slot - A slot for adding nested `calcite-combobox-item`s.
  * @slot content-end - A slot for adding non-actionable elements after the component's content.
  * @slot content-start - A slot for adding non-actionable elements before the component's content.

--- a/packages/components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.tsx
@@ -14,7 +14,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-dropdown-item`s. */
+/**
+ * @parent calcite-dropdown
+ * @slot - A slot for adding `calcite-dropdown-item`s.
+ */
 export class DropdownGroup extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.tsx
@@ -25,7 +25,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding text. */
+/**
+ * @parent calcite-dropdown
+ * @slot - A slot for adding text.
+ */
 export class DropdownItem extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/flow-item/flow-item.tsx
+++ b/packages/components/src/components/flow-item/flow-item.tsx
@@ -23,6 +23,7 @@ declare global {
 }
 
 /**
+ * @parent calcite-flow
  * @slot - A slot for adding custom content.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  * @slot alerts - A slot for adding `calcite-alert`s to the component.

--- a/packages/components/src/components/list-item-group/list-item-group.tsx
+++ b/packages/components/src/components/list-item-group/list-item-group.tsx
@@ -11,7 +11,10 @@ declare global {
     "calcite-list-item-group": ListItemGroup;
   }
 }
-/** @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements. */
+/**
+ * @parent calcite-list
+ * @slot - A slot for adding `calcite-list-item` and `calcite-list-item-group` elements.
+ */
 export class ListItemGroup extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/list-item/list-item.tsx
+++ b/packages/components/src/components/list-item/list-item.tsx
@@ -42,6 +42,7 @@ declare global {
 const focusMap = new Map<List["el"], number | undefined>();
 
 /**
+ * @parent calcite-list
  * @slot - A slot for adding `calcite-list`, `calcite-list-item` and `calcite-list-item-group` elements.
  * @slot actions-start - A slot for adding actionable `calcite-action` elements before the content of the component.
  * @slot content-start - A slot for adding non-actionable elements before the component's `label` and `description`.

--- a/packages/components/src/components/menu-item/menu-item.tsx
+++ b/packages/components/src/components/menu-item/menu-item.tsx
@@ -28,7 +28,10 @@ declare global {
   }
 }
 
-/** @slot submenu-item - A slot for adding `calcite-menu-item`s in a submenu. */
+/**
+ * @parent calcite-menu
+ * @slot submenu-item - A slot for adding `calcite-menu-item`s in a submenu.
+ */
 export class MenuItem extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/navigation-logo/navigation-logo.tsx
+++ b/packages/components/src/components/navigation-logo/navigation-logo.tsx
@@ -12,6 +12,9 @@ declare global {
   }
 }
 
+/**
+ * @parent calcite-navigation
+ */
 export class NavigationLogo extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/navigation-user/navigation-user.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.tsx
@@ -10,6 +10,9 @@ declare global {
   }
 }
 
+/**
+ * @parent calcite-navigation
+ */
 export class NavigationUser extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/option-group/option-group.tsx
+++ b/packages/components/src/components/option-group/option-group.tsx
@@ -6,7 +6,10 @@ declare global {
     "calcite-option-group": OptionGroup;
   }
 }
-/** @slot - A slot for adding `calcite-option`s. */
+/**
+ * @parent calcite-select
+ * @slot - A slot for adding `calcite-option`s.
+ */
 export class OptionGroup extends LitElement {
   //#region Public Properties
 

--- a/packages/components/src/components/option/option.tsx
+++ b/packages/components/src/components/option/option.tsx
@@ -12,6 +12,9 @@ declare global {
 const whitespaceCharsToTrim = [" ", "\n", "\t", "\r"];
 const whitespaceToReplaceRegexp = /[^\S\u00A0]+/g;
 
+/**
+ * @parent calcite-select
+ */
 export class Option extends LitElement {
   // #endregion
 

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.tsx
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.tsx
@@ -13,6 +13,9 @@ declare global {
   }
 }
 
+/**
+ * @parent calcite-segmented-control
+ */
 export class SegmentedControlItem extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/shell-panel/shell-panel.tsx
+++ b/packages/components/src/components/shell-panel/shell-panel.tsx
@@ -46,6 +46,7 @@ declare global {
 }
 
 /**
+ * @parent calcite-shell
  * @slot - A slot for adding custom content.
  * @slot action-bar - A slot for adding a `calcite-action-bar` to the component.
  */

--- a/packages/components/src/components/stepper-item/stepper-item.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.tsx
@@ -35,7 +35,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding custom content. */
+/**
+ * @parent calcite-stepper
+ * @slot - A slot for adding custom content.
+ */
 export class StepperItem extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -31,7 +31,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-tab-title`s. */
+/**
+ * @parent calcite-tabs
+ * @slot - A slot for adding `calcite-tab-title`s.
+ */
 export class TabNav extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -37,6 +37,7 @@ declare global {
 /**
  * Tab-titles are optionally individually closable.
  *
+ * @parent calcite-tabs
  * @slot - A slot for adding text.
  */
 export class TabTitle extends LitElement {

--- a/packages/components/src/components/tab/tab.tsx
+++ b/packages/components/src/components/tab/tab.tsx
@@ -13,7 +13,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding custom content. */
+/**
+ * @parent calcite-tabs
+ * @slot - A slot for adding custom content.
+ */
 export class Tab extends LitElement {
   // #region Static Members
 

--- a/packages/components/src/components/table-cell/table-cell.tsx
+++ b/packages/components/src/components/table-cell/table-cell.tsx
@@ -18,7 +18,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding content, usually text content. */
+/**
+ * @parent calcite-table
+ * @slot - A slot for adding content, usually text content.
+ */
 export class TableCell extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/table-header/table-header.tsx
+++ b/packages/components/src/components/table-header/table-header.tsx
@@ -16,6 +16,9 @@ declare global {
   }
 }
 
+/**
+ * @parent calcite-table
+ */
 export class TableHeader extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/table-row/table-row.tsx
+++ b/packages/components/src/components/table-row/table-row.tsx
@@ -23,7 +23,10 @@ declare global {
   }
 }
 
-/** @slot - A slot for adding `calcite-table-cell` or `calcite-table-header` elements. */
+/**
+ * @parent calcite-table
+ * @slot - A slot for adding `calcite-table-cell` or `calcite-table-header` elements.
+ */
 export class TableRow extends LitElement {
   //#region Static Members
 

--- a/packages/components/src/components/tree-item/tree-item.tsx
+++ b/packages/components/src/components/tree-item/tree-item.tsx
@@ -25,6 +25,7 @@ declare global {
 }
 
 /**
+ * @parent calcite-tree
  * @slot - A slot for adding text.
  * @slot children - A slot for adding nested `calcite-tree` elements.
  * @slot actions-end - A slot for adding actions to the end of the component. It is recommended to use two or fewer actions.


### PR DESCRIPTION
**Related Issue:** TBA

## Summary

> [!WARNING]
> 🚧 WIP
> Pending feedback:
> - Tag name subject to change
> - Needs related issue
> - Should include doc

Adds `@parent` JSDoc tags to child components to support automated documentation linking/navigation.
