### PR TITLE
refactor: derive a shared commonTests helper for scale propagation

### DIFF
--- a/packages/components/src/components/accordion/accordion.browser.e2e.tsx
+++ b/packages/components/src/components/accordion/accordion.browser.e2e.tsx
@@ -1,7 +1,14 @@
 import { Fragment, h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { defaults, reflects, hidden, renders, themed } from "../../tests/commonTests/browser";
+import {
+  defaults,
+  reflects,
+  hidden,
+  renders,
+  scalePropagates,
+  themed,
+} from "../../tests/commonTests/browser";
 import { CSS as ACCORDION_ITEM_CSS } from "../accordion-item/resources";
 import { CSS } from "./resources";
 
@@ -83,6 +90,19 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-accordion"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-accordion>
+          <calcite-accordion-item heading="Item 1" />
+          <calcite-accordion-item heading="Item 2" />
+        </calcite-accordion>,
+      ),
+    { targetSelector: "calcite-accordion-item" },
+  );
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/accordion/accordion.browser.e2e.tsx
+++ b/packages/components/src/components/accordion/accordion.browser.e2e.tsx
@@ -94,12 +94,13 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-accordion scale={scale}>
+        <calcite-accordion>
           <calcite-accordion-item heading="Item 1" />
           <calcite-accordion-item heading="Item 2" />
         </calcite-accordion>,
+        mountOptions,
       ),
     { targetSelector: "calcite-accordion-item" },
   );

--- a/packages/components/src/components/accordion/accordion.browser.e2e.tsx
+++ b/packages/components/src/components/accordion/accordion.browser.e2e.tsx
@@ -94,9 +94,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-accordion>
+        <calcite-accordion scale={scale}>
           <calcite-accordion-item heading="Item 1" />
           <calcite-accordion-item heading="Item 2" />
         </calcite-accordion>,

--- a/packages/components/src/components/accordion/accordion.browser.e2e.tsx
+++ b/packages/components/src/components/accordion/accordion.browser.e2e.tsx
@@ -92,7 +92,7 @@ describe("renders", () => {
   renders(() => mount("calcite-accordion"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -186,7 +186,7 @@ describe("renders", () => {
   renders(() => mount("calcite-action-bar"), { display: "inline-flex" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-action-bar />, mountOptions), {
     targetSelector: "calcite-action-group, calcite-action",
   });

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -187,7 +187,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-action-bar"), {
+  scalePropagates((scale) => mount(<calcite-action-bar scale={scale} />), {
     targetSelector: "calcite-action-group calcite-action",
   });
 });

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -187,7 +187,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-action-bar scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-action-bar />, mountOptions), {
     targetSelector: "calcite-action-group, calcite-action",
   });
 });

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -188,7 +188,7 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates((scale) => mount(<calcite-action-bar scale={scale} />), {
-    targetSelector: "calcite-action-group calcite-action",
+    targetSelector: "calcite-action-group, calcite-action",
   });
 });
 

--- a/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
+++ b/packages/components/src/components/action-bar/action-bar.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   slots,
   t9n,
   delegatesToFloatingUiOwningComponent,
@@ -183,6 +184,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-action-bar"), { display: "inline-flex" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-action-bar"), {
+    targetSelector: "calcite-action-group calcite-action",
+  });
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -234,7 +234,9 @@ describe("selection change event and selectedActions state", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-action-group"), { targetSelector: "calcite-action-menu" });
+  scalePropagates((scale) => mount(<calcite-action-group scale={scale} />), {
+    targetSelector: "calcite-action-menu",
+  });
 });
 
 it("should honor overlayPositioning", async () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   slots,
   t9n,
   accessible,
@@ -232,11 +233,17 @@ describe("selection change event and selectedActions state", () => {
   });
 });
 
-it("should honor scale of expand icon", async () => {
-  await mount(renderActionGroup);
-  const menu = page.getBySelector(`calcite-action-group calcite-action-menu`);
-
-  await expect.element(menu).toHaveProperty("scale", "l");
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-action-group>
+          <calcite-action icon="plus" slot="menu-actions" text="Add" />
+          <calcite-action icon="banana" slot="menu-actions" text="Banana" />
+        </calcite-action-group>,
+      ),
+    { targetSelector: "calcite-action-menu" },
+  );
 });
 
 it("should honor overlayPositioning", async () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -233,7 +233,7 @@ describe("selection change event and selectedActions state", () => {
   });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-action-group />, mountOptions), {
     targetSelector: "calcite-action-menu",
   });

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -234,16 +234,7 @@ describe("selection change event and selectedActions state", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(
-    () =>
-      mount(
-        <calcite-action-group>
-          <calcite-action icon="plus" slot="menu-actions" text="Add" />
-          <calcite-action icon="banana" slot="menu-actions" text="Banana" />
-        </calcite-action-group>,
-      ),
-    { targetSelector: "calcite-action-menu" },
-  );
+  scalePropagates(() => mount("calcite-action-group"), { targetSelector: "calcite-action-menu" });
 });
 
 it("should honor overlayPositioning", async () => {

--- a/packages/components/src/components/action-group/action-group.browser.e2e.tsx
+++ b/packages/components/src/components/action-group/action-group.browser.e2e.tsx
@@ -234,7 +234,7 @@ describe("selection change event and selectedActions state", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-action-group scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-action-group />, mountOptions), {
     targetSelector: "calcite-action-menu",
   });
 });

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -230,7 +230,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-action-menu"), {
+  scalePropagates((scale) => mount(<calcite-action-menu scale={scale} />), {
     targetSelector: `.${CSS.defaultTrigger}`,
   });
 });

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -229,7 +229,7 @@ describe("renders", () => {
   renders(() => mount("calcite-action-menu"), { display: "flex" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-action-menu />, mountOptions), {
     targetSelector: `.${CSS.defaultTrigger}`,
   });

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -230,7 +230,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-action-menu scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-action-menu />, mountOptions), {
     targetSelector: `.${CSS.defaultTrigger}`,
   });
 });

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -7,6 +7,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   slots,
   delegatesToFloatingUiOwningComponent,
   focusable,
@@ -226,6 +227,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-action-menu"), { display: "flex" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-action-menu"), {
+    targetSelector: `.${CSS.defaultTrigger}`,
+  });
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
+++ b/packages/components/src/components/action-menu/action-menu.browser.e2e.tsx
@@ -231,7 +231,7 @@ describe("renders", () => {
 
 describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-action-menu />, mountOptions), {
-    targetSelector: `.${CSS.defaultTrigger}`,
+    targetSelector: `.${CSS.defaultTrigger}, calcite-popover`,
   });
 });
 

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -7,6 +7,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   slots,
   delegatesToFloatingUiOwningComponent,
   focusable,
@@ -128,6 +129,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-action-pad"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-action-pad"), {
+    targetSelector: "calcite-action-group calcite-action",
+  });
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -132,7 +132,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-action-pad scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-action-pad />, mountOptions), {
     targetSelector: "calcite-action-group, calcite-action",
   });
 });

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -131,7 +131,7 @@ describe("renders", () => {
   renders(() => mount("calcite-action-pad"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-action-pad />, mountOptions), {
     targetSelector: "calcite-action-group, calcite-action",
   });

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -133,7 +133,7 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates((scale) => mount(<calcite-action-pad scale={scale} />), {
-    targetSelector: "calcite-action-group calcite-action",
+    targetSelector: "calcite-action-group, calcite-action",
   });
 });
 

--- a/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
+++ b/packages/components/src/components/action-pad/action-pad.browser.e2e.tsx
@@ -132,7 +132,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-action-pad"), {
+  scalePropagates((scale) => mount(<calcite-action-pad scale={scale} />), {
     targetSelector: "calcite-action-group calcite-action",
   });
 });

--- a/packages/components/src/components/alert/alert.browser.e2e.tsx
+++ b/packages/components/src/components/alert/alert.browser.e2e.tsx
@@ -76,6 +76,10 @@ describe("defaults", () => {
         propertyName: "queue",
         defaultValue: "last",
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -18,6 +18,7 @@ import {
   openClose,
   topLayer,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { defaultMenuPlacement } from "../../utils/floating-ui";
@@ -268,6 +269,20 @@ describe("internal label", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-autocomplete"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-autocomplete>
+          <calcite-autocomplete-item-group heading="Group">
+            <calcite-autocomplete-item heading="Item" label="Item" value="item" />
+          </calcite-autocomplete-item-group>
+        </calcite-autocomplete>,
+      ),
+    { targetSelector: "calcite-autocomplete-item, calcite-autocomplete-item-group" },
+  );
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -273,9 +273,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-autocomplete>
+        <calcite-autocomplete scale={scale}>
           <calcite-autocomplete-item-group>
             <calcite-autocomplete-item value="item" />
           </calcite-autocomplete-item-group>

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -271,7 +271,7 @@ describe("renders", () => {
   renders(() => mount("calcite-autocomplete"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -276,8 +276,8 @@ describe("scale propagation", () => {
     () =>
       mount(
         <calcite-autocomplete>
-          <calcite-autocomplete-item-group heading="Group">
-            <calcite-autocomplete-item heading="Item" label="Item" value="item" />
+          <calcite-autocomplete-item-group>
+            <calcite-autocomplete-item value="item" />
           </calcite-autocomplete-item-group>
         </calcite-autocomplete>,
       ),

--- a/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.browser.e2e.tsx
@@ -273,13 +273,14 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-autocomplete scale={scale}>
+        <calcite-autocomplete>
           <calcite-autocomplete-item-group>
             <calcite-autocomplete-item value="item" />
           </calcite-autocomplete-item-group>
         </calcite-autocomplete>,
+        mountOptions,
       ),
     { targetSelector: "calcite-autocomplete-item, calcite-autocomplete-item-group" },
   );

--- a/packages/components/src/components/avatar/avatar.browser.e2e.tsx
+++ b/packages/components/src/components/avatar/avatar.browser.e2e.tsx
@@ -42,7 +42,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-avatar scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-avatar />, mountOptions), {
     targetSelector: "calcite-icon",
   });
 });

--- a/packages/components/src/components/avatar/avatar.browser.e2e.tsx
+++ b/packages/components/src/components/avatar/avatar.browser.e2e.tsx
@@ -1,7 +1,14 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { accessible, defaults, hidden, renders, themed } from "../../tests/commonTests/browser";
+import {
+  accessible,
+  defaults,
+  hidden,
+  renders,
+  scalePropagates,
+  themed,
+} from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
 
 describe("accessible", () => {
@@ -32,6 +39,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-avatar"), { display: "inline-block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-avatar"), {
+    targetSelector: "calcite-icon",
+  });
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/avatar/avatar.browser.e2e.tsx
+++ b/packages/components/src/components/avatar/avatar.browser.e2e.tsx
@@ -41,7 +41,7 @@ describe("renders", () => {
   renders(() => mount("calcite-avatar"), { display: "inline-block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-avatar />, mountOptions), {
     targetSelector: "calcite-icon",
   });

--- a/packages/components/src/components/avatar/avatar.browser.e2e.tsx
+++ b/packages/components/src/components/avatar/avatar.browser.e2e.tsx
@@ -42,7 +42,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-avatar"), {
+  scalePropagates((scale) => mount(<calcite-avatar scale={scale} />), {
     targetSelector: "calcite-icon",
   });
 });

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -121,12 +121,13 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-block-group scale={scale}>
+        <calcite-block-group>
           <calcite-block />
           <calcite-block-group />
         </calcite-block-group>,
+        mountOptions,
       ),
     {
       targetSelector:

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -119,7 +119,7 @@ describe("renders", () => {
   renders(() => mount(<calcite-block-group>content</calcite-block-group>), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -11,6 +11,7 @@ import {
   renders,
   disabled,
   focusable,
+  scalePropagates,
 } from "../../tests/commonTests/browser";
 import { page, userEvent } from "vitest/browser";
 import { TemplateResult } from "lit";
@@ -116,6 +117,22 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount(<calcite-block-group>content</calcite-block-group>), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-block-group>
+          <calcite-block />
+          <calcite-block-group />
+        </calcite-block-group>,
+      ),
+    {
+      targetSelector:
+        "calcite-block-group > calcite-block, calcite-block-group > calcite-block-group",
+    },
+  );
 });
 
 function renderBlock(): JsxNode {

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -121,9 +121,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-block-group>
+        <calcite-block-group scale={scale}>
           <calcite-block />
           <calcite-block-group />
         </calcite-block-group>,

--- a/packages/components/src/components/block-section/block-section.browser.e2e.tsx
+++ b/packages/components/src/components/block-section/block-section.browser.e2e.tsx
@@ -145,7 +145,7 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) => mount(<calcite-block-section scale={scale} toggle-display="switch" />),
+    (mountOptions) => mount(<calcite-block-section toggle-display="switch" />, mountOptions),
     { targetSelector: "calcite-switch" },
   );
 });

