### PR TITLE
docs(tab-nav, tab-title): fix formatting for `@internal` `position` property

### DIFF
--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -90,9 +90,9 @@ export class TabNav extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`, defaults to `top`.
+   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`.
    *
-   *  @internal
+   * @internal
    */
   @property() position: TabPosition = "bottom";
 

--- a/packages/components/src/components/tab-title/tab-title.tsx
+++ b/packages/components/src/components/tab-title/tab-title.tsx
@@ -116,9 +116,9 @@ export class TabTitle extends LitElement {
   @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
-   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`, defaults to `top`.
+   * Specifies the position of `calcite-tab-nav` and `calcite-tab-title` components in relation to, and is inherited from the parent `calcite-tabs`.
    *
-   *  @internal
+   * @internal
    */
   @property() position: TabPosition = "top";
 


### PR DESCRIPTION
**Related Issue:** n/a

## Summary
Noticed that these two `position` properties were showing up on the doc site with the `@internal` tags as part of the
description. This PR updates the formatting to hide them from the doc site and removes unnecessary/inaccurate "defaults" language.

Requesting some dev reviews to ensure these are supposed to be `@internal`.
