### PR TITLE
ci(actions): ignore scripts for `notify-new-icon` dependency install

### DIFF
--- a/.github/actions/notify-new-icon/action.yml
+++ b/.github/actions/notify-new-icon/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Install CLI dependencies
       shell: bash
-      run: npm ci --workspace=@esri/monorepo-cli
+      run: npm ci --workspace=@esri/monorepo-cli --ignore-scripts
 
     - name: Send notification
       shell: bash


### PR DESCRIPTION
**Related Issue:** #14992

## Summary

Fixes the broken dependency install step in the `notify-new-icon` Action by ignoring scripts. The step was broken since filtering the install to only `@esri/monorepo-cli` does not include the postinstall scripts, producing the below error:

```bash
npm ci --workspace=@esri/monorepo-cli
  
  > calcite-design-system@0.0.0 postinstall
  > patch-package
  
  sh: 1: patch-package: not found
```