--- a/packages/components/src/components/block-section/block-section.browser.e2e.tsx
+++ b/packages/components/src/components/block-section/block-section.browser.e2e.tsx
@@ -8,6 +8,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   t9n,
   accessible,
   themed,
@@ -140,6 +141,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-block-section"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-block-section toggle-display="switch" />), {
+    targetSelector: "calcite-switch",
+  });
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/block-section/block-section.browser.e2e.tsx
+++ b/packages/components/src/components/block-section/block-section.browser.e2e.tsx
@@ -143,7 +143,7 @@ describe("renders", () => {
   renders(() => mount("calcite-block-section"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) => mount(<calcite-block-section toggle-display="switch" />, mountOptions),
     { targetSelector: "calcite-switch" },

--- a/packages/components/src/components/block-section/block-section.browser.e2e.tsx
+++ b/packages/components/src/components/block-section/block-section.browser.e2e.tsx
@@ -144,9 +144,10 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-block-section toggle-display="switch" />), {
-    targetSelector: "calcite-switch",
-  });
+  scalePropagates(
+    (scale) => mount(<calcite-block-section scale={scale} toggle-display="switch" />),
+    { targetSelector: "calcite-switch" },
+  );
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -186,7 +186,7 @@ describe("renders", () => {
   renders(() => mount("calcite-block"), { display: "flex" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -188,9 +188,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-block>
+        <calcite-block scale={scale}>
           <calcite-block-section />
         </calcite-block>,
       ),

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -16,6 +16,7 @@ import {
   disabled,
   openClose,
   accessible,
+  scalePropagates,
   topLayer,
   themed,
 } from "../../tests/commonTests/browser";
@@ -183,6 +184,18 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-block"), { display: "flex" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-block>
+          <calcite-block-section />
+        </calcite-block>,
+      ),
+    { targetSelector: "calcite-block-section" },
+  );
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -188,11 +188,12 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-block scale={scale}>
+        <calcite-block>
           <calcite-block-section />
         </calcite-block>,
+        mountOptions,
       ),
     { targetSelector: "calcite-block-section" },
   );

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -195,7 +195,7 @@ describe("propagates", () => {
         </calcite-block>,
         mountOptions,
       ),
-    { targetSelector: "calcite-block-section" },
+    { targetSelector: "calcite-block-section, calcite-action-menu" },
   );
 });
 

--- a/packages/components/src/components/card-group/card-group.browser.e2e.tsx
+++ b/packages/components/src/components/card-group/card-group.browser.e2e.tsx
@@ -138,9 +138,9 @@ describe("disabled", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-card-group>
+        <calcite-card-group scale={scale}>
           <calcite-card />
           <calcite-card />
         </calcite-card-group>,

--- a/packages/components/src/components/card-group/card-group.browser.e2e.tsx
+++ b/packages/components/src/components/card-group/card-group.browser.e2e.tsx
@@ -136,7 +136,7 @@ describe("disabled", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/card-group/card-group.browser.e2e.tsx
+++ b/packages/components/src/components/card-group/card-group.browser.e2e.tsx
@@ -138,12 +138,13 @@ describe("disabled", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-card-group scale={scale}>
+        <calcite-card-group>
           <calcite-card />
           <calcite-card />
         </calcite-card-group>,
+        mountOptions,
       ),
     { targetSelector: "calcite-card" },
   );

--- a/packages/components/src/components/card-group/card-group.browser.e2e.tsx
+++ b/packages/components/src/components/card-group/card-group.browser.e2e.tsx
@@ -1,17 +1,16 @@
 import { h } from "@arcgis/lumina";
-import { describe, expect, it } from "vitest";
+import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { page } from "vitest/browser";
 import {
   defaults,
   disabled,
   focusable,
   hidden,
   renders,
+  scalePropagates,
   accessible,
   themed,
 } from "../../tests/commonTests/browser";
-import type { CardGroup } from "./card-group";
 import { CSS } from "./resources";
 
 describe("accessible", () => {
@@ -138,40 +137,16 @@ describe("disabled", () => {
 });
 
 describe("scale propagation", () => {
-  it("applies initial card-group scale to slotted cards", async () => {
-    await mount<CardGroup>(
-      <calcite-card-group scale="m">
-        <calcite-card />
-        <calcite-card />
-      </calcite-card-group>,
-    );
-
-    const card1 = page.getBySelector("calcite-card:first-of-type");
-    const card2 = page.getBySelector("calcite-card:last-of-type");
-
-    await expect.element(card1).toHaveProperty("scale", "m");
-    await expect.element(card2).toHaveProperty("scale", "m");
-  });
-
-  it("updates slotted card scale when card-group scale changes", async () => {
-    const { el } = await mount<CardGroup>(
-      <calcite-card-group>
-        <calcite-card />
-        <calcite-card />
-      </calcite-card-group>,
-    );
-
-    const card1 = page.getBySelector("calcite-card:first-of-type");
-    const card2 = page.getBySelector("calcite-card:last-of-type");
-
-    await expect.element(card1).toHaveProperty("scale", "m");
-    await expect.element(card2).toHaveProperty("scale", "m");
-
-    el.scale = "l";
-
-    await expect.element(card1).toHaveProperty("scale", "l");
-    await expect.element(card2).toHaveProperty("scale", "l");
-  });
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-card-group>
+          <calcite-card />
+          <calcite-card />
+        </calcite-card-group>,
+      ),
+    { targetSelector: "calcite-card" },
+  );
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
+++ b/packages/components/src/components/checkbox/checkbox.browser.e2e.tsx
@@ -44,6 +44,10 @@ describe("defaults", () => {
         propertyName: "validity",
         defaultValue: defaultValidity,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -1,7 +1,14 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { disabled, focusable, hidden, renders, accessible } from "../../tests/commonTests/browser";
+import {
+  disabled,
+  focusable,
+  hidden,
+  renders,
+  scalePropagates,
+  accessible,
+} from "../../tests/commonTests/browser";
 
 describe("accessible", () => {
   describe("selection mode none (default)", () => {
@@ -64,6 +71,19 @@ describe("renders", () => {
     {
       display: "flex",
     },
+  );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-chip-group>
+          <calcite-chip />
+          <calcite-chip />
+        </calcite-chip-group>,
+      ),
+    { targetSelector: "calcite-chip" },
   );
 });
 

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -79,7 +79,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -76,9 +76,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-chip-group>
+        <calcite-chip-group scale={scale}>
           <calcite-chip />
           <calcite-chip />
         </calcite-chip-group>,

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -2,6 +2,7 @@ import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
+  defaults,
   disabled,
   focusable,
   hidden,
@@ -54,6 +55,10 @@ describe("accessible", () => {
       ),
     );
   });
+});
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-chip-group"), [{ propertyName: "scale", defaultValue: "m" }]);
 });
 
 describe("honors hidden attribute", () => {

--- a/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
+++ b/packages/components/src/components/chip-group/chip-group.browser.e2e.tsx
@@ -81,12 +81,13 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-chip-group scale={scale}>
+        <calcite-chip-group>
           <calcite-chip />
           <calcite-chip />
         </calcite-chip-group>,
+        mountOptions,
       ),
     { targetSelector: "calcite-chip" },
   );

--- a/packages/components/src/components/chip-group/chip-group.tsx
+++ b/packages/components/src/components/chip-group/chip-group.tsx
@@ -113,7 +113,10 @@ export class ChipGroup extends LitElement {
     To account for this semantics change, the checks for (this.hasUpdated || value != defaultValue) was added in this method
     Please refactor your code to reduce the need for this check.
     Docs: https://webgis.esri.com/arcgis-components/?path=/docs/lumina-transition-from-stencil--docs#watching-for-property-changes */
-    if (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) {
+    if (
+      (changes.has("scale") || changes.has("selectionMode")) &&
+      (this.hasUpdated || this.selectionMode !== "none")
+    ) {
       this.updateItems();
     }
   }

--- a/packages/components/src/components/chip/chip.browser.e2e.tsx
+++ b/packages/components/src/components/chip/chip.browser.e2e.tsx
@@ -77,7 +77,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-chip closable />), {
+  scalePropagates((scale) => mount(<calcite-chip closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/chip/chip.browser.e2e.tsx
+++ b/packages/components/src/components/chip/chip.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   slots,
   t9n,
   themed,
@@ -73,6 +74,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount(<calcite-chip>doritos</calcite-chip>), { display: "inline-flex" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-chip closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("slots", () => {

--- a/packages/components/src/components/chip/chip.browser.e2e.tsx
+++ b/packages/components/src/components/chip/chip.browser.e2e.tsx
@@ -76,7 +76,7 @@ describe("renders", () => {
   renders(() => mount(<calcite-chip>doritos</calcite-chip>), { display: "inline-flex" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-chip closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/chip/chip.browser.e2e.tsx
+++ b/packages/components/src/components/chip/chip.browser.e2e.tsx
@@ -77,7 +77,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-chip closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-chip closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker-hex-input/color-picker-hex-input.browser.e2e.tsx
@@ -40,6 +40,10 @@ describe("defaults", () => {
         propertyName: "value",
         defaultValue: "#000000",
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/color-picker-swatch/color-picker-swatch.browser.e2e.tsx
+++ b/packages/components/src/components/color-picker-swatch/color-picker-swatch.browser.e2e.tsx
@@ -29,6 +29,10 @@ describe("defaults", () => {
         propertyName: "active",
         defaultValue: false,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
+++ b/packages/components/src/components/combobox-item/combobox-item.browser.e2e.tsx
@@ -28,6 +28,7 @@ describe("defaults", () => {
       { propertyName: "selected", defaultValue: false },
       { propertyName: "shortHeading", defaultValue: undefined },
       { propertyName: "value", defaultValue: undefined },
+      { propertyName: "scale", defaultValue: "m" },
     ],
   );
 });

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -221,8 +221,8 @@ describe("scale propagation", () => {
     () =>
       mount(
         <calcite-combobox>
-          <calcite-combobox-item-group label="Group">
-            <calcite-combobox-item heading="Item" value="item" />
+          <calcite-combobox-item-group>
+            <calcite-combobox-item value="item" />
           </calcite-combobox-item-group>
         </calcite-combobox>,
       ),

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -15,6 +15,7 @@ import {
   openClose,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
   topLayer,
@@ -213,6 +214,20 @@ describe("internal label", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-combobox"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-combobox>
+          <calcite-combobox-item-group label="Group">
+            <calcite-combobox-item heading="Item" value="item" />
+          </calcite-combobox-item-group>
+        </calcite-combobox>,
+      ),
+    { targetSelector: "calcite-combobox-item, calcite-combobox-item-group" },
+  );
 });
 
 describe("focusable", () => {

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -216,7 +216,7 @@ describe("renders", () => {
   renders(() => mount("calcite-combobox"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -222,12 +222,12 @@ describe("propagates", () => {
       mount(
         <calcite-combobox>
           <calcite-combobox-item-group>
-            <calcite-combobox-item value="item" />
+            <calcite-combobox-item selected value="item" />
           </calcite-combobox-item-group>
         </calcite-combobox>,
         mountOptions,
       ),
-    { targetSelector: "calcite-combobox-item, calcite-combobox-item-group" },
+    { targetSelector: "calcite-combobox-item, calcite-combobox-item-group, calcite-chip" },
   );
 });
 

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -218,9 +218,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-combobox>
+        <calcite-combobox scale={scale}>
           <calcite-combobox-item-group>
             <calcite-combobox-item value="item" />
           </calcite-combobox-item-group>

--- a/packages/components/src/components/combobox/combobox.browser.e2e.tsx
+++ b/packages/components/src/components/combobox/combobox.browser.e2e.tsx
@@ -218,13 +218,14 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-combobox scale={scale}>
+        <calcite-combobox>
           <calcite-combobox-item-group>
             <calcite-combobox-item value="item" />
           </calcite-combobox-item-group>
         </calcite-combobox>,
+        mountOptions,
       ),
     { targetSelector: "calcite-combobox-item, calcite-combobox-item-group" },
   );

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -58,7 +58,10 @@ const setupDatePickerMonthHeader = async (el: DatePickerMonthHeader["el"]) => {
 
 describe("defaults", () => {
   defaults(
-    () => mount("calcite-date-picker-month-header"),
+    () =>
+      mount("calcite-date-picker-month-header", {
+        afterConnect: setupDatePickerMonthHeader,
+      }),
     [{ propertyName: "scale", defaultValue: "m" }],
   );
 });

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { defaults, renders, scalePropagates } from "../../tests/commonTests/browser";
+import { renders, scalePropagates } from "../../tests/commonTests/browser";
 import { DateLocaleData } from "../date-picker/utils";
 import { DatePickerMonthHeader } from "./date-picker-month-header";
 
@@ -56,16 +56,6 @@ const setupDatePickerMonthHeader = async (el: DatePickerMonthHeader["el"]) => {
   el.monthStyle = "wide";
 };
 
-describe("defaults", () => {
-  defaults(
-    () =>
-      mount("calcite-date-picker-month-header", {
-        afterConnect: setupDatePickerMonthHeader,
-      }),
-    [{ propertyName: "scale", defaultValue: "m" }],
-  );
-});
-
 describe("renders", () => {
   renders(
     () =>
@@ -78,9 +68,13 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
-      mount(<calcite-date-picker-month-header scale={scale} />, {
-        afterConnect: setupDatePickerMonthHeader,
+    (mountOptions) =>
+      mount(<calcite-date-picker-month-header />, {
+        ...mountOptions,
+        afterConnect: async (el) => {
+          await setupDatePickerMonthHeader(el);
+          await mountOptions.afterConnect(el);
+        },
       }),
     { targetSelector: ".chevron" },
   );

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -69,11 +69,11 @@ describe("renders", () => {
 describe("scale propagation", () => {
   scalePropagates(
     (mountOptions) =>
-      mount(<calcite-date-picker-month-header />, {
+      mount<"calcite-date-picker-month-header">(<calcite-date-picker-month-header />, {
         ...mountOptions,
         afterConnect: async (el) => {
           await setupDatePickerMonthHeader(el);
-          await mountOptions.afterConnect(el);
+          await mountOptions.afterConnect?.(el);
         },
       }),
     { targetSelector: ".chevron" },

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -66,7 +66,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount<"calcite-date-picker-month-header">(<calcite-date-picker-month-header />, {

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -1,8 +1,7 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { describe, it, expect } from "vitest";
-import { renders } from "../../tests/commonTests/browser";
+import { describe } from "vitest";
+import { renders, scalePropagates } from "../../tests/commonTests/browser";
 import { DateLocaleData } from "../date-picker/utils";
-import { Action } from "../action/action";
 import { DatePickerMonthHeader } from "./date-picker-month-header";
 
 const setupDatePickerMonthHeader = async (el: DatePickerMonthHeader["el"]) => {
@@ -66,20 +65,12 @@ describe("renders", () => {
   );
 });
 
-it("displays the correct scale for actions", async () => {
-  const { el, reRender } = await mount("calcite-date-picker-month-header", {
-    afterConnect: setupDatePickerMonthHeader,
-  });
-
-  const datePickerMonthHeader = el;
-  const [prev, next] = el.shadowRoot.querySelectorAll<Action>(".chevron");
-
-  const scales = ["s", "m", "l"] as const;
-
-  for (const scale of scales) {
-    datePickerMonthHeader.scale = scale;
-    await reRender();
-    expect(prev.scale).toBe(scale);
-    expect(next.scale).toBe(scale);
-  }
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount("calcite-date-picker-month-header", {
+        afterConnect: setupDatePickerMonthHeader,
+      }),
+    { targetSelector: ".chevron" },
+  );
 });

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
-import { renders, scalePropagates } from "../../tests/commonTests/browser";
+import { defaults, renders, scalePropagates } from "../../tests/commonTests/browser";
 import { DateLocaleData } from "../date-picker/utils";
 import { DatePickerMonthHeader } from "./date-picker-month-header";
 
@@ -55,6 +55,13 @@ const setupDatePickerMonthHeader = async (el: DatePickerMonthHeader["el"]) => {
   el.messages = messages;
   el.monthStyle = "wide";
 };
+
+describe("defaults", () => {
+  defaults(
+    () => mount("calcite-date-picker-month-header"),
+    [{ propertyName: "scale", defaultValue: "m" }],
+  );
+});
 
 describe("renders", () => {
   renders(

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.browser.e2e.tsx
@@ -1,3 +1,4 @@
+import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe } from "vitest";
 import { renders, scalePropagates } from "../../tests/commonTests/browser";
@@ -67,8 +68,8 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
-      mount("calcite-date-picker-month-header", {
+    (scale) =>
+      mount(<calcite-date-picker-month-header scale={scale} />, {
         afterConnect: setupDatePickerMonthHeader,
       }),
     { targetSelector: ".chevron" },

--- a/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
+++ b/packages/components/src/components/date-picker-month-header/date-picker-month-header.tsx
@@ -104,7 +104,7 @@ export class DatePickerMonthHeader extends LitElement {
   @property() position?: Extract<"start" | "end", Position>;
 
   /** Specifies the size of the component. */
-  @property({ reflect: true }) scale!: Scale;
+  @property({ reflect: true }) scale: Scale = "m";
 
   /** Already selected date. */
   @property() selectedDate?: Date;

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -46,7 +46,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-date-picker"), {
+  scalePropagates((scale) => mount(<calcite-date-picker scale={scale} />), {
     targetSelector: "calcite-date-picker-month",
   });
 });

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -2,7 +2,15 @@ import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { Locator, page } from "vitest/browser";
-import { defaults, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests/browser";
+import {
+  defaults,
+  focusable,
+  hidden,
+  renders,
+  scalePropagates,
+  t9n,
+  themed,
+} from "../../tests/commonTests/browser";
 import { CSS as MONTH_CSS } from "../date-picker-month/resources";
 import { CSS as MONTH_HEADER_CSS } from "../date-picker-month-header/resources";
 import { DatePicker } from "./date-picker";
@@ -35,6 +43,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-date-picker"), { display: "inline-block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-date-picker"), {
+    targetSelector: "calcite-date-picker-month",
+  });
 });
 
 describe("focusable", () => {

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -45,7 +45,7 @@ describe("renders", () => {
   renders(() => mount("calcite-date-picker"), { display: "inline-block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-date-picker />, mountOptions), {
     targetSelector: "calcite-date-picker-month",
   });

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -46,7 +46,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-date-picker scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-date-picker />, mountOptions), {
     targetSelector: "calcite-date-picker-month",
   });
 });

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -132,7 +132,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-dialog />, mountOptions), {
     targetSelector: "calcite-panel",
   });

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -133,7 +133,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-dialog"), {
+  scalePropagates((scale) => mount(<calcite-dialog scale={scale} />), {
     targetSelector: "calcite-panel",
   });
 });

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -16,6 +16,7 @@ import {
   topLayer,
   openClose,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -129,6 +130,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-dialog"), {
+    targetSelector: "calcite-panel",
+  });
 });
 
 describe("is focusable", () => {

--- a/packages/components/src/components/dialog/dialog.browser.e2e.tsx
+++ b/packages/components/src/components/dialog/dialog.browser.e2e.tsx
@@ -133,7 +133,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-dialog scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-dialog />, mountOptions), {
     targetSelector: "calcite-panel",
   });
 });

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -54,7 +54,6 @@ it("should set internal panel properties", async () => {
   dialog.setProperty("overlayPositioning", "fixed");
   dialog.setProperty("heading", "My Heading");
   dialog.setProperty("description", "My Description");
-  dialog.setProperty("scale", "l");
   dialog.setProperty("icon", "x");
   dialog.setProperty("iconFlipRtl", true);
   dialog.setProperty("messageOverrides", messageOverrides);
@@ -67,7 +66,6 @@ it("should set internal panel properties", async () => {
   expect(await panel.getProperty("overlayPositioning")).toBe("fixed");
   expect(await panel.getProperty("heading")).toBe("My Heading");
   expect(await panel.getProperty("description")).toBe("My Description");
-  expect(await panel.getProperty("scale")).toBe("l");
   expect(await panel.getProperty("icon")).toBe("x");
   expect(await panel.getProperty("iconFlipRtl")).toBe(true);
   expect(await panel.getProperty("focusTrapEnabled")).toBe(false);

--- a/packages/components/src/components/dropdown-group/dropdown-group.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown-group/dropdown-group.browser.e2e.tsx
@@ -16,6 +16,10 @@ describe("defaults", () => {
         propertyName: "selectionMode",
         defaultValue: "single",
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/dropdown-item/dropdown-item.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.browser.e2e.tsx
@@ -2,11 +2,15 @@ import { h } from "@arcgis/lumina";
 import { describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { userEvent } from "vitest/browser";
-import { focusable, hidden, renders, themed } from "../../tests/commonTests/browser";
+import { defaults, focusable, hidden, renders, themed } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS } from "./resources";
 
 mockConsole();
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-dropdown-item"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("is focusable", () => {
   focusable(() => mount(`calcite-dropdown-item`));

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -70,9 +70,9 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-dropdown>
+        <calcite-dropdown scale={scale}>
           <calcite-dropdown-group>
             <calcite-dropdown-item />
           </calcite-dropdown-group>

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -12,6 +12,7 @@ import {
   openClose,
   reflects,
   renders,
+  scalePropagates,
   themed,
   topLayer,
 } from "../../tests/commonTests/browser";
@@ -65,6 +66,20 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-dropdown"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-dropdown>
+          <calcite-dropdown-group>
+            <calcite-dropdown-item />
+          </calcite-dropdown-group>
+        </calcite-dropdown>,
+      ),
+    { targetSelector: "calcite-dropdown-group, calcite-dropdown-item" },
+  );
 });
 
 function renderDropdown(): JsxNode {

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -70,13 +70,14 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-dropdown scale={scale}>
+        <calcite-dropdown>
           <calcite-dropdown-group>
             <calcite-dropdown-item />
           </calcite-dropdown-group>
         </calcite-dropdown>,
+        mountOptions,
       ),
     { targetSelector: "calcite-dropdown-group, calcite-dropdown-item" },
   );

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -68,7 +68,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-dropdown"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -54,10 +54,10 @@ it("renders requested props when valid props are provided", async () => {
   expect(group1).toEqualAttribute("selection-mode", "multiple");
 });
 
-it("inheritable non-default props `selectionMode` and `scale` set on parent get passed into items", async () => {
+it("inheritable non-default prop `selectionMode` set on parent gets passed into items", async () => {
   const page = await newE2EPage();
   await page.setContent(html`
-    <calcite-dropdown selection-mode="single" scale="s">
+    <calcite-dropdown selection-mode="single">
       <calcite-button slot="trigger">Open dropdown</calcite-button>
       <calcite-dropdown-group id="group-1">
         <calcite-dropdown-item id="item-1">Content</calcite-dropdown-item>
@@ -70,7 +70,6 @@ it("inheritable non-default props `selectionMode` and `scale` set on parent get 
 
   for (const item of dropdownItems) {
     expect(await item.getProperty("selectionMode")).toBe("single");
-    expect(await item.getProperty("scale")).toBe("s");
   }
 });
 

--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -80,7 +80,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-filter scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-filter />, mountOptions), {
     targetSelector: "calcite-input",
   });
 });

--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -12,6 +12,7 @@ import {
   disabled,
   accessible,
   themed,
+  scalePropagates,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS } from "./resources";
@@ -75,6 +76,12 @@ describe("honors hidden attribute", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-filter"), { display: "flex" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-filter"), {
+    targetSelector: "calcite-input",
+  });
 });
 
 describe("translation support", () => {

--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -1,3 +1,4 @@
+import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
@@ -79,7 +80,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-filter"), {
+  scalePropagates((scale) => mount(<calcite-filter scale={scale} />), {
     targetSelector: "calcite-input",
   });
 });

--- a/packages/components/src/components/filter/filter.browser.e2e.tsx
+++ b/packages/components/src/components/filter/filter.browser.e2e.tsx
@@ -79,7 +79,7 @@ describe("renders", () => {
   renders(() => mount("calcite-filter"), { display: "flex" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-filter />, mountOptions), {
     targetSelector: "calcite-input",
   });

--- a/packages/components/src/components/filter/filter.e2e.ts
+++ b/packages/components/src/components/filter/filter.e2e.ts
@@ -8,15 +8,6 @@ import type { Filter } from "./filter";
 
 mockConsole();
 
-it("sets scale on the input", async () => {
-  const scale = "s";
-  const page = await newE2EPage();
-  await page.setContent(`<calcite-filter scale="${scale}"></calcite-filter>`);
-
-  const input = await page.find(`calcite-filter >>> calcite-input`);
-  expect(await input.getProperty("scale")).toBe(scale);
-});
-
 it("honors label property", async () => {
   const page = await newE2EPage();
   const label = "hello world";

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -205,7 +205,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-flow-item show-back-button />), {
+  scalePropagates((scale) => mount(<calcite-flow-item scale={scale} show-back-button />), {
     targetSelector: "calcite-panel, calcite-action",
   });
 });

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -205,7 +205,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-flow-item scale={scale} show-back-button />), {
+  scalePropagates((mountOptions) => mount(<calcite-flow-item show-back-button />, mountOptions), {
     targetSelector: "calcite-panel, calcite-action",
   });
 });

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -204,7 +204,7 @@ describe("renders", () => {
   });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-flow-item show-back-button />, mountOptions), {
     targetSelector: "calcite-panel, calcite-action",
   });

--- a/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
+++ b/packages/components/src/components/flow-item/flow-item.browser.e2e.tsx
@@ -7,6 +7,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   slots,
   delegatesToFloatingUiOwningComponent,
   focusable,
@@ -200,6 +201,12 @@ describe("honors hidden attribute", () => {
 describe("renders", () => {
   renders(() => mount(<calcite-flow-item selected>content</calcite-flow-item>), {
     display: "flex",
+  });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-flow-item show-back-button />), {
+    targetSelector: "calcite-panel, calcite-action",
   });
 });
 

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -11,6 +11,7 @@ import {
   focusable,
   hidden,
   renders,
+  scalePropagates,
   t9n,
   accessible,
   themed,
@@ -86,6 +87,12 @@ describe("defaults", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-inline-editable"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-inline-editable"), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -89,7 +89,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-inline-editable"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-inline-editable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -90,7 +90,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-inline-editable"), {
+  scalePropagates((scale) => mount(<calcite-inline-editable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.browser.e2e.tsx
@@ -90,7 +90,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-inline-editable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-inline-editable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -95,7 +95,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-input-date-picker"), {
+  scalePropagates((scale) => mount(<calcite-input-date-picker scale={scale} />), {
     targetSelector: "calcite-date-picker, calcite-input-text",
   });
 });

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -59,6 +59,10 @@ describe("defaults", () => {
         defaultValue: undefined,
       },
       {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
+      {
         propertyName: "status",
         defaultValue: "idle",
       },

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -98,7 +98,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-input-date-picker"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-input-date-picker />, mountOptions), {
     targetSelector: "calcite-date-picker, calcite-input-text",
   });

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -99,7 +99,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input-date-picker scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-input-date-picker />, mountOptions), {
     targetSelector: "calcite-date-picker, calcite-input-text",
   });
 });

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -14,6 +14,7 @@ import {
   openClose,
   accessible,
   renders,
+  scalePropagates,
   t9n,
   themed,
   topLayer,
@@ -91,6 +92,12 @@ describe("is focusable", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-input-date-picker"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-input-date-picker"), {
+    targetSelector: "calcite-date-picker, calcite-input-text",
+  });
 });
 
 describe("internal label", () => {

--- a/packages/components/src/components/input-message/input-message.browser.e2e.tsx
+++ b/packages/components/src/components/input-message/input-message.browser.e2e.tsx
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { h } from "@arcgis/lumina";
-import { accessible, hidden, renders, themed } from "../../tests/commonTests/browser";
+import { accessible, defaults, hidden, renders, themed } from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
 import { StatusIconDefaults } from "./resources";
 import type { InputMessage } from "./input-message";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-input-message"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("accessible", () => {
   accessible(() => mount(<calcite-input-message>Text</calcite-input-message>));

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -73,7 +73,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-input-number />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
 } from "../../tests/commonTests/browser";
@@ -70,6 +71,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-input-number"), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -74,7 +74,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-input-number"), {
+  scalePropagates((scale) => mount(<calcite-input-number scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/input-number/input-number.browser.e2e.tsx
+++ b/packages/components/src/components/input-number/input-number.browser.e2e.tsx
@@ -74,7 +74,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input-number scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-input-number />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/input-text/input-text.browser.e2e.tsx
+++ b/packages/components/src/components/input-text/input-text.browser.e2e.tsx
@@ -66,9 +66,12 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input-text clearable scale={scale} value="value" />), {
-    targetSelector: "calcite-action",
-  });
+  scalePropagates(
+    (mountOptions) => mount(<calcite-input-text clearable value="value" />, mountOptions),
+    {
+      targetSelector: "calcite-action",
+    },
+  );
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/input-text/input-text.browser.e2e.tsx
+++ b/packages/components/src/components/input-text/input-text.browser.e2e.tsx
@@ -66,7 +66,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-input-text clearable value="value" />), {
+  scalePropagates((scale) => mount(<calcite-input-text clearable scale={scale} value="value" />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/input-text/input-text.browser.e2e.tsx
+++ b/packages/components/src/components/input-text/input-text.browser.e2e.tsx
@@ -65,7 +65,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) => mount(<calcite-input-text clearable value="value" />, mountOptions),
     {

--- a/packages/components/src/components/input-text/input-text.browser.e2e.tsx
+++ b/packages/components/src/components/input-text/input-text.browser.e2e.tsx
@@ -11,6 +11,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
 } from "../../tests/commonTests/browser";
@@ -62,6 +63,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-input-text clearable value="value" />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -69,7 +69,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-input-time-picker />, mountOptions), {
     targetSelector: "calcite-time-picker",
   });

--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -70,7 +70,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input-time-picker scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-input-time-picker />, mountOptions), {
     targetSelector: "calcite-time-picker",
   });
 });

--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -70,7 +70,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-input-time-picker"), {
+  scalePropagates((scale) => mount(<calcite-input-time-picker scale={scale} />), {
     targetSelector: "calcite-time-picker",
   });
 });

--- a/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.browser.e2e.tsx
@@ -15,6 +15,7 @@ import {
   openClose,
   formAssociated,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -66,6 +67,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-input-time-picker"), {
+    targetSelector: "calcite-time-picker",
+  });
 });
 
 describe("is focusable", () => {

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -78,7 +78,7 @@ describe("renders", () => {
   renders(() => mount("calcite-input-time-zone"), { display: "block" });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-input-time-zone />, mountOptions), {
     targetSelector: "calcite-combobox",
   });

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -1,3 +1,4 @@
+import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { CSS as ComboboxCSS } from "../combobox/resources";
@@ -78,7 +79,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-input-time-zone"), {
+  scalePropagates((scale) => mount(<calcite-input-time-zone scale={scale} />), {
     targetSelector: "calcite-combobox",
   });
 });

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -79,7 +79,7 @@ describe("renders", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input-time-zone scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-input-time-zone />, mountOptions), {
     targetSelector: "calcite-combobox",
   });
 });

--- a/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
   openClose,
@@ -74,6 +75,12 @@ describe("hidden", () => {
 
 describe("renders", () => {
   renders(() => mount("calcite-input-time-zone"), { display: "block" });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-input-time-zone"), {
+    targetSelector: "calcite-combobox",
+  });
 });
 
 describe("focusable", () => {

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -13,6 +13,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
 } from "../../tests/commonTests/browser";
@@ -77,6 +78,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-input type="number" />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -81,7 +81,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-input scale={scale} type="number" />), {
+  scalePropagates((mountOptions) => mount(<calcite-input type="number" />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -80,7 +80,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-input type="number" />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/input/input.browser.e2e.tsx
+++ b/packages/components/src/components/input/input.browser.e2e.tsx
@@ -81,7 +81,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-input type="number" />), {
+  scalePropagates((scale) => mount(<calcite-input scale={scale} type="number" />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -103,7 +103,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-list-item closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-list-item closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -94,6 +94,10 @@ describe("defaults", () => {
         propertyName: "sortDisabled",
         defaultValue: false,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -99,7 +99,7 @@ describe("defaults", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-list-item closable />), {
+  scalePropagates((scale) => mount(<calcite-list-item closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   slots,
   topLayer,
   themed,
@@ -95,6 +96,12 @@ describe("defaults", () => {
       },
     ],
   );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-list-item closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/list-item/list-item.browser.e2e.tsx
+++ b/packages/components/src/components/list-item/list-item.browser.e2e.tsx
@@ -102,7 +102,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-list-item closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -198,7 +198,7 @@ describe("scale propagation", () => {
           <calcite-list-item label="Three" />
         </calcite-list>,
       ),
-    { targetSelector: "calcite-list > calcite-list-item" },
+    { targetSelector: "calcite-list > calcite-list-item, calcite-list-item-group" },
   );
 });
 

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -186,9 +186,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-list>
+        <calcite-list scale={scale}>
           <calcite-list-item label="One" />
           <calcite-list-item label="Two" />
           <calcite-list-item label="Three" />

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -188,7 +188,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -97,6 +97,10 @@ describe("defaults", () => {
         defaultValue: "none",
       },
       {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
+      {
         propertyName: "interactionMode",
         defaultValue: "interactive",
       },

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -190,13 +190,14 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-list scale={scale}>
+        <calcite-list>
           <calcite-list-item label="One" />
           <calcite-list-item label="Two" />
           <calcite-list-item label="Three" />
         </calcite-list>,
+        mountOptions,
       ),
     { targetSelector: "calcite-list > calcite-list-item, calcite-list-item-group" },
   );

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   accessible,
   themed,
@@ -180,6 +181,20 @@ describe("renders", () => {
         </calcite-list>,
       ),
     { display: "block" },
+  );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-list>
+          <calcite-list-item label="One" />
+          <calcite-list-item label="Two" />
+          <calcite-list-item label="Three" />
+        </calcite-list>,
+      ),
+    { targetSelector: "calcite-list > calcite-list-item" },
   );
 });
 

--- a/packages/components/src/components/list/list.e2e.ts
+++ b/packages/components/src/components/list/list.e2e.ts
@@ -251,68 +251,6 @@ it("should set the dragHandle property on items which are not direct children", 
   }
 });
 
-it("should set the scale property on items", async () => {
-  const page = await newE2EPage();
-  await page.setContent(
-    html`<calcite-list id="root" display-mode="nested" group="my-list">
-      <calcite-list-item open label="Depth 1" description="Item 1">
-        <calcite-list group="my-list">
-          <calcite-list-item open label="Depth 2" description="Item 2">
-            <calcite-list display-mode="nested" group="my-list">
-              <calcite-list-item label="Depth 3" description="Item 3">
-                <calcite-list display-mode="nested" group="my-list"></calcite-list>
-              </calcite-list-item>
-              <calcite-list-item label="Depth 3" description="Item 4"></calcite-list-item>
-            </calcite-list>
-          </calcite-list-item>
-          <calcite-list-item label="Depth 2" description="Item 5"></calcite-list-item>
-        </calcite-list>
-      </calcite-list-item>
-      <calcite-list-item label="Depth 1" description="Item 6"></calcite-list-item>
-      <calcite-list-item drag-disabled label="Depth 1" description="Item 7"></calcite-list-item>
-    </calcite-list>`,
-  );
-
-  await page.waitForChanges();
-  await page.waitForTimeout(DEBOUNCE.filter);
-
-  const rootListItems = await findAll(page, "#root > calcite-list-item");
-
-  expect(rootListItems).toHaveLength(3);
-
-  for (let i = 0; i < rootListItems.length; i++) {
-    expect(await rootListItems[i].getProperty("scale")).toBe("m");
-  }
-
-  const rootList = await page.find("#root");
-  rootList.setProperty("scale", "s");
-
-  await page.waitForChanges();
-  await page.waitForTimeout(DEBOUNCE.filter);
-
-  for (let i = 0; i < rootListItems.length; i++) {
-    expect(await rootListItems[i].getProperty("scale")).toBe("s");
-  }
-
-  rootList.setProperty("scale", "m");
-
-  await page.waitForChanges();
-  await page.waitForTimeout(DEBOUNCE.filter);
-
-  for (let i = 0; i < rootListItems.length; i++) {
-    expect(await rootListItems[i].getProperty("scale")).toBe("m");
-  }
-
-  rootList.setProperty("scale", "l");
-
-  await page.waitForChanges();
-  await page.waitForTimeout(DEBOUNCE.filter);
-
-  for (let i = 0; i < rootListItems.length; i++) {
-    expect(await rootListItems[i].getProperty("scale")).toBe("l");
-  }
-});
-
 it("disabling and enabling an item restores actions from being tabbable", async () => {
   const page = await newE2EPage();
   await page.setContent(html`

--- a/packages/components/src/components/loader/loader.browser.e2e.tsx
+++ b/packages/components/src/components/loader/loader.browser.e2e.tsx
@@ -1,9 +1,13 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { hidden, renders, themed } from "../../tests/commonTests/browser";
+import { defaults, hidden, renders, themed } from "../../tests/commonTests/browser";
 
 import { CSS } from "./resources";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-loader"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-loader"));

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -50,7 +50,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-menu-item"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-menu-item />, mountOptions), {
     targetSelector: "calcite-menu",
   });

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -7,6 +7,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   t9n,
   accessible,
   themed,
@@ -42,6 +43,12 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-menu-item"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-menu-item"), {
+    targetSelector: "calcite-menu",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -46,7 +46,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-menu-item"), {
+  scalePropagates((scale) => mount(<calcite-menu-item scale={scale} />), {
     targetSelector: "calcite-menu",
   });
 });

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -3,6 +3,7 @@ import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
   focusable,
+  defaults,
   type ComponentTestTokens,
   reflects,
   hidden,
@@ -23,6 +24,10 @@ describe("accessible", () => {
       </calcite-menu>,
     ),
   );
+});
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-menu-item"), [{ propertyName: "scale", defaultValue: "m" }]);
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -51,7 +51,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-menu-item scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-menu-item />, mountOptions), {
     targetSelector: "calcite-menu",
   });
 });

--- a/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
+++ b/packages/components/src/components/menu-item/menu-item.browser.e2e.tsx
@@ -51,9 +51,16 @@ describe("honors hidden attribute", () => {
 });
 
 describe("propagates", () => {
-  scalePropagates((mountOptions) => mount(<calcite-menu-item />, mountOptions), {
-    targetSelector: "calcite-menu",
-  });
+  scalePropagates(
+    (mountOptions) =>
+      mount(
+        <calcite-menu-item href="#" text="Parent">
+          <calcite-menu-item slot={SLOTS.submenuItem} text="Child" />
+        </calcite-menu-item>,
+        mountOptions,
+      ),
+    { targetSelector: "calcite-menu, calcite-action" },
+  );
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/menu/menu.browser.e2e.tsx
+++ b/packages/components/src/components/menu/menu.browser.e2e.tsx
@@ -3,14 +3,14 @@ import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { userEvent } from "vitest/browser";
 import {
+  defaults,
   focusable,
   hidden,
   renders,
+  scalePropagates,
   t9n,
   accessible,
-  defaults,
 } from "../../tests/commonTests/browser";
-import type { MenuItem } from "../menu-item/menu-item";
 
 describe("accessible", () => {
   accessible(() =>
@@ -46,6 +46,20 @@ describe("renders", () => {
   );
 });
 
+describe("focusable", () => {
+  focusable(
+    () =>
+      mount(
+        <calcite-menu>
+          <calcite-menu-item text="calcite" />
+        </calcite-menu>,
+      ),
+    {
+      focusTargetSelector: "calcite-menu-item",
+    },
+  );
+});
+
 describe("defaults", () => {
   defaults(
     () => mount("calcite-menu"),
@@ -58,39 +72,17 @@ describe("defaults", () => {
   );
 });
 
-describe("scale", () => {
-  it("propagates scale to direct and nested menu items", async () => {
-    const { el } = await mount<"calcite-menu">(
-      <calcite-menu scale="s">
-        <calcite-menu-item id="parent-item" text="Parent item">
-          <calcite-menu-item id="child-item" slot="submenu-item" text="Child item" />
-        </calcite-menu-item>
-      </calcite-menu>,
-    );
-    const parentItem = el.querySelector<MenuItem["el"]>("#parent-item")!;
-    const childItem = el.querySelector<MenuItem["el"]>("#child-item")!;
-
-    await expect.element(parentItem).toHaveProperty("scale", "s");
-    await expect.element(childItem).toHaveProperty("scale", "s");
-
-    el.scale = "l";
-
-    await expect.element(parentItem).toHaveProperty("scale", "l");
-    await expect.element(childItem).toHaveProperty("scale", "l");
-  });
-});
-
-describe("focusable", () => {
-  focusable(
+describe("scale propagation", () => {
+  scalePropagates(
     () =>
       mount(
         <calcite-menu>
-          <calcite-menu-item text="calcite" />
+          <calcite-menu-item>
+            <calcite-menu-item slot="submenu-item" />
+          </calcite-menu-item>
         </calcite-menu>,
       ),
-    {
-      focusTargetSelector: "calcite-menu-item",
-    },
+    { targetSelector: "calcite-menu-item" },
   );
 });
 

--- a/packages/components/src/components/menu/menu.browser.e2e.tsx
+++ b/packages/components/src/components/menu/menu.browser.e2e.tsx
@@ -72,7 +72,7 @@ describe("defaults", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/menu/menu.browser.e2e.tsx
+++ b/packages/components/src/components/menu/menu.browser.e2e.tsx
@@ -74,13 +74,14 @@ describe("defaults", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-menu scale={scale}>
+        <calcite-menu>
           <calcite-menu-item>
             <calcite-menu-item slot="submenu-item" />
           </calcite-menu-item>
         </calcite-menu>,
+        mountOptions,
       ),
     { targetSelector: "calcite-menu-item" },
   );

--- a/packages/components/src/components/menu/menu.browser.e2e.tsx
+++ b/packages/components/src/components/menu/menu.browser.e2e.tsx
@@ -74,9 +74,9 @@ describe("defaults", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-menu>
+        <calcite-menu scale={scale}>
           <calcite-menu-item>
             <calcite-menu-item slot="submenu-item" />
           </calcite-menu-item>

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -59,7 +59,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-navigation-user scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-navigation-user />, mountOptions), {
     targetSelector: "calcite-avatar",
   });
 });

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -58,7 +58,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-navigation-user"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-navigation-user />, mountOptions), {
     targetSelector: "calcite-avatar",
   });

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   renders,
   focusable,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
@@ -55,6 +56,12 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-navigation-user"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-navigation-user"), {
+    targetSelector: "calcite-avatar",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
+++ b/packages/components/src/components/navigation-user/navigation-user.browser.e2e.tsx
@@ -59,7 +59,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-navigation-user"), {
+  scalePropagates((scale) => mount(<calcite-navigation-user scale={scale} />), {
     targetSelector: "calcite-avatar",
   });
 });

--- a/packages/components/src/components/navigation/navigation.browser.e2e.tsx
+++ b/packages/components/src/components/navigation/navigation.browser.e2e.tsx
@@ -82,7 +82,7 @@ describe("is focusable", () => {
   });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/navigation/navigation.browser.e2e.tsx
+++ b/packages/components/src/components/navigation/navigation.browser.e2e.tsx
@@ -84,14 +84,15 @@ describe("is focusable", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-navigation scale={scale}>
+        <calcite-navigation>
           <calcite-navigation-logo slot="logo" />
           <calcite-navigation-user slot="user" />
           <calcite-navigation slot="navigation-secondary" />
           <calcite-navigation slot="navigation-tertiary" />
         </calcite-navigation>,
+        mountOptions,
       ),
     {
       targetSelector:

--- a/packages/components/src/components/navigation/navigation.browser.e2e.tsx
+++ b/packages/components/src/components/navigation/navigation.browser.e2e.tsx
@@ -84,9 +84,9 @@ describe("is focusable", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-navigation>
+        <calcite-navigation scale={scale}>
           <calcite-navigation-logo slot="logo" />
           <calcite-navigation-user slot="user" />
           <calcite-navigation slot="navigation-secondary" />

--- a/packages/components/src/components/navigation/navigation.browser.e2e.tsx
+++ b/packages/components/src/components/navigation/navigation.browser.e2e.tsx
@@ -8,6 +8,7 @@ import {
   hidden,
   renders,
   focusable,
+  scalePropagates,
   accessible,
   themed,
 } from "../../tests/commonTests/browser";
@@ -82,58 +83,21 @@ describe("is focusable", () => {
 });
 
 describe("scale propagation", () => {
-  it("applies initial navigation scale to slotted navigation-logo, navigation-user, and nested navigation", async () => {
-    await mount<Navigation>(
-      <calcite-navigation scale="l">
-        <calcite-navigation-logo heading="Heading text" slot="logo" />
-        <calcite-navigation-user full-name="John Doe" slot="user" username="jdoe" />
-        <calcite-navigation slot="navigation-secondary" />
-        <calcite-navigation slot="navigation-tertiary" />
-      </calcite-navigation>,
-    );
-
-    const logo = page.getBySelector("calcite-navigation-logo");
-    const user = page.getBySelector("calcite-navigation-user");
-    const secondaryNavigation = page.getBySelector(
-      'calcite-navigation[slot="navigation-secondary"]',
-    );
-    const tertiaryNavigation = page.getBySelector('calcite-navigation[slot="navigation-tertiary"]');
-
-    await expect.element(logo).toHaveProperty("scale", "l");
-    await expect.element(user).toHaveProperty("scale", "l");
-    await expect.element(secondaryNavigation).toHaveProperty("scale", "l");
-    await expect.element(tertiaryNavigation).toHaveProperty("scale", "l");
-  });
-
-  it("updates slotted navigation-logo, navigation-user, and nested navigation scale when navigation scale changes", async () => {
-    const { el } = await mount<Navigation>(
-      <calcite-navigation>
-        <calcite-navigation-logo heading="Heading text" slot="logo" />
-        <calcite-navigation-user full-name="John Doe" slot="user" username="jdoe" />
-        <calcite-navigation slot="navigation-secondary" />
-        <calcite-navigation slot="navigation-tertiary" />
-      </calcite-navigation>,
-    );
-
-    const logo = page.getBySelector("calcite-navigation-logo");
-    const user = page.getBySelector("calcite-navigation-user");
-    const secondaryNavigation = page.getBySelector(
-      'calcite-navigation[slot="navigation-secondary"]',
-    );
-    const tertiaryNavigation = page.getBySelector('calcite-navigation[slot="navigation-tertiary"]');
-
-    await expect.element(logo).toHaveProperty("scale", "m");
-    await expect.element(user).toHaveProperty("scale", "m");
-    await expect.element(secondaryNavigation).toHaveProperty("scale", "m");
-    await expect.element(tertiaryNavigation).toHaveProperty("scale", "m");
-
-    el.scale = "l";
-
-    await expect.element(logo).toHaveProperty("scale", "l");
-    await expect.element(user).toHaveProperty("scale", "l");
-    await expect.element(secondaryNavigation).toHaveProperty("scale", "l");
-    await expect.element(tertiaryNavigation).toHaveProperty("scale", "l");
-  });
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-navigation>
+          <calcite-navigation-logo slot="logo" />
+          <calcite-navigation-user slot="user" />
+          <calcite-navigation slot="navigation-secondary" />
+          <calcite-navigation slot="navigation-tertiary" />
+        </calcite-navigation>,
+      ),
+    {
+      targetSelector:
+        'calcite-navigation-logo, calcite-navigation-user, calcite-navigation[slot="navigation-secondary"], calcite-navigation[slot="navigation-tertiary"]',
+    },
+  );
 
   it("updates nested navigation scale when slot is reassigned to navigation-secondary", async () => {
     await mount<Navigation>(

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -106,7 +106,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-notice closable />), {
+  scalePropagates((scale) => mount(<calcite-notice closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -110,7 +110,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-notice"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-notice closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -2,6 +2,7 @@ import { Fragment, h, JsxNode } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
+  defaults,
   focusable,
   hidden,
   renders,
@@ -62,6 +63,10 @@ describe("accessible", () => {
       ),
     );
   });
+});
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-notice"), [{ propertyName: "scale", defaultValue: "m" }]);
 });
 
 describe("is focusable", () => {

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   t9n,
   openClose,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -102,6 +103,12 @@ describe("is focusable", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-notice"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-notice closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/notice/notice.browser.e2e.tsx
+++ b/packages/components/src/components/notice/notice.browser.e2e.tsx
@@ -111,7 +111,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-notice closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-notice closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/pagination/pagination.browser.e2e.tsx
+++ b/packages/components/src/components/pagination/pagination.browser.e2e.tsx
@@ -28,6 +28,10 @@ describe("defaults", () => {
         propertyName: "startItem",
         defaultValue: 1,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -248,7 +248,7 @@ describe("honors hidden attribute", () => {
 
 describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-panel closable />, mountOptions), {
-    targetSelector: "calcite-action",
+    targetSelector: "calcite-action, calcite-action-menu",
   });
 });
 

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -247,7 +247,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-panel closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-panel closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -247,7 +247,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-panel closable />), {
+  scalePropagates((scale) => mount(<calcite-panel closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -246,7 +246,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-panel"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-panel closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -14,6 +14,7 @@ import {
   t9n,
   disabled,
   accessible,
+  scalePropagates,
   topLayer,
   themed,
 } from "../../tests/commonTests/browser";
@@ -243,6 +244,12 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-panel"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-panel closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -14,6 +14,7 @@ import {
   topLayer,
   openClose,
   accessible,
+  scalePropagates,
   themed,
 } from "../../tests/commonTests/browser";
 import { mockConsole } from "../../tests/utils/logging";
@@ -140,6 +141,12 @@ describe("is focusable", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount(<calcite-popover open />));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-popover closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -147,7 +147,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount(<calcite-popover open />));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-popover closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -144,7 +144,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-popover closable />), {
+  scalePropagates((scale) => mount(<calcite-popover closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -148,7 +148,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-popover closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-popover closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/popover/popover.browser.e2e.tsx
+++ b/packages/components/src/components/popover/popover.browser.e2e.tsx
@@ -101,6 +101,10 @@ describe("defaults", () => {
         defaultValue: false,
       },
       {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
+      {
         propertyName: "overlayPositioning",
         defaultValue: "absolute",
       },

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -130,12 +130,10 @@ describe("scale propagation", () => {
       mount(
         <calcite-radio-button-group>
           <calcite-label>
-            <calcite-radio-button value="one" />
-            One
+            <calcite-radio-button />
           </calcite-label>
           <calcite-label>
-            <calcite-radio-button value="two" />
-            Two
+            <calcite-radio-button />
           </calcite-label>
         </calcite-radio-button-group>,
       ),

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -124,7 +124,7 @@ describe("honors hidden attribute", () => {
   });
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -126,9 +126,9 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-radio-button-group scale={scale}>
+        <calcite-radio-button-group>
           <calcite-label>
             <calcite-radio-button />
           </calcite-label>
@@ -136,6 +136,7 @@ describe("scale propagation", () => {
             <calcite-radio-button />
           </calcite-label>
         </calcite-radio-button-group>,
+        mountOptions,
       ),
     { targetSelector: "calcite-radio-button" },
   );

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -11,6 +11,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
 } from "../../tests/commonTests/browser";
@@ -121,6 +122,25 @@ describe("honors hidden attribute", () => {
     expect(name).toBe("third");
     expect(value).toBe("first");
   });
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-radio-button-group>
+          <calcite-label>
+            <calcite-radio-button value="one" />
+            One
+          </calcite-label>
+          <calcite-label>
+            <calcite-radio-button value="two" />
+            Two
+          </calcite-label>
+        </calcite-radio-button-group>,
+      ),
+    { targetSelector: "calcite-radio-button" },
+  );
 });
 
 describe("internal label", () => {

--- a/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.browser.e2e.tsx
@@ -126,9 +126,9 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-radio-button-group>
+        <calcite-radio-button-group scale={scale}>
           <calcite-label>
             <calcite-radio-button />
           </calcite-label>

--- a/packages/components/src/components/radio-button-group/radio-button-group.e2e.ts
+++ b/packages/components/src/components/radio-button-group/radio-button-group.e2e.ts
@@ -341,10 +341,8 @@ it("radio-buttons receive necessary props", async () => {
 
   const radio = await page.find("calcite-radio-button");
   const name = await radio.getProperty("name");
-  const scale = await radio.getProperty("scale");
   const required = await radio.getProperty("required");
   expect(name).toBe("radio");
-  expect(scale).toBe("m");
   expect(required).toBe(false);
 });
 

--- a/packages/components/src/components/rating/rating.browser.e2e.tsx
+++ b/packages/components/src/components/rating/rating.browser.e2e.tsx
@@ -70,7 +70,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-rating count={1} show-chip />), {
+  scalePropagates((scale) => mount(<calcite-rating count={1} scale={scale} show-chip />), {
     targetSelector: "calcite-chip",
   });
 });

--- a/packages/components/src/components/rating/rating.browser.e2e.tsx
+++ b/packages/components/src/components/rating/rating.browser.e2e.tsx
@@ -70,7 +70,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-rating count={1} scale={scale} show-chip />), {
+  scalePropagates((mountOptions) => mount(<calcite-rating count={1} show-chip />, mountOptions), {
     targetSelector: "calcite-chip",
   });
 });

--- a/packages/components/src/components/rating/rating.browser.e2e.tsx
+++ b/packages/components/src/components/rating/rating.browser.e2e.tsx
@@ -69,7 +69,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-rating"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-rating count={1} show-chip />, mountOptions), {
     targetSelector: "calcite-chip",
   });

--- a/packages/components/src/components/rating/rating.browser.e2e.tsx
+++ b/packages/components/src/components/rating/rating.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   formAssociated,
   accessible,
@@ -66,6 +67,12 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-rating"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-rating count={1} show-chip />), {
+    targetSelector: "calcite-chip",
+  });
 });
 
 describe("internal label", () => {

--- a/packages/components/src/components/segmented-control-item/segmented-control-item.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control-item/segmented-control-item.browser.e2e.tsx
@@ -1,9 +1,16 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { hidden, renders, themed } from "../../tests/commonTests/browser";
+import { defaults, hidden, renders, themed } from "../../tests/commonTests/browser";
 
 import { CSS } from "./resources";
+
+describe("defaults", () => {
+  defaults(
+    () => mount("calcite-segmented-control-item"),
+    [{ propertyName: "scale", defaultValue: "m" }],
+  );
+});
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-segmented-control-item"));

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -200,12 +200,13 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-segmented-control scale={scale}>
+        <calcite-segmented-control>
           <calcite-segmented-control-item value="1" />
           <calcite-segmented-control-item value="2" />
         </calcite-segmented-control>,
+        mountOptions,
       ),
     { targetSelector: "calcite-segmented-control-item" },
   );

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -198,7 +198,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -203,8 +203,8 @@ describe("scale propagation", () => {
     () =>
       mount(
         <calcite-segmented-control>
-          <calcite-segmented-control-item value="1">One</calcite-segmented-control-item>
-          <calcite-segmented-control-item value="2">Two</calcite-segmented-control-item>
+          <calcite-segmented-control-item value="1" />
+          <calcite-segmented-control-item value="2" />
         </calcite-segmented-control>,
       ),
     { targetSelector: "calcite-segmented-control-item" },

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -200,9 +200,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-segmented-control>
+        <calcite-segmented-control scale={scale}>
           <calcite-segmented-control-item value="1" />
           <calcite-segmented-control-item value="2" />
         </calcite-segmented-control>,

--- a/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.browser.e2e.tsx
@@ -10,6 +10,7 @@ import {
   internalLabel,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   themed,
 } from "../../tests/commonTests/browser";
@@ -194,6 +195,19 @@ describe("renders", () => {
         </calcite-segmented-control>,
       ),
     { display: "flex" },
+  );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-segmented-control>
+          <calcite-segmented-control-item value="1">One</calcite-segmented-control-item>
+          <calcite-segmented-control-item value="2">Two</calcite-segmented-control-item>
+        </calcite-segmented-control>,
+      ),
+    { targetSelector: "calcite-segmented-control-item" },
   );
 });
 

--- a/packages/components/src/components/segmented-control/segmented-control.e2e.ts
+++ b/packages/components/src/components/segmented-control/segmented-control.e2e.ts
@@ -311,18 +311,17 @@ it("renders requested props", async () => {
   expect(element).toEqualAttribute("width", "full");
 });
 
-it("inheritable props: `appearance`, `layout`, and `scale` modified on the parent get passed to items", async () => {
+it("inheritable props: `appearance` and `layout` modified on the parent get passed to items", async () => {
   async function inheritsProps(segmentedControlItems: E2EElement[]): Promise<void> {
     for (const item of segmentedControlItems) {
       expect(await item.getProperty("appearance")).toBe("outline");
       expect(await item.getProperty("layout")).toBe("vertical");
-      expect(await item.getProperty("scale")).toBe("l");
     }
   }
 
   const page = await newE2EPage();
   await page.setContent(html`
-    <calcite-segmented-control appearance="outline" layout="vertical" scale="l">
+    <calcite-segmented-control appearance="outline" layout="vertical">
       <calcite-segmented-control-item id="child-1" value="1">one</calcite-segmented-control-item>
       <calcite-segmented-control-item id="child-2" value="2">two</calcite-segmented-control-item>
       <calcite-segmented-control-item id="child-3" value="3">three</calcite-segmented-control-item>

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -93,12 +93,12 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
         <calcite-sort-handle
           addToItems={[{ element: document.createElement("div"), id: "item", label: "Item" }]}
-          scale={scale}
         />,
+        mountOptions,
       ),
     { targetSelector: "calcite-dropdown-group" },
   );

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -100,7 +100,7 @@ describe("propagates", () => {
         />,
         mountOptions,
       ),
-    { targetSelector: "calcite-dropdown-group" },
+    { targetSelector: "calcite-dropdown-group, calcite-dropdown, calcite-action" },
   );
 });
 

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   t9n,
   openClose,
   accessible,
@@ -84,6 +85,18 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-sort-handle"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-sort-handle
+          addToItems={[{ element: document.createElement("div"), id: "item", label: "Item" }]}
+        />,
+      ),
+    { targetSelector: "calcite-dropdown-group" },
+  );
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -63,6 +63,10 @@ describe("defaults", () => {
         propertyName: "placement",
         defaultValue: "bottom-start",
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -89,10 +89,11 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
         <calcite-sort-handle
           addToItems={[{ element: document.createElement("div"), id: "item", label: "Item" }]}
+          scale={scale}
         />,
       ),
     { targetSelector: "calcite-dropdown-group" },

--- a/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
+++ b/packages/components/src/components/sort-handle/sort-handle.browser.e2e.tsx
@@ -91,7 +91,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-sort-handle"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -156,7 +156,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount("calcite-split-button"), {
+  scalePropagates((scale) => mount(<calcite-split-button scale={scale} />), {
     targetSelector: "calcite-button, calcite-dropdown",
   });
 });

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -159,7 +159,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-split-button"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-split-button />, mountOptions), {
     targetSelector: "calcite-button, calcite-dropdown",
   });

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   reflects,
   hidden,
   renders,
+  scalePropagates,
   disabled,
   accessible,
   topLayer,
@@ -152,6 +153,12 @@ describe("reflects", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-split-button"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount("calcite-split-button"), {
+    targetSelector: "calcite-button, calcite-dropdown",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -119,6 +119,10 @@ describe("defaults", () => {
         propertyName: "target",
         defaultValue: undefined,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/split-button/split-button.browser.e2e.tsx
+++ b/packages/components/src/components/split-button/split-button.browser.e2e.tsx
@@ -160,7 +160,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-split-button scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-split-button />, mountOptions), {
     targetSelector: "calcite-button, calcite-dropdown",
   });
 });

--- a/packages/components/src/components/stepper-item/stepper-item.browser.e2e.tsx
+++ b/packages/components/src/components/stepper-item/stepper-item.browser.e2e.tsx
@@ -1,9 +1,21 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { disabled, focusable, hidden, renders, t9n, themed } from "../../tests/commonTests/browser";
+import {
+  defaults,
+  disabled,
+  focusable,
+  hidden,
+  renders,
+  t9n,
+  themed,
+} from "../../tests/commonTests/browser";
 
 import { CSS } from "./resources";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-stepper-item"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-stepper-item"));

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -95,7 +95,7 @@ describe("translation support", () => {
   t9n(() => mount("calcite-stepper"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -99,13 +99,13 @@ describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(
-        <calcite-stepper layout="horizontal-single">
+        <calcite-stepper>
           <calcite-stepper-item heading="Step 1" />
           <calcite-stepper-item heading="Step 2" />
         </calcite-stepper>,
         mountOptions,
       ),
-    { targetSelector: "calcite-stepper-item, calcite-action" },
+    { targetSelector: "calcite-stepper-item" },
   );
 });
 

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -99,13 +99,13 @@ describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(
-        <calcite-stepper>
+        <calcite-stepper layout="horizontal-single">
           <calcite-stepper-item heading="Step 1" />
           <calcite-stepper-item heading="Step 2" />
         </calcite-stepper>,
         mountOptions,
       ),
-    { targetSelector: "calcite-stepper-item" },
+    { targetSelector: "calcite-stepper-item, calcite-action" },
   );
 });
 

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -3,7 +3,15 @@ import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page, userEvent } from "vitest/browser";
 import { LitElement } from "@arcgis/lumina";
-import { defaults, reflects, hidden, renders, t9n, themed } from "../../tests/commonTests/browser";
+import {
+  defaults,
+  reflects,
+  hidden,
+  renders,
+  scalePropagates,
+  t9n,
+  themed,
+} from "../../tests/commonTests/browser";
 import { CSS as STEPPER_ITEM_CSS } from "../stepper-item/resources";
 import type { Stepper } from "./stepper";
 import { CSS } from "./resources";
@@ -85,6 +93,19 @@ describe("renders", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-stepper"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-stepper>
+          <calcite-stepper-item heading="Step 1" />
+          <calcite-stepper-item heading="Step 2" />
+        </calcite-stepper>,
+      ),
+    { targetSelector: "calcite-stepper-item" },
+  );
 });
 
 describe("fixed height sizing", () => {

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -97,12 +97,13 @@ describe("translation support", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-stepper scale={scale}>
+        <calcite-stepper>
           <calcite-stepper-item heading="Step 1" />
           <calcite-stepper-item heading="Step 2" />
         </calcite-stepper>,
+        mountOptions,
       ),
     { targetSelector: "calcite-stepper-item" },
   );

--- a/packages/components/src/components/stepper/stepper.browser.e2e.tsx
+++ b/packages/components/src/components/stepper/stepper.browser.e2e.tsx
@@ -97,9 +97,9 @@ describe("translation support", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-stepper>
+        <calcite-stepper scale={scale}>
           <calcite-stepper-item heading="Step 1" />
           <calcite-stepper-item heading="Step 2" />
         </calcite-stepper>,

--- a/packages/components/src/components/stepper/stepper.e2e.ts
+++ b/packages/components/src/components/stepper/stepper.e2e.ts
@@ -27,10 +27,10 @@ it("root container display is set to grid in horizontal layout", async () => {
   expect((await containerEl.getComputedStyle()).display).toBe("grid");
 });
 
-it("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to items from parents", async () => {
+it("inheritable props: `icon`, `layout`, and `numbered` get passed to items from parents", async () => {
   const page = await newE2EPage();
   await page.setContent(html`
-    <calcite-stepper layout="vertical" scale="l" numbered icon>
+    <calcite-stepper layout="vertical" numbered icon>
       <calcite-stepper-item heading="Step 1" id="step-1">
         <div>Step 1 content</div>
       </calcite-stepper-item>
@@ -50,7 +50,6 @@ it("inheritable props: `icon`, `layout`, `numbered`, and `scale` get passed to i
   for (const item of stepperItems) {
     expect(await item.getProperty("icon")).toBe(true);
     expect(await item.getProperty("layout")).toBe("vertical");
-    expect(await item.getProperty("scale")).toBe("l");
     expect(await item.getProperty("numbered")).toBe(true);
   }
 });

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -61,9 +61,9 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-swatch-group>
+        <calcite-swatch-group scale={scale}>
           <calcite-swatch />
           <calcite-swatch />
         </calcite-swatch-group>,

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -2,6 +2,7 @@ import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
+  defaults,
   hidden,
   renders,
   disabled,
@@ -53,6 +54,10 @@ describe("accessible", () => {
       ),
     );
   });
+});
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-swatch-group"), [{ propertyName: "scale", defaultValue: "m" }]);
 });
 
 describe("honors hidden attribute", () => {

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -1,7 +1,13 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { hidden, renders, disabled, accessible } from "../../tests/commonTests/browser";
+import {
+  hidden,
+  renders,
+  disabled,
+  accessible,
+  scalePropagates,
+} from "../../tests/commonTests/browser";
 
 describe("accessible", () => {
   describe("selection mode single-persist", () => {
@@ -51,6 +57,19 @@ describe("accessible", () => {
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-swatch-group"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-swatch-group>
+          <calcite-swatch />
+          <calcite-swatch />
+        </calcite-swatch-group>,
+      ),
+    { targetSelector: "calcite-swatch" },
+  );
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -66,12 +66,13 @@ describe("honors hidden attribute", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-swatch-group scale={scale}>
+        <calcite-swatch-group>
           <calcite-swatch />
           <calcite-swatch />
         </calcite-swatch-group>,
+        mountOptions,
       ),
     { targetSelector: "calcite-swatch" },
   );

--- a/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.browser.e2e.tsx
@@ -64,7 +64,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-swatch-group"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/swatch-group/swatch-group.tsx
+++ b/packages/components/src/components/swatch-group/swatch-group.tsx
@@ -103,7 +103,10 @@ export class SwatchGroup extends LitElement {
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
-    if (changes.has("selectionMode") && (this.hasUpdated || this.selectionMode !== "none")) {
+    if (
+      (changes.has("scale") || changes.has("selectionMode")) &&
+      (this.hasUpdated || this.selectionMode !== "none")
+    ) {
       this.updateItems();
     }
   }

--- a/packages/components/src/components/swatch/swatch.browser.e2e.tsx
+++ b/packages/components/src/components/swatch/swatch.browser.e2e.tsx
@@ -2,6 +2,7 @@ import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
+  defaults,
   disabled,
   focusable,
   hidden,
@@ -11,6 +12,10 @@ import {
   themed,
 } from "../../tests/commonTests/browser";
 import { CSS, IDS, SLOTS } from "./resources";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-swatch"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("accessible", () => {
   describe("default", () => {

--- a/packages/components/src/components/switch/switch.browser.e2e.tsx
+++ b/packages/components/src/components/switch/switch.browser.e2e.tsx
@@ -42,6 +42,10 @@ describe("defaults", () => {
         propertyName: "required",
         defaultValue: false,
       },
+      {
+        propertyName: "scale",
+        defaultValue: "m",
+      },
     ],
   );
 });

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -21,7 +21,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates((scale) => mount(<calcite-tab-title closable scale={scale} />), {
+  scalePropagates((mountOptions) => mount(<calcite-tab-title closable />, mountOptions), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -1,12 +1,24 @@
 import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { hidden, renders, disabled, themed } from "../../tests/commonTests/browser";
+import {
+  hidden,
+  renders,
+  disabled,
+  themed,
+  scalePropagates,
+} from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
 import { mockConsole } from "../../tests/utils/logging";
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-tab-title"));
+});
+
+describe("scale propagation", () => {
+  scalePropagates(() => mount(<calcite-tab-title closable />), {
+    targetSelector: "calcite-action",
+  });
 });
 
 describe("renders", () => {

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -20,7 +20,7 @@ describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-tab-title"));
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates((mountOptions) => mount(<calcite-tab-title closable />, mountOptions), {
     targetSelector: "calcite-action",
   });

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -2,6 +2,7 @@ import { h } from "@arcgis/lumina";
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import {
+  defaults,
   hidden,
   renders,
   disabled,
@@ -10,6 +11,10 @@ import {
 } from "../../tests/commonTests/browser";
 import { CSS } from "./resources";
 import { mockConsole } from "../../tests/utils/logging";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-tab-title"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("honors hidden attribute", () => {
   hidden(() => mount("calcite-tab-title"));

--- a/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
+++ b/packages/components/src/components/tab-title/tab-title.browser.e2e.tsx
@@ -16,7 +16,7 @@ describe("honors hidden attribute", () => {
 });
 
 describe("scale propagation", () => {
-  scalePropagates(() => mount(<calcite-tab-title closable />), {
+  scalePropagates((scale) => mount(<calcite-tab-title closable scale={scale} />), {
     targetSelector: "calcite-action",
   });
 });

--- a/packages/components/src/components/table-cell/table-cell.browser.e2e.tsx
+++ b/packages/components/src/components/table-cell/table-cell.browser.e2e.tsx
@@ -1,6 +1,10 @@
 import { describe } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { focusable } from "../../tests/commonTests/browser";
+import { defaults, focusable } from "../../tests/commonTests/browser";
+
+describe("defaults", () => {
+  defaults(() => mount("calcite-table-cell"), [{ propertyName: "scale", defaultValue: "m" }]);
+});
 
 describe("focusable", () => {
   focusable(() => mount("calcite-table-cell"));

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -432,7 +432,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -9,6 +9,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   accessible,
   themed,
 } from "../../tests/commonTests/browser";
@@ -428,6 +429,20 @@ describe("renders", () => {
         </calcite-table>,
       ),
     { display: "flex" },
+  );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-table>
+          <calcite-table-row>
+            <calcite-table-cell />
+          </calcite-table-row>
+        </calcite-table>,
+      ),
+    { targetSelector: "calcite-table-row" },
   );
 });
 

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -434,13 +434,14 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-table scale={scale}>
+        <calcite-table>
           <calcite-table-row>
             <calcite-table-cell />
           </calcite-table-row>
         </calcite-table>,
+        mountOptions,
       ),
     { targetSelector: "calcite-table-row" },
   );

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -436,14 +436,14 @@ describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(
-        <calcite-table>
+        <calcite-table selection-mode="multiple">
           <calcite-table-row>
             <calcite-table-cell />
           </calcite-table-row>
         </calcite-table>,
         mountOptions,
       ),
-    { targetSelector: "calcite-table-row" },
+    { targetSelector: "calcite-table-row, calcite-chip" },
   );
 });
 

--- a/packages/components/src/components/table/table.browser.e2e.tsx
+++ b/packages/components/src/components/table/table.browser.e2e.tsx
@@ -434,9 +434,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-table>
+        <calcite-table scale={scale}>
           <calcite-table-row>
             <calcite-table-cell />
           </calcite-table-row>

--- a/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
+++ b/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
@@ -110,9 +110,9 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    () =>
+    (scale) =>
       mount(
-        <calcite-tile-group>
+        <calcite-tile-group scale={scale}>
           <calcite-tile label="Tile 1" />
           <calcite-tile label="Tile 2" />
           <calcite-tile label="Tile 3" />

--- a/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
+++ b/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
@@ -110,13 +110,14 @@ describe("renders", () => {
 
 describe("scale propagation", () => {
   scalePropagates(
-    (scale) =>
+    (mountOptions) =>
       mount(
-        <calcite-tile-group scale={scale}>
+        <calcite-tile-group>
           <calcite-tile label="Tile 1" />
           <calcite-tile label="Tile 2" />
           <calcite-tile label="Tile 3" />
         </calcite-tile-group>,
+        mountOptions,
       ),
     { targetSelector: "calcite-tile" },
   );

--- a/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
+++ b/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
@@ -6,6 +6,7 @@ import {
   hidden,
   reflects,
   renders,
+  scalePropagates,
   disabled,
   accessible,
 } from "../../tests/commonTests/browser";
@@ -104,6 +105,20 @@ describe("renders", () => {
         </calcite-tile-group>,
       ),
     { display: "inline-block" },
+  );
+});
+
+describe("scale propagation", () => {
+  scalePropagates(
+    () =>
+      mount(
+        <calcite-tile-group>
+          <calcite-tile label="Tile 1" />
+          <calcite-tile label="Tile 2" />
+          <calcite-tile label="Tile 3" />
+        </calcite-tile-group>,
+      ),
+    { targetSelector: "calcite-tile" },
   );
 });
 

--- a/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
+++ b/packages/components/src/components/tile-group/tile-group.browser.e2e.tsx
@@ -108,7 +108,7 @@ describe("renders", () => {
   );
 });
 
-describe("scale propagation", () => {
+describe("propagates", () => {
   scalePropagates(
     (mountOptions) =>
       mount(

--- a/packages/components/src/components/tile-group/tile-group.e2e.ts
+++ b/packages/components/src/components/tile-group/tile-group.e2e.ts
@@ -1,8 +1,7 @@
 import { newE2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
 import { describe, expect, it } from "vitest";
 import { html } from "../../../support/formatting";
-import { createSelectedItemsAsserter, findAll, isElementFocused } from "../../tests/utils/puppeteer";
-import type { TileGroup } from "./tile-group";
+import { createSelectedItemsAsserter, isElementFocused } from "../../tests/utils/puppeteer";
 
 describe("keyboard", () => {
   it("focuses tiles with the tab key and arrow keys and allows selection with the enter and space key", async () => {
@@ -90,32 +89,6 @@ describe("keyboard", () => {
     await page.waitForChanges();
 
     expect(await isElementFocused(page, "#item-1")).toBe(true);
-  });
-});
-
-describe("prop passing", () => {
-  it("tiles receive parent scale prop on initial load and when scale attribute is mutated", async () => {
-    const page = await newE2EPage();
-    await page.setContent(html`
-      <calcite-tile-group scale="s">
-        <calcite-tile></calcite-tile>
-        <calcite-tile></calcite-tile>
-        <calcite-tile></calcite-tile>
-      </calcite-tile-group>
-    `);
-
-    let tiles = await findAll(page, "calcite-tile");
-    tiles.forEach((tile) => {
-      expect(tile.getAttribute("scale")).toBe("s");
-    });
-
-    await page.$eval("calcite-tile-group", (element: TileGroup["el"]) => element.setAttribute("scale", "l"));
-    await page.waitForChanges();
-
-    tiles = await findAll(page, "calcite-tile");
-    tiles.forEach((tile) => {
-      expect(tile.getAttribute("scale")).toBe("l");
-    });
   });
 });
 

--- a/packages/components/src/tests/commonTests/browser/index.ts
+++ b/packages/components/src/tests/commonTests/browser/index.ts
@@ -11,6 +11,7 @@ export { internalLabel } from "./internal-label";
 export { openClose } from "./open-close";
 export { reflects } from "./reflects";
 export { renders } from "./renders";
+export { scalePropagates } from "./scale";
 export { slots } from "./slots";
 export { t9n } from "./t9n";
 export { type ComponentTestTokens, themed } from "./themed";

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -1,0 +1,61 @@
+import { expect, it } from "vitest";
+import { type mount } from "@arcgis/lumina-compiler/testing";
+import type { Scale } from "../../../components/types";
+
+const scales: Scale[] = ["s", "l"];
+
+/**
+ * Verifies that scale-controlled elements match their parent's scale initially and after each remaining scale change.
+ *
+ * Targets are selected from the document and the mounted parent's shadow root.
+ *
+ * Note that this helper should be used within a describe block.
+ *
+ * @example
+ * describe("scale propagation", () => {
+ *   scalePropagates(
+ *     () => mount(
+ *         <calcite-card-group>
+ *           <calcite-card />
+ *           <calcite-card />
+ *         </calcite-card-group>,
+ *       ),
+ *     { targetSelector: "calcite-card" },
+ *   );
+ * });
+ */
+export function scalePropagates(
+  setup: () => ReturnType<typeof mount>,
+  { targetSelector }: { targetSelector: string },
+): void {
+  it("propagates scale to targets", async () => {
+    const { el, reRender } = await setup();
+    const parent = el as typeof el & { scale: Scale };
+
+    const assertTargetsMatchParent = async (): Promise<void> => {
+      const targets = [
+        ...document.querySelectorAll<HTMLElement>(targetSelector),
+        ...(parent.shadowRoot?.querySelectorAll<HTMLElement>(targetSelector) ?? []),
+      ];
+
+      expect(targets.length).toBeGreaterThan(0);
+
+      for (const target of targets) {
+        await expect.element(target).toHaveProperty("scale", parent.scale);
+      }
+    };
+
+    await assertTargetsMatchParent();
+
+    for (const scale of scales) {
+      if (scale === parent.scale) {
+        continue;
+      }
+
+      parent.scale = scale;
+      await reRender();
+
+      await assertTargetsMatchParent();
+    }
+  });
+}

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -5,9 +5,10 @@ import type { Scale } from "../../../components/types";
 const scales: Scale[] = ["s", "l"];
 
 /**
- * Verifies that scale-controlled elements match their parent's scale initially and after each remaining scale change.
+ * Verifies that scale-controlled elements match their parent's scale initially and after scale change.
  *
- * Targets are selected from the document and the mounted parent's shadow root.
+ * Callers provide a selector for scale-controlled elements. The selector is searched in the document and the mounted
+ * parent's shadow root.
  *
  * Note that this helper should be used within a describe block.
  *
@@ -26,7 +27,10 @@ const scales: Scale[] = ["s", "l"];
  */
 export function scalePropagates(
   setup: () => ReturnType<typeof mount>,
-  { targetSelector }: { targetSelector: string },
+  {
+    /** Selector for the elements whose scale should match the parent. */
+    targetSelector,
+  }: { targetSelector: string },
 ): void {
   it("propagates scale to targets", async () => {
     const { el, reRender } = await setup();

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -5,6 +5,11 @@ import type { Scale } from "../../../components/types";
 const initialScale: Scale = "s";
 const scales: Scale[] = ["m", "l"];
 
+interface TestSetupMountOptions {
+  /** Helper required for initializing scale propagation testing. */
+  afterConnect: NonNullable<Parameters<typeof mount>[1]>["afterConnect"];
+}
+
 /**
  * Verifies that scale-controlled elements match their parent's scale initially and after scale change.
  *
@@ -15,25 +20,30 @@ const scales: Scale[] = ["m", "l"];
  * @example
  * describe("scale propagation", () => {
  *   scalePropagates(
- *     (scale) => mount(
- *         <calcite-card-group scale={scale}>
+ *     (mountOptions) => mount(
+ *         <calcite-card-group>
  *           <calcite-card />
  *           <calcite-card />
  *         </calcite-card-group>,
+ *         mountOptions,
  *       ),
  *     { targetSelector: "calcite-card" },
  *   );
  * });
  */
 export function scalePropagates(
-  setup: (initialScale: Scale) => ReturnType<typeof mount>,
+  setup: (mountOptions: TestSetupMountOptions) => ReturnType<typeof mount>,
   {
     /** Selector for the elements whose scale should match the parent. */
     targetSelector,
   }: { targetSelector: string },
 ): void {
   it("propagates scale to targets", async () => {
-    const { el, reRender } = await setup(initialScale);
+    const { el, reRender } = await setup({
+      afterConnect: (el) => {
+        (el as typeof el & { scale: Scale }).scale = initialScale;
+      },
+    });
     const parent = el as typeof el & { scale: Scale };
 
     expect(parent.scale).toBe(initialScale);

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -21,7 +21,7 @@ interface TestSetupMountOptions {
  * Note that this helper should be used within a describe block.
  *
  * @example
- * describe("scale propagation", () => {
+ * describe("propagates", () => {
  *   scalePropagates(
  *     (mountOptions) => mount(
  *         <calcite-card-group>

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { type mount } from "@arcgis/lumina-compiler/testing";
+import { mount } from "@arcgis/lumina-compiler/testing";
 import type { Scale } from "../../../components/types";
 
 const scales: Scale[] = ["s", "l"];
@@ -7,8 +7,7 @@ const scales: Scale[] = ["s", "l"];
 /**
  * Verifies that scale-controlled elements match their parent's scale initially and after scale change.
  *
- * Callers provide a selector for scale-controlled elements. The selector is searched in the document and the mounted
- * parent's shadow root.
+ * Callers provide a selector for scale-controlled elements. The selector is searched in the document and the mounted parent's shadow root.
  *
  * Note that this helper should be used within a describe block.
  *

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -1,9 +1,12 @@
 import { expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import type { Scale } from "../../../components/types";
+import type { IntrinsicElementsWithProp } from "../../utils/types";
 
 const initialScale: Scale = "s";
 const scales: Scale[] = ["m", "l"];
+type ScaleComponent = IntrinsicElementsWithProp<"scale">;
 
 interface TestSetupMountOptions {
   /** Helper required for initializing scale propagation testing. */
@@ -13,7 +16,7 @@ interface TestSetupMountOptions {
 /**
  * Verifies that scale-controlled elements match their parent's scale initially and after scale change.
  *
- * Callers provide a selector for scale-controlled elements. The selector is searched in the document and the mounted parent's shadow root.
+ * Callers provide a selector for scale-controlled elements.
  *
  * Note that this helper should be used within a describe block.
  *
@@ -33,31 +36,26 @@ interface TestSetupMountOptions {
  */
 export function scalePropagates(
   setup: (mountOptions: TestSetupMountOptions) => ReturnType<typeof mount>,
-  {
-    /** Selector for the elements whose scale should match the parent. */
-    targetSelector,
-  }: { targetSelector: string },
+  { targetSelector }: { targetSelector: string },
 ): void {
   it("propagates scale to targets", async () => {
     const { el, reRender } = await setup({
       afterConnect: (el) => {
-        (el as typeof el & { scale: Scale }).scale = initialScale;
+        (el as ScaleComponent).scale = initialScale;
       },
     });
-    const parent = el as typeof el & { scale: Scale };
+    const parent = el as ScaleComponent;
 
     expect(parent.scale).toBe(initialScale);
 
     const assertTargetsMatchParent = async (): Promise<void> => {
-      const targets = [
-        ...document.querySelectorAll<HTMLElement>(targetSelector),
-        ...(parent.shadowRoot?.querySelectorAll<HTMLElement>(targetSelector) ?? []),
-      ];
+      const targets = page.getBySelector(targetSelector);
+      const targetCount = targets.elements().length;
 
-      expect(targets.length).toBeGreaterThan(0);
+      expect(targetCount).toBeGreaterThan(0);
 
-      for (const target of targets) {
-        await expect.element(target).toHaveProperty("scale", parent.scale);
+      for (let index = 0; index < targetCount; index++) {
+        await expect.element(targets.nth(index)).toHaveProperty("scale", parent.scale);
       }
     };
 

--- a/packages/components/src/tests/commonTests/browser/scale.ts
+++ b/packages/components/src/tests/commonTests/browser/scale.ts
@@ -2,7 +2,8 @@ import { expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import type { Scale } from "../../../components/types";
 
-const scales: Scale[] = ["s", "l"];
+const initialScale: Scale = "s";
+const scales: Scale[] = ["m", "l"];
 
 /**
  * Verifies that scale-controlled elements match their parent's scale initially and after scale change.
@@ -14,8 +15,8 @@ const scales: Scale[] = ["s", "l"];
  * @example
  * describe("scale propagation", () => {
  *   scalePropagates(
- *     () => mount(
- *         <calcite-card-group>
+ *     (scale) => mount(
+ *         <calcite-card-group scale={scale}>
  *           <calcite-card />
  *           <calcite-card />
  *         </calcite-card-group>,
@@ -25,15 +26,17 @@ const scales: Scale[] = ["s", "l"];
  * });
  */
 export function scalePropagates(
-  setup: () => ReturnType<typeof mount>,
+  setup: (initialScale: Scale) => ReturnType<typeof mount>,
   {
     /** Selector for the elements whose scale should match the parent. */
     targetSelector,
   }: { targetSelector: string },
 ): void {
   it("propagates scale to targets", async () => {
-    const { el, reRender } = await setup();
+    const { el, reRender } = await setup(initialScale);
     const parent = el as typeof el & { scale: Scale };
+
+    expect(parent.scale).toBe(initialScale);
 
     const assertTargetsMatchParent = async (): Promise<void> => {
       const targets = [


### PR DESCRIPTION
**Related Issue:** #7701

## Summary
- Derived a shared commonTests helper `scalePropagates`.
- Updated several component browser E2E tests to replace legacy scale-propagation assertions with the new shared helper.
- Updated all remaining relevant components to use `scalePropagates` along with `defaults` (to scale m) for a full scale coverage.