### PR TITLE
chore: sync `package-lock.json` file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30818,7 +30818,7 @@
     },
     "packages/monorepo-cli": {
       "name": "@esri/monorepo-cli",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "SEE LICENSE.md",
       "bin": {
         "cli": "src/run.ts"


### PR DESCRIPTION
**Related issue:** n/a

## Summary
Updates to the correct version of `@esri/monorepo-cli`. Was missing in the commit that added the package.
