### PR TITLE
chore: add `monorepo-cli` to release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
   "packages/ui-icons": "4.5.0",
   "packages/eslint-plugin-components": "2.0.3",
   "packages/tailwind-preset": "1.1.1",
-  "packages/stylelint-plugin-components": "0.1.0"
+  "packages/stylelint-plugin-components": "0.1.0",
+  "packages/monorepo-cli": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -91,6 +91,9 @@
     },
     "packages/stylelint-plugin-components": {
       "component": "@esri/stylelint-plugin-calcite-components"
+    },
+    "packages/monorepo-cli": {
+      "component": "@esri/monorepo-cli"
     }
   },
   "plugins": [


### PR DESCRIPTION
**Related issue:** #15005

## Summary
Adds the `@esri/monorepo-cli` package to release-please in order to generate changelog entries.
