### PR TITLE
ci(actions): use mise to determine node version

### DIFF
--- a/.github/workflows/chromatic/build-storybook/action.yml
+++ b/.github/workflows/chromatic/build-storybook/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v6
       with:
-        node-version-file: package.json
+        node-version-file: mise.toml
 
     - shell: bash
       env:

--- a/.github/workflows/deploy-latest.yml
+++ b/.github/workflows/deploy-latest.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.release.outputs.releases_created == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version-file: mise.toml
           registry-url: "https://registry.npmjs.org"
       - name: Build Packages and Publish to NPM
         if: steps.release.outputs.releases_created == 'true'

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.base_ref || github.ref_name }}
       - uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version-file: mise.toml
           registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - if: steps.diff-check.outputs.SKIP == 'false'
         uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version-file: mise.toml
       - if: steps.diff-check.outputs.SKIP == 'false'
         name: Run tests for testable changes
         run: npm install && npm run build && npm run test:ci

--- a/.github/workflows/schedule-updates.yml
+++ b/.github/workflows/schedule-updates.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version-file: mise.toml
           cache: npm
       - name: Run update-browserslist-db
         run: |

--- a/.github/workflows/update-components.yml
+++ b/.github/workflows/update-components.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version-file: mise.toml
       - name: Install dependencies
         run: npm ci || true
       - name: Run updater


### PR DESCRIPTION
**Related Issue:** #15065

## Summary

When reviewing the PR above, I noticed we are still using `package.json` to determine the node version, which is where volta stored their info. This PR ensures workflows use the node version specified in `mise.toml`.
