### PR TITLE
refactor: swap `chalk` for Node's `styleText` util

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -55,7 +55,7 @@
     {
       "groupName": "Util Scripts",
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["@inquirer/**", "chalk", "concurrently", "cpy**", "globby", "rimraf", "semver", "yargs"]
+      "matchPackageNames": ["@inquirer/**", "concurrently", "cpy**", "globby", "rimraf", "semver", "yargs"]
     },
     {
       "groupName": "Tests (Browser)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "@whitespace/storybook-addon-html": "9.0.0",
         "autoprefixer": "10.5.4",
         "axe-core": "4.12.1",
-        "chalk": "5.6.2",
         "change-case": "5.4.4",
         "chromatic": "16.6.3",
         "concurrently": "9.2.1",
@@ -30818,7 +30817,7 @@
     },
     "packages/monorepo-cli": {
       "name": "@esri/monorepo-cli",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "SEE LICENSE.md",
       "bin": {
         "cli": "src/run.ts"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@whitespace/storybook-addon-html": "9.0.0",
     "autoprefixer": "10.5.4",
     "axe-core": "4.12.1",
-    "chalk": "5.6.2",
     "change-case": "5.4.4",
     "chromatic": "16.6.3",
     "concurrently": "9.2.1",

--- a/packages/components/support/log-test-output.ts
+++ b/packages/components/support/log-test-output.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import chalk from "chalk";
+import { styleText } from "node:util";
 
 interface TestLog {
   name: string;
@@ -15,28 +15,28 @@ const logs: TestLog[] = [
 let hadError = false;
 
 // eslint-disable-next-line no-console -- script logging
-console.log(chalk.bgMagenta.bold.whiteBright("\n=======Test Summary======="));
+console.log(styleText(["bgMagenta", "bold", "whiteBright"], "\n=======Test Summary======="));
 
 for (const { name, file } of logs) {
   if (existsSync(file) && statSync(file).size > 0) {
     hadError = true;
     // eslint-disable-next-line no-console -- script logging
-    console.log(chalk.bold.underline.magentaBright(`\n${name} Errors\n`));
+    console.log(styleText(["bold", "underline", "magentaBright"], `\n${name} Errors\n`));
     process.stdout.write(readFileSync(file, "utf8"));
     // eslint-disable-next-line no-console -- script logging
-    console.log(chalk.bold.gray("\n==================================================================="));
+    console.log(styleText(["bold", "gray"], "\n==================================================================="));
   } else {
     // eslint-disable-next-line no-console -- script logging
-    console.log(chalk.green(`\n[${name}] No errors found.`));
+    console.log(styleText("green", `\n[${name}] No errors found.`));
   }
 }
 
 if (hadError) {
   // eslint-disable-next-line no-console -- script logging
-  console.log(chalk.bgRed.whiteBright("\nSome tests failed. See above for details.\n"));
+  console.log(styleText(["bgRed", "whiteBright"], "\nSome tests failed. See above for details.\n"));
 } else {
   // eslint-disable-next-line no-console -- script logging
-  console.log(chalk.bgGreen.blackBright("\nAll tests passed!\n"));
+  console.log(styleText(["bgGreen", "blackBright"], "\nAll tests passed!\n"));
 }
 
 process.exit(hadError ? 1 : 0);


### PR DESCRIPTION
**monday.com sync:** #12904600402

**Related Issue:** N/A

## Summary

Replaces [`chalk`](https://www.npmjs.com/package/chalk) with `node:util`'s [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) added in (v20). 

Inspired by https://github.com/Esri/calcite-design-system/pull/15072. Thanks, @isaacbraun!