### PR TITLE
feat(action-bar, action-menu, action-group): include action-menu in roving navigation and sync active descendant

### DIFF
--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -15,6 +15,351 @@
       <!-- you can add a demo snippet by running `npx snippet` -->
 
       <!-- demo snippet end -->
+      <style>
+        body {
+          margin: 30px;
+        }
+
+        .demo-stack {
+          display: grid;
+          gap: 1rem;
+          max-width: 36rem;
+        }
+
+        .demo-row {
+          display: grid;
+          gap: 0.35rem;
+        }
+
+        .demo-label {
+          font: 600 0.875rem/1.4 sans-serif;
+        }
+
+        .keyboard-nav-action-bar {
+          inline-size: 14rem;
+        }
+
+        .narrow-action-bar {
+          inline-size: 16rem;
+        }
+
+        .vertical-overflow-action-bar {
+          block-size: 18rem;
+          inline-size: 8rem;
+        }
+
+        .tool-group {
+          display: flex;
+          align-items: stretch;
+          overflow: hidden;
+        }
+
+        .tool-group:hover {
+          background: var(--calcite-color-foreground-2);
+        }
+
+        .tool-group:hover calcite-action {
+          --calcite-action-background-color: var(--calcite-color-foreground-2);
+          --calcite-action-background-color-hover: var(--calcite-color-foreground-2);
+        }
+
+        /* Dropdown open state */
+        .tool-group:has(calcite-dropdown[open]) {
+          background: transparent;
+          outline: none;
+        }
+
+        /* Disable action highlight while menu is open */
+        .tool-group:has(calcite-dropdown[open]) calcite-action {
+          --calcite-action-background-color: transparent;
+          --calcite-action-background-color-hover: transparent;
+        }
+
+        #text-example {
+          padding: 1rem;
+          font-weight: var(--calcite-font-weight-bold);
+          font-style: var(--calcite-font-style-normal);
+          text-decoration: none;
+          text-align: left;
+        }
+      </style>
+
+      <div class="demo-stack">
+        <div class="demo-row">
+          <span class="demo-label">Vertical multiple selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="Add" icon="plus"></calcite-action>
+              <calcite-action text="Layers" icon="layers"></calcite-action>
+              <calcite-action text="Save" icon="save"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Vertical single selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+            <calcite-action-group selection-mode="single">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <calcite-action text="Select" icon="cursor"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Vertical single selection (automatic overflow disabled)</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar narrow-action-bar vertical-overflow-action-bar"
+            expand-disabled
+            layout="vertical"
+          >
+            <calcite-action-group selection-mode="single" label="Edit actions">
+              <calcite-action text="Identify" icon="information"></calcite-action>
+              <calcite-action text="Filter" icon="filter"></calcite-action>
+              <calcite-action text="Refresh" icon="refresh"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group selection-mode="multiple" label="Share actions">
+              <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
+              <calcite-action text="Settings" icon="gear"></calcite-action>
+              <calcite-action text="Configure" icon="sliders"></calcite-action>
+              <calcite-action text="Share" icon="share"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Horizontal multiple selection (automatic overflow disabled)</span>
+          <calcite-action-bar class="keyboard-nav-action-bar narrow-action-bar" expand-disabled layout="horizontal">
+            <calcite-action-group selection-mode="multiple" label="View actions">
+              <calcite-action text="Identify" icon="information"></calcite-action>
+              <calcite-action text="Filter" icon="filter"></calcite-action>
+              <calcite-action text="Refresh" icon="refresh"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group selection-mode="single" label="Project actions">
+              <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
+              <calcite-action text="Settings" icon="gear"></calcite-action>
+              <calcite-action text="Configure" icon="sliders"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Horizontal non-selection group (overflow menu allowed)</span>
+          <calcite-action-bar class="keyboard-nav-action-bar narrow-action-bar" expand-disabled layout="horizontal">
+            <calcite-action-group>
+              <calcite-action text="Identify" icon="information"></calcite-action>
+              <calcite-action text="Filter" icon="filter"></calcite-action>
+              <calcite-action text="Refresh" icon="refresh"></calcite-action>
+              <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
+              <calcite-action text="Settings" icon="gear"></calcite-action>
+              <calcite-action text="Configure" icon="sliders"></calcite-action>
+              <calcite-action text="Share" icon="share"></calcite-action>
+              <calcite-action text="Export" icon="download"></calcite-action>
+              <calcite-action text="Print" icon="print"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Vertical non-selection group (overflow menu allowed)</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar narrow-action-bar vertical-overflow-action-bar"
+            expand-disabled
+            layout="vertical"
+          >
+            <calcite-action-group>
+              <calcite-action text="Identify" icon="information"></calcite-action>
+              <calcite-action text="Filter" icon="filter"></calcite-action>
+              <calcite-action text="Refresh" icon="refresh"></calcite-action>
+              <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
+              <calcite-action text="Settings" icon="gear"></calcite-action>
+              <calcite-action text="Configure" icon="sliders"></calcite-action>
+              <calcite-action text="Share" icon="share"></calcite-action>
+              <calcite-action text="Export" icon="download"></calcite-action>
+              <calcite-action text="Print" icon="print"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Horizontal single-persist selection</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar"
+            expand-disabled
+            layout="horizontal"
+            overflow-actions-disabled
+          >
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action active text="Pan" icon="pan"></calcite-action>
+              <calcite-action text="Zoom in" icon="zoom-in-fixed"></calcite-action>
+              <calcite-action text="Zoom out" icon="zoom-out-fixed"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Multiple selection - overflow disabled</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar narrow-action-bar"
+            expand-disabled
+            overflow-actions-disabled
+          >
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="Add" icon="plus"></calcite-action>
+              <calcite-action text="Undo" icon="undo"></calcite-action>
+              <calcite-action text="Redo" icon="redo"></calcite-action>
+              <calcite-action text="Save" icon="save"></calcite-action>
+              <calcite-action text="Delete" icon="trash"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Single selection - overflow disabled</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar narrow-action-bar"
+            expand-disabled
+            overflow-actions-disabled
+          >
+            <calcite-action-group selection-mode="single">
+              <calcite-action text="Point" icon="pin"></calcite-action>
+              <calcite-action text="Line" icon="line"></calcite-action>
+              <calcite-action text="Area" icon="polygon"></calcite-action>
+              <calcite-action text="Circle" icon="circle"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Single-persist selection - overflow disabled</span>
+          <calcite-action-bar
+            class="keyboard-nav-action-bar narrow-action-bar"
+            expand-disabled
+            overflow-actions-disabled
+          >
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action active text="Pan" icon="pan"></calcite-action>
+              <calcite-action text="Zoom in" icon="zoom-in-fixed"></calcite-action>
+              <calcite-action text="Zoom out" icon="zoom-out-fixed"></calcite-action>
+              <calcite-action text="Full extent" icon="extent"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Two vertical bars for Tab then ArrowDown</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="First add" icon="plus"></calcite-action>
+              <calcite-action text="First save" icon="save"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="Second layers" icon="layers"></calcite-action>
+              <calcite-action text="Second basemaps" icon="layer-basemap"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div>
+          <calcite-action-bar layout="horizontal" expand-disabled floating>
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action text="Curve" icon="curve"></calcite-action>
+              <calcite-action text="Right angle" icon="right-angle"></calcite-action>
+              <calcite-action text="Line" icon="line"></calcite-action>
+              <calcite-action text="Line straight" icon="line-straight"></calcite-action>
+            </calcite-action-group>
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="Split geometry" icon="split-geometry"></calcite-action>
+              <calcite-action text="Stretch" icon="stretch"></calcite-action>
+              <calcite-action text="Trace" icon="trace"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Floating text formatting toolbar</span>
+          <calcite-action-bar
+            id="font-configuration-settings"
+            layout="horizontal"
+            floating
+            expand-disabled
+            overflow-actions-disabled
+          >
+            <calcite-action-group label="Text formatting" selection-mode="multiple">
+              <calcite-action id="bold" active context text="Bold" icon="bold"></calcite-action>
+              <calcite-tooltip reference-element="bold" placement="bottom">
+                <span>Bold</span>
+              </calcite-tooltip>
+              <calcite-action id="italic" text="Italicize" icon="italicize"></calcite-action>
+              <calcite-tooltip reference-element="italic" placement="bottom">
+                <span>Italic</span>
+              </calcite-tooltip>
+              <calcite-action id="underline" text="Underline" icon="underline"></calcite-action>
+              <calcite-tooltip reference-element="underline" placement="bottom">
+                <span>Underline</span>
+              </calcite-tooltip>
+            </calcite-action-group>
+            <calcite-action-group label="Text alignment" selection-mode="single-persist">
+              <calcite-action id="left-text" active text="Left align text" icon="left-align"></calcite-action>
+              <calcite-tooltip reference-element="left-text" placement="bottom">
+                <span>Left align text</span>
+              </calcite-tooltip>
+              <calcite-action id="center-text" text="Center align text" icon="center-align"></calcite-action>
+              <calcite-tooltip reference-element="center-text" placement="bottom">
+                <span>Center align text</span>
+              </calcite-tooltip>
+              <calcite-action id="right-text" text="Right align text" icon="right-align"></calcite-action>
+              <calcite-tooltip reference-element="right-text" placement="bottom">
+                <span>Right align text</span>
+              </calcite-tooltip>
+            </calcite-action-group>
+            <calcite-action-group label="Text lists - disabled" selection-mode="single">
+              <calcite-action id="list-bullet" disabled text="Bullet list" icon="list-bullet"></calcite-action>
+              <calcite-tooltip reference-element="list-bullet" placement="bottom">
+                <span>Bullet list - disabled</span>
+              </calcite-tooltip>
+              <calcite-action id="numb-list" disabled text="Numbered list" icon="list-number"></calcite-action>
+              <calcite-tooltip reference-element="numb-list" placement="bottom">
+                <span>Numbered list - disabled</span>
+              </calcite-tooltip>
+            </calcite-action-group>
+            <calcite-action-group label="Align items - disabled" selection-mode="single">
+              <calcite-action
+                id="align-items-left"
+                disabled
+                text="Align items left"
+                icon="ltr-elements-align"
+              ></calcite-action>
+              <calcite-tooltip reference-element="align-items-left" placement="bottom">
+                <span>Align items left - disabled</span>
+              </calcite-tooltip>
+              <calcite-action
+                id="align-items-right"
+                disabled
+                text="Align items right"
+                icon="rtl-elements-align"
+              ></calcite-action>
+              <calcite-tooltip reference-element="align-items-right" placement="bottom">
+                <span>Align items right - disabled</span>
+              </calcite-tooltip>
+              <calcite-action
+                id="add-config"
+                disabled
+                text="Additional configurations"
+                icon="ellipsis"
+              ></calcite-action>
+              <calcite-tooltip reference-element="add-config" placement="bottom">
+                <span>Additional configurations - disabled</span>
+              </calcite-tooltip>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <p id="text-example">Some great content</p>
+      </div>
     </demo-dom-swapper>
     <demo-options></demo-options>
   </body>

--- a/packages/components/index.html
+++ b/packages/components/index.html
@@ -26,9 +26,13 @@
           max-width: 36rem;
         }
 
+        .demo-stack-wide {
+          max-width: min(100%, 90rem);
+        }
+
         .demo-row {
           display: grid;
-          gap: 0.35rem;
+          gap: 0.645rem;
         }
 
         .demo-label {
@@ -36,16 +40,26 @@
         }
 
         .keyboard-nav-action-bar {
-          inline-size: 14rem;
+          justify-self: start;
+          inline-size: clamp(8rem, 40vw, 14rem);
         }
 
         .narrow-action-bar {
-          inline-size: 16rem;
+          inline-size: clamp(8rem, 45vw, 16rem);
+        }
+
+        .toolbar-action-bar {
+          inline-size: min(100%, 72rem);
         }
 
         .vertical-overflow-action-bar {
-          block-size: 18rem;
-          inline-size: 8rem;
+          block-size: clamp(10rem, 55vh, 18rem);
+          inline-size: clamp(6rem, 25vw, 8rem);
+        }
+
+        .vertical-expanded-action-bar {
+          inline-size: clamp(14rem, 45vw, 18rem);
+          min-block-size: clamp(12rem, 50vh, 20rem);
         }
 
         .tool-group {
@@ -84,10 +98,12 @@
         }
       </style>
 
+      <h3>Vertical Action bars</h3>
+
       <div class="demo-stack">
         <div class="demo-row">
           <span class="demo-label">Vertical multiple selection</span>
-          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled>
             <calcite-action-group selection-mode="multiple">
               <calcite-action text="Add" icon="plus"></calcite-action>
               <calcite-action text="Layers" icon="layers"></calcite-action>
@@ -98,7 +114,7 @@
 
         <div class="demo-row">
           <span class="demo-label">Vertical single selection</span>
-          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled>
             <calcite-action-group selection-mode="single">
               <calcite-action text="Draw" icon="pencil"></calcite-action>
               <calcite-action text="Measure" icon="measure"></calcite-action>
@@ -108,7 +124,20 @@
         </div>
 
         <div class="demo-row">
-          <span class="demo-label">Vertical single selection (automatic overflow disabled)</span>
+          <span class="demo-label">Vertical single persist selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled>
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <calcite-action text="Select" icon="cursor"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label"
+            >Vertical action-bar with different selection-modes (single, multiple, single-persist)</span
+          >
           <calcite-action-bar
             class="keyboard-nav-action-bar narrow-action-bar vertical-overflow-action-bar"
             expand-disabled
@@ -117,19 +146,62 @@
             <calcite-action-group selection-mode="single" label="Edit actions">
               <calcite-action text="Identify" icon="information"></calcite-action>
               <calcite-action text="Filter" icon="filter"></calcite-action>
-              <calcite-action text="Refresh" icon="refresh"></calcite-action>
+              <!-- <calcite-action text="Refresh" icon="refresh"></calcite-action> -->
             </calcite-action-group>
             <calcite-action-group selection-mode="multiple" label="Share actions">
               <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
               <calcite-action text="Settings" icon="gear"></calcite-action>
-              <calcite-action text="Configure" icon="sliders"></calcite-action>
-              <calcite-action text="Share" icon="share"></calcite-action>
+              <!-- <calcite-action text="Configure" icon="sliders"></calcite-action> -->
+              <!-- <calcite-action text="Share" icon="share"></calcite-action> -->
+            </calcite-action-group>
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <!-- <calcite-action text="Select" icon="cursor"></calcite-action> -->
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+      </div>
+
+      <h3>Horizontal Action bars</h3>
+      <div class="demo-stack">
+        <div class="demo-row">
+          <span class="demo-label">Horizontal multiple selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled layout="horizontal">
+            <calcite-action-group selection-mode="multiple">
+              <calcite-action text="Add" icon="plus"></calcite-action>
+              <calcite-action text="Layers" icon="layers"></calcite-action>
+              <calcite-action text="Save" icon="save"></calcite-action>
             </calcite-action-group>
           </calcite-action-bar>
         </div>
 
         <div class="demo-row">
-          <span class="demo-label">Horizontal multiple selection (automatic overflow disabled)</span>
+          <span class="demo-label">Horizontal single selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled layout="horizontal">
+            <calcite-action-group selection-mode="single">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <calcite-action text="Select" icon="cursor"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label">Horizontal single persist selection</span>
+          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled layout="horizontal">
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <calcite-action text="Select" icon="cursor"></calcite-action>
+            </calcite-action-group>
+          </calcite-action-bar>
+        </div>
+
+        <div class="demo-row">
+          <span class="demo-label"
+            >Horizontal action-bar with different selection-modes (multiple, single, single-persist)</span
+          >
           <calcite-action-bar class="keyboard-nav-action-bar narrow-action-bar" expand-disabled layout="horizontal">
             <calcite-action-group selection-mode="multiple" label="View actions">
               <calcite-action text="Identify" icon="information"></calcite-action>
@@ -141,11 +213,16 @@
               <calcite-action text="Settings" icon="gear"></calcite-action>
               <calcite-action text="Configure" icon="sliders"></calcite-action>
             </calcite-action-group>
+            <calcite-action-group selection-mode="single-persist">
+              <calcite-action text="Draw" icon="pencil"></calcite-action>
+              <calcite-action text="Measure" icon="measure"></calcite-action>
+              <calcite-action text="Select" icon="cursor"></calcite-action>
+            </calcite-action-group>
           </calcite-action-bar>
         </div>
 
         <div class="demo-row">
-          <span class="demo-label">Horizontal non-selection group (overflow menu allowed)</span>
+          <span class="demo-label">Horizontal with selection-mode none (default)</span>
           <calcite-action-bar class="keyboard-nav-action-bar narrow-action-bar" expand-disabled layout="horizontal">
             <calcite-action-group>
               <calcite-action text="Identify" icon="information"></calcite-action>
@@ -160,118 +237,20 @@
             </calcite-action-group>
           </calcite-action-bar>
         </div>
+      </div>
 
+      <h3>Other examples</h3>
+      <div class="demo-stack">
         <div class="demo-row">
-          <span class="demo-label">Vertical non-selection group (overflow menu allowed)</span>
-          <calcite-action-bar
-            class="keyboard-nav-action-bar narrow-action-bar vertical-overflow-action-bar"
-            expand-disabled
-            layout="vertical"
-          >
-            <calcite-action-group>
-              <calcite-action text="Identify" icon="information"></calcite-action>
-              <calcite-action text="Filter" icon="filter"></calcite-action>
-              <calcite-action text="Refresh" icon="refresh"></calcite-action>
-              <calcite-action text="Bookmark" icon="bookmark"></calcite-action>
-              <calcite-action text="Settings" icon="gear"></calcite-action>
-              <calcite-action text="Configure" icon="sliders"></calcite-action>
-              <calcite-action text="Share" icon="share"></calcite-action>
-              <calcite-action text="Export" icon="download"></calcite-action>
-              <calcite-action text="Print" icon="print"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div class="demo-row">
-          <span class="demo-label">Horizontal single-persist selection</span>
-          <calcite-action-bar
-            class="keyboard-nav-action-bar"
-            expand-disabled
-            layout="horizontal"
-            overflow-actions-disabled
-          >
-            <calcite-action-group selection-mode="single-persist">
-              <calcite-action active text="Pan" icon="pan"></calcite-action>
-              <calcite-action text="Zoom in" icon="zoom-in-fixed"></calcite-action>
-              <calcite-action text="Zoom out" icon="zoom-out-fixed"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div class="demo-row">
-          <span class="demo-label">Multiple selection - overflow disabled</span>
-          <calcite-action-bar
-            class="keyboard-nav-action-bar narrow-action-bar"
-            expand-disabled
-            overflow-actions-disabled
-          >
-            <calcite-action-group selection-mode="multiple">
-              <calcite-action text="Add" icon="plus"></calcite-action>
-              <calcite-action text="Undo" icon="undo"></calcite-action>
-              <calcite-action text="Redo" icon="redo"></calcite-action>
-              <calcite-action text="Save" icon="save"></calcite-action>
-              <calcite-action text="Delete" icon="trash"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div class="demo-row">
-          <span class="demo-label">Single selection - overflow disabled</span>
-          <calcite-action-bar
-            class="keyboard-nav-action-bar narrow-action-bar"
-            expand-disabled
-            overflow-actions-disabled
-          >
-            <calcite-action-group selection-mode="single">
-              <calcite-action text="Point" icon="pin"></calcite-action>
-              <calcite-action text="Line" icon="line"></calcite-action>
-              <calcite-action text="Area" icon="polygon"></calcite-action>
-              <calcite-action text="Circle" icon="circle"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div class="demo-row">
-          <span class="demo-label">Single-persist selection - overflow disabled</span>
-          <calcite-action-bar
-            class="keyboard-nav-action-bar narrow-action-bar"
-            expand-disabled
-            overflow-actions-disabled
-          >
-            <calcite-action-group selection-mode="single-persist">
-              <calcite-action active text="Pan" icon="pan"></calcite-action>
-              <calcite-action text="Zoom in" icon="zoom-in-fixed"></calcite-action>
-              <calcite-action text="Zoom out" icon="zoom-out-fixed"></calcite-action>
-              <calcite-action text="Full extent" icon="extent"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div class="demo-row">
-          <span class="demo-label">Two vertical bars for Tab then ArrowDown</span>
-          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
-            <calcite-action-group selection-mode="multiple">
-              <calcite-action text="First add" icon="plus"></calcite-action>
-              <calcite-action text="First save" icon="save"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-          <calcite-action-bar class="keyboard-nav-action-bar" expand-disabled overflow-actions-disabled>
-            <calcite-action-group selection-mode="multiple">
-              <calcite-action text="Second layers" icon="layers"></calcite-action>
-              <calcite-action text="Second basemaps" icon="layer-basemap"></calcite-action>
-            </calcite-action-group>
-          </calcite-action-bar>
-        </div>
-
-        <div>
-          <calcite-action-bar layout="horizontal" expand-disabled floating>
-            <calcite-action-group selection-mode="single-persist">
+          <span class="demo-label">Vertical action bar with selection mode none</span>
+          <calcite-action-bar class="vertical-expanded-action-bar" layout="vertical" expand-disabled floating>
+            <calcite-action-group selection-mode="none">
               <calcite-action text="Curve" icon="curve"></calcite-action>
