### PR TITLE
chore(cli): add turbo build override

### DIFF
--- a/packages/monorepo-cli/turbo.json
+++ b/packages/monorepo-cli/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": [],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
**Related Issue:** #15005

## Summary
Adds a `turbo.json` file to the `@esri/monorepo-cli` package to override the outputs, as no built files are created.
