### PR TITLE
feat(block): deprecate `collapsible` in favor of `expandable`

### DIFF
--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -23,7 +23,7 @@ describe("accessible", () => {
   accessible(() =>
     mount(
       <calcite-block-group>
-        <calcite-block collapsible description="description" heading="heading" open>
+        <calcite-block description="description" expandable heading="heading" open>
           <div>content</div>
         </calcite-block>
       </calcite-block-group>,
@@ -138,7 +138,7 @@ describe("propagates", () => {
 
 function renderBlock(): JsxNode {
   return (
-    <calcite-block collapsible description="description" heading="heading" open>
+    <calcite-block description="description" expandable heading="heading" open>
       <div>content</div>
     </calcite-block>
   );
@@ -160,11 +160,11 @@ describe("expandMode", () => {
   const nestedBlockHTML = (expandMode: BlockGroup["expandMode"]): TemplateResult => {
     return (
       <calcite-block-group expandMode={expandMode}>
-        <calcite-block collapsible heading="Asia">
-          <calcite-block collapsible heading="Himalayas" slot="children" />
-          <calcite-block collapsible heading="Karakoram" slot="children" />
+        <calcite-block expandable heading="Asia">
+          <calcite-block expandable heading="Himalayas" slot="children" />
+          <calcite-block expandable heading="Karakoram" slot="children" />
         </calcite-block>
-        <calcite-block collapsible heading="Africa" />
+        <calcite-block expandable heading="Africa" />
       </calcite-block-group>
     );
   };
@@ -173,12 +173,12 @@ describe("expandMode", () => {
     return (
       <calcite-block-group expandMode={expandMode} label="Water Layers">
         <calcite-block-group label="Rivers">
-          <calcite-block collapsible heading="Rivers" />
-          <calcite-block collapsible heading="Gauging Stations" />
+          <calcite-block expandable heading="Rivers" />
+          <calcite-block expandable heading="Gauging Stations" />
         </calcite-block-group>
         <calcite-block-group expandMode={expandMode} label="Lakes & Ponds">
-          <calcite-block collapsible heading="Lakes" />
-          <calcite-block collapsible heading="Ponds" />
+          <calcite-block expandable heading="Lakes" />
+          <calcite-block expandable heading="Ponds" />
         </calcite-block-group>
       </calcite-block-group>
     );

--- a/packages/components/src/components/block-group/block-group.stories.ts
+++ b/packages/components/src/components/block-group/block-group.stories.ts
@@ -36,26 +36,26 @@ export default {
 };
 
 const blockHTML = html`<calcite-block
-    collapsible
+    expandable
     heading="A rubber chicken"
     description="Why did the chicken cross the road? To avoid being squeezed!"
     >My block content!</calcite-block
   >
-  <calcite-block collapsible heading="Invisible ink" description="You can't see me!">My block content!</calcite-block>
-  <calcite-block collapsible heading="Whoopee cushion" description="The sound of laughter!"
+  <calcite-block expandable heading="Invisible ink" description="You can't see me!">My block content!</calcite-block>
+  <calcite-block expandable heading="Whoopee cushion" description="The sound of laughter!"
     >My block content!</calcite-block
   >
-  <calcite-block collapsible heading="Fake mustache" description="Incognito mode activated!"
+  <calcite-block expandable heading="Fake mustache" description="Incognito mode activated!"
     >My block content!</calcite-block
   >
-  <calcite-block collapsible heading="Giant foam finger" description="We're number one!"
+  <calcite-block expandable heading="Giant foam finger" description="We're number one!"
     >My block content!</calcite-block
   >
-  <calcite-block drag-disabled collapsible heading="Clown nose" description="Honk if you love clowns!"
+  <calcite-block drag-disabled expandable heading="Clown nose" description="Honk if you love clowns!"
     >My block content!</calcite-block
   >
   <calcite-block
-    collapsible
+    expandable
     heading="Joke book"
     description="Why don't scientists trust atoms? Because they make up everything!"
     >My block content!</calcite-block
@@ -80,7 +80,7 @@ export const dragEnabled = (): string => html`
 
 export const sortHandleOpen = (): string => html`
   <calcite-block-group drag-enabled label="My Group">
-    <calcite-block sort-handle-open collapsible heading="Invisible ink" description="You can't see me!"
+    <calcite-block sort-handle-open expandable heading="Invisible ink" description="You can't see me!"
       >My block content!</calcite-block
     >
     ${blockHTML}
@@ -112,53 +112,53 @@ export const allScales = (): string =>
 const nestedBlockGroupHTML = (expandMode: BlockGroup["expandMode"]): string => html`
   <calcite-block-group label="Rivers">
     <calcite-block
-      collapsible
+      expandable
       heading="Rivers"
       description="Primary waterways and regional flow lines"
       expanded
     ></calcite-block>
     <calcite-block
-      collapsible
+      expandable
       heading="Gauging Stations"
       description="Monitoring sites reporting water level metrics"
     ></calcite-block>
   </calcite-block-group>
   <calcite-block-group expand-mode="${expandMode}" label="Lakes & Ponds">
-    <calcite-block collapsible heading="Lakes" description="Large standing-water bodies and reservoirs"></calcite-block>
-    <calcite-block collapsible heading="Ponds" description="Small standing-water features and basins"></calcite-block>
+    <calcite-block expandable heading="Lakes" description="Large standing-water bodies and reservoirs"></calcite-block>
+    <calcite-block expandable heading="Ponds" description="Small standing-water features and basins"></calcite-block>
   </calcite-block-group>
 `;
 
 const nestedBlockHTML = (): string => html`
-  <calcite-block collapsible heading="Rivers" description="Primary waterways and regional flow lines" expanded>
+  <calcite-block expandable heading="Rivers" description="Primary waterways and regional flow lines" expanded>
     <calcite-block
-      collapsible
+      expandable
       heading="Gauging Stations"
       description="Monitoring sites reporting water level metrics"
       slot="children"
     ></calcite-block>
     <calcite-block
-      collapsible
+      expandable
       heading="Streams"
       description="Secondary channels feeding larger rivers"
       expanded
       slot="children"
     >
       <calcite-block
-        collapsible
+        expandable
         heading="Sub Streams"
         description="Minor stream branches in local watersheds"
         slot="children"
       ></calcite-block>
       <calcite-block
-        collapsible
+        expandable
         heading="Tributaries"
         description="Contributing flow sources into stream network"
         slot="children"
       ></calcite-block>
     </calcite-block>
   </calcite-block>
-  <calcite-block collapsible heading="Lakes" description="Large standing-water bodies and reservoirs"></calcite-block>
+  <calcite-block expandable heading="Lakes" description="Large standing-water bodies and reservoirs"></calcite-block>
 `;
 
 const expandModeDecorator: Decorator = (storyFn, context) =>

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -30,7 +30,7 @@ mockConsole();
 describe("accessible", () => {
   accessible(() =>
     mount(
-      <calcite-block collapsible description="description" expanded heading="heading">
+      <calcite-block description="description" expandable expanded heading="heading">
         <div>content</div>
       </calcite-block>,
     ),
@@ -43,6 +43,10 @@ describe("defaults", () => {
     [
       {
         propertyName: "collapsible",
+        defaultValue: false,
+      },
+      {
+        propertyName: "expandable",
         defaultValue: false,
       },
       {
@@ -94,7 +98,7 @@ describe("setFocus", () => {
     focusable(
       () =>
         mount(
-          <calcite-block collapsible description="summary" expanded heading="Heading">
+          <calcite-block description="summary" expandable expanded heading="Heading">
             <calcite-block-section expanded text="input block-section">
               <calcite-input
                 icon="form-field"
@@ -140,6 +144,10 @@ describe("reflects", () => {
     [
       {
         propertyName: "collapsible",
+        value: true,
+      },
+      {
+        propertyName: "expandable",
         value: true,
       },
       {
@@ -242,7 +250,7 @@ describe("top layer placement", () => {
 });
 
 describe("disabled", () => {
-  disabled(() => mount(<calcite-block collapsible description="description" heading="heading" />));
+  disabled(() => mount(<calcite-block description="description" expandable heading="heading" />));
 });
 
 describe("theme", () => {
@@ -251,8 +259,8 @@ describe("theme", () => {
       () =>
         mount(
           <calcite-block
-            collapsible
             description="description"
+            expandable
             expanded
             heading="heading"
             icon-end="pen"
@@ -335,8 +343,8 @@ describe("theme", () => {
       () =>
         mount(
           <calcite-block
-            collapsible
             description="description"
+            expandable
             expanded
             heading="heading"
             icon-end="pen"
@@ -393,7 +401,7 @@ describe("theme", () => {
   describe("toggleDisplay", () => {
     it("should toggle the expanded state when the toggleDisplay is switch", async () => {
       const { el } = await mount(
-        <calcite-block collapsible heading="heading" toggle-display="switch">
+        <calcite-block expandable heading="heading" toggle-display="switch">
           <div>content</div>
         </calcite-block>,
       );

--- a/packages/components/src/components/block/block.e2e.ts
+++ b/packages/components/src/components/block/block.e2e.ts
@@ -11,7 +11,7 @@ mockConsole();
 it("has a loading state", async () => {
   const page = await newE2EPage({
     html: `
-        <calcite-block heading="heading" description="description" expanded collapsible>
+        <calcite-block heading="heading" description="description" expanded expandable>
           <div class="content">content</div>
         </calcite-block>
     `,
@@ -61,7 +61,7 @@ it("can display/hide content", async () => {
 it("allows toggling its content", async () => {
   const heading = "heading";
   const page = await newE2EPage();
-  await page.setContent(html`<calcite-block collapsible heading=${heading}></calcite-block>`);
+  await page.setContent(html`<calcite-block expandable heading=${heading}></calcite-block>`);
   await skipAnimations(page);
   const messages = await import("./assets/t9n/messages.json");
 
@@ -112,6 +112,23 @@ it("should map deprecated 'open' prop to 'expanded' prop", async () => {
   block.setProperty("open", false);
   await page.waitForChanges();
   expect(await block.getProperty("expanded")).toBe(false);
+});
+
+it("should map deprecated 'collapsible' prop to 'expandable' prop", async () => {
+  const page = await newE2EPage({
+    html: html`<calcite-block></calcite-block>`,
+  });
+  const block = await page.find("calcite-block");
+
+  expect(await block.getProperty("expandable")).toBe(false);
+
+  block.setProperty("collapsible", true);
+  await page.waitForChanges();
+  expect(await block.getProperty("expandable")).toBe(true);
+
+  block.setProperty("collapsible", false);
+  await page.waitForChanges();
+  expect(await block.getProperty("expandable")).toBe(false);
 });
 
 describe("header", () => {

--- a/packages/components/src/components/block/block.stories.ts
+++ b/packages/components/src/components/block/block.stories.ts
@@ -17,9 +17,9 @@ interface BlockStoryArgs
       | "heading"
       | "description"
       | "expanded"
+      | "expandable"
       | "iconEnd"
       | "iconStart"
-      | "collapsible"
       | "loading"
       | "disabled"
       | "headingLevel"
@@ -40,7 +40,7 @@ export default {
     heading: "Heading",
     description: "description",
     expanded: true,
-    collapsible: true,
+    expandable: true,
     loading: false,
     disabled: false,
     dragDisabled: false,
@@ -89,7 +89,7 @@ export const simple = (args: BlockStoryArgs): string => html`
     ${optionalAttribute("icon-end", args.iconEnd)}
     menu-placement="${args.menuPlacement}"
     ${boolean("expanded", args.expanded)}
-    ${boolean("collapsible", args.collapsible)}
+    ${boolean("expandable", args.expandable)}
     ${boolean("loading", args.loading)}
     ${boolean("disabled", args.disabled)}
     ${boolean("drag-disabled", args.dragDisabled)}
@@ -111,7 +111,7 @@ export const simple = (args: BlockStoryArgs): string => html`
 `;
 
 export const disabled = (): string => html`
-  <calcite-block heading="heading" description="description" expanded collapsible disabled>
+  <calcite-block heading="heading" description="description" expanded expandable disabled>
     <calcite-block-section text="Nature" expanded>
       <img alt="demo" src="${placeholderImage({ width: 320, height: 240 })}" />
     </calcite-block-section>
@@ -123,7 +123,7 @@ export const paddingDisabled = (): string =>
     <calcite-block
       heading="Example block heading"
       description="example summary heading"
-      collapsible
+      expandable
       expanded
       style="--calcite-block-padding: 0;"
     >
@@ -136,7 +136,7 @@ export const darkModeRTL = (): string => html`
     heading="Heading"
     description="description"
     expanded
-    collapsible
+    expandable
     heading-level="2"
     class="calcite-mode-dark"
     dir="rtl"
@@ -170,11 +170,11 @@ export const contentSpacing = (): string => html`
 `;
 
 export const loading = (): string => html`
-  <calcite-block collapsible expanded loading heading="Layer effects" description="Adjust blur">
+  <calcite-block expandable expanded loading heading="Layer effects" description="Adjust blur">
     With no status
   </calcite-block>
   <br />
-  <calcite-block loading heading="Valid status" description="summary" collapsible status="valid">
+  <calcite-block loading heading="Valid status" description="summary" expandable status="valid">
     With valid status
   </calcite-block>
   <br />
@@ -184,7 +184,7 @@ export const loading = (): string => html`
 export const longWrappingTextInBlockAndBlockSection = (): string => html`
   <calcite-panel style="width:250px">
     <calcite-block
-      collapsible
+      expandable
       expanded
       heading="Planes, trains, and automobiles are some examples of modes of transportation"
       description="Planes, trains, and automobiles are some examples of modes of transportation"
@@ -206,7 +206,7 @@ export const longWrappingTextInBlockAndBlockSection = (): string => html`
       </calcite-block-section>
     </calcite-block>
     <calcite-block
-      collapsible
+      expandable
       heading="Planes, trains, and automobiles are some examples of modes of transportation"
       description="Planes, trains, and automobiles are some examples of modes of transportation"
     >
@@ -269,7 +269,7 @@ export const toggleDisplayWithLongText = (): string =>
   </calcite-block>`;
 
 export const icons = (): string => html`
-  <calcite-block heading="Heading" description="summary" collapsible expanded>
+  <calcite-block heading="Heading" description="summary" expandable expanded>
     <calcite-block-section
       text="Planes, trains, and automobiles are some examples of modes of transportation"
       expanded
@@ -300,7 +300,7 @@ export const iconStartEnd = (): string => html`
   <calcite-block
     heading="Valid status"
     description="summary"
-    collapsible
+    expandable
     icon-start="pen"
     icon-end="pen"
     style="width: 500px"
@@ -326,7 +326,7 @@ export const iconStartEnd = (): string => html`
 
   <calcite-block
     heading="Valid status"
-    collapsible
+    expandable
     status="valid"
     icon-start="pen"
     icon-end="pen"
@@ -342,7 +342,7 @@ const blockHTML = (scale: Scale): string => html`
     heading="Heading"
     description="description"
     expanded
-    collapsible
+    expandable
     scale="${scale}"
     icon-start="layers"
     icon-end="layers"
@@ -409,7 +409,7 @@ export const emptyHeader = (): string => html`
 `;
 
 export const toggleDisplaySwitch = (): string => html`
-  <calcite-block heading="Heading" description="description" toggle-display="switch" collapsible> </calcite-block>
+  <calcite-block heading="Heading" description="description" toggle-display="switch" expandable> </calcite-block>
 `;
 
 const nestedBlockHTML = (slottedAsChildren = true): string => html`
@@ -417,7 +417,7 @@ const nestedBlockHTML = (slottedAsChildren = true): string => html`
     heading="Road network"
     description="Highways, arterials, and local streets"
     ${slottedAsChildren ? 'slot="children"' : ""}
-    collapsible
+    expandable
     expanded
   >
     <calcite-block heading="County roads" description="County roads" slot="children"></calcite-block>
@@ -426,14 +426,14 @@ const nestedBlockHTML = (slottedAsChildren = true): string => html`
 `;
 
 export const nestedBlockInChildrenSlot = (): string => html`
-  <calcite-block heading="Transportation" description="Roads, rail, and transit overlays" collapsible expanded>
+  <calcite-block heading="Transportation" description="Roads, rail, and transit overlays" expandable expanded>
     ${nestedBlockHTML()}
   </calcite-block>
   <calcite-block heading="Hydrology" description="Rivers, lakes, and watershed boundaries"></calcite-block>
 `;
 
 export const nestedBlockGroupInChildrenSlot = (): string => html`
-  <calcite-block heading="Transportation" description="Roads, rail, and transit overlays" collapsible expanded>
+  <calcite-block heading="Transportation" description="Roads, rail, and transit overlays" expandable expanded>
     <calcite-block-group slot="children"> ${nestedBlockHTML(false)} </calcite-block-group>
   </calcite-block>
 `;

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -89,9 +89,6 @@ export class Block extends LitElement {
 
   //#region Public Properties
 
-  /** When `true`, the component is collapsible. */
-  @property({ reflect: true }) collapsible = false;
-
   /** @copyDoc */
   @property() description?: string;
 
@@ -110,6 +107,28 @@ export class Block extends LitElement {
 
   /** When `true`, expands the component and its contents. */
   @property({ reflect: true }) expanded = false;
+
+  /** When `true`, the component can be expanded and collapsed. */
+  @property({ reflect: true }) expandable = false;
+
+  /**
+   * When `true`, the component can be expanded and collapsed.
+   *
+   * @deprecated in v5.2.0, removal target v7.0.0 - Use the `expandable` property instead.
+   */
+  @property({ reflect: true })
+  get collapsible(): boolean {
+    return this.expandable;
+  }
+  set collapsible(value: boolean) {
+    logger.deprecated("property", {
+      component: this,
+      name: "collapsible",
+      removalVersion: 7,
+      suggested: "expandable",
+    });
+    this.expandable = value;
+  }
 
   /** @copyDoc */
   @property() heading?: string;
@@ -489,7 +508,7 @@ export class Block extends LitElement {
   private renderContentEnd(): JsxNode {
     return (
       <div
-        class={{ [CSS.iconEndContainer]: !this.iconEnd && !this.collapsible }}
+        class={{ [CSS.iconEndContainer]: !this.iconEnd && !this.expandable }}
         hidden={!this.hasContentEnd}
       >
         <div class={CSS.contentEnd}>
@@ -547,7 +566,7 @@ export class Block extends LitElement {
 
   override render(): JsxNode {
     const {
-      collapsible,
+      expandable,
       loading,
       expanded,
       label,
@@ -619,11 +638,11 @@ export class Block extends LitElement {
             topLayerDisabled={this.topLayerDisabled}
           />
         ) : null}
-        {collapsible ? (
+        {expandable ? (
           <button
             aria-controls={IDS.content}
             aria-describedby={IDS.header}
-            ariaExpanded={collapsible ? expanded : undefined}
+            ariaExpanded={expandable ? expanded : undefined}
             class={CSS.toggle}
             id={IDS.toggle}
             onClick={this.onHeaderClick}
@@ -654,12 +673,12 @@ export class Block extends LitElement {
         ) : (
           headerContent
         )}
-        {iconEnd && !collapsible ? (
+        {iconEnd && !expandable ? (
           <div class={CSS.iconEndContainer}>
             {this.renderContentEnd()}
             {this.renderIcon("end")}
           </div>
-        ) : !iconEnd && !collapsible ? (
+        ) : !iconEnd && !expandable ? (
           this.renderContentEnd()
         ) : null}
         <calcite-action-menu

--- a/packages/components/src/components/flow-item/flow-item.e2e.ts
+++ b/packages/components/src/components/flow-item/flow-item.e2e.ts
@@ -105,22 +105,22 @@ it("allows scrolling content", async () => {
   await page.setContent(html`
     <calcite-flow style="height: 300px">
       <calcite-flow-item heading="Flow heading" id="flowOrPanel">
-        <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+        <calcite-block heading="Block example" summary="Some subtext" expandable open>
           <calcite-notice open>
             <div slot="message">An excellent assortment of content.</div>
           </calcite-notice>
         </calcite-block>
-        <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+        <calcite-block heading="Block example" summary="Some subtext" expandable open>
           <calcite-notice open>
             <div slot="message">An excellent assortment of content.</div>
           </calcite-notice>
         </calcite-block>
-        <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+        <calcite-block heading="Block example" summary="Some subtext" expandable open>
           <calcite-notice open>
             <div slot="message">An excellent assortment of content.</div>
           </calcite-notice>
         </calcite-block>
-        <calcite-block heading="Block example" summary="Some subtext" collapsible open>
+        <calcite-block heading="Block example" summary="Some subtext" expandable open>
           <calcite-notice open>
             <div slot="message">An excellent assortment of content.</div>
           </calcite-notice>

--- a/packages/components/src/components/shell/shell.e2e.ts
+++ b/packages/components/src/components/shell/shell.e2e.ts
@@ -231,7 +231,7 @@ describe("embedded", () => {
       html` <calcite-shell>
         <calcite-shell-panel slot="panel-start">
           <calcite-panel heading="Example">
-            <calcite-block heading="Example" collapsible id="example-block"></calcite-block>
+            <calcite-block heading="Example" expandable id="example-block"></calcite-block>
           </calcite-panel>
         </calcite-shell-panel>
         <calcite-panel heading="Content">
@@ -259,7 +259,7 @@ describe("embedded", () => {
       html` <calcite-shell>
         <calcite-shell-panel slot="panel-start">
           <calcite-panel heading="Example">
-            <calcite-block heading="Example" collapsible></calcite-block>
+            <calcite-block heading="Example" expandable></calcite-block>
           </calcite-panel>
         </calcite-shell-panel>
         <calcite-panel heading="Content">

--- a/packages/components/src/components/shell/shell.stories.ts
+++ b/packages/components/src/components/shell/shell.stories.ts
@@ -199,28 +199,28 @@ const contentHTML = html`
 const advancedLeadingPanelHTML = html`
   ${actionBarStartHTML}
   <calcite-panel heading="Advanced panel example">
-    <calcite-block collapsible open heading="Start Content" description="This is the primary.">
+    <calcite-block expandable open heading="Start Content" description="This is the primary.">
       <calcite-block-content>
         <calcite-action text="Play" text-enabled indicator icon="play"></calcite-action>
         <calcite-action text="Extent" text-enabled icon="extent"></calcite-action>
         <calcite-action text="Chart" text-enabled icon="arrow-up-right"></calcite-action>
       </calcite-block-content>
     </calcite-block>
-    <calcite-block collapsible open heading="Another Block" description="This is the primary.">
+    <calcite-block expandable open heading="Another Block" description="This is the primary.">
       <calcite-block-content>
         <div style="height: 300px;">
           <p>Cool thing.</p>
         </div>
       </calcite-block-content>
     </calcite-block>
-    <calcite-block collapsible open heading="Additional Block" description="This is the primary.">
+    <calcite-block expandable open heading="Additional Block" description="This is the primary.">
       <calcite-block-content>
         <div style="height: 300px;">
           <p>Cool thing.</p>
         </div>
       </calcite-block-content>
     </calcite-block>
-    <calcite-block collapsible open heading="More Block" description="This is the primary.">
+    <calcite-block expandable open heading="More Block" description="This is the primary.">
       <calcite-block-content>
         <div style="height: 300px;">
           <p>Cool thing.</p>
@@ -239,7 +239,7 @@ const advancedTrailingPanelHTMl = html`
       <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
       <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
       <calcite-action slot="header-menu-actions" text="Cool thing" text-enabled></calcite-action>
-      <calcite-block collapsible open heading="End Content" description="Select goodness">
+      <calcite-block expandable open heading="End Content" description="Select goodness">
         <calcite-block-content>
           <img alt="demo" src="${placeholderImage({ width: 640, height: 480 })}" width="100%" />
           <calcite-block-section text="Cool things">
@@ -258,7 +258,7 @@ const advancedTrailingPanelHTMl = html`
       <calcite-button slot="footer" width="half">Save</calcite-button>
     </calcite-flow-item>
     <calcite-flow-item heading="Deeper flow item">
-      <calcite-block collapsible open heading="End Content" description="Select goodness">
+      <calcite-block expandable open heading="End Content" description="Select goodness">
         <calcite-block-content>
           <calcite-block-section text="Cool things">
             <calcite-action text="Cool thing" text-enabled></calcite-action>
@@ -273,7 +273,7 @@ const advancedTrailingPanelHTMl = html`
           </calcite-block-section>
         </calcite-block-content>
       </calcite-block>
-      <calcite-block collapsible open heading="Even more content" description="Select goodness">
+      <calcite-block expandable open heading="Even more content" description="Select goodness">
         <calcite-block-content>
           <calcite-block-section text="Cool things">
             <calcite-action text="Cool thing" text-enabled></calcite-action>
@@ -366,27 +366,27 @@ const actionBarHTML = html`
 
 const panelHTML = html`
   <calcite-panel heading="Panel heading">
-    <calcite-block collapsible heading="Block heading" description="Description">
+    <calcite-block expandable heading="Block heading" description="Description">
       <calcite-notice open>
         <div slot="message">The viewers are going to love this</div>
       </calcite-notice>
     </calcite-block>
-    <calcite-block collapsible heading="Block heading" description="Description">
+    <calcite-block expandable heading="Block heading" description="Description">
       <calcite-notice open>
         <div slot="message">The viewers are going to love this</div>
       </calcite-notice>
     </calcite-block>
-    <calcite-block collapsible heading="Block heading" description="Description">
+    <calcite-block expandable heading="Block heading" description="Description">
       <calcite-notice open>
         <div slot="message">The viewers are going to love this</div>
       </calcite-notice>
     </calcite-block>
-    <calcite-block collapsible heading="Block heading" description="Description">
+    <calcite-block expandable heading="Block heading" description="Description">
       <calcite-notice open>
         <div slot="message">The viewers are going to love this</div>
       </calcite-notice>
     </calcite-block>
-    <calcite-block collapsible heading="Block heading" description="Description">
+    <calcite-block expandable heading="Block heading" description="Description">
       <calcite-notice open>
         <div slot="message">The viewers are going to love this</div>
       </calcite-notice>
@@ -807,7 +807,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0;
             appearance="solid"
             scale="m"
           ></calcite-action>
-          <calcite-block collapsible open heading="End Content" description="Select goodness">
+          <calcite-block expandable open heading="End Content" description="Select goodness">
             <calcite-block-content>
               <img
                 alt="demo"
@@ -834,7 +834,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0;
           </calcite-button>
         </calcite-flow-item>
         <calcite-flow-item heading="Deeper flow item" show-back-button>
-          <calcite-block collapsible open heading="End Content" description="Select goodness">
+          <calcite-block expandable open heading="End Content" description="Select goodness">
             <calcite-block-content>
               <calcite-block-section text="Cool things" toggle-display="button">
                 <calcite-action text="Cool thing" text-enabled appearance="solid" scale="m"></calcite-action>
@@ -853,7 +853,7 @@ background-position: 0 0, 0 10px, 10px -10px, -10px 0;
               </calcite-block-section>
             </calcite-block-content>
           </calcite-block>
-          <calcite-block collapsible open heading="Even more content" description="Select goodness">
+          <calcite-block expandable open heading="Even more content" description="Select goodness">
             <calcite-block-content>
               <calcite-block-section text="Cool things" toggle-display="button">
                 <calcite-action text="Cool thing" text-enabled appearance="solid" scale="m"></calcite-action>
@@ -1674,7 +1674,7 @@ position:relative;
           width-scale="m"
         >
           <calcite-action slot="header-actions-end" icon="x" text="Close"> </calcite-action>
-          <calcite-block heading="Title" description="County: {NAME}" collapsible icon-start="title">
+          <calcite-block heading="Title" description="County: {NAME}" expandable icon-start="title">
             <div class="combo-control">
               <div class="combo-button">
                 <button class="combo-button__main">County: {NAME}</button>
@@ -1683,7 +1683,7 @@ position:relative;
             </div>
           </calcite-block>
           <calcite-sortable-list>
-            <calcite-block drag-handle heading="Attributes" description="2/98" collapsible icon-start="feature-details">
+            <calcite-block drag-handle heading="Attributes" description="2/98" expandable icon-start="feature-details">
               <calcite-action label="ellipsis" slot="actions-end" icon="ellipsis" scale="m"></calcite-action>
               <calcite-list drag-enabled>
                 <calcite-list-item
@@ -1703,7 +1703,7 @@ position:relative;
                 >
               </div>
             </calcite-block>
-            <calcite-block drag-handle heading="Image" collapsible icon-start="image">
+            <calcite-block drag-handle heading="Image" expandable icon-start="image">
               <calcite-action label="ellipsis" slot="actions-end" icon="ellipsis" scale="m"></calcite-action>
               <section class="form-section">
                 <label>
@@ -1756,7 +1756,7 @@ position:relative;
               drag-handle
               heading="Text"
               description="Cool. he {expression/..."
-              collapsible
+              expandable
               icon-start="image"
             >
               <calcite-action label="ellipsis" slot="actions-end" icon="ellipsis" scale="m"></calcite-action>
@@ -1844,7 +1844,7 @@ export const panelEndWithPositionStart = (): string =>
       <calcite-panel heading="Map Options">
         <calcite-button width="half" slot="footer"> Next </calcite-button>
         <calcite-block
-          collapsible
+          expandable
           heading="Layer effects"
           description="Adjust blur, highlight, and more"
           icon-start="effects"
@@ -1854,7 +1854,7 @@ export const panelEndWithPositionStart = (): string =>
           </calcite-notice>
         </calcite-block>
         <calcite-block
-          collapsible
+          expandable
           heading="Symbology"
           description="Select type, color, and transparency"
           icon-start="map-pin"
@@ -1980,7 +1980,7 @@ export const resizeHandlePositioning = (): string =>
         </calcite-action-group>
       </calcite-action-bar>
       <calcite-panel heading="Panel 1">
-        <calcite-block heading="Block 1" collapsible></calcite-block>
+        <calcite-block heading="Block 1" expandable></calcite-block>
       </calcite-panel>
     </calcite-shell-panel>
     <calcite-panel heading="Main content"></calcite-panel>
@@ -1992,7 +1992,7 @@ export const resizeHandlePositioning = (): string =>
         </calcite-action-group>
       </calcite-action-bar>
       <calcite-panel heading="Panel 1">
-        <calcite-block heading="Block 1" collapsible></calcite-block>
+        <calcite-block heading="Block 1" expandable></calcite-block>
       </calcite-panel>
     </calcite-shell-panel>
   </calcite-shell>`;
@@ -2017,7 +2017,7 @@ export const shellPanelWithTabs = (): string =>
       </calcite-action-bar>
       <calcite-panel heading="Layers" id="panel-start" closable>
         <calcite-block
-          collapsible
+          expandable
           heading="Symbology"
           description="Select type, color, and transparency"
           icon-start="map-pin"
@@ -2187,7 +2187,7 @@ export const popoverZIndex = (): string =>
         <calcite-action icon="layer" text="Layer"></calcite-action>
       </calcite-action-bar>
       <calcite-panel heading="Map" id="panel-start">
-        <calcite-block heading="Block 1" collapsible></calcite-block>
+        <calcite-block heading="Block 1" expandable></calcite-block>
       </calcite-panel>
     </calcite-shell-panel>
 
@@ -2204,7 +2204,7 @@ export const popoverZIndex = (): string =>
         <calcite-action text="Configure" icon="popup"></calcite-action>
       </calcite-action-bar>
       <calcite-panel id="panel-end" closable closed>
-        <calcite-block heading="Block 1" collapsible></calcite-block>
+        <calcite-block heading="Block 1" expandable></calcite-block>
       </calcite-panel>
     </calcite-shell-panel>
     <calcite-panel heading="Content"></calcite-panel>

--- a/packages/components/src/custom-theme/block.ts
+++ b/packages/components/src/custom-theme/block.ts
@@ -21,7 +21,7 @@ export const block = html` <calcite-block
   heading="heading"
   description="description"
   open
-  collapsible
+  expandable
   icon-end="pen"
   icon-start="pen"
 >


### PR DESCRIPTION
**Related Issue:** #11671

## Summary
Deprecates `collapsible` in favor of `expandable`.

- Maps deprecated collapsible to expandable via an accessor that logs a deprecation warning.
- Updates Storybook stories and browser tests (and legacy e2e) to use expandable and adds coverage verifying collapsible maps to expandable.