-              <calcite-action text="Right angle" icon="right-angle"></calcite-action>
+              <calcite-action text="Configure" icon="sliders"></calcite-action>
               <calcite-action text="Line" icon="line"></calcite-action>
               <calcite-action text="Line straight" icon="line-straight"></calcite-action>
             </calcite-action-group>
-            <calcite-action-group selection-mode="multiple">
+            <calcite-action-group>
               <calcite-action text="Split geometry" icon="split-geometry"></calcite-action>
               <calcite-action text="Stretch" icon="stretch"></calcite-action>
               <calcite-action text="Trace" icon="trace"></calcite-action>
@@ -280,13 +259,13 @@
         </div>
 
         <div class="demo-row">
-          <span class="demo-label">Floating text formatting toolbar</span>
+          <span class="demo-label">Toolbar example (multiple, single-persist, none, none)</span>
           <calcite-action-bar
             id="font-configuration-settings"
+            class="toolbar-action-bar"
             layout="horizontal"
             floating
             expand-disabled
-            overflow-actions-disabled
           >
             <calcite-action-group label="Text formatting" selection-mode="multiple">
               <calcite-action id="bold" active context text="Bold" icon="bold"></calcite-action>
@@ -316,7 +295,7 @@
                 <span>Right align text</span>
               </calcite-tooltip>
             </calcite-action-group>
-            <calcite-action-group label="Text lists - disabled" selection-mode="single">
+            <calcite-action-group label="Text lists - disabled">
               <calcite-action id="list-bullet" disabled text="Bullet list" icon="list-bullet"></calcite-action>
               <calcite-tooltip reference-element="list-bullet" placement="bottom">
                 <span>Bullet list - disabled</span>
@@ -326,40 +305,60 @@
                 <span>Numbered list - disabled</span>
               </calcite-tooltip>
             </calcite-action-group>
-            <calcite-action-group label="Align items - disabled" selection-mode="single">
-              <calcite-action
-                id="align-items-left"
-                disabled
-                text="Align items left"
-                icon="ltr-elements-align"
-              ></calcite-action>
+            <calcite-action-group label="Align items - disabled">
+              <calcite-action id="align-items-left" text="Align items left" icon="ltr-elements-align"></calcite-action>
               <calcite-tooltip reference-element="align-items-left" placement="bottom">
                 <span>Align items left - disabled</span>
               </calcite-tooltip>
               <calcite-action
                 id="align-items-right"
-                disabled
                 text="Align items right"
                 icon="rtl-elements-align"
               ></calcite-action>
               <calcite-tooltip reference-element="align-items-right" placement="bottom">
                 <span>Align items right - disabled</span>
               </calcite-tooltip>
-              <calcite-action
-                id="add-config"
-                disabled
-                text="Additional configurations"
-                icon="ellipsis"
-              ></calcite-action>
+              <calcite-action id="add-config" text="Additional configurations" icon="ellipsis"></calcite-action>
               <calcite-tooltip reference-element="add-config" placement="bottom">
                 <span>Additional configurations - disabled</span>
               </calcite-tooltip>
             </calcite-action-group>
           </calcite-action-bar>
         </div>
-
-        <p id="text-example">Some great content</p>
       </div>
+
+      <p id="text-example">Some great content</p>
+
+      <script>
+        const actionEls = [...document.getElementsByTagName("calcite-action")];
+        const textExample = document.getElementById("text-example");
+
+        actionEls.forEach((actionEl) => {
+          actionEl.addEventListener("click", () => {
+            requestAnimationFrame(() => {
+              if (actionEl.text == "Bold" && actionEl.active) {
+                textExample.style.setProperty("font-weight", "var(--calcite-font-weight-bold)");
+              } else if (actionEl.text == "Bold" && !actionEl.active) {
+                textExample.style.setProperty("font-weight", "var(--calcite-font-weight-normal)");
+              } else if (actionEl.text == "Italicize" && actionEl.active) {
+                textExample.style.setProperty("font-style", "var(--calcite-font-style-emphasis)");
+              } else if (actionEl.text == "Italicize" && !actionEl.active) {
+                textExample.style.setProperty("font-style", "var(--calcite-font-style-normal)");
+              } else if (actionEl.text == "Underline" && actionEl.active) {
+                textExample.style.setProperty("text-decoration", "underline");
+              } else if (actionEl.text == "Underline" && !actionEl.active) {
+                textExample.style.setProperty("text-decoration", "none");
+              } else if (actionEl.text == "Left align text" && actionEl.active) {
+                textExample.style.setProperty("text-align", "left");
+              } else if (actionEl.text == "Center align text" && actionEl.active) {
+                textExample.style.setProperty("text-align", "center");
+              } else if (actionEl.text == "Right align text" && actionEl.active) {
+                textExample.style.setProperty("text-align", "right");
+              }
+            });
+          });
+        });
+      </script>
     </demo-dom-swapper>
     <demo-options></demo-options>
   </body>

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -19,6 +19,7 @@ import { SLOTS } from "./resources";
 import { ActionBar } from "./action-bar";
 import type { Action } from "../action/action";
 import type { ActionGroup } from "../action-group/action-group";
+import type { ActionMenu } from "../action-menu/action-menu";
 import { overflowActions } from "./utils";
 import { html } from "lit";
 
@@ -145,6 +146,26 @@ describe("translation support", () => {
 });
 
 describe("selection-mode", () => {
+  it("automatically disables overflow layout and hides the overflow menu when selection mode is enabled", async () => {
+    const { el } = await mount<"calcite-action-bar">(
+      <calcite-action-bar expand-disabled layout="horizontal">
+        <calcite-action-group selection-mode="multiple">
+          <calcite-action icon="information" text="Identify" />
+          <calcite-action icon="filter" text="Filter" />
+          <calcite-action icon="refresh" text="Refresh" />
+          <calcite-action icon="bookmark" text="Bookmark" />
+          <calcite-action icon="gear" text="Settings" />
+          <calcite-action icon="sliders" text="Configure" />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    const actionGroup = el.querySelector("calcite-action-group");
+    const actionMenu = actionGroup?.shadowRoot?.querySelector("calcite-action-menu");
+
+    expect(actionMenu?.hidden).toBe(true);
+  });
+
   it("supports toolbar pattern keyboard navigation", async () => {
     await mount<"calcite-action-bar">(
       <calcite-action-bar expand-disabled layout="horizontal" overflow-actions-disabled>
@@ -177,6 +198,37 @@ describe("selection-mode", () => {
 
     await userEvent.keyboard("{Enter}");
     expect(action1.active).toBe(true);
+  });
+
+  it("does not use secondary arrow keys within multiple-selection action group", async () => {
+    await mount<"calcite-action-bar">(
+      <calcite-action-bar expand-disabled layout="horizontal" overflow-actions-disabled>
+        <calcite-action-group selection-mode="multiple">
+          <calcite-action
+            data-testid="secondary-nav-add"
+            icon="plus"
+            label="Secondary nav add"
+            text="add"
+          />
+          <calcite-action icon="save" label="Secondary nav save" text="save" />
+          <calcite-action icon="trash" label="Secondary nav delete" text="delete" />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    const action1 = page.getByTestId("secondary-nav-add");
+
+    await userEvent.click(action1);
+    await expect.element(action1).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(action1).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(action1).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowUp}");
+    await expect.element(action1).toHaveFocus();
   });
 
   it("has single-persist and multiple selection modes", async () => {
@@ -548,6 +600,219 @@ describe("per-group overflow-actions-disabled", () => {
 
     await userEvent.keyboard("{ArrowDown}");
     await expect.element(secondNextAction).toHaveFocus();
+  });
+
+  it("tabs backward from the current action when multiple action bars are present", async () => {
+    await mount(html`
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="first-bar-action"
+            icon="number-circle1"
+            text="first"
+          ></calcite-action>
+          <calcite-action
+            data-testid="first-bar-next-action"
+            icon="number-circle2"
+            text="second"
+          ></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="second-bar-action"
+            icon="number-circle3"
+            text="third"
+          ></calcite-action>
+          <calcite-action
+            data-testid="second-bar-next-action"
+            icon="number-circle4"
+            text="fourth"
+          ></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+    `);
+
+    const firstAction = page.getByTestId("first-bar-action");
+    const firstNextAction = page.getByTestId("first-bar-next-action");
+    const secondAction = page.getByTestId("second-bar-action");
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(firstNextAction).toHaveFocus();
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(secondAction).toHaveFocus();
+
+    await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+    await expect.element(firstNextAction).toHaveFocus();
+  });
+
+  it("opens a focused action menu with Enter", async () => {
+    await mount(html`
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="first-action"
+            icon="number-circle1"
+            text="first"
+          ></calcite-action>
+        </calcite-action-group>
+        <calcite-action-menu data-testid="action-menu" label="more">
+          <calcite-action icon="number-circle2" text="second"></calcite-action>
+        </calcite-action-menu>
+      </calcite-action-bar>
+    `);
+
+    const firstAction = page.getByTestId("first-action");
+    const actionMenu = page.getByTestId("action-menu").element() as HTMLElement & {
+      open: boolean;
+    };
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(actionMenu).toHaveFocus();
+
+    await userEvent.keyboard("{Enter}");
+    expect(actionMenu.open).toBe(true);
+  });
+
+  it("opens a focused overflow action menu at its last item in a vertical action bar", async () => {
+    await mount<"calcite-action-bar">(
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group data-testid="overflow-action-group">
+          <calcite-action data-testid="first-action" icon="number-circle1" text="first" />
+          <calcite-action
+            icon="number-circle2"
+            id="second-action"
+            slot="menu-actions"
+            text="second"
+          />
+          <calcite-action
+            data-testid="third-action"
+            icon="number-circle3"
+            id="third-action"
+            slot="menu-actions"
+            text="third"
+          />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    const firstAction = page.getByTestId("first-action");
+    const actionGroup = page.getByTestId("overflow-action-group").element() as ActionGroup["el"];
+    const actionMenu = actionGroup.shadowRoot?.querySelector(
+      "calcite-action-menu",
+    ) as ActionMenu["el"];
+    const thirdAction = page.getByTestId("third-action").element();
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ArrowLeft}");
+
+    expect(actionMenu.open).toBe(true);
+    expect(actionMenu.ariaActiveDescendantElement).toBe(thirdAction);
+  });
+
+  it("opens a focused overflow action menu at its first item in a vertical action bar", async () => {
+    await mount<"calcite-action-bar">(
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group data-testid="overflow-action-group">
+          <calcite-action data-testid="first-action" icon="number-circle1" text="first" />
+          <calcite-action
+            data-testid="second-action"
+            icon="number-circle2"
+            id="second-action"
+            slot="menu-actions"
+            text="second"
+          />
+          <calcite-action
+            icon="number-circle3"
+            id="third-action"
+            slot="menu-actions"
+            text="third"
+          />
+        </calcite-action-group>
+      </calcite-action-bar>,
+    );
+
+    const firstAction = page.getByTestId("first-action");
+    const actionGroup = page.getByTestId("overflow-action-group").element() as ActionGroup["el"];
+    const actionMenu = actionGroup.shadowRoot?.querySelector(
+      "calcite-action-menu",
+    ) as ActionMenu["el"];
+    const secondAction = page.getByTestId("second-action").element();
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ArrowRight}");
+
+    expect(actionMenu.open).toBe(true);
+    expect(actionMenu.ariaActiveDescendantElement).toBe(secondAction);
+  });
+
+  it("tabs backward to the previous action menu when multiple action bars are present", async () => {
+    await mount(html`
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="first-bar-action"
+            icon="number-circle1"
+            text="first"
+          ></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="second-bar-action"
+            icon="number-circle2"
+            text="second"
+          ></calcite-action>
+        </calcite-action-group>
+        <calcite-action-menu data-testid="second-bar-menu" label="more">
+          <calcite-action icon="number-circle3" text="third"></calcite-action>
+        </calcite-action-menu>
+      </calcite-action-bar>
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group>
+          <calcite-action
+            data-testid="third-bar-action"
+            icon="number-circle4"
+            text="fourth"
+          ></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+    `);
+
+    const firstAction = page.getByTestId("first-bar-action");
+    const secondAction = page.getByTestId("second-bar-action");
+    const actionMenu = page.getByTestId("second-bar-menu").element() as HTMLElement;
+    const thirdAction = page.getByTestId("third-bar-action");
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(secondAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(actionMenu).toHaveFocus();
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(thirdAction).toHaveFocus();
+
+    await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
+    await expect.element(actionMenu).toHaveFocus();
   });
 });
 

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -147,7 +147,7 @@ describe("translation support", () => {
 describe("selection-mode", () => {
   it("supports toolbar pattern keyboard navigation", async () => {
     await mount<"calcite-action-bar">(
-      <calcite-action-bar overflow-actions-disabled>
+      <calcite-action-bar expand-disabled layout="horizontal" overflow-actions-disabled>
         <calcite-action-group selection-mode="single-persist">
           <calcite-action icon="plus" text="Add" />
           <calcite-action icon="save" text="Save" />
@@ -459,6 +459,95 @@ describe("per-group overflow-actions-disabled", () => {
 
     await userEvent.keyboard("{Shift>}{Tab}{Shift/}");
     expect(document.body).toHaveFocus();
+  });
+
+  it("clears action focus styling after focus returns from an action menu", async () => {
+    const { component, el } = await mount<ActionBar>(
+      <calcite-action-bar expand-disabled>
+        <calcite-action icon="number-circle1" id="first-action" text="first" />
+        <calcite-action-menu id="action-menu">
+          <calcite-action icon="number-circle2" id="menu-action" text="second" />
+        </calcite-action-menu>
+      </calcite-action-bar>,
+    );
+
+    const actionMenu = page.getBySelector("#action-menu").element() as HTMLElement;
+    const firstAction = page.getBySelector("#first-action").element() as Action["el"];
+    const menuAction = page.getBySelector("#menu-action").element() as HTMLElement;
+
+    (actionMenu as typeof actionMenu & { open: boolean }).open = true;
+    menuAction.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+    await component.updateComplete;
+    expect(el).toHaveAttribute("aria-activedescendant", "menu-action");
+
+    (actionMenu as typeof actionMenu & { open: boolean }).open = false;
+    actionMenu.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+    await component.updateComplete;
+    expect(el).not.toHaveAttribute("aria-activedescendant");
+    expect(firstAction.activeDescendant).toBe(false);
+  });
+
+  it("clears action focus styling when focus moves to another action bar", async () => {
+    await mount(html`
+      <calcite-action-bar expand-disabled>
+        <calcite-action id="first-bar-action" icon="number-circle1" text="first"></calcite-action>
+      </calcite-action-bar>
+      <calcite-action-bar expand-disabled>
+        <calcite-action id="second-bar-action" icon="number-circle2" text="second"></calcite-action>
+      </calcite-action-bar>
+    `);
+
+    const [firstActionBar, secondActionBar] = page
+      .getBySelector("calcite-action-bar")
+      .elements() as ActionBar["el"][];
+    const firstAction = page.getBySelector("#first-bar-action").element() as Action["el"];
+    const secondAction = page.getBySelector("#second-bar-action").element() as Action["el"];
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(firstAction).toHaveFocus();
+    expect(firstAction.activeDescendant).toBe(true);
+    expect(firstActionBar).toHaveAttribute("aria-activedescendant", "first-bar-action");
+
+    await userEvent.keyboard("{Tab}");
+    await expect.element(secondAction).toHaveFocus();
+    expect(firstAction.activeDescendant).toBe(false);
+    expect(firstActionBar).not.toHaveAttribute("aria-activedescendant");
+    expect(secondAction.activeDescendant).toBe(true);
+    expect(secondActionBar).toHaveAttribute("aria-activedescendant", "second-bar-action");
+  });
+
+  it("supports keyboard navigation after focus moves to another action bar", async () => {
+    await mount(html`
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group selection-mode="multiple">
+          <calcite-action id="first-bar-action" icon="number-circle1" text="first"></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+      <calcite-action-bar expand-disabled>
+        <calcite-action-group selection-mode="multiple">
+          <calcite-action
+            data-testid="second-bar-action"
+            icon="number-circle2"
+            text="second"
+          ></calcite-action>
+          <calcite-action
+            data-testid="second-bar-next-action"
+            icon="number-circle3"
+            text="third"
+          ></calcite-action>
+        </calcite-action-group>
+      </calcite-action-bar>
+    `);
+
+    const secondAction = page.getByTestId("second-bar-action");
+    const secondNextAction = page.getByTestId("second-bar-next-action");
+
+    await userEvent.keyboard("{Tab}");
+    await userEvent.keyboard("{Tab}");
+    await expect.element(secondAction).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(secondNextAction).toHaveFocus();
   });
 });
 

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -31,6 +31,7 @@ import { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import { getOverflowCount } from "../../utils/overflow";
 import { type ActionMenu } from "../action-menu/action-menu";
+import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { guid } from "../../utils/guid";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, IDS, SLOTS } from "./resources";
@@ -71,6 +72,10 @@ export class ActionBar extends LitElement {
   private expandToggleEl?: Action["el"];
 
   private actionGroups: ActionGroup["el"][] = [];
+
+  private actionMenuIdIndex = 0;
+
+  private actionGroupsRenderSync = 0;
 
   private mutationObserver = createObserver("mutation", () => this.mutationObserverHandler());
 
@@ -310,7 +315,7 @@ export class ActionBar extends LitElement {
       "calciteActionMenuOpen",
       this.actionMenuOpenHandler,
     );
-    this.listen("keydown", this.handleKeyDown);
+    this.listen("keydown", this.handleKeyDown, { capture: true });
     this.listen("focusin", this.handleFocusIn);
   }
 
@@ -411,10 +416,6 @@ export class ActionBar extends LitElement {
   private actionMenuOpenHandler(event: CustomEvent<void>): void {
     const actionMenu = event.target as ActionMenu["el"];
 
-    if (actionMenu) {
-      this.setActiveDescendantId(actionMenu.id);
-    }
-
     if ((event.target as ActionGroup["el"]).menuOpen) {
       const composedPath = event.composedPath();
       this.actionGroups?.forEach((group) => {
@@ -426,6 +427,11 @@ export class ActionBar extends LitElement {
 
     if (actionMenu?.open) {
       this.syncActiveDescendantToActionMenu(actionMenu);
+      return;
+    }
+
+    if (actionMenu) {
+      this.syncActiveDescendant(actionMenu);
       return;
     }
 
@@ -453,6 +459,27 @@ export class ActionBar extends LitElement {
     });
 
     this.ensureActionBarChildIds();
+    this.syncNavigationItemsAfterActionGroupsRender();
+  }
+
+  private syncNavigationItemsAfterActionGroupsRender(): void {
+    const sync = ++this.actionGroupsRenderSync;
+    const { actionGroups } = this;
+
+    void Promise.all(
+      actionGroups.map(async (group) => {
+        await group.componentOnReady();
+        await group.manager.component.updateComplete;
+      }),
+    ).then(() => {
+      if (sync !== this.actionGroupsRenderSync || !this.el.isConnected) {
+        return;
+      }
+
+      this.queryAndStoreNavigableItems();
+      this.syncActiveDescendant();
+      this.updateActions();
+    });
   }
 
   private handleDefaultSlotChange(): void {
@@ -492,55 +519,102 @@ export class ActionBar extends LitElement {
 
     this.actions = Array.from(this.el.querySelectorAll("calcite-action"));
 
-    const shadowActionMenus = this.actionGroups
-      .flatMap((group) =>
-        group.shadowRoot
-          ? Array.from(group.shadowRoot.querySelectorAll("calcite-action-menu"))
-          : [],
-      )
-      .filter((menu): menu is ActionMenu["el"] => {
-        if (menu.hasAttribute("hidden")) {
-          return false;
-        }
+    const navigationItems: Array<Action["el"] | ActionMenu["el"]> = [];
+    const internalStartGroup = this.el.shadowRoot?.querySelector(`.${CSS.actionGroupStart}`) as
+      | ActionGroup["el"]
+      | null;
+    const internalEndGroup = this.el.shadowRoot?.querySelector(`.${CSS.actionGroupEnd}`) as
+      | ActionGroup["el"]
+      | null;
 
-        this.syncActionMenuId(menu);
-        return !!menu.id;
-      });
+    if (internalStartGroup) {
+      navigationItems.push(...this.getActionGroupNavigationItems(internalStartGroup));
+    }
 
-    const lightDomNavigationItems = Array.from(
-      this.el.querySelectorAll("calcite-action, calcite-action-menu"),
-    ).filter((el): el is Action["el"] | ActionMenu["el"] => {
-      if (isAction(el)) {
-        if (el.disabled || el.hasAttribute("hidden")) {
-          return false;
-        }
-
-        const closestMenu = el.closest("calcite-action-menu");
-        return !closestMenu;
+    Array.from(this.el.children).forEach((child) => {
+      if (child.slot === SLOTS.actionsStart || child.slot === SLOTS.actionsEnd) {
+        return;
       }
 
-      if (el.hasAttribute("hidden")) {
-        return false;
+      if (isAction(child)) {
+        if (this.isNavigableAction(child)) {
+          navigationItems.push(child);
+        }
+        return;
       }
 
-      this.syncActionMenuId(el as ActionMenu["el"]);
-      return !!el.id;
+      if (child.matches("calcite-action-menu")) {
+        const actionMenu = child;
+
+        if (this.isNavigableActionMenu(actionMenu)) {
+          navigationItems.push(actionMenu);
+        }
+        return;
+      }
+
+      if (child.matches("calcite-action-group")) {
+        const actionGroup = child;
+
+        navigationItems.push(...this.getActionGroupNavigationItems(actionGroup));
+      }
     });
 
-    this.navigationItems = [...lightDomNavigationItems, ...shadowActionMenus];
+    if (internalEndGroup) {
+      navigationItems.push(...this.getActionGroupNavigationItems(internalEndGroup));
+    }
 
-    console.log("calcite-action-bar navigation items", {
-      navigationItems: this.navigationItems.map((item) => ({
-        id: item.id,
-        tagName: item.tagName.toLowerCase(),
-      })),
-    });
+    this.navigationItems = navigationItems;
+
+    console.log("calcite-action-bar active element id", document.activeElement?.id);
+  }
+
+  private getActionGroupNavigationItems(
+    actionGroup: ActionGroup["el"],
+  ): Array<Action["el"] | ActionMenu["el"]> {
+    if (actionGroup.hasAttribute("hidden")) {
+      return [];
+    }
+
+    const actions = [
+      ...Array.from(actionGroup.querySelectorAll("calcite-action")),
+      ...Array.from(actionGroup.querySelectorAll("slot")).flatMap((slot) =>
+        slot.assignedElements({ flatten: true }).filter((el): el is Action["el"] => isAction(el)),
+      ),
+    ].filter((action) => this.isNavigableAction(action));
+
+    const actionMenu = actionGroup.shadowRoot?.querySelector("calcite-action-menu");
+
+    return actionMenu && this.isNavigableActionMenu(actionMenu)
+      ? [...actions, actionMenu]
+      : actions;
+  }
+
+  private isNavigableAction(action: Action["el"]): boolean {
+    return (
+      !action.disabled &&
+      !action.hasAttribute("hidden") &&
+      action.slot !== "menu-actions" &&
+      !action.closest("calcite-action-menu")
+    );
+  }
+
+  private isNavigableActionMenu(actionMenu: ActionMenu["el"]): boolean {
+    if (actionMenu.hasAttribute("hidden")) {
+      return false;
+    }
+
+    this.syncActionMenuId(actionMenu);
+    return !!actionMenu.id;
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
-    const actionMenu = this.getEventActionMenu(event);
+    const actionMenu = this.getEventActionMenu(event) || this.getOpenActionMenu();
 
     if (actionMenu?.open) {
+      if (event.key === "Escape") {
+        return;
+      }
+
       this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
@@ -564,33 +638,39 @@ export class ActionBar extends LitElement {
         if (isVertical) {
           this.focusNavigationItem("next", current);
           event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "ArrowUp":
         if (isVertical) {
           this.focusNavigationItem("previous", current);
           event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "ArrowRight":
         if (!isVertical) {
           this.focusNavigationItem("next", current);
           event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "ArrowLeft":
         if (!isVertical) {
           this.focusNavigationItem("previous", current);
           event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "Home":
         this.focusNavigationItem("first", current);
         event.preventDefault();
+        event.stopPropagation();
         break;
       case "End":
         this.focusNavigationItem("last", current);
         event.preventDefault();
+        event.stopPropagation();
         break;
       case "Tab":
         this.setNavigationItemTabIndexes(current);
@@ -602,19 +682,21 @@ export class ActionBar extends LitElement {
   private handleFocusIn(event: FocusEvent): void {
     this.queryAndStoreNavigableItems();
 
-    const actionMenu = this.getEventActionMenu(event);
+    const focusedItem = this.getNavigationItemFromEvent(event);
+    const actionMenu = this.getEventActionMenu(event) || this.getOpenActionMenu();
+
     if (actionMenu?.open) {
       this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
 
-    if (actionMenu) {
+    if (focusedItem?.matches("calcite-action-menu") && actionMenu) {
       this.setActiveDescendantId(actionMenu.id);
       this.syncActiveDescendant(actionMenu);
       return;
     }
 
-    this.syncActiveDescendant(this.getNavigationItemFromEvent(event) ?? undefined);
+    this.syncActiveDescendant(focusedItem ?? undefined);
   }
 
   private focusNavigationItem(
@@ -656,6 +738,27 @@ export class ActionBar extends LitElement {
   }
 
   private focusItem(item: Action["el"] | ActionMenu["el"]): void {
+    if (item.matches("calcite-action-menu")) {
+      const triggerAction = [
+        item.querySelector("calcite-action[slot='trigger']"),
+        item.shadowRoot?.querySelector("calcite-action"),
+      ].find((el): el is Action["el"] => !!el && isAction(el));
+
+      if ("setFocus" in item && typeof item.setFocus === "function") {
+        void item.setFocus().then(() => {
+          if (!item.matches(":focus-within") && triggerAction) {
+            void triggerAction.setFocus();
+          }
+        });
+        return;
+      }
+
+      if (triggerAction) {
+        void triggerAction.setFocus();
+        return;
+      }
+    }
+
     if ("setFocus" in item && typeof item.setFocus === "function") {
       void item.setFocus();
       return;
@@ -679,10 +782,12 @@ export class ActionBar extends LitElement {
         return activeItem as Action["el"] | ActionMenu["el"];
       }
 
-      const activeItemId = (activeItem as Action["el"] | ActionMenu["el"]).id;
-      const activeNavigationItem = this.navigationItems.find((item) => item.id === activeItemId);
-      if (activeNavigationItem) {
-        return activeNavigationItem;
+      if (activeItem) {
+        const activeItemId = (activeItem as Action["el"] | ActionMenu["el"]).id;
+        const activeNavigationItem = this.navigationItems.find((item) => item.id === activeItemId);
+        if (activeNavigationItem) {
+          return activeNavigationItem;
+        }
       }
 
       const activeActionMenu = activeElement.closest("calcite-action-menu");
@@ -706,7 +811,11 @@ export class ActionBar extends LitElement {
       }
     }
 
-    return this.navigationItems[0];
+    return (
+      this.navigationItems.find(
+        (item): item is Action["el"] => isAction(item) && item !== this.expandToggleEl,
+      ) || this.navigationItems[0]
+    );
   }
 
   private getEventActionMenu(event: Event): ActionMenu["el"] | null {
@@ -732,34 +841,85 @@ export class ActionBar extends LitElement {
     return null;
   }
 
-  private syncActiveDescendantToActionMenu(actionMenu: ActionMenu["el"]): void {
-    const activeMenuItem =
-      actionMenu.querySelector("calcite-action[active-descendant]") ||
-      Array.from(actionMenu.querySelectorAll("calcite-action")).find(
-        (action) => !action.disabled && !action.hidden,
-      );
+  private getOpenActionMenu(): ActionMenu["el"] | undefined {
+    return this.navigationItems.find(
+      (item): item is ActionMenu["el"] => item.matches("calcite-action-menu") && item.open,
+    );
+  }
 
-    this.setActiveDescendantId(activeMenuItem?.id || this.getActionMenuId(actionMenu));
-    this.updateActions();
+  private syncActiveDescendantToActionMenu(actionMenu: ActionMenu["el"]): void {
+    const menuActions = this.getActionMenuActions(actionMenu);
+    const activeMenuItem =
+      menuActions.find((action) => action.activeDescendant) ||
+      menuActions.find((action) => !action.disabled && !action.hidden);
+
+    this.setActiveDescendantId(activeMenuItem?.id);
+    this.clearActionsActiveDescendant();
+  }
+
+  private clearActionsActiveDescendant(): void {
+    this.actions.forEach((action) => {
+      action.activeDescendant = false;
+    });
+  }
+
+  private getActionMenuActions(actionMenu: ActionMenu["el"]): Action["el"][] {
+    const directActions = Array.from(actionMenu.querySelectorAll("calcite-action"));
+    const slottedActions = [
+      ...Array.from(actionMenu.querySelectorAll("slot")),
+      ...Array.from(actionMenu.shadowRoot?.querySelectorAll("slot") ?? []),
+    ].flatMap((slot) =>
+      slot.assignedElements({ flatten: true }).flatMap((el) => {
+        if (isAction(el)) {
+          return [el];
+        }
+
+        if (el instanceof HTMLSlotElement) {
+          return el
+            .assignedElements({ flatten: true })
+            .filter((assignedEl): assignedEl is Action["el"] => isAction(assignedEl));
+        }
+
+        return [];
+      }),
+    );
+
+    return [...directActions, ...slottedActions].filter(
+      (action) => action.slot !== ACTION_MENU_SLOTS.trigger,
+    );
   }
 
   private getNavigationItemFromEvent(event: Event): Action["el"] | ActionMenu["el"] | null {
-    const pathItem = event
-      .composedPath()
-      .find(
-        (pathEl): pathEl is Action["el"] | ActionMenu["el"] =>
-          pathEl instanceof HTMLElement &&
-          pathEl.matches("calcite-action, calcite-action-menu") &&
-          this.navigationItems.some((item) => item === pathEl || item.id === pathEl.id),
+    for (const pathEl of event.composedPath()) {
+      if (
+        !(pathEl instanceof HTMLElement) ||
+        !pathEl.matches("calcite-action, calcite-action-menu")
+      ) {
+        continue;
+      }
+
+      const navigationItem = this.navigationItems.find(
+        (item) => item === pathEl || item.id === pathEl.id,
       );
 
-    if (!pathItem) {
-      return null;
+      if (navigationItem) {
+        return navigationItem;
+      }
+
+      const actionMenu = pathEl.closest("calcite-action-menu");
+      if (actionMenu) {
+        const actionMenuId = this.getActionMenuId(actionMenu);
+        const actionMenuNavigationItem = this.navigationItems.find(
+          (item) => item === actionMenu || item.id === actionMenuId,
+        );
+
+        if (actionMenuNavigationItem) {
+          return actionMenuNavigationItem;
+        }
+      }
     }
 
-    return (
-      this.navigationItems.find((item) => item === pathItem || item.id === pathItem.id) ?? null
-    );
+    return null;
   }
 
   private ensureActionBarChildIds(): void {
@@ -791,9 +951,13 @@ export class ActionBar extends LitElement {
       this.navigationItems.find((item) => item.id === this.activeDescendantId) ||
       this.getCurrentNavigationItem();
 
-    this.setActiveDescendantId(this.getNavigationItemId(current));
-
     this.setNavigationItemTabIndexes(current);
+
+    const activeDescendantId = this.el.matches(":focus-within")
+      ? this.getNavigationItemId(current)
+      : undefined;
+
+    this.setActiveDescendantId(activeDescendantId);
     this.updateActions();
   }
 
@@ -815,9 +979,7 @@ export class ActionBar extends LitElement {
     }
 
     const existingId = this.getActionMenuId(actionMenu);
-    if (existingId) {
-      actionMenu.id = existingId;
-    }
+    actionMenu.id = existingId || `${this.guid}-action-menu-${this.actionMenuIdIndex++}`;
   }
 
   private getActionMenuId(actionMenu: ActionMenu["el"]): string | undefined {
@@ -832,14 +994,6 @@ export class ActionBar extends LitElement {
     this.activeDescendantId = id;
     const toolbarEl = this.containerRef.value;
 
-    console.log("calcite-action-bar active descendant", {
-      activeDescendantId: this.activeDescendantId,
-      navigationItems: this.navigationItems.map((item) => ({
-        id: item.id,
-        tagName: item.tagName.toLowerCase(),
-      })),
-    });
-
     if (this.activeDescendantId) {
       this.el.setAttribute("aria-activedescendant", this.activeDescendantId);
       toolbarEl?.setAttribute("aria-activedescendant", this.activeDescendantId);
@@ -851,7 +1005,7 @@ export class ActionBar extends LitElement {
 
   private setNavigationItemTabIndexes(active: Action["el"] | ActionMenu["el"]): void {
     this.navigationItems.forEach((item) => {
-      const isActive = item === active;
+      const isActive = item === active || item.id === active.id;
 
       if (isAction(item)) {
         if (isActive && !item.disabled && !item.hidden) {
@@ -863,7 +1017,15 @@ export class ActionBar extends LitElement {
         return;
       }
 
-      item.tabIndex = isActive ? 0 : -1;
+      item.tabIndex = -1;
+
+      const triggerAction =
+        item.querySelector("calcite-action[slot='trigger']") ||
+        item.shadowRoot?.querySelector("calcite-action");
+
+      if (triggerAction) {
+        triggerAction.setAttribute("tabindex", isActive ? "0" : "-1");
+      }
     });
   }
 

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -13,13 +13,20 @@ import {
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
 import {
+  closestElementCrossShadowBoundary,
   getStylePixelValue,
   slotChangeGetAssignedElements,
   slotChangeHasAssignedElement,
 } from "../../utils/dom";
 import { createObserver } from "../../utils/observers";
 import { ExpandToggle, toggleChildActionText } from "../functional/ExpandToggle";
-import { Layout, Position, Scale, SelectionAppearance } from "../interfaces";
+import {
+  ActiveDescendantElement,
+  Layout,
+  Position,
+  Scale,
+  SelectionAppearance,
+} from "../interfaces";
 import { OverlayPositioning } from "../../utils/floating-ui";
 import { DEBOUNCE } from "../../utils/resources";
 import { useT9n } from "../../controllers/useT9n";
@@ -315,8 +322,13 @@ export class ActionBar extends LitElement {
       "calciteActionMenuOpen",
       this.actionMenuOpenHandler,
     );
+    this.listen<ToEvents<ActionMenu>["calciteInternalActiveDescendantChange"]>(
+      "calciteInternalActiveDescendantChange",
+      this.calciteInternalActiveDescendantChangeHandler,
+    );
     this.listen("keydown", this.handleKeyDown, { capture: true });
     this.listen("focusin", this.handleFocusIn);
+    this.listen("focusout", this.handleFocusOut);
   }
 
   override connectedCallback(): void {
@@ -426,12 +438,12 @@ export class ActionBar extends LitElement {
     }
 
     if (actionMenu?.open) {
-      this.syncActiveDescendantToActionMenu(actionMenu);
+      void this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
 
     if (actionMenu) {
-      this.syncActiveDescendant(actionMenu);
+      this.syncClosedActionMenu(actionMenu);
       return;
     }
 
@@ -510,8 +522,8 @@ export class ActionBar extends LitElement {
   private updateActions(): void {
     this.actions.forEach((action) => {
       action.selectionAppearance = this.selectionAppearance;
-      action.activeDescendant = action.id === this.activeDescendantId;
     });
+    this.updateActiveDescendantElements();
   }
 
   private queryAndStoreNavigableItems(): void {
@@ -564,8 +576,6 @@ export class ActionBar extends LitElement {
     }
 
     this.navigationItems = navigationItems;
-
-    console.log("calcite-action-bar active element id", document.activeElement?.id);
   }
 
   private getActionGroupNavigationItems(
@@ -607,6 +617,22 @@ export class ActionBar extends LitElement {
     return !!actionMenu.id;
   }
 
+  private calciteInternalActiveDescendantChangeHandler(event: CustomEvent<void>): void {
+    const actionMenu = this.getEventActionMenu(event);
+
+    if (!actionMenu?.open) {
+      return;
+    }
+
+    event.stopPropagation();
+    if (!actionMenu.activeDescendantElement) {
+      void this.syncActiveDescendantToActionMenu(actionMenu);
+      return;
+    }
+
+    this.setActiveDescendantElement(actionMenu.activeDescendantElement);
+  }
+
   private handleKeyDown(event: KeyboardEvent): void {
     const actionMenu = this.getEventActionMenu(event) || this.getOpenActionMenu();
 
@@ -614,8 +640,6 @@ export class ActionBar extends LitElement {
       if (event.key === "Escape") {
         return;
       }
-
-      this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
 
@@ -686,17 +710,29 @@ export class ActionBar extends LitElement {
     const actionMenu = this.getEventActionMenu(event) || this.getOpenActionMenu();
 
     if (actionMenu?.open) {
-      this.syncActiveDescendantToActionMenu(actionMenu);
+      void this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
 
     if (focusedItem?.matches("calcite-action-menu") && actionMenu) {
-      this.setActiveDescendantId(actionMenu.id);
-      this.syncActiveDescendant(actionMenu);
+      this.syncClosedActionMenu(actionMenu);
       return;
     }
 
     this.syncActiveDescendant(focusedItem ?? undefined);
+  }
+
+  private handleFocusOut(event: FocusEvent): void {
+    const { relatedTarget } = event;
+
+    if (
+      relatedTarget instanceof Element &&
+      closestElementCrossShadowBoundary(relatedTarget, "calcite-action-bar") === this.el
+    ) {
+      return;
+    }
+
+    this.setActiveDescendantElement();
   }
 
   private focusNavigationItem(
@@ -847,20 +883,57 @@ export class ActionBar extends LitElement {
     );
   }
 
-  private syncActiveDescendantToActionMenu(actionMenu: ActionMenu["el"]): void {
-    const menuActions = this.getActionMenuActions(actionMenu);
-    const activeMenuItem =
-      menuActions.find((action) => action.activeDescendant) ||
-      menuActions.find((action) => !action.disabled && !action.hidden);
+  private async syncActiveDescendantToActionMenu(actionMenu: ActionMenu["el"]): Promise<void> {
+    let menuActions = this.getActionMenuActions(actionMenu);
+    let activeMenuItem = this.getActiveActionMenuItem(menuActions);
 
-    this.setActiveDescendantId(activeMenuItem?.id);
-    this.clearActionsActiveDescendant();
+    if (!activeMenuItem && actionMenu.open) {
+      await actionMenu.componentOnReady();
+
+      if (!actionMenu.open) {
+        return;
+      }
+
+      menuActions = this.getActionMenuActions(actionMenu);
+      activeMenuItem = this.getActiveActionMenuItem(menuActions);
+    }
+
+    if (!activeMenuItem) {
+      return;
+    }
+
+    this.setActiveDescendantElement(activeMenuItem);
   }
 
-  private clearActionsActiveDescendant(): void {
+  private getActiveActionMenuItem(menuActions: Action["el"][]): Action["el"] | undefined {
+    return (
+      menuActions.find((action) => action.activeDescendant) ||
+      menuActions.find((action) => !action.disabled && !action.hidden)
+    );
+  }
+
+  private setActiveDescendantElement(activeDescendantElement?: ActiveDescendantElement): void {
+    this.setActiveDescendantId(activeDescendantElement?.id);
+    this.updateActiveDescendantElements();
+  }
+
+  private updateActiveDescendantElements(): void {
     this.actions.forEach((action) => {
-      action.activeDescendant = false;
+      action.activeDescendant = action.id === this.activeDescendantId;
     });
+  }
+
+  private syncClosedActionMenu(actionMenu: ActionMenu["el"]): void {
+    this.queryAndStoreNavigableItems();
+    const navigationActionMenu = this.navigationItems.find(
+      (item) => item === actionMenu || item.id === actionMenu.id,
+    );
+
+    if (navigationActionMenu) {
+      this.setNavigationItemTabIndexes(navigationActionMenu);
+    }
+
+    this.setActiveDescendantElement();
   }
 
   private getActionMenuActions(actionMenu: ActionMenu["el"]): Action["el"][] {
@@ -923,8 +996,8 @@ export class ActionBar extends LitElement {
   }
 
   private ensureActionBarChildIds(): void {
-    const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
-    const actions = Array.from(this.el.querySelectorAll("calcite-action"));
+    const groups = Array.from(this.el.getElementsByTagName("calcite-action-group"));
+    const actions = Array.from(this.el.getElementsByTagName("calcite-action"));
 
     groups.forEach((group, index) => {
       if (!group.id) {

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -76,6 +76,10 @@ export class ActionBar extends LitElement {
 
   private containerRef = createRef<HTMLDivElement>();
 
+  private actionsStartGroupRef = createRef<ActionGroup["el"]>();
+
+  private actionsEndGroupRef = createRef<ActionGroup["el"]>();
+
   private direction = useDirection();
 
   private expandToggleEl?: Action["el"];
@@ -333,7 +337,7 @@ export class ActionBar extends LitElement {
 
   override connectedCallback(): void {
     this.updateGroups();
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
     this.syncActiveDescendant();
     this.overflowActions();
     this.updateActions();
@@ -453,7 +457,7 @@ export class ActionBar extends LitElement {
   private mutationObserverHandler(): void {
     this.updateGroups();
     this.overflowActions();
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
     this.syncActiveDescendant();
     this.updateActions();
   }
@@ -483,14 +487,14 @@ export class ActionBar extends LitElement {
       return;
     }
 
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
     this.syncActiveDescendant();
     this.updateActions();
   }
 
   private handleDefaultSlotChange(): void {
     this.updateGroups();
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
     this.syncActiveDescendant();
     this.updateActions();
   }
@@ -520,18 +524,14 @@ export class ActionBar extends LitElement {
     this.updateActiveDescendantElements();
   }
 
-  private queryAndStoreNavigableItems(): void {
+  private updateNavigationItems(): void {
     this.ensureActionBarChildIds();
 
     this.actions = Array.from(this.el.querySelectorAll("calcite-action"));
 
     const navigationItems: Array<Action["el"] | ActionMenu["el"]> = [];
-    const internalStartGroup = this.el.shadowRoot?.querySelector(`.${CSS.actionGroupStart}`) as
-      | ActionGroup["el"]
-      | null;
-    const internalEndGroup = this.el.shadowRoot?.querySelector(`.${CSS.actionGroupEnd}`) as
-      | ActionGroup["el"]
-      | null;
+    const internalStartGroup = this.actionsStartGroupRef.value;
+    const internalEndGroup = this.actionsEndGroupRef.value;
 
     if (internalStartGroup) {
       navigationItems.push(...this.getActionGroupNavigationItems(internalStartGroup));
@@ -641,7 +641,7 @@ export class ActionBar extends LitElement {
       return;
     }
 
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
 
     const current = this.getNavigationItemFromEvent(event) ?? this.getCurrentNavigationItem();
 
@@ -698,7 +698,7 @@ export class ActionBar extends LitElement {
   }
 
   private handleFocusIn(event: FocusEvent): void {
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
 
     const focusedItem = this.getNavigationItemFromEvent(event);
     const actionMenu = this.getEventActionMenu(event) || this.getOpenActionMenu();
@@ -962,7 +962,7 @@ export class ActionBar extends LitElement {
   }
 
   private syncClosedActionMenu(actionMenu: ActionMenu["el"]): void {
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
     const navigationActionMenu = this.navigationItems.find(
       (item) => item === actionMenu || item.id === actionMenu.id,
     );
@@ -1051,7 +1051,7 @@ export class ActionBar extends LitElement {
   }
 
   private syncActiveDescendant(activeItem?: Action["el"] | ActionMenu["el"]): void {
-    this.queryAndStoreNavigableItems();
+    this.updateNavigationItems();
 
     const activeItemInNavigation = activeItem
       ? this.navigationItems.find((item) => item === activeItem || item.id === activeItem.id)
@@ -1189,6 +1189,7 @@ export class ActionBar extends LitElement {
     const label = isStart ? this.actionsStartGroupLabel : this.actionsEndGroupLabel;
     const hidden = !hasExpandToggle && !(isStart ? this.hasActionsStart : this.hasActionsEnd);
     const className = isStart ? CSS.actionGroupStart : CSS.actionGroupEnd;
+    const actionGroupRef = isStart ? this.actionsStartGroupRef : this.actionsEndGroupRef;
 
     return (
       <calcite-action-group
@@ -1197,6 +1198,7 @@ export class ActionBar extends LitElement {
         label={label}
         layout={layout}
         overlayPositioning={overlayPositioning}
+        ref={actionGroupRef}
         scale={scale}
       >
         {isStart && hasExpandToggle ? this.renderExpandToggle() : null}

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -70,6 +70,8 @@ export class ActionBar extends LitElement {
 
   private navigationItems: Array<Action["el"] | ActionMenu["el"]> = [];
 
+  private currentFocusItem?: Action["el"] | ActionMenu["el"];
+
   private guid = guid();
 
   private containerRef = createRef<HTMLDivElement>();
@@ -81,8 +83,6 @@ export class ActionBar extends LitElement {
   private actionGroups: ActionGroup["el"][] = [];
 
   private actionMenuIdIndex = 0;
-
-  private actionGroupsRenderSync = 0;
 
   private mutationObserver = createObserver("mutation", () => this.mutationObserverHandler());
 
@@ -471,27 +471,21 @@ export class ActionBar extends LitElement {
     });
 
     this.ensureActionBarChildIds();
-    this.syncNavigationItemsAfterActionGroupsRender();
+    void this.syncNavigationItemsAfterActionGroupsRender();
   }
 
-  private syncNavigationItemsAfterActionGroupsRender(): void {
-    const sync = ++this.actionGroupsRenderSync;
+  private async syncNavigationItemsAfterActionGroupsRender(): Promise<void> {
     const { actionGroups } = this;
 
-    void Promise.all(
-      actionGroups.map(async (group) => {
-        await group.componentOnReady();
-        await group.manager.component.updateComplete;
-      }),
-    ).then(() => {
-      if (sync !== this.actionGroupsRenderSync || !this.el.isConnected) {
-        return;
-      }
+    await Promise.all(actionGroups.map((group) => group.componentOnReady()));
 
-      this.queryAndStoreNavigableItems();
-      this.syncActiveDescendant();
-      this.updateActions();
-    });
+    if (!this.el.isConnected) {
+      return;
+    }
+
+    this.queryAndStoreNavigableItems();
+    this.syncActiveDescendant();
+    this.updateActions();
   }
 
   private handleDefaultSlotChange(): void {
@@ -715,11 +709,35 @@ export class ActionBar extends LitElement {
     }
 
     if (focusedItem?.matches("calcite-action-menu") && actionMenu) {
+      if (this.isForwardFocusIn(event)) {
+        const defaultNavigationItem = this.getDefaultNavigationItem();
+
+        if (defaultNavigationItem && defaultNavigationItem !== focusedItem) {
+          this.setNavigationItemTabIndexes(defaultNavigationItem);
+          this.focusItem(defaultNavigationItem);
+          return;
+        }
+      }
+
       this.syncClosedActionMenu(actionMenu);
       return;
     }
 
     this.syncActiveDescendant(focusedItem ?? undefined);
+  }
+
+  private isForwardFocusIn(focusEvent: FocusEvent): boolean {
+    const { relatedTarget } = focusEvent;
+
+    if (!(relatedTarget instanceof Element)) {
+      return false;
+    }
+
+    if (closestElementCrossShadowBoundary(relatedTarget, "calcite-action-bar") === this.el) {
+      return false;
+    }
+
+    return !!(relatedTarget.compareDocumentPosition(this.el) & Node.DOCUMENT_POSITION_FOLLOWING);
   }
 
   private handleFocusOut(event: FocusEvent): void {
@@ -803,7 +821,7 @@ export class ActionBar extends LitElement {
     item.focus();
   }
 
-  private getCurrentNavigationItem(): Action["el"] | ActionMenu["el"] {
+  private getCurrentNavigationItem(): Action["el"] | ActionMenu["el"] | undefined {
     const { activeElement } = document;
 
     if (activeElement instanceof HTMLElement) {
@@ -847,6 +865,26 @@ export class ActionBar extends LitElement {
       }
     }
 
+    const currentFocusItem = this.getCurrentFocusItem();
+
+    if (currentFocusItem) {
+      return currentFocusItem;
+    }
+
+    return this.getDefaultNavigationItem();
+  }
+
+  private getCurrentFocusItem(): Action["el"] | ActionMenu["el"] | undefined {
+    const { currentFocusItem } = this;
+
+    return currentFocusItem
+      ? this.navigationItems.find(
+          (item) => item === currentFocusItem || item.id === currentFocusItem.id,
+        )
+      : undefined;
+  }
+
+  private getDefaultNavigationItem(): Action["el"] | ActionMenu["el"] | undefined {
     return (
       this.navigationItems.find(
         (item): item is Action["el"] => isAction(item) && item !== this.expandToggleEl,
@@ -1024,6 +1062,11 @@ export class ActionBar extends LitElement {
       this.navigationItems.find((item) => item.id === this.activeDescendantId) ||
       this.getCurrentNavigationItem();
 
+    if (!current) {
+      this.setActiveDescendantElement();
+      return;
+    }
+
     this.setNavigationItemTabIndexes(current);
 
     const activeDescendantId = this.el.matches(":focus-within")
@@ -1077,6 +1120,8 @@ export class ActionBar extends LitElement {
   }
 
   private setNavigationItemTabIndexes(active: Action["el"] | ActionMenu["el"]): void {
+    this.currentFocusItem = active;
+
     this.navigationItems.forEach((item) => {
       const isActive = item === active || item.id === active.id;
 
@@ -1090,14 +1135,14 @@ export class ActionBar extends LitElement {
         return;
       }
 
-      item.tabIndex = -1;
+      item.tabIndex = isActive ? 0 : -1;
 
       const triggerAction =
         item.querySelector("calcite-action[slot='trigger']") ||
         item.shadowRoot?.querySelector("calcite-action");
 
       if (triggerAction) {
-        triggerAction.setAttribute("tabindex", isActive ? "0" : "-1");
+        triggerAction.setAttribute("tabindex", "-1");
       }
     });
   }

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -13,7 +13,6 @@ import {
 import { createRef } from "lit/directives/ref.js";
 import { useDirection } from "@arcgis/lumina/controllers";
 import {
-  focusElementInGroup,
   getStylePixelValue,
   slotChangeGetAssignedElements,
   slotChangeHasAssignedElement,
@@ -32,8 +31,9 @@ import { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import { getOverflowCount } from "../../utils/overflow";
 import { type ActionMenu } from "../action-menu/action-menu";
+import { guid } from "../../utils/guid";
 import T9nStrings from "./assets/t9n/messages.en.json";
-import { CSS, SLOTS } from "./resources";
+import { CSS, IDS, SLOTS } from "./resources";
 import { overflowActions, queryActions } from "./utils";
 import { styles } from "./action-bar.scss";
 
@@ -59,6 +59,10 @@ export class ActionBar extends LitElement {
   //#region Private Properties
 
   private actions: Action["el"][] = [];
+
+  private navigationItems: Array<Action["el"] | ActionMenu["el"]> = [];
+
+  private guid = guid();
 
   private containerRef = createRef<HTMLDivElement>();
 
@@ -176,7 +180,7 @@ export class ActionBar extends LitElement {
 
   private focusSetter = useSetFocus<this>()(this);
 
-  private setExpandToggleEl = (el: Action["el"]): void => {
+  private setExpandToggleEl = (el?: Action["el"]): void => {
     this.expandToggleEl = el;
   };
 
@@ -189,6 +193,8 @@ export class ActionBar extends LitElement {
   @state() hasActionsEnd = false;
 
   @state() hasActionsStart = false;
+
+  @state() activeDescendantId?: string;
 
   //#endregion
 
@@ -305,10 +311,13 @@ export class ActionBar extends LitElement {
       this.actionMenuOpenHandler,
     );
     this.listen("keydown", this.handleKeyDown);
+    this.listen("focusin", this.handleFocusIn);
   }
 
   override connectedCallback(): void {
     this.updateGroups();
+    this.queryAndStoreNavigableItems();
+    this.syncActiveDescendant();
     this.overflowActions();
     this.updateActions();
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
@@ -400,6 +409,12 @@ export class ActionBar extends LitElement {
   }
 
   private actionMenuOpenHandler(event: CustomEvent<void>): void {
+    const actionMenu = event.target as ActionMenu["el"];
+
+    if (actionMenu) {
+      this.setActiveDescendantId(actionMenu.id);
+    }
+
     if ((event.target as ActionGroup["el"]).menuOpen) {
       const composedPath = event.composedPath();
       this.actionGroups?.forEach((group) => {
@@ -408,12 +423,20 @@ export class ActionBar extends LitElement {
         }
       });
     }
+
+    if (actionMenu?.open) {
+      this.syncActiveDescendantToActionMenu(actionMenu);
+      return;
+    }
+
+    this.updateActions();
   }
 
   private mutationObserverHandler(): void {
     this.updateGroups();
     this.overflowActions();
-    this.queryAndStoreActions();
+    this.queryAndStoreNavigableItems();
+    this.syncActiveDescendant();
     this.updateActions();
   }
 
@@ -428,11 +451,14 @@ export class ActionBar extends LitElement {
       group.layout = this.layout;
       group.scale = this.scale;
     });
+
+    this.ensureActionBarChildIds();
   }
 
   private handleDefaultSlotChange(): void {
     this.updateGroups();
-    this.queryAndStoreActions();
+    this.queryAndStoreNavigableItems();
+    this.syncActiveDescendant();
     this.updateActions();
   }
 
@@ -457,57 +483,387 @@ export class ActionBar extends LitElement {
   private updateActions(): void {
     this.actions.forEach((action) => {
       action.selectionAppearance = this.selectionAppearance;
+      action.activeDescendant = action.id === this.activeDescendantId;
     });
   }
 
-  private queryAndStoreActions(): void {
+  private queryAndStoreNavigableItems(): void {
+    this.ensureActionBarChildIds();
+
     this.actions = Array.from(this.el.querySelectorAll("calcite-action"));
+
+    const shadowActionMenus = this.actionGroups
+      .flatMap((group) =>
+        group.shadowRoot
+          ? Array.from(group.shadowRoot.querySelectorAll("calcite-action-menu"))
+          : [],
+      )
+      .filter((menu): menu is ActionMenu["el"] => {
+        if (menu.hasAttribute("hidden")) {
+          return false;
+        }
+
+        this.syncActionMenuId(menu);
+        return !!menu.id;
+      });
+
+    const lightDomNavigationItems = Array.from(
+      this.el.querySelectorAll("calcite-action, calcite-action-menu"),
+    ).filter((el): el is Action["el"] | ActionMenu["el"] => {
+      if (isAction(el)) {
+        if (el.disabled || el.hasAttribute("hidden")) {
+          return false;
+        }
+
+        const closestMenu = el.closest("calcite-action-menu");
+        return !closestMenu;
+      }
+
+      if (el.hasAttribute("hidden")) {
+        return false;
+      }
+
+      this.syncActionMenuId(el as ActionMenu["el"]);
+      return !!el.id;
+    });
+
+    this.navigationItems = [...lightDomNavigationItems, ...shadowActionMenus];
+
+    console.log("calcite-action-bar navigation items", {
+      navigationItems: this.navigationItems.map((item) => ({
+        id: item.id,
+        tagName: item.tagName.toLowerCase(),
+      })),
+    });
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
-    this.queryAndStoreActions();
-    const actions = this.actions.filter((action) => !action.disabled);
-    const current = document.activeElement;
+    const actionMenu = this.getEventActionMenu(event);
 
-    if (!isAction(current) || !actions.includes(current)) {
+    if (actionMenu?.open) {
+      this.syncActiveDescendantToActionMenu(actionMenu);
       return;
     }
 
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    this.queryAndStoreNavigableItems();
+
+    const current = this.getNavigationItemFromEvent(event) ?? this.getCurrentNavigationItem();
+
+    if (!current || !this.navigationItems.length) {
+      return;
+    }
+
+    const isVertical = this.layout !== "horizontal";
+
     switch (event.key) {
-      case "ArrowRight":
       case "ArrowDown":
-        focusElementInGroup(actions, current, "next", true);
-        event.preventDefault();
+        if (isVertical) {
+          this.focusNavigationItem("next", current);
+          event.preventDefault();
+        }
+        break;
+      case "ArrowUp":
+        if (isVertical) {
+          this.focusNavigationItem("previous", current);
+          event.preventDefault();
+        }
+        break;
+      case "ArrowRight":
+        if (!isVertical) {
+          this.focusNavigationItem("next", current);
+          event.preventDefault();
+        }
         break;
       case "ArrowLeft":
-      case "ArrowUp":
-        focusElementInGroup(actions, current, "previous", true);
-        event.preventDefault();
+        if (!isVertical) {
+          this.focusNavigationItem("previous", current);
+          event.preventDefault();
+        }
         break;
       case "Home":
-        focusElementInGroup(actions, current, "first", true);
+        this.focusNavigationItem("first", current);
         event.preventDefault();
         break;
       case "End":
-        focusElementInGroup(actions, current, "last", true);
+        this.focusNavigationItem("last", current);
         event.preventDefault();
         break;
       case "Tab":
-        this.setActionTabIndexes(current);
+        this.setNavigationItemTabIndexes(current);
+        this.syncActiveDescendant(current);
         break;
     }
   }
 
-  private setActionTabIndexes(active: Action["el"]): void {
-    this.actions.forEach((action) => {
-      const tabIndex = !action.disabled && action === active ? 0 : -1;
+  private handleFocusIn(event: FocusEvent): void {
+    this.queryAndStoreNavigableItems();
 
-      if (tabIndex === 0) {
-        // action's internal button is tabbable by default, so we remove the attribute to avoid an extra tabbable element
-        action.removeAttribute("tabindex");
-      } else {
-        action.tabIndex = tabIndex;
+    const actionMenu = this.getEventActionMenu(event);
+    if (actionMenu?.open) {
+      this.syncActiveDescendantToActionMenu(actionMenu);
+      return;
+    }
+
+    if (actionMenu) {
+      this.setActiveDescendantId(actionMenu.id);
+      this.syncActiveDescendant(actionMenu);
+      return;
+    }
+
+    this.syncActiveDescendant(this.getNavigationItemFromEvent(event) ?? undefined);
+  }
+
+  private focusNavigationItem(
+    direction: "next" | "previous" | "first" | "last",
+    current: Action["el"] | ActionMenu["el"],
+  ): void {
+    const { navigationItems } = this;
+    const currentIndex = navigationItems.findIndex(
+      (item) => item === current || item.id === current.id,
+    );
+
+    if (currentIndex === -1) {
+      return;
+    }
+
+    let nextIndex = currentIndex;
+
+    if (direction === "first") {
+      nextIndex = 0;
+    } else if (direction === "last") {
+      nextIndex = navigationItems.length - 1;
+    } else if (direction === "next") {
+      nextIndex = (currentIndex + 1) % navigationItems.length;
+    } else {
+      nextIndex = (currentIndex - 1 + navigationItems.length) % navigationItems.length;
+    }
+
+    const nextItem = navigationItems[nextIndex];
+
+    if (nextItem?.matches("calcite-action-menu")) {
+      this.setActiveDescendantId(this.getActionMenuId(nextItem));
+    }
+
+    if (nextItem && nextItem !== current) {
+      this.focusItem(nextItem);
+    }
+
+    this.syncActiveDescendant(nextItem);
+  }
+
+  private focusItem(item: Action["el"] | ActionMenu["el"]): void {
+    if ("setFocus" in item && typeof item.setFocus === "function") {
+      void item.setFocus();
+      return;
+    }
+
+    item.focus();
+  }
+
+  private getCurrentNavigationItem(): Action["el"] | ActionMenu["el"] {
+    const { activeElement } = document;
+
+    if (activeElement instanceof HTMLElement) {
+      const activeItem = activeElement.matches("calcite-action, calcite-action-menu")
+        ? activeElement
+        : activeElement.closest("calcite-action, calcite-action-menu");
+
+      if (
+        activeItem &&
+        this.navigationItems.includes(activeItem as Action["el"] | ActionMenu["el"])
+      ) {
+        return activeItem as Action["el"] | ActionMenu["el"];
       }
+
+      const activeItemId = (activeItem as Action["el"] | ActionMenu["el"]).id;
+      const activeNavigationItem = this.navigationItems.find((item) => item.id === activeItemId);
+      if (activeNavigationItem) {
+        return activeNavigationItem;
+      }
+
+      const activeActionMenu = activeElement.closest("calcite-action-menu");
+      if (activeActionMenu) {
+        const activeActionMenuId = this.getActionMenuId(activeActionMenu);
+        const activeActionMenuItem = this.navigationItems.find(
+          (item) => item.id === activeActionMenuId,
+        );
+        if (activeActionMenuItem) {
+          return activeActionMenuItem;
+        }
+      }
+    }
+
+    if (this.activeDescendantId) {
+      const activeDescendant = this.navigationItems.find(
+        (item) => item.id === this.activeDescendantId,
+      );
+      if (activeDescendant) {
+        return activeDescendant;
+      }
+    }
+
+    return this.navigationItems[0];
+  }
+
+  private getEventActionMenu(event: Event): ActionMenu["el"] | null {
+    const pathActionMenu = event
+      .composedPath()
+      .find(
+        (pathEl): pathEl is ActionMenu["el"] =>
+          pathEl instanceof HTMLElement && pathEl.matches("calcite-action-menu"),
+      );
+
+    if (pathActionMenu) {
+      return pathActionMenu;
+    }
+
+    const target = event.target;
+    if (target instanceof HTMLElement) {
+      const closestActionMenu = target.closest("calcite-action-menu");
+      if (closestActionMenu) {
+        return closestActionMenu;
+      }
+    }
+
+    return null;
+  }
+
+  private syncActiveDescendantToActionMenu(actionMenu: ActionMenu["el"]): void {
+    const activeMenuItem =
+      actionMenu.querySelector("calcite-action[active-descendant]") ||
+      Array.from(actionMenu.querySelectorAll("calcite-action")).find(
+        (action) => !action.disabled && !action.hidden,
+      );
+
+    this.setActiveDescendantId(activeMenuItem?.id || this.getActionMenuId(actionMenu));
+    this.updateActions();
+  }
+
+  private getNavigationItemFromEvent(event: Event): Action["el"] | ActionMenu["el"] | null {
+    const pathItem = event
+      .composedPath()
+      .find(
+        (pathEl): pathEl is Action["el"] | ActionMenu["el"] =>
+          pathEl instanceof HTMLElement &&
+          pathEl.matches("calcite-action, calcite-action-menu") &&
+          this.navigationItems.some((item) => item === pathEl || item.id === pathEl.id),
+      );
+
+    if (!pathItem) {
+      return null;
+    }
+
+    return (
+      this.navigationItems.find((item) => item === pathItem || item.id === pathItem.id) ?? null
+    );
+  }
+
+  private ensureActionBarChildIds(): void {
+    const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
+    const actions = Array.from(this.el.querySelectorAll("calcite-action"));
+
+    groups.forEach((group, index) => {
+      if (!group.id) {
+        group.id = IDS.actionGroup(this.guid, index);
+      }
+    });
+
+    actions.forEach((action, index) => {
+      if (!action.id) {
+        action.id = IDS.action(this.guid, index);
+      }
+    });
+  }
+
+  private syncActiveDescendant(activeItem?: Action["el"] | ActionMenu["el"]): void {
+    this.queryAndStoreNavigableItems();
+
+    const activeItemInNavigation = activeItem
+      ? this.navigationItems.find((item) => item === activeItem || item.id === activeItem.id)
+      : undefined;
+
+    const current =
+      activeItemInNavigation ||
+      this.navigationItems.find((item) => item.id === this.activeDescendantId) ||
+      this.getCurrentNavigationItem();
+
+    this.setActiveDescendantId(this.getNavigationItemId(current));
+
+    this.setNavigationItemTabIndexes(current);
+    this.updateActions();
+  }
+
+  private getNavigationItemId(item?: Action["el"] | ActionMenu["el"]): string | undefined {
+    if (!item) {
+      return undefined;
+    }
+
+    if (item.matches("calcite-action-menu")) {
+      return this.getActionMenuId(item);
+    }
+
+    return item.id;
+  }
+
+  private syncActionMenuId(actionMenu: ActionMenu["el"]): void {
+    if (actionMenu.id) {
+      return;
+    }
+
+    const existingId = this.getActionMenuId(actionMenu);
+    if (existingId) {
+      actionMenu.id = existingId;
+    }
+  }
+
+  private getActionMenuId(actionMenu: ActionMenu["el"]): string | undefined {
+    return (
+      actionMenu.id ||
+      (actionMenu.shadowRoot?.querySelector("[role='menu']") as HTMLElement | null)?.id ||
+      undefined
+    );
+  }
+
+  private setActiveDescendantId(id?: string): void {
+    this.activeDescendantId = id;
+    const toolbarEl = this.containerRef.value;
+
+    console.log("calcite-action-bar active descendant", {
+      activeDescendantId: this.activeDescendantId,
+      navigationItems: this.navigationItems.map((item) => ({
+        id: item.id,
+        tagName: item.tagName.toLowerCase(),
+      })),
+    });
+
+    if (this.activeDescendantId) {
+      this.el.setAttribute("aria-activedescendant", this.activeDescendantId);
+      toolbarEl?.setAttribute("aria-activedescendant", this.activeDescendantId);
+    } else {
+      this.el.removeAttribute("aria-activedescendant");
+      toolbarEl?.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  private setNavigationItemTabIndexes(active: Action["el"] | ActionMenu["el"]): void {
+    this.navigationItems.forEach((item) => {
+      const isActive = item === active;
+
+      if (isAction(item)) {
+        if (isActive && !item.disabled && !item.hidden) {
+          // action's internal button is tabbable by default, so we remove the attribute to avoid an extra tabbable element
+          item.removeAttribute("tabindex");
+        } else {
+          item.tabIndex = -1;
+        }
+        return;
+      }
+
+      item.tabIndex = isActive ? 0 : -1;
     });
   }
 
@@ -574,6 +930,7 @@ export class ActionBar extends LitElement {
   override render(): JsxNode {
     return (
       <div
+        aria-activedescendant={this.activeDescendantId}
         ariaOrientation={this.layout === "horizontal" ? "horizontal" : "vertical"}
         class={CSS.container}
         ref={this.containerRef}

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -94,6 +94,9 @@ export class ActionBar extends LitElement {
 
   private resize = debounce(({ width, height }: { width: number; height: number }): void => {
     const { expanded, expandDisabled, layout, expandPosition } = this;
+
+    this.updateGroups();
+
     const overflowActionsDisabled = this.effectiveOverflowActionsDisabled;
 
     if (
@@ -104,8 +107,6 @@ export class ActionBar extends LitElement {
     ) {
       return;
     }
-
-    this.updateGroups();
 
     const itemSizes = this.getItemSizes();
 
@@ -442,6 +443,9 @@ export class ActionBar extends LitElement {
     }
 
     this.resizeObserver?.observe(this.el);
+    if (this.containerRef.value) {
+      this.resizeObserver?.observe(this.containerRef.value);
+    }
     this.overflowActions();
   }
 
@@ -485,7 +489,12 @@ export class ActionBar extends LitElement {
   private updateGroups(): void {
     const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
     this.actionGroups = groups;
-    this.selectionOverflowDisabled = groups.some((group) => group.selectionMode !== "none");
+    this.selectionOverflowDisabled =
+      groups.length > 0 &&
+      groups.every((group) => {
+        const selectionMode = group.selectionMode || "none";
+        return selectionMode !== "none";
+      });
 
     groups.forEach((group) => {
       group.layout = this.layout;
@@ -672,10 +681,12 @@ export class ActionBar extends LitElement {
     const currentGroup = this.getNavigationItemActionGroup(current);
     const secondaryNextKey = isVertical ? "ArrowRight" : "ArrowDown";
     const secondaryPreviousKey = isVertical ? "ArrowLeft" : "ArrowUp";
+    const isClosedActionMenu = current.matches("calcite-action-menu") && !current.open;
 
     if (
       (currentGroup?.selectionMode === "multiple" || currentGroup?.selectionMode === "none") &&
-      (event.key === secondaryNextKey || event.key === secondaryPreviousKey)
+      (event.key === secondaryNextKey || event.key === secondaryPreviousKey) &&
+      !isClosedActionMenu
     ) {
       event.preventDefault();
       event.stopPropagation();

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -493,10 +493,10 @@ export class ActionBar extends LitElement {
     });
 
     this.ensureActionBarChildIds();
-    void this.syncNavigationItemsAfterActionGroupsRender();
+    void this.syncNavItemsAfterRender();
   }
 
-  private async syncNavigationItemsAfterActionGroupsRender(): Promise<void> {
+  private async syncNavItemsAfterRender(): Promise<void> {
     const { actionGroups } = this;
 
     await Promise.all(actionGroups.map((group) => group.componentOnReady()));
@@ -668,6 +668,19 @@ export class ActionBar extends LitElement {
     }
 
     const isVertical = this.layout !== "horizontal";
+
+    const currentGroup = this.getNavigationItemActionGroup(current);
+    const secondaryNextKey = isVertical ? "ArrowRight" : "ArrowDown";
+    const secondaryPreviousKey = isVertical ? "ArrowLeft" : "ArrowUp";
+
+    if (
+      (currentGroup?.selectionMode === "multiple" || currentGroup?.selectionMode === "none") &&
+      (event.key === secondaryNextKey || event.key === secondaryPreviousKey)
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
 
     if (this.handleSecondaryArrowActionMenuOpen(event, current, isVertical)) {
       return;
@@ -887,6 +900,10 @@ export class ActionBar extends LitElement {
     const currentGroup = this.getNavigationItemActionGroup(current);
 
     if (!currentGroup) {
+      return false;
+    }
+
+    if (currentGroup.selectionMode === "multiple" || currentGroup.selectionMode === "none") {
       return false;
     }
 

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -93,7 +93,8 @@ export class ActionBar extends LitElement {
   private cancelable = useCancelable<this>()(this);
 
   private resize = debounce(({ width, height }: { width: number; height: number }): void => {
-    const { expanded, expandDisabled, layout, overflowActionsDisabled, expandPosition } = this;
+    const { expanded, expandDisabled, layout, expandPosition } = this;
+    const overflowActionsDisabled = this.effectiveOverflowActionsDisabled;
 
     if (
       overflowActionsDisabled ||
@@ -211,6 +212,8 @@ export class ActionBar extends LitElement {
   @state() hasActionsStart = false;
 
   @state() activeDescendantId?: string;
+
+  @state() selectionOverflowDisabled = false;
 
   //#endregion
 
@@ -341,8 +344,13 @@ export class ActionBar extends LitElement {
     this.syncActiveDescendant();
     this.overflowActions();
     this.updateActions();
-    this.mutationObserver?.observe(this.el, { childList: true, subtree: true });
-    this.overflowActionsDisabledHandler(this.overflowActionsDisabled);
+    this.mutationObserver?.observe(this.el, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["selection-mode", "overflow-actions-disabled"],
+    });
+    this.overflowActionsDisabledHandler(this.effectiveOverflowActionsDisabled);
     this.cancelable.add(this.resize);
   }
 
@@ -366,7 +374,11 @@ export class ActionBar extends LitElement {
       changes.has("overflowActionsDisabled") &&
       (this.hasUpdated || this.overflowActionsDisabled !== false)
     ) {
-      this.overflowActionsDisabledHandler(this.overflowActionsDisabled);
+      this.overflowActionsDisabledHandler(this.effectiveOverflowActionsDisabled);
+    }
+
+    if (changes.has("selectionOverflowDisabled") && this.hasUpdated) {
+      this.overflowActionsDisabledHandler(this.effectiveOverflowActionsDisabled);
     }
 
     if (changes.has("expanded") && this.hasUpdated) {
@@ -419,6 +431,10 @@ export class ActionBar extends LitElement {
     this.overflowActions();
   }
 
+  private get effectiveOverflowActionsDisabled(): boolean {
+    return this.overflowActionsDisabled || this.selectionOverflowDisabled;
+  }
+
   private overflowActionsDisabledHandler(overflowActionsDisabled: boolean): void {
     if (overflowActionsDisabled) {
       this.resizeObserver?.disconnect();
@@ -469,6 +485,8 @@ export class ActionBar extends LitElement {
   private updateGroups(): void {
     const groups = Array.from(this.el.querySelectorAll("calcite-action-group"));
     this.actionGroups = groups;
+    this.selectionOverflowDisabled = groups.some((group) => group.selectionMode !== "none");
+
     groups.forEach((group) => {
       group.layout = this.layout;
       group.scale = this.scale;
@@ -651,10 +669,17 @@ export class ActionBar extends LitElement {
 
     const isVertical = this.layout !== "horizontal";
 
+    if (this.handleSecondaryArrowActionMenuOpen(event, current, isVertical)) {
+      return;
+    }
+
     switch (event.key) {
       case "ArrowDown":
         if (isVertical) {
           this.focusNavigationItem("next", current);
+          event.preventDefault();
+          event.stopPropagation();
+        } else if (this.focusActionGroupItem("next", current)) {
           event.preventDefault();
           event.stopPropagation();
         }
@@ -664,6 +689,9 @@ export class ActionBar extends LitElement {
           this.focusNavigationItem("previous", current);
           event.preventDefault();
           event.stopPropagation();
+        } else if (this.focusActionGroupItem("previous", current)) {
+          event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "ArrowRight":
@@ -671,11 +699,17 @@ export class ActionBar extends LitElement {
           this.focusNavigationItem("next", current);
           event.preventDefault();
           event.stopPropagation();
+        } else if (this.focusActionGroupItem("next", current)) {
+          event.preventDefault();
+          event.stopPropagation();
         }
         break;
       case "ArrowLeft":
         if (!isVertical) {
           this.focusNavigationItem("previous", current);
+          event.preventDefault();
+          event.stopPropagation();
+        } else if (this.focusActionGroupItem("previous", current)) {
           event.preventDefault();
           event.stopPropagation();
         }
@@ -695,6 +729,61 @@ export class ActionBar extends LitElement {
         this.syncActiveDescendant(current);
         break;
     }
+  }
+
+  private handleSecondaryArrowActionMenuOpen(
+    event: KeyboardEvent,
+    current: Action["el"] | ActionMenu["el"],
+    isVertical: boolean,
+  ): boolean {
+    if (!current.matches("calcite-action-menu") || current.open) {
+      return false;
+    }
+
+    const menuFirstItemOpenKey = isVertical ? "ArrowRight" : "ArrowUp";
+    const menuLastItemOpenKey = isVertical ? "ArrowLeft" : "ArrowDown";
+
+    if (event.key !== menuFirstItemOpenKey && event.key !== menuLastItemOpenKey) {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.openActionMenuAndFocusBoundaryItem(
+      current,
+      event.key === menuFirstItemOpenKey ? "first" : "last",
+    );
+
+    return true;
+  }
+
+  private openActionMenuAndFocusBoundaryItem(
+    actionMenu: ActionMenu["el"],
+    boundary: "first" | "last",
+  ): void {
+    actionMenu.open = true;
+    void this.focusActionMenuBoundaryItem(actionMenu, boundary);
+  }
+
+  private async focusActionMenuBoundaryItem(
+    actionMenu: ActionMenu["el"],
+    boundary: "first" | "last",
+  ): Promise<void> {
+    await actionMenu.componentOnReady();
+
+    if (!actionMenu.open) {
+      return;
+    }
+
+    await actionMenu.setFocus();
+
+    actionMenu.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        composed: true,
+        key: boundary === "first" ? "Home" : "End",
+      }),
+    );
   }
 
   private handleFocusIn(event: FocusEvent): void {
@@ -789,6 +878,52 @@ export class ActionBar extends LitElement {
     }
 
     this.syncActiveDescendant(nextItem);
+  }
+
+  private focusActionGroupItem(
+    direction: "next" | "previous",
+    current: Action["el"] | ActionMenu["el"],
+  ): boolean {
+    const currentGroup = this.getNavigationItemActionGroup(current);
+
+    if (!currentGroup) {
+      return false;
+    }
+
+    const groupItems = this.navigationItems.filter(
+      (item) => this.getNavigationItemActionGroup(item) === currentGroup,
+    );
+    const currentIndex = groupItems.findIndex((item) => item === current || item.id === current.id);
+
+    if (groupItems.length < 2 || currentIndex === -1) {
+      return false;
+    }
+
+    const nextIndex =
+      direction === "next"
+        ? (currentIndex + 1) % groupItems.length
+        : (currentIndex - 1 + groupItems.length) % groupItems.length;
+
+    const nextItem = groupItems[nextIndex];
+
+    if (!nextItem || nextItem === current) {
+      return false;
+    }
+
+    if (nextItem.matches("calcite-action-menu")) {
+      this.setActiveDescendantId(this.getActionMenuId(nextItem));
+    }
+
+    this.focusItem(nextItem);
+    this.syncActiveDescendant(nextItem);
+
+    return true;
+  }
+
+  private getNavigationItemActionGroup(
+    item: Action["el"] | ActionMenu["el"],
+  ): ActionGroup["el"] | null {
+    return closestElementCrossShadowBoundary(item, "calcite-action-group");
   }
 
   private focusItem(item: Action["el"] | ActionMenu["el"]): void {

--- a/packages/components/src/components/action-bar/action-bar.tsx
+++ b/packages/components/src/components/action-bar/action-bar.tsx
@@ -175,14 +175,7 @@ export class ActionBar extends LitElement {
     });
   }, DEBOUNCE.resize);
 
-  private resizeHandler = (entry: ResizeObserverEntry): void => {
-    const { width, height } = entry.contentRect;
-    this.resize({ width, height });
-  };
-
-  private resizeObserver = createObserver("resize", (entries) =>
-    this.resizeHandlerEntries(entries),
-  );
+  private resizeObserver = createObserver("resize", () => this.resizeHandlerEntries());
 
   private toggleExpand = (): void => {
     this.expanded = !this.expanded;
@@ -482,8 +475,8 @@ export class ActionBar extends LitElement {
     this.updateActions();
   }
 
-  private resizeHandlerEntries(entries: ResizeObserverEntry[]): void {
-    entries.forEach(this.resizeHandler);
+  private resizeHandlerEntries(): void {
+    this.resize({ width: this.el.clientWidth, height: this.el.clientHeight });
   }
 
   private updateGroups(): void {

--- a/packages/components/src/components/action-bar/resources.ts
+++ b/packages/components/src/components/action-bar/resources.ts
@@ -4,6 +4,13 @@ export const CSS = {
   actionGroupStart: "action-group--start",
 };
 
+const idPrefix = "calcite-action-bar";
+
+export const IDS = {
+  action: (id: string, index: number) => `${idPrefix}-${id}-action-${index}`,
+  actionGroup: (id: string, index: number) => `${idPrefix}-${id}-action-group-${index}`,
+} as const;
+
 export const SLOTS = {
   actionsEnd: "actions-end",
   actionsStart: "actions-start",

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -205,6 +205,13 @@ it("should honor scale of expand icon", async () => {
   await expect.element(menu).toHaveProperty("scale", "l");
 });
 
+it("should set side flip placements on vertical action menu", async () => {
+  await mount(renderActionGroup);
+  const menu = page.getBySelector(`calcite-action-group calcite-action-menu`);
+
+  await expect.element(menu).toHaveProperty("flipPlacements", ["left", "right"]);
+});
+
 it("should honor overlayPositioning", async () => {
   await mount(
     <calcite-action-group overlay-positioning="fixed" scale="l">
@@ -229,6 +236,20 @@ it("should honor label", async () => {
   await expect.element(menu).toBeVisible();
 });
 
+it("hides overflow menu when selection mode is enabled", async () => {
+  await mount(
+    <calcite-action-group selection-mode="multiple">
+      <calcite-action icon="plus" id="plus" slot="menu-actions" text="Add" />
+      <calcite-action icon="banana" id="banana" slot="menu-actions" text="Banana" />
+      <calcite-action icon="save" text="Save" />
+    </calcite-action-group>,
+  );
+
+  const menu = page.getBySelector(`calcite-action-group calcite-action-menu`);
+
+  await expect.element(menu).toHaveAttribute("hidden");
+});
+
 it("should emit expanded/collapsed events when toggled", async () => {
   const { el, reRender } = await mount<ActionGroup>(<calcite-action-group label="Test" />);
   const expandEventHandler = vi.fn();
@@ -247,4 +268,46 @@ it("should emit expanded/collapsed events when toggled", async () => {
 
   expect(expandEventHandler).toHaveBeenCalledTimes(1);
   expect(collapseEventHandler).toHaveBeenCalledTimes(1);
+});
+
+describe("overflowActionsDisabled semantics", () => {
+  it("honors overflowActionsDisabled when selectionMode is none", async () => {
+    const { el, reRender } = await mount<ActionGroup>(
+      <calcite-action-group label="Overflow test">
+        <calcite-action icon="plus" slot="menu-actions" text="Add" />
+        <calcite-action icon="save" slot="menu-actions" text="Save" />
+        <calcite-action icon="trash" text="Delete" />
+      </calcite-action-group>,
+    );
+
+    const menu = page.getBySelector("calcite-action-group calcite-action-menu");
+
+    el.overflowActionsDisabled = true;
+    await reRender();
+    expect(el.overflowActionsDisabled).toBe(true);
+    await expect.element(menu).toHaveAttribute("hidden");
+
+    el.overflowActionsDisabled = false;
+    await reRender();
+    expect(el.overflowActionsDisabled).toBe(false);
+    await expect.element(menu).not.toHaveAttribute("hidden");
+  });
+
+  it("forces overflowActionsDisabled when selectionMode is not none", async () => {
+    const { el, reRender } = await mount<ActionGroup>(
+      <calcite-action-group label="Overflow test" selection-mode="multiple">
+        <calcite-action icon="plus" slot="menu-actions" text="Add" />
+        <calcite-action icon="save" slot="menu-actions" text="Save" />
+        <calcite-action icon="trash" text="Delete" />
+      </calcite-action-group>,
+    );
+
+    const menu = page.getBySelector("calcite-action-group calcite-action-menu");
+
+    el.overflowActionsDisabled = false;
+    await reRender();
+
+    expect(el.overflowActionsDisabled).toBe(true);
+    await expect.element(menu).toHaveAttribute("hidden");
+  });
 });

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -113,7 +113,8 @@ export class ActionGroup extends LitElement {
   /** When `true`, the component's actions will not be overflowed into a menu by a parent `calcite-action-bar`. */
   @property({ reflect: true })
   get overflowActionsDisabled(): boolean {
-    return this.selectionMode === "none" ? this._overflowActionsDisabled : true;
+    const selectionMode = this.selectionMode || "none";
+    return selectionMode === "none" ? this._overflowActionsDisabled : true;
   }
   set overflowActionsDisabled(value: boolean) {
     this._overflowActionsDisabled = value;

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -60,6 +60,8 @@ export class ActionGroup extends LitElement {
 
   private menuActions: Action["el"][] = [];
 
+  private _overflowActionsDisabled = false;
+
   //#endregion
 
   //#region State Properties
@@ -109,7 +111,13 @@ export class ActionGroup extends LitElement {
   @property({ reflect: true }) overlayPositioning: OverlayPositioning = "absolute";
 
   /** When `true`, the component's actions will not be overflowed into a menu by a parent `calcite-action-bar`. */
-  @property({ reflect: true }) overflowActionsDisabled = false;
+  @property({ reflect: true })
+  get overflowActionsDisabled(): boolean {
+    return this.selectionMode === "none" ? this._overflowActionsDisabled : true;
+  }
+  set overflowActionsDisabled(value: boolean) {
+    this._overflowActionsDisabled = value;
+  }
 
   /** Specifies the size of the `calcite-action-menu`. */
   @property({ reflect: true }) scale: Scale = "m";
@@ -375,7 +383,7 @@ export class ActionGroup extends LitElement {
         flipPlacements={
           menuFlipPlacements ?? (layout === "horizontal" ? ["top", "bottom"] : ["left", "right"])
         }
-        hidden={!hasMenuActions}
+        hidden={!hasMenuActions || this.overflowActionsDisabled}
         label={messages.more}
         oncalciteActionMenuOpen={this.setMenuOpen}
         open={menuOpen}

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -60,18 +60,6 @@ export class ActionGroup extends LitElement {
 
   private menuActions: Action["el"][] = [];
 
-  private handleActionMenuSelection = (action: Action["el"]): boolean => {
-    if (action.slot !== SLOTS.menuActions || this.selectionMode === "none") {
-      return false;
-    }
-
-    const menuActions = this.getMenuActions();
-    this.menuActions = menuActions.includes(action) ? menuActions : [...menuActions, action];
-
-    this.setActiveAction(this.getSelectableActions().indexOf(action), action);
-    return true;
-  };
-
   //#endregion
 
   //#region State Properties
@@ -136,6 +124,7 @@ export class ActionGroup extends LitElement {
    * `"single-persist"` allows one selection and prevents de-selection, and
    *
    * `"none"` disables selection (default).
+   *
    */
   @property({ reflect: true }) selectionMode: Extract<
     "single" | "single-persist" | "multiple" | "none",
@@ -194,7 +183,6 @@ export class ActionGroup extends LitElement {
   constructor() {
     super();
     this.listen("click", this.handleActionClick);
-    this.listen("calciteInternalActionMenuSelect", this.handleActionMenuSelect);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -304,41 +292,6 @@ export class ActionGroup extends LitElement {
     this.setActiveAction(index, target);
   }
 
-  private handleActionMenuSelect(event: Event): void {
-    if (!event.composedPath().includes(this.el) || this.selectionMode === "none") {
-      return;
-    }
-
-    this.syncActionMenuSelection();
-  }
-
-  private syncActionMenuSelection(): void {
-    this.menuActions = this.getMenuActions();
-
-    const actions = this.getSelectableActions();
-
-    if (this.selectionMode === "multiple") {
-      this.updateSelectedActions(actions.filter((action) => action.active));
-      this.calciteActionGroupChange.emit();
-      return;
-    }
-
-    const activeMenuAction = this.menuActions.find((action) => action.active);
-
-    if (this.selectionMode === "single") {
-      actions.forEach((action) => this.updateAction(action, action === activeMenuAction));
-      this.updateSelectedActions(activeMenuAction ? [activeMenuAction] : []);
-      this.calciteActionGroupChange.emit();
-      return;
-    }
-
-    if (this.selectionMode === "single-persist" && activeMenuAction) {
-      actions.forEach((action) => this.updateAction(action, action === activeMenuAction));
-      this.updateSelectedActions([activeMenuAction]);
-      this.calciteActionGroupChange.emit();
-    }
-  }
-
   private setRoleOnActions(): void {
     this.actions.forEach((action) => {
       action.aria = {
@@ -353,21 +306,13 @@ export class ActionGroup extends LitElement {
   }
 
   private getSelectableActions(): Action["el"][] {
-    return [...(this.actions ?? []), ...this.menuActions];
+    return this.actions ?? [];
   }
 
   private getMenuActions(): Action["el"][] {
     return Array.from(this.el.children).filter(
       (el): el is Action["el"] => isAction(el) && el.slot === SLOTS.menuActions,
     );
-  }
-
-  private setActionMenuSelectionHandler(el: ActionMenu["el"] | undefined): void {
-    if (!el) {
-      return;
-    }
-
-    el.selectionHandler = this.handleActionMenuSelection;
   }
 
   private setActionAriaChecked(action: Action["el"], checked: boolean): void {
@@ -436,9 +381,7 @@ export class ActionGroup extends LitElement {
         open={menuOpen}
         overlayPositioning={overlayPositioning}
         placement={menuPlacement ?? (layout === "horizontal" ? "bottom-start" : "leading-start")}
-        ref={this.setActionMenuSelectionHandler}
         scale={scale}
-        selectionMode={this.selectionMode}
         topLayerDisabled={this.topLayerDisabled}
       >
         <calcite-action

--- a/packages/components/src/components/action-group/action-group.tsx
+++ b/packages/components/src/components/action-group/action-group.tsx
@@ -13,7 +13,6 @@ import { queryAssignedElements } from "lit/decorators.js";
 import { SLOTS as ACTION_MENU_SLOTS } from "../action-menu/resources";
 import { Layout, Scale } from "../interfaces";
 import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
-import { slotChangeHasAssignedElement } from "../../utils/dom";
 import { useT9n } from "../../controllers/useT9n";
 import type { Action } from "../action/action";
 import { isAction } from "../action/resources";
@@ -58,6 +57,20 @@ export class ActionGroup extends LitElement {
 
   @queryAssignedElements({ selector: "calcite-action" })
   private actions!: Action["el"][];
+
+  private menuActions: Action["el"][] = [];
+
+  private handleActionMenuSelection = (action: Action["el"]): boolean => {
+    if (action.slot !== SLOTS.menuActions || this.selectionMode === "none") {
+      return false;
+    }
+
+    const menuActions = this.getMenuActions();
+    this.menuActions = menuActions.includes(action) ? menuActions : [...menuActions, action];
+
+    this.setActiveAction(this.getSelectableActions().indexOf(action), action);
+    return true;
+  };
 
   //#endregion
 
@@ -181,6 +194,7 @@ export class ActionGroup extends LitElement {
   constructor() {
     super();
     this.listen("click", this.handleActionClick);
+    this.listen("calciteInternalActionMenuSelect", this.handleActionMenuSelect);
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
@@ -231,23 +245,25 @@ export class ActionGroup extends LitElement {
   //#region Private Methods
 
   private setActiveAction(index: number, active: Action["el"]): void {
+    const actions = this.getSelectableActions();
+
     if (this.selectionMode === "multiple") {
       const nextActive = !active.active;
       this.updateAction(active, nextActive);
-      this.updateSelectedActions(this.actions.filter((action) => action.active));
+      this.updateSelectedActions(actions.filter((action) => action.active));
       this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single") {
       const nextActive = !active.active;
-      this.actions.forEach((action, i) => this.updateAction(action, i === index && nextActive));
-      this.updateSelectedActions(this.actions.filter((action) => action.active));
+      actions.forEach((action, i) => this.updateAction(action, i === index && nextActive));
+      this.updateSelectedActions(actions.filter((action) => action.active));
       this.calciteActionGroupChange.emit();
       return;
     }
     if (this.selectionMode === "single-persist") {
-      if (!this.actions[index].active) {
-        this.actions.forEach((action, i) => this.updateAction(action, i === index));
+      if (!actions[index].active) {
+        actions.forEach((action, i) => this.updateAction(action, i === index));
         this.updateSelectedActions([active]);
         this.calciteActionGroupChange.emit();
       }
@@ -260,7 +276,12 @@ export class ActionGroup extends LitElement {
   }
 
   private handleMenuActionsSlotChange(event: Event): void {
-    this.hasMenuActions = slotChangeHasAssignedElement(event);
+    const menuActions = (event.target as HTMLSlotElement)
+      .assignedElements({ flatten: true })
+      .filter((el): el is Action["el"] => isAction(el));
+
+    this.menuActions = menuActions.length > 0 ? menuActions : this.getMenuActions();
+    this.hasMenuActions = this.menuActions.length > 0;
   }
 
   private handleActionClick(event: MouseEvent): void {
@@ -271,11 +292,51 @@ export class ActionGroup extends LitElement {
     if (!target || target.disabled) {
       return;
     }
-    const index = this.actions.indexOf(target);
+
+    if (this.menuActions.includes(target)) {
+      return;
+    }
+
+    const index = this.getSelectableActions().indexOf(target);
     if (index === -1 || this.selectionMode === "none") {
       return;
     }
     this.setActiveAction(index, target);
+  }
+
+  private handleActionMenuSelect(event: Event): void {
+    if (!event.composedPath().includes(this.el) || this.selectionMode === "none") {
+      return;
+    }
+
+    this.syncActionMenuSelection();
+  }
+
+  private syncActionMenuSelection(): void {
+    this.menuActions = this.getMenuActions();
+
+    const actions = this.getSelectableActions();
+
+    if (this.selectionMode === "multiple") {
+      this.updateSelectedActions(actions.filter((action) => action.active));
+      this.calciteActionGroupChange.emit();
+      return;
+    }
+
+    const activeMenuAction = this.menuActions.find((action) => action.active);
+
+    if (this.selectionMode === "single") {
+      actions.forEach((action) => this.updateAction(action, action === activeMenuAction));
+      this.updateSelectedActions(activeMenuAction ? [activeMenuAction] : []);
+      this.calciteActionGroupChange.emit();
+      return;
+    }
+
+    if (this.selectionMode === "single-persist" && activeMenuAction) {
+      actions.forEach((action) => this.updateAction(action, action === activeMenuAction));
+      this.updateSelectedActions([activeMenuAction]);
+      this.calciteActionGroupChange.emit();
+    }
   }
 
   private setRoleOnActions(): void {
@@ -289,6 +350,24 @@ export class ActionGroup extends LitElement {
       };
       this.setActionAriaChecked(action, action.active);
     });
+  }
+
+  private getSelectableActions(): Action["el"][] {
+    return [...(this.actions ?? []), ...this.menuActions];
+  }
+
+  private getMenuActions(): Action["el"][] {
+    return Array.from(this.el.children).filter(
+      (el): el is Action["el"] => isAction(el) && el.slot === SLOTS.menuActions,
+    );
+  }
+
+  private setActionMenuSelectionHandler(el: ActionMenu["el"] | undefined): void {
+    if (!el) {
+      return;
+    }
+
+    el.selectionHandler = this.handleActionMenuSelection;
   }
 
   private setActionAriaChecked(action: Action["el"], checked: boolean): void {
@@ -357,7 +436,9 @@ export class ActionGroup extends LitElement {
         open={menuOpen}
         overlayPositioning={overlayPositioning}
         placement={menuPlacement ?? (layout === "horizontal" ? "bottom-start" : "leading-start")}
+        ref={this.setActionMenuSelectionHandler}
         scale={scale}
+        selectionMode={this.selectionMode}
         topLayerDisabled={this.topLayerDisabled}
       >
         <calcite-action

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -142,6 +142,30 @@ describe("accessibility", () => {
     expect(menu?.ariaActiveDescendantElement?.id).toBe("create-action");
   });
 
+  it("sets vertical aria orientation on the menu", async () => {
+    const { el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu flipPlacements={["top", "bottom"]}>
+        <calcite-action icon="plus" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']");
+
+    expect(menu).toHaveAttribute("aria-orientation", "vertical");
+  });
+
+  it("does not set aria orientation on the menu by default", async () => {
+    const { el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu>
+        <calcite-action icon="plus" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']");
+
+    expect(menu).not.toHaveAttribute("aria-orientation");
+  });
+
   it("updates active descendant on the host and menu during keyboard navigation", async () => {
     const { component, el } = await mount<"calcite-action-menu">(
       <calcite-action-menu>
@@ -171,5 +195,116 @@ describe("accessibility", () => {
 
     expect(el.ariaActiveDescendantElement?.id).toBe("save-action");
     expect(menu?.ariaActiveDescendantElement?.id).toBe("save-action");
+  });
+
+  it.each(["{ArrowLeft}", "{ArrowRight}"])(
+    "opens a horizontal menu with %s and sets the active descendant to the first action",
+    async (key) => {
+      const { component, el } = await mount<"calcite-action-menu">(
+        <calcite-action-menu flipPlacements={["left", "right"]}>
+          <calcite-action icon="undo" id="undo-action" text="Undo" />
+          <calcite-action icon="redo" id="redo-action" text="Redo" />
+        </calcite-action-menu>,
+      );
+
+      await component.updateComplete;
+      await el.setFocus();
+      await userEvent.keyboard(key);
+      await component.updateComplete;
+
+      expect(el.open).toBe(true);
+      expect(el.ariaActiveDescendantElement?.id).toBe("undo-action");
+    },
+  );
+
+  it.each([
+    ["{ArrowDown}", "undo-action"],
+    ["{ArrowUp}", "redo-action"],
+  ])("opens a vertical menu with %s and sets the active descendant", async (key, expectedId) => {
+    const { component, el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu flipPlacements={["top", "bottom"]}>
+        <calcite-action icon="undo" id="undo-action" text="Undo" />
+        <calcite-action icon="redo" id="redo-action" text="Redo" />
+      </calcite-action-menu>,
+    );
+
+    await component.updateComplete;
+    await el.setFocus();
+    await userEvent.keyboard(key);
+    await component.updateComplete;
+
+    expect(el.open).toBe(true);
+    expect(el.ariaActiveDescendantElement?.id).toBe(expectedId);
+  });
+
+  it("toggles action active state without selection mode semantics and closes", async () => {
+    const { component, el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu>
+        <calcite-action icon="plus" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    el.open = true;
+    await component.updateComplete;
+
+    const action = el.querySelector("calcite-action");
+
+    expect(action?.active).toBe(false);
+    expect(action).toHaveAttribute("role", "menuitem");
+    expect(action).not.toHaveAttribute("aria-checked");
+
+    await userEvent.click(action);
+    await component.updateComplete;
+
+    expect(action?.active).toBe(true);
+    expect(el.open).toBe(false);
+    expect(action).toHaveAttribute("role", "menuitem");
+    expect(action).not.toHaveAttribute("aria-checked");
+  });
+
+  it.each(["{Enter}", "{Space}"])(
+    "toggles the active descendant with %s and closes",
+    async (key) => {
+      const { component, el } = await mount<"calcite-action-menu">(
+        <calcite-action-menu>
+          <calcite-action icon="plus" text="Add" />
+        </calcite-action-menu>,
+      );
+
+      el.open = true;
+      await component.updateComplete;
+
+      const action = el.querySelector("calcite-action");
+
+      await el.setFocus();
+      await userEvent.keyboard(key);
+      await component.updateComplete;
+
+      expect(action?.active).toBe(true);
+      expect(el.open).toBe(false);
+      expect(action).toHaveAttribute("role", "menuitem");
+      expect(action).not.toHaveAttribute("aria-checked");
+    },
+  );
+
+  it("opens from a focused trigger action without immediately activating the first menu item", async () => {
+    const { component, el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu>
+        <calcite-action icon="ellipsis" id="trigger-action" slot={SLOTS.trigger} text="More" />
+        <calcite-action icon="plus" id="menu-action" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    const triggerAction = el.querySelector<Action["el"]>("#trigger-action");
+    const menuAction = el.querySelector<Action["el"]>("#menu-action");
+
+    await component.updateComplete;
+    await triggerAction?.setFocus();
+    await userEvent.keyboard("{Enter}");
+    await component.updateComplete;
+
+    expect(el.open).toBe(true);
+    expect(menuAction?.active).toBe(false);
+    expect(el.ariaActiveDescendantElement?.id).toBe("menu-action");
   });
 });

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -1,5 +1,6 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   defaults,
@@ -109,4 +110,66 @@ describe("delegates to floating-ui-owner component", () => {
       ),
     "calcite-popover",
   );
+});
+
+describe("accessibility", () => {
+  it("sets an accessible name on menuitem actions", async () => {
+    const { el } = await mount(
+      <calcite-action-menu>
+        <calcite-action icon="plus" label="Create item" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    const action = el.querySelector("calcite-action");
+
+    expect(action).toHaveAttribute("aria-label", "Create item");
+    expect(action).toHaveAttribute("role", "menuitem");
+  });
+
+  it("sets active descendant on the host and menu", async () => {
+    const { component, el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu>
+        <calcite-action icon="plus" id="create-action" text="Add" />
+      </calcite-action-menu>,
+    );
+
+    el.open = true;
+    await component.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']");
+
+    expect(el.ariaActiveDescendantElement?.id).toBe("create-action");
+    expect(menu?.ariaActiveDescendantElement?.id).toBe("create-action");
+  });
+
+  it("updates active descendant on the host and menu during keyboard navigation", async () => {
+    const { component, el } = await mount<"calcite-action-menu">(
+      <calcite-action-menu>
+        <calcite-action icon="undo" id="undo-action" text="Undo" />
+        <calcite-action icon="redo" id="redo-action" text="Redo" />
+        <calcite-action icon="save" id="save-action" text="Save" />
+      </calcite-action-menu>,
+    );
+
+    el.open = true;
+    await component.updateComplete;
+
+    const menu = el.shadowRoot?.querySelector("[role='menu']");
+
+    expect(el.ariaActiveDescendantElement?.id).toBe("undo-action");
+    expect(menu?.ariaActiveDescendantElement?.id).toBe("undo-action");
+
+    await el.setFocus();
+    await userEvent.keyboard("{ArrowDown}");
+    await component.updateComplete;
+
+    expect(el.ariaActiveDescendantElement?.id).toBe("redo-action");
+    expect(menu?.ariaActiveDescendantElement?.id).toBe("redo-action");
+
+    await userEvent.keyboard("{ArrowDown}");
+    await component.updateComplete;
+
+    expect(el.ariaActiveDescendantElement?.id).toBe("save-action");
+    expect(menu?.ariaActiveDescendantElement?.id).toBe("save-action");
+  });
 });

--- a/packages/components/src/components/action-menu/action-menu.e2e.ts
+++ b/packages/components/src/components/action-menu/action-menu.e2e.ts
@@ -521,6 +521,39 @@ describe("Keyboard navigation", () => {
     expect(clickSpy).toHaveReceivedEventTimes(1);
   });
 
+  it("should select the active action on Enter key and keep selectable action groups open", async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      html`<calcite-action-menu>
+        <calcite-action-group selection-mode="multiple">
+          <calcite-action id="first" text="Add" icon="plus" text-enabled></calcite-action>
+          <calcite-action id="second" text="Remove" icon="minus" text-enabled></calcite-action>
+          <calcite-action id="third" text="View" icon="banana" text-enabled></calcite-action>
+        </calcite-action-group>
+      </calcite-action-menu>`,
+    );
+    await skipAnimations(page);
+    const actionMenu = await page.find("calcite-action-menu");
+    const actions = await findAll(page, "calcite-action");
+
+    await actionMenu.callMethod("setFocus");
+    await page.waitForChanges();
+    const openEventSpy = await actionMenu.spyOnEvent("calciteActionMenuOpen");
+    await page.keyboard.press("ArrowDown");
+    await page.waitForChanges();
+    await openEventSpy.next();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+    expect(await actions[0].getProperty("activeDescendant")).toBe(true);
+    expect(await actions[0].getProperty("active")).toBe(false);
+
+    await page.keyboard.press("Enter");
+    await page.waitForChanges();
+
+    expect(await actionMenu.getProperty("open")).toBe(true);
+    expect(await actions[0].getProperty("active")).toBe(true);
+  });
+
   it("should move the focus ring to the active action on mousedown", async () => {
     const page = await newE2EPage();
     await page.setContent(

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -14,7 +14,7 @@ import { toAriaBoolean } from "../../utils/aria";
 import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import { guid } from "../../utils/guid";
 import { isActivationKey } from "../../utils/key";
-import { ActiveDescendantManager, Appearance, Scale } from "../interfaces";
+import { ActiveDescendantManager, Appearance, Scale, SelectionMode } from "../interfaces";
 import type { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import type { Tooltip } from "../tooltip/tooltip";
@@ -110,11 +110,17 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
   private tooltipEl: Tooltip["el"];
 
   private updateAction = (action: Action["el"], index: number): void => {
-    const { activeDescendantControlDisabled, guid, activeMenuItemIndex } = this;
+    const { activeDescendantControlDisabled, guid, activeMenuItemIndex, selectionMode } = this;
     const id = IDS.action(guid, index);
     action.tabIndex = -1;
     action.setAttribute("aria-label", action.label || action.text);
-    action.setAttribute("role", "menuitem");
+    action.setAttribute("role", this.getActionRole());
+
+    if (selectionMode === "none") {
+      action.removeAttribute("aria-checked");
+    } else {
+      action.setAttribute("aria-checked", toAriaBoolean(action.active));
+    }
 
     if (!action.id) {
       action.id = id;
@@ -217,6 +223,23 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
   /** Specifies the size of the component's trigger `calcite-action`. */
   @property({ reflect: true }) scale: Scale = "m";
 
+  /**
+   * Specifies the selection mode of slotted actions.
+   *
+   * @private
+   */
+  @property() selectionMode: Extract<
+    "single" | "single-persist" | "multiple" | "none",
+    SelectionMode
+  > = "none";
+
+  /**
+   * Specifies a function to handle selection updates for slotted actions.
+   *
+   * @private
+   */
+  @property() selectionHandler?: (action: Action["el"]) => boolean;
+
   //#endregion
 
   //#region Public Methods
@@ -255,6 +278,17 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     cancelable: false,
   });
 
+  /**
+   * Fires when the component updates action selection.
+   *
+   * @private
+   */
+  calciteInternalActionMenuSelect = createEvent({
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  });
+
   //#endregion
 
   //#region Lifecycle
@@ -282,6 +316,10 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     }
 
     if (changes.has("activeDescendantControlDisabled") && this.hasUpdated) {
+      this.updateActions(this.actionElements);
+    }
+
+    if (changes.has("selectionMode") && this.hasUpdated) {
       this.updateActions(this.actionElements);
     }
 
@@ -427,7 +465,17 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
       return;
     }
 
-    if (this.isSelectionAction(action)) {
+    this.activeMenuItemIndex = this.actionElements.indexOf(action);
+
+    if (this.selectionMode !== "none") {
+      if (this.selectionHandler?.(action)) {
+        this.updateActions(this.actionElements);
+        return;
+      }
+
+      this.setActiveAction(action);
+      this.updateActions(this.actionElements);
+      this.calciteInternalActionMenuSelect.emit();
       return;
     }
 
@@ -435,10 +483,39 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     this.setFocus();
   }
 
-  private isSelectionAction(action: Action["el"]): boolean {
-    const actionGroup = action.closest("calcite-action-group");
+  private getActionRole(): "menuitem" | "menuitemcheckbox" | "menuitemradio" {
+    if (this.selectionMode === "multiple") {
+      return "menuitemcheckbox";
+    }
 
-    return !!actionGroup && actionGroup.selectionMode !== "none";
+    if (this.selectionMode === "single" || this.selectionMode === "single-persist") {
+      return "menuitemradio";
+    }
+
+    return "menuitem";
+  }
+
+  private setActiveAction(activeAction: Action["el"]): void {
+    const { actionElements, selectionMode } = this;
+
+    if (selectionMode === "multiple") {
+      activeAction.active = !activeAction.active;
+      return;
+    }
+
+    if (selectionMode === "single") {
+      const nextActive = !activeAction.active;
+      actionElements.forEach((action) => {
+        action.active = action === activeAction && nextActive;
+      });
+      return;
+    }
+
+    if (selectionMode === "single-persist" && !activeAction.active) {
+      actionElements.forEach((action) => {
+        action.active = action === activeAction;
+      });
+    }
   }
 
   private updateTooltip(event: Event): void {

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -74,11 +74,18 @@ export class ActionMenu extends LitElement {
       }
 
       const action = actionElements[activeMenuItemIndex];
+      if (open) {
+        if (action) {
+          action.click();
+        }
+        return;
+      }
+
+      this.toggleOpen(true);
       if (action) {
         action.click();
-      } else {
-        this.toggleOpen(false);
       }
+      return;
     }
 
     if (key === "Tab") {
@@ -412,7 +419,7 @@ export class ActionMenu extends LitElement {
       })
       .reduce<Action["el"][]>((previousValue, currentValue) => {
         if (currentValue?.matches("calcite-action")) {
-          previousValue.push(currentValue as Action["el"]);
+          previousValue.push(currentValue);
           return previousValue;
         }
 
@@ -438,36 +445,27 @@ export class ActionMenu extends LitElement {
 
     event.preventDefault();
 
-    if (!this.open) {
-      this.toggleOpen();
-
-      if (key === "Home" || key === "ArrowDown") {
+    if (this.open) {
+      if (key === "Home") {
         this.activeMenuItemIndex = 0;
       }
 
-      if (key === "End" || key === "ArrowUp") {
+      if (key === "End") {
         this.activeMenuItemIndex = actions.length - 1;
       }
 
-      return;
-    }
+      const currentIndex = this.activeMenuItemIndex;
 
-    if (key === "Home") {
-      this.activeMenuItemIndex = 0;
-    }
+      if (key === "ArrowUp") {
+        this.activeMenuItemIndex = getRoundRobinIndex(
+          Math.max(currentIndex - 1, -1),
+          actions.length,
+        );
+      }
 
-    if (key === "End") {
-      this.activeMenuItemIndex = actions.length - 1;
-    }
-
-    const currentIndex = this.activeMenuItemIndex;
-
-    if (key === "ArrowUp") {
-      this.activeMenuItemIndex = getRoundRobinIndex(Math.max(currentIndex - 1, -1), actions.length);
-    }
-
-    if (key === "ArrowDown") {
-      this.activeMenuItemIndex = getRoundRobinIndex(currentIndex + 1, actions.length);
+      if (key === "ArrowDown") {
+        this.activeMenuItemIndex = getRoundRobinIndex(currentIndex + 1, actions.length);
+      }
     }
   }
 

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -14,7 +14,7 @@ import { toAriaBoolean } from "../../utils/aria";
 import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import { guid } from "../../utils/guid";
 import { isActivationKey } from "../../utils/key";
-import { Appearance, Scale } from "../interfaces";
+import { ActiveDescendantManager, Appearance, Scale } from "../interfaces";
 import type { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import type { Tooltip } from "../tooltip/tooltip";
@@ -36,7 +36,7 @@ const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
  * @slot trigger - A slot for adding a `calcite-action` to trigger opening the menu.
  * @slot tooltip - A slot for adding a tooltip for the menu.
  */
-export class ActionMenu extends LitElement {
+export class ActionMenu extends LitElement implements ActiveDescendantManager {
   //#region Static Members
 
   static override styles = styles;
@@ -67,11 +67,6 @@ export class ActionMenu extends LitElement {
 
     if (isActivationKey(key)) {
       event.preventDefault();
-
-      if (!open) {
-        this.toggleOpen();
-        return;
-      }
 
       const action = actionElements[activeMenuItemIndex];
       if (open) {
@@ -104,26 +99,31 @@ export class ActionMenu extends LitElement {
 
   private menuId = IDS.menu(this.guid);
 
+  private menuEl: HTMLDivElement;
+
   private _open = false;
 
   private popoverEl: Popover["el"];
 
-  private slottedMenuButtonEl: Action["el"];
+  private slottedMenuButtonEl?: Action["el"];
 
   private tooltipEl: Tooltip["el"];
 
   private updateAction = (action: Action["el"], index: number): void => {
-    const { guid, activeMenuItemIndex } = this;
+    const { activeDescendantControlDisabled, guid, activeMenuItemIndex } = this;
     const id = IDS.action(guid, index);
     action.tabIndex = -1;
+    action.setAttribute("aria-label", action.label || action.text);
     action.setAttribute("role", "menuitem");
 
     if (!action.id) {
       action.id = id;
     }
 
-    // Used to style the "activeMenuItemIndex" action using token focus styling.
-    action.activeDescendant = index === activeMenuItemIndex;
+    if (!activeDescendantControlDisabled) {
+      // Used to style the "activeMenuItemIndex" action using token focus styling.
+      action.activeDescendant = index === activeMenuItemIndex;
+    }
   };
 
   private focusSetter = useSetFocus<this>()(this);
@@ -148,8 +148,24 @@ export class ActionMenu extends LitElement {
 
   //#region Public Properties
 
+  /**
+   * The component's active descendant.
+   *
+   * @private
+   */
+  get activeDescendantElement(): Action["el"] | undefined {
+    return this.actionElements[this.activeMenuItemIndex];
+  }
+
   /** Specifies the appearance of the component. */
   @property({ reflect: true }) appearance: Extract<"solid" | "transparent", Appearance> = "solid";
+
+  /**
+   * When `true`, disables the component's internal active-descendant handling.
+   *
+   * @private
+   */
+  @property() activeDescendantControlDisabled = false;
 
   /** When `true`, expands the component and its contents. */
   @property({ reflect: true }) expanded = false;
@@ -214,7 +230,7 @@ export class ActionMenu extends LitElement {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => this.menuButtonEl, options);
+    return this.focusSetter(() => (this.open ? this.menuEl : this.menuButtonEl), options);
   }
 
   //#endregion
@@ -229,6 +245,15 @@ export class ActionMenu extends LitElement {
 
   /** Fires when the `open` property is toggled. */
   calciteActionMenuOpen = createEvent({ cancelable: false });
+
+  /**
+   * Fires when the component's active descendant changes.
+   *
+   * @private
+   */
+  calciteInternalActiveDescendantChange = createEvent({
+    cancelable: false,
+  });
 
   //#endregion
 
@@ -253,6 +278,11 @@ export class ActionMenu extends LitElement {
       (this.hasUpdated || this.activeMenuItemIndex !== -1)
     ) {
       this.updateActions(this.actionElements);
+      this.emitInternalActiveDescendantChange();
+    }
+
+    if (changes.has("activeDescendantControlDisabled") && this.hasUpdated) {
+      this.updateActions(this.actionElements);
     }
 
     if (changes.has("expanded") && this.hasUpdated) {
@@ -275,6 +305,10 @@ export class ActionMenu extends LitElement {
   private expandedHandler(): void {
     this.open = false;
     this.setTooltipReferenceElement();
+  }
+
+  private focusMenuButton(options?: FocusOptions): Promise<void> {
+    return this.focusSetter(() => this.menuButtonEl, options);
   }
 
   private openHandler(open: boolean): void {
@@ -382,11 +416,29 @@ export class ActionMenu extends LitElement {
     el.open = this.open;
   }
 
-  private handleCalciteActionClick(event): void {
-    if (this.actionElements?.some((action) => event.composedPath().includes(action))) {
-      this.open = false;
-      this.setFocus();
+  private setMenuEl(el: HTMLDivElement): void {
+    this.menuEl = el;
+  }
+
+  private handleCalciteActionClick(event: MouseEvent): void {
+    const action = this.actionElements?.find((action) => event.composedPath().includes(action));
+
+    if (!action) {
+      return;
     }
+
+    if (this.isSelectionAction(action)) {
+      return;
+    }
+
+    this.open = false;
+    this.setFocus();
+  }
+
+  private isSelectionAction(action: Action["el"]): boolean {
+    const actionGroup = action.closest("calcite-action-group");
+
+    return !!actionGroup && actionGroup.selectionMode !== "none";
   }
 
   private updateTooltip(event: Event): void {
@@ -410,6 +462,20 @@ export class ActionMenu extends LitElement {
 
   private updateActions(actions: Action["el"][]): void {
     actions?.forEach(this.updateAction);
+    this.syncActiveDescendantElement();
+  }
+
+  private getActiveDescendantElement(): Action["el"] | undefined {
+    return this.activeDescendantControlDisabled ? undefined : this.activeDescendantElement;
+  }
+
+  private syncActiveDescendantElement(): void {
+    (this.el as HTMLElement).ariaActiveDescendantElement =
+      this.getActiveDescendantElement() ?? null;
+  }
+
+  private emitInternalActiveDescendantChange(): void {
+    this.calciteInternalActiveDescendantChange.emit();
   }
 
   private async handleDefaultSlotChange(event: Event): Promise<void> {
@@ -432,6 +498,8 @@ export class ActionMenu extends LitElement {
 
     await this.componentOnReady();
     this.actionElements = actions.filter((action) => !action.disabled && !action.hidden);
+    this.updateActions(this.actionElements);
+    this.emitInternalActiveDescendantChange();
   }
 
   private isValidKey(key: string, supportedKeys: string[]): boolean {
@@ -482,6 +550,7 @@ export class ActionMenu extends LitElement {
   private handlePopoverClose(event: CustomEvent<void>): void {
     event.stopPropagation();
     this.open = false;
+    void this.focusMenuButton();
   }
 
   //#endregion
@@ -510,19 +579,9 @@ export class ActionMenu extends LitElement {
   }
 
   private renderMenuItems(): JsxNode {
-    const {
-      actionElements,
-      activeMenuItemIndex,
-      menuId,
-      menuButtonEl,
-      label,
-      placement,
-      overlayPositioning,
-      flipPlacements,
-    } = this;
+    const { menuId, menuButtonEl, label, placement, overlayPositioning, flipPlacements } = this;
 
-    const activeAction = actionElements[activeMenuItemIndex];
-    const activeDescendantId = activeAction?.id || null;
+    const activeDescendantElement = this.getActiveDescendantElement();
 
     return (
       <calcite-popover
@@ -543,11 +602,13 @@ export class ActionMenu extends LitElement {
         triggerDisabled={true}
       >
         <div
-          aria-activedescendant={activeDescendantId}
           aria-labelledby={menuButtonEl?.id}
+          ariaActiveDescendantElement={activeDescendantElement}
           class={CSS.menu}
           id={menuId}
           onClick={this.handleCalciteActionClick}
+          onKeyDown={this.menuButtonKeyDown}
+          ref={this.setMenuEl}
           role="menu"
           tabIndex={-1}
         >

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -514,6 +514,7 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
       return;
     }
 
+    action.active = !action.active;
     this.open = false;
     void this.setFocus();
   }

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -14,7 +14,7 @@ import { toAriaBoolean } from "../../utils/aria";
 import { FlipPlacement, LogicalPlacement, OverlayPositioning } from "../../utils/floating-ui";
 import { guid } from "../../utils/guid";
 import { isActivationKey } from "../../utils/key";
-import { ActiveDescendantManager, Appearance, Scale, SelectionMode } from "../interfaces";
+import { ActiveDescendantManager, Appearance, Scale } from "../interfaces";
 import type { Action } from "../action/action";
 import { isAction } from "../action/resources";
 import type { Tooltip } from "../tooltip/tooltip";
@@ -30,6 +30,10 @@ declare global {
 }
 
 const SUPPORTED_MENU_NAV_KEYS = ["ArrowUp", "ArrowDown", "End", "Home"];
+const HORIZONTAL_MENU_OPEN_KEYS = ["ArrowLeft", "ArrowRight"];
+const VERTICAL_MENU_OPEN_KEYS = ["ArrowUp", "ArrowDown"];
+const HORIZONTAL_PLACEMENT_PREFIXES = ["left", "right", "leading", "trailing"];
+const VERTICAL_PLACEMENT_PREFIXES = ["top", "bottom"];
 
 /**
  * @slot - A slot for adding `calcite-action`s.
@@ -59,7 +63,14 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
 
   private menuButtonKeyDown = (event: KeyboardEvent): void => {
     const { key } = event;
-    const { actionElements, activeMenuItemIndex, open } = this;
+    const { activeMenuItemIndex, open } = this;
+    let { actionElements } = this;
+
+    if (!actionElements.length) {
+      actionElements = this.queryActionElements();
+      this.actionElements = actionElements;
+      this.updateActions(actionElements);
+    }
 
     if (!actionElements.length) {
       return;
@@ -77,13 +88,11 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
       }
 
       this.toggleOpen(true);
-      if (action) {
-        action.click();
-      }
       return;
     }
 
-    if (key === "Tab") {
+    if (key === "Tab" && open) {
+      this.focusMenuButtonOnClose = false;
       this.open = false;
       return;
     }
@@ -94,12 +103,61 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
       return;
     }
 
+    const placementOrientation = !open ? this.placementOrientation : undefined;
+    const supportedOpenKeys =
+      placementOrientation === "horizontal"
+        ? HORIZONTAL_MENU_OPEN_KEYS
+        : placementOrientation === "vertical"
+          ? VERTICAL_MENU_OPEN_KEYS
+          : undefined;
+
+    if (supportedOpenKeys && this.isValidKey(key, supportedOpenKeys)) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.toggleOpen(true);
+      this.activeMenuItemIndex =
+        placementOrientation === "vertical" && key === "ArrowUp" ? actionElements.length - 1 : 0;
+      this.updateActions(actionElements);
+      this.emitInternalActiveDescendantChange();
+      return;
+    }
+
     this.handleActionNavigation(event, key, actionElements);
+  };
+
+  private handleHostKeyDown = (event: KeyboardEvent): void => {
+    if (event.composedPath()[0] !== this.el) {
+      return;
+    }
+
+    this.menuButtonKeyDown(event);
   };
 
   private menuId = IDS.menu(this.guid);
 
   private menuEl: HTMLDivElement;
+
+  private get placementOrientation(): "horizontal" | "vertical" | undefined {
+    const placements = this.flipPlacements?.length ? this.flipPlacements : [this.placement];
+    const placement = placements.find((placement) =>
+      this.hasPlacementPrefix(
+        placement,
+        HORIZONTAL_PLACEMENT_PREFIXES.concat(VERTICAL_PLACEMENT_PREFIXES),
+      ),
+    );
+
+    if (!placement) {
+      return;
+    }
+
+    if (this.hasPlacementPrefix(placement, HORIZONTAL_PLACEMENT_PREFIXES)) {
+      return "horizontal";
+    }
+
+    if (this.hasPlacementPrefix(placement, VERTICAL_PLACEMENT_PREFIXES)) {
+      return "vertical";
+    }
+  }
 
   private _open = false;
 
@@ -110,17 +168,12 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
   private tooltipEl: Tooltip["el"];
 
   private updateAction = (action: Action["el"], index: number): void => {
-    const { activeDescendantControlDisabled, guid, activeMenuItemIndex, selectionMode } = this;
+    const { activeDescendantControlDisabled, guid, activeMenuItemIndex } = this;
     const id = IDS.action(guid, index);
     action.tabIndex = -1;
     action.setAttribute("aria-label", action.label || action.text);
-    action.setAttribute("role", this.getActionRole());
-
-    if (selectionMode === "none") {
-      action.removeAttribute("aria-checked");
-    } else {
-      action.setAttribute("aria-checked", toAriaBoolean(action.active));
-    }
+    action.setAttribute("role", "menuitem");
+    action.removeAttribute("aria-checked");
 
     if (!action.id) {
       action.id = id;
@@ -134,11 +187,14 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
 
   private focusSetter = useSetFocus<this>()(this);
 
+  private focusMenuButtonOnClose = true;
+
   private mouseDownHandler = (event: MouseEvent): void => {
-    if (!event.composedPath().some(isAction)) {
+    if (!event.composedPath().some((el): boolean => el instanceof Element && isAction(el))) {
       return;
     }
 
+    this.focusMenuButtonOnClose = false;
     this.activeMenuItemIndex = this.actionElements?.findIndex((action) => action === event.target);
   };
 
@@ -160,7 +216,13 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
    * @private
    */
   get activeDescendantElement(): Action["el"] | undefined {
-    return this.actionElements[this.activeMenuItemIndex];
+    const actionElements = this.actionElements.length
+      ? this.actionElements
+      : this.queryActionElements();
+    const activeMenuItemIndex =
+      this.open && this.activeMenuItemIndex === -1 ? 0 : this.activeMenuItemIndex;
+
+    return actionElements[activeMenuItemIndex];
   }
 
   /** Specifies the appearance of the component. */
@@ -223,23 +285,6 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
   /** Specifies the size of the component's trigger `calcite-action`. */
   @property({ reflect: true }) scale: Scale = "m";
 
-  /**
-   * Specifies the selection mode of slotted actions.
-   *
-   * @private
-   */
-  @property() selectionMode: Extract<
-    "single" | "single-persist" | "multiple" | "none",
-    SelectionMode
-  > = "none";
-
-  /**
-   * Specifies a function to handle selection updates for slotted actions.
-   *
-   * @private
-   */
-  @property() selectionHandler?: (action: Action["el"]) => boolean;
-
   //#endregion
 
   //#region Public Methods
@@ -253,7 +298,7 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => (this.open ? this.menuEl : this.menuButtonEl), options);
+    return this.focusSetter(() => (this.open ? this.menuEl : this.el), options);
   }
 
   //#endregion
@@ -278,23 +323,13 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     cancelable: false,
   });
 
-  /**
-   * Fires when the component updates action selection.
-   *
-   * @private
-   */
-  calciteInternalActionMenuSelect = createEvent({
-    bubbles: true,
-    cancelable: false,
-    composed: true,
-  });
-
   //#endregion
 
   //#region Lifecycle
 
   override connectedCallback(): void {
     this.connectMenuButtonEl();
+    this.listen("keydown", this.handleHostKeyDown);
     this.listen("mousedown", this.mouseDownHandler);
   }
 
@@ -316,10 +351,6 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     }
 
     if (changes.has("activeDescendantControlDisabled") && this.hasUpdated) {
-      this.updateActions(this.actionElements);
-    }
-
-    if (changes.has("selectionMode") && this.hasUpdated) {
       this.updateActions(this.actionElements);
     }
 
@@ -466,56 +497,10 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     }
 
     this.activeMenuItemIndex = this.actionElements.indexOf(action);
-
-    if (this.selectionMode !== "none") {
-      if (this.selectionHandler?.(action)) {
-        this.updateActions(this.actionElements);
-        return;
-      }
-
-      this.setActiveAction(action);
-      this.updateActions(this.actionElements);
-      this.calciteInternalActionMenuSelect.emit();
-      return;
-    }
-
+    action.active = !action.active;
+    this.focusMenuButtonOnClose = false;
     this.open = false;
-    this.setFocus();
-  }
-
-  private getActionRole(): "menuitem" | "menuitemcheckbox" | "menuitemradio" {
-    if (this.selectionMode === "multiple") {
-      return "menuitemcheckbox";
-    }
-
-    if (this.selectionMode === "single" || this.selectionMode === "single-persist") {
-      return "menuitemradio";
-    }
-
-    return "menuitem";
-  }
-
-  private setActiveAction(activeAction: Action["el"]): void {
-    const { actionElements, selectionMode } = this;
-
-    if (selectionMode === "multiple") {
-      activeAction.active = !activeAction.active;
-      return;
-    }
-
-    if (selectionMode === "single") {
-      const nextActive = !activeAction.active;
-      actionElements.forEach((action) => {
-        action.active = action === activeAction && nextActive;
-      });
-      return;
-    }
-
-    if (selectionMode === "single-persist" && !activeAction.active) {
-      actionElements.forEach((action) => {
-        action.active = action === activeAction;
-      });
-    }
+    void this.setFocus();
   }
 
   private updateTooltip(event: Event): void {
@@ -579,8 +564,18 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     this.emitInternalActiveDescendantChange();
   }
 
+  private queryActionElements(): Action["el"][] {
+    return Array.from(this.el.querySelectorAll<Action["el"]>("calcite-action")).filter(
+      (action) => action.slot !== SLOTS.trigger && !action.disabled && !action.hidden,
+    );
+  }
+
   private isValidKey(key: string, supportedKeys: string[]): boolean {
     return !!supportedKeys.find((k) => k === key);
+  }
+
+  private hasPlacementPrefix(placement: LogicalPlacement, prefixes: string[]): boolean {
+    return prefixes.some((prefix) => placement === prefix || placement.startsWith(`${prefix}-`));
   }
 
   private handleActionNavigation(event: KeyboardEvent, key: string, actions: Action["el"][]): void {
@@ -625,9 +620,15 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
   }
 
   private handlePopoverClose(event: CustomEvent<void>): void {
+    const { focusMenuButtonOnClose } = this;
+
+    this.focusMenuButtonOnClose = true;
     event.stopPropagation();
     this.open = false;
-    void this.focusMenuButton();
+
+    if (focusMenuButtonOnClose) {
+      void this.focusMenuButton();
+    }
   }
 
   //#endregion
@@ -681,6 +682,7 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
         <div
           aria-labelledby={menuButtonEl?.id}
           ariaActiveDescendantElement={activeDescendantElement}
+          ariaOrientation={this.placementOrientation === "vertical" ? "vertical" : undefined}
           class={CSS.menu}
           id={menuId}
           onClick={this.handleCalciteActionClick}

--- a/packages/components/src/components/action-menu/action-menu.tsx
+++ b/packages/components/src/components/action-menu/action-menu.tsx
@@ -104,19 +104,21 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     }
 
     const placementOrientation = !open ? this.placementOrientation : undefined;
-    const supportedOpenKeys =
-      placementOrientation === "horizontal"
+    const supportedOpenKeys = !open
+      ? placementOrientation === "horizontal"
         ? HORIZONTAL_MENU_OPEN_KEYS
-        : placementOrientation === "vertical"
+        : placementOrientation === "vertical" || !placementOrientation
           ? VERTICAL_MENU_OPEN_KEYS
-          : undefined;
+          : undefined
+      : undefined;
 
     if (supportedOpenKeys && this.isValidKey(key, supportedOpenKeys)) {
       event.preventDefault();
       event.stopPropagation();
       this.toggleOpen(true);
+      const opensVertically = placementOrientation !== "horizontal";
       this.activeMenuItemIndex =
-        placementOrientation === "vertical" && key === "ArrowUp" ? actionElements.length - 1 : 0;
+        opensVertically && key === "ArrowUp" ? actionElements.length - 1 : 0;
       this.updateActions(actionElements);
       this.emitInternalActiveDescendantChange();
       return;
@@ -298,7 +300,7 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
    */
   @method()
   async setFocus(options?: FocusOptions): Promise<void> {
-    return this.focusSetter(() => (this.open ? this.menuEl : this.el), options);
+    return this.focusSetter(() => this.menuButtonEl || this.el, options);
   }
 
   //#endregion
@@ -395,6 +397,10 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     this.activeMenuItemIndex = this.open ? 0 : -1;
     this.calciteActionMenuOpen.emit();
     this.setTooltipReferenceElement();
+
+    if (open) {
+      void this.setFocus();
+    }
   }
 
   private connectMenuButtonEl(): void {
@@ -497,8 +503,17 @@ export class ActionMenu extends LitElement implements ActiveDescendantManager {
     }
 
     this.activeMenuItemIndex = this.actionElements.indexOf(action);
-    action.active = !action.active;
     this.focusMenuButtonOnClose = false;
+
+    const actionGroup = action.closest("calcite-action-group") as { selectionMode?: string } | null;
+    const keepSelectableActionGroupOpen =
+      !!actionGroup?.selectionMode && actionGroup.selectionMode !== "none";
+
+    if (keepSelectableActionGroupOpen) {
+      void this.setFocus();
+      return;
+    }
+
     this.open = false;
     void this.setFocus();
   }

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -4,6 +4,7 @@ import { guid } from "../../utils/guid";
 import { createObserver } from "../../utils/observers";
 import { getIconScale } from "../../utils/component";
 import {
+  ActiveDescendantElement,
   Alignment,
   Appearance,
   AriaAttributesCamelCased,
@@ -29,7 +30,7 @@ declare global {
 /**
  * @slot - A slot for adding non-interactive content, such as a `calcite-icon`.
  */
-export class Action extends LitElement {
+export class Action extends LitElement implements ActiveDescendantElement {
   //#region Static Members
 
   static formAssociated = true;

--- a/packages/components/src/components/interfaces.ts
+++ b/packages/components/src/components/interfaces.ts
@@ -3,6 +3,13 @@ import { CamelCase, ReadonlyTuple } from "type-fest";
 
 export type Alignment = "start" | "center" | "end";
 export type Appearance = "solid" | "outline" | "outline-fill" | "transparent";
+export interface ActiveDescendantElement extends HTMLElement {
+  activeDescendant: boolean;
+}
+export interface ActiveDescendantManager extends HTMLElement {
+  activeDescendantElement?: ActiveDescendantElement;
+  activeDescendantControlDisabled: boolean;
+}
 export interface Dimensions {
   width: number;
   height: number;


### PR DESCRIPTION
**Related Issue:** [#7052](https://github.com/Esri/calcite-design-system/issues/7052) 

## Summary

- Includes direct and overflow action menus in `Action Bar` roving keyboard navigation.
- Synchronizes `Action Menu` actions and `active-descendant` state when slotted content changes.
- Aligns directional-key behavior with `Action Bar` orientation and menu placement.
- Restores responsive overflow recalculation when `Action Bar` dimensions change.
- Prevents selection-enabled `Action Groups` from displaying overflow menus.
