### PR TITLE
ci(actions): fix update-components `.js` import

### DIFF
--- a/.github/workflows/update-components.yml
+++ b/.github/workflows/update-components.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm ci || true
       - name: Run updater
         run: |
-          node .github/scripts/updateIssueTemplateComponents.js
+          node .github/scripts/updateIssueTemplateComponents.cjs
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Fixes the `.js` import to `.cjs` in the `update-components.yml` workflow, hopefully resolving workflow failures ([example](https://github.com/Esri/calcite-design-system/actions/runs/32877436345/job/97898702925)).

Did a search for `.js` imports, and think this is the last one.
