### PR TITLE
refactor(useLabel): move void controller to constructor

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.tsx
+++ b/packages/components/src/components/autocomplete/autocomplete.tsx
@@ -103,8 +103,6 @@ export class Autocomplete
 
   labelEl?: Label["el"];
 
-  labelable = useLabel(this);
-
   private listId = IDS.list(this.guid);
 
   /**
@@ -403,6 +401,7 @@ export class Autocomplete
 
   constructor() {
     super();
+    useLabel(this);
     this.listenOn(document, "click", this.documentClickHandler);
     this.listen("calciteAutocompleteItemSelect", this.handleAutocompleteItemSelect);
     this.listen("calciteInternalAutocompleteItemChange", this.handleAutocompleteItemChange);

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -79,8 +79,6 @@ export class Button extends LitElement {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region State Properties
@@ -198,6 +196,11 @@ export class Button extends LitElement {
   //#endregion
 
   //#region Lifecycle
+
+  constructor() {
+    super();
+    useLabel(this);
+  }
 
   override connectedCallback(): void {
     this.setupTextContentObserver();

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -47,8 +47,6 @@ export class Checkbox extends LitElement implements LabelableComponent {
 
   labelEl?: Label["el"];
 
-  labelable = useLabel(this);
-
   onLabelClick = (): void => {
     this.toggle();
   };
@@ -172,6 +170,7 @@ export class Checkbox extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("click", this.clickHandler);
     this.listen("keydown", this.keyDownHandler);
   }

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -201,8 +201,6 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
 
   labelEl?: Label["el"];
 
-  labelable = useLabel(this);
-
   private listContainerEl?: HTMLDivElement;
 
   private maxCompactBreakpoint?: number;
@@ -600,6 +598,7 @@ export class Combobox extends LitElement implements LabelableComponent, Floating
 
   constructor() {
     super();
+    useLabel(this);
     this.listenOn(document, "click", this.documentClickHandler);
     this.listen<ToEvents<ComboboxItem>["calciteComboboxItemChange"]>(
       "calciteComboboxItemChange",

--- a/packages/components/src/components/inline-editable/inline-editable.tsx
+++ b/packages/components/src/components/inline-editable/inline-editable.tsx
@@ -64,8 +64,6 @@ export class InlineEditable extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   private get shouldShowControls(): boolean {
     return this.editingEnabled && this.controls;
   }
@@ -140,6 +138,7 @@ export class InlineEditable extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("calciteInternalInputBlur", this.blurHandler);
     this.listen("calciteInternalInputNumberBlur", this.blurHandler);
     this.listen("calciteInternalInputTextBlur", this.blurHandler);

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -147,8 +147,6 @@ export class InputDatePicker extends LitElement implements FloatingUIComponent, 
 
   labelEl?: Label["el"];
 
-  labelable = useLabel(this);
-
   transitionProp = "opacity" as const;
 
   private placeholderTextId = IDS.placeholder(guid());
@@ -410,6 +408,7 @@ export class InputDatePicker extends LitElement implements FloatingUIComponent, 
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("blur", this.blurHandler);
     this.listen("keydown", this.keyDownHandler);
     this.handleDateTimeFormatChange();

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -154,8 +154,6 @@ export class InputNumber
     },
   });
 
-  labelable = useLabel(this);
-
   // `calcite-inline-editable` deprecated in v5.2.0, removal target v7.0.0 (remove !this.inlineEditableEl)
   private get selfManagedInlineEditable(): boolean {
     return this.inlineEditable && !this.inlineEditableEl;
@@ -435,6 +433,7 @@ export class InputNumber
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("click", this.clickHandler);
     this.listen("keydown", this.keyDownHandler);
   }

--- a/packages/components/src/components/input-text/input-text.tsx
+++ b/packages/components/src/components/input-text/input-text.tsx
@@ -134,8 +134,6 @@ export class InputText extends LitElement implements LabelableComponent, Textual
     },
   });
 
-  labelable = useLabel(this);
-
   // `calcite-inline-editable` deprecated in v5.2.0, removal target v7.0.0 (remove !this.inlineEditableEl)
   private get selfManagedInlineEditable(): boolean {
     return this.inlineEditable && !this.inlineEditableEl;
@@ -375,6 +373,7 @@ export class InputText extends LitElement implements LabelableComponent, Textual
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("click", this.clickHandler);
     this.listen("keydown", this.keyDownHandler);
   }

--- a/packages/components/src/components/input-time-picker/input-time-picker.tsx
+++ b/packages/components/src/components/input-time-picker/input-time-picker.tsx
@@ -103,8 +103,6 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   private timePickerRef = createRef<TimePicker>();
 
   //#endregion
@@ -270,6 +268,7 @@ export class InputTimePicker extends LitElement implements LabelableComponent, T
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("blur", this.blurHandler);
     this.listen("focus", this.focusHandler);
     this.listen("focusout", this.focusOutHandler);

--- a/packages/components/src/components/input-time-zone/input-time-zone.tsx
+++ b/packages/components/src/components/input-time-zone/input-time-zone.tsx
@@ -81,8 +81,6 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   /**
    * Note: The `internal` context is reserved for future use to provide more granular update context information.
    */
