### PR TITLE
ci(actions): fix `update-components` push paths and node version

### DIFF
--- a/.github/workflows/update-components.yml
+++ b/.github/workflows/update-components.yml
@@ -2,7 +2,7 @@ name: Update Issue Template Components
 on:
   push:
     paths:
-      - "packages/src/components/**"
+      - "packages/components/src/components/**"
   workflow_dispatch:
 jobs:
   update:
@@ -12,9 +12,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version-file: package.json
       - name: Install dependencies
-        run: npm ci || true
+        run: npm ci
       - name: Run updater
         run: |
           node .github/scripts/updateIssueTemplateComponents.cjs


### PR DESCRIPTION
**Related Issue:** n/a

## Summary

Fixes a few error points for the `update-components.yml` workflow to fix run failures. PR #15064 did not fully fix the workflow failures.

- Updates the `push.paths` glob to match the current component dir path
- Removes `|| true` from the dep install to avoid silent install errors
- Updates `Setup Node` to use the `package.json` file for the Node version
