### PR TITLE
test(cli): set up test support

### DIFF
--- a/packages/monorepo-cli/src/run.test.ts
+++ b/packages/monorepo-cli/src/run.test.ts
@@ -1,0 +1,16 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("CLI entrypoint", () => {
+  it("prints help without loading test modules", () => {
+    const cliPath = join(import.meta.dirname, "../../../cli.js");
+    const output = execFileSync(process.execPath, [cliPath, "--help"], {
+      encoding: "utf8",
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+
+    expect(output).toContain("Usage: node cli [options]");
+    expect(Math.max(...output.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
+  });
+});

--- a/packages/monorepo-cli/src/run.ts
+++ b/packages/monorepo-cli/src/run.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "@commander-js/extra-typings";
 import fs from "node:fs";
+import { styleText } from "node:util";
 
 interface CommandModule {
   registerCommand: (program: Command) => void;
@@ -10,7 +11,25 @@ const program = new Command();
 
 program
   .name("node cli")
-  .description(`CLI for managing monorepo tasks. Use node cli <command> --help to see more details about a command.`);
+  .description(`CLI for managing monorepo tasks. Use node cli <command> --help to see more details about a command.`)
+  .configureHelp({
+    helpWidth: Math.min(process.stdout.columns ?? 120, 120),
+    styleSubcommandText: (text) => styleText("green", text, { stream: process.stdout }),
+    formatItem(term, _termWidth, description, helper) {
+      const termIndent = 2;
+      const descriptionIndent = 6;
+      const lines = [`${" ".repeat(termIndent)}${term}`];
+
+      if (description) {
+        const descriptionIndentText = " ".repeat(descriptionIndent);
+        const wrappedDescription = helper.boxWrap(description, (helper.helpWidth ?? 120) - descriptionIndent);
+        lines.push(`${descriptionIndentText}${wrappedDescription.replaceAll("\n", `\n${descriptionIndentText}`)}`);
+      }
+
+      lines.push("");
+      return lines.join("\n");
+    },
+  });
 
 const commandsDirectory = import.meta.dirname;
 
@@ -22,7 +41,7 @@ const commandName = process.argv[2];
 const commandsToLoad =
   commandName !== undefined && commandName !== "help" && !commandName.startsWith("-")
     ? [`${commandName}.ts`]
-    : fs.readdirSync(commandsDirectory);
+    : fs.readdirSync(commandsDirectory).filter((file) => !file.endsWith(".test.ts"));
 
 // Load all commands in the ./commands directory
 Promise.all(


### PR DESCRIPTION
**Related Issue:** #15005

## Summary

Adds a basic test for `run.ts`, aligning with the SDK and fixing broken [CI runs](https://github.com/Esri/calcite-design-system/actions/runs/32895933068) cause by lack of tests.

Minorly adapted from SDK code.

- Supports test files by filtering them out in `run.ts`
- Adds a `configureHelp` block to highlight command names, recently added in the SDK
