### PR TITLE
fix: assetPathChanged must be true after defineCustomElement's resourcesUrl

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -4,8 +4,6 @@
  * Place in this file any utility functions you wish to expose for the consumers
  * of your package
  */
-import { Runtime } from "@arcgis/lumina";
-import { setAssetPath as runtimeSetAssetPath } from "./runtime";
 
 /** @public */
 declare module "csstype" {
@@ -15,11 +13,5 @@ declare module "csstype" {
 }
 
 /** @internal */
-export let assetPathChanged = false;
-
-export const setAssetPath: Runtime["setAssetPath"] = (path) => {
-  assetPathChanged = true;
-  runtimeSetAssetPath(path);
-};
-
-export { getAssetPath } from "./runtime";
+export { assetPathChanged } from "./runtime";
+export { setAssetPath, getAssetPath } from "./runtime";

--- a/packages/components/src/runtime.ts
+++ b/packages/components/src/runtime.ts
@@ -3,6 +3,15 @@ import "./utils/globalScript";
 
 export const runtime = makeRuntime();
 
+const originalSetAssetPath = runtime.setAssetPath;
+runtime.setAssetPath = (path) => {
+  assetPathChanged = true;
+  originalSetAssetPath(path);
+};
+
+/** @internal */
+export let assetPathChanged = false;
+
 /**
  * "customElement" needs to be exported - it will be used by the build system.
  * You should not call it directly.

--- a/packages/components/src/runtime.ts
+++ b/packages/components/src/runtime.ts
@@ -6,7 +6,7 @@ export const runtime = makeRuntime();
 const originalSetAssetPath = runtime.setAssetPath;
 runtime.setAssetPath = (path) => {
   assetPathChanged = true;
-  originalSetAssetPath(path);
+  return originalSetAssetPath.call(runtime, path);
 };
 
 /** @internal */


### PR DESCRIPTION
**Related Issue:** https://github.com/Esri/calcite-design-system/issues/15067

Lumina's defineCustomElements calls runtime.setAssetPath if resourcesUrl was provided.

Before, calcite had a wrapper over setAssetPath, which was not visible to defineCustomElements.
By mutating runtime.setAssetPath directly, both defineCustomElements() and setAssetPath() calls behave correctly