@@ -256,6 +254,11 @@ export class InputTimeZone extends LitElement implements LabelableComponent {
   //#endregion
 
   //#region Lifecycle
+
+  constructor() {
+    super();
+    useLabel(this);
+  }
 
   async load(): Promise<void> {
     this.normalizer = await getNormalizer(this.mode);

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -113,8 +113,6 @@ export class Input
 
   labelEl?: Label["el"];
 
-  labelable = useLabel(this);
-
   private maxString?: string;
 
   private minString?: string;
@@ -491,6 +489,7 @@ export class Input
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("click", this.clickHandler);
     this.listen("keydown", this.keyDownHandler);
   }

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -49,8 +49,6 @@ export class RadioButton extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region Public Properties
@@ -199,6 +197,7 @@ export class RadioButton extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("pointerenter", this.pointerEnterHandler);
     this.listen("pointerleave", this.pointerLeaveHandler);
     this.listen("click", this.clickHandler);

--- a/packages/components/src/components/rating/rating.tsx
+++ b/packages/components/src/components/rating/rating.tsx
@@ -82,8 +82,6 @@ export class Rating extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region State Properties
@@ -192,6 +190,7 @@ export class Rating extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("keydown", this.handleHostKeyDown);
     this.listen("pointerout", this.handleRatingPointerOut);
     this.listen("pointerover", this.handleRatingPointerOver);

--- a/packages/components/src/components/segmented-control/segmented-control.tsx
+++ b/packages/components/src/components/segmented-control/segmented-control.tsx
@@ -71,8 +71,6 @@ export class SegmentedControl extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region Public Properties
@@ -173,6 +171,7 @@ export class SegmentedControl extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen<ToEvents<SegmentedControlItem>["calciteInternalSegmentedControlItemChange"]>(
       "calciteInternalSegmentedControlItemChange",
       this.handleSelected,

--- a/packages/components/src/components/select/select.tsx
+++ b/packages/components/src/components/select/select.tsx
@@ -77,8 +77,6 @@ export class Select extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region Public Properties
@@ -176,6 +174,7 @@ export class Select extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("calciteInternalOptionChange", this.handleOptionOrGroupChange);
     this.listen("calciteInternalOptionGroupChange", this.handleOptionOrGroupChange);
   }

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -185,8 +185,6 @@ export class Slider extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   private _value: number | number[] = defaultValue;
 
   //#endregion
@@ -393,6 +391,7 @@ export class Slider extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("pointerdown", this.pointerDownHandler);
     this.listen("keydown", this.handleKeyDown);
     this.listen("touchstart", this.handleTouchStart);

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -45,8 +45,6 @@ export class Switch extends LitElement implements LabelableComponent {
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region Public Properties
@@ -120,6 +118,7 @@ export class Switch extends LitElement implements LabelableComponent {
 
   constructor() {
     super();
+    useLabel(this);
     this.listen("click", this.clickHandler);
     this.listen("keydown", this.keyDownHandler);
   }

--- a/packages/components/src/components/text-area/text-area.tsx
+++ b/packages/components/src/components/text-area/text-area.tsx
@@ -133,8 +133,6 @@ export class TextArea
 
   private interactiveContainer = useInteractive(this);
 
-  labelable = useLabel(this);
-
   //#endregion
 
   //#region State Properties
@@ -307,6 +305,11 @@ export class TextArea
   //#endregion
 
   //#region Lifecycle
+
+  constructor() {
+    super();
+    useLabel(this);
+  }
 
   override connectedCallback(): void {
     this.cancelable.add(this.updateSizeToAuto);

--- a/packages/components/src/controllers/useLabel.browser.spec.tsx
+++ b/packages/components/src/controllers/useLabel.browser.spec.tsx
@@ -23,7 +23,10 @@ class LabelableComponent extends LitElement {
     this.inputRef.value!.focus();
   }
 
-  labelController = useLabel(this);
+  constructor() {
+    super();
+    useLabel(this);
+  }
 
   override render(): JsxNode {
     return <input ref={this.inputRef} />;

--- a/packages/components/src/utils/label.browser.spec.tsx
+++ b/packages/components/src/utils/label.browser.spec.tsx
@@ -15,7 +15,10 @@ class LabelableComponent extends LitElement {
 
   labelEl?: Label["el"];
 
-  labelController = useLabel(this);
+  constructor() {
+    super();
+    useLabel(this);
+  }
 
   onLabelClick(): void {}
 


### PR DESCRIPTION
**monday.com sync:** #12903980113

**Related Issue:** N/A

## Summary

We’ve consistently been invoking controllers and storing their result:

```tsx
foo = useFoo(this);
```

This is misleading for controllers that don’t return anything (`void`). This PR updates `useLabel`, the only void-returning controller so far, to be invoked in the constructor instead, avoiding unnecessary boilerplate and potential confusion.

```tsx
constructor() {
  useFoo(this);
}
```