### PR TITLE
feat(block): add background color token

### DIFF
--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -272,6 +272,9 @@ describe("theme", () => {
           </calcite-block>,
         ),
       {
+        "--calcite-block-background-color": {
+          targetProp: "backgroundColor",
+        },
         "--calcite-block-border-color": {
           targetProp: "borderColor",
         },
@@ -285,10 +288,6 @@ describe("theme", () => {
             targetProp: "paddingInline",
           },
         ],
-        "--calcite-block-header-background-color": {
-          shadowSelector: `.${CSS.toggle}`,
-          targetProp: "backgroundColor",
-        },
         "--calcite-block-header-background-color-hover": {
           shadowSelector: `.${CSS.toggle}`,
           targetProp: "backgroundColor",
@@ -356,6 +355,10 @@ describe("theme", () => {
           </calcite-block>,
         ),
       {
+        "--calcite-block-header-background-color": {
+          shadowSelector: `.${CSS.toggle}`,
+          targetProp: "backgroundColor",
+        },
         "--calcite-block-padding": [
           {
             shadowSelector: `section.${CSS.content}`,

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -5,7 +5,8 @@
  *
  * @prop --calcite-block-border-color: Specifies the component's border color.
  * @prop --calcite-block-content-space: Specifies the space of the component's `default` slot.
- * @prop --calcite-block-header-background-color: Specifies the component's `heading` background color.
+ * @prop --calcite-block-background-color: Specifies the component's background color.
+ * @prop --calcite-block-header-background-color: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-background-color` instead. Specifies the component's `heading` background color.
  * @prop --calcite-block-header-background-color-hover: Specifies the component's `heading` background color when hovered.
  * @prop --calcite-block-header-background-color-press: Specifies the component's `heading` background color when pressed.
  * @prop --calcite-block-heading-text-color: Specifies the component's `heading` text color.
@@ -130,6 +131,7 @@
     flex-col border-0 border-b border-solid p-0;
   flex-basis: auto;
   border-color: var(--calcite-block-border-color, var(--calcite-color-border-3));
+  background-color: var(--calcite-block-background-color);
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -131,7 +131,7 @@
     flex-col border-0 border-b border-solid p-0;
   flex-basis: auto;
   border-color: var(--calcite-block-border-color, var(--calcite-color-border-3));
-  background-color: var(--calcite-block-background-color);
+  background-color: var(--calcite-block-background-color, var(--calcite-color-foreground-1));
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/block/block.stories.ts
+++ b/packages/components/src/components/block/block.stories.ts
@@ -150,6 +150,21 @@ export const darkModeRTL = (): string => html`
   </calcite-block>
 `;
 
+export const transparentAppearance = (): string => html`
+  <style>
+    calcite-block {
+      --calcite-block-background-color: var(--calcite-color-transparent);
+      --calcite-block-border-color: var(--calcite-color-transparent);
+      --calcite-block-header-background-color-hover: var(--calcite-color-transparent-hover);
+      --calcite-block-header-background-color-press: var(--calcite-color-transparent-press);
+    }
+  </style>
+  <calcite-block-group>
+    <calcite-block heading="Heading" description="Description" collapsible> Block content </calcite-block>
+    <calcite-block heading="Heading" description="Description" collapsible expanded> Block content </calcite-block>
+  </calcite-block-group>
+`;
+
 export const contentCanTakeFullHeight = (): string =>
   html`<calcite-block expanded heading="Heading" description="description" style="height: 250px">
     <div style="background: red; height: 100%;">should take full width of the content area</div>

--- a/packages/components/src/components/block/block.stories.ts
+++ b/packages/components/src/components/block/block.stories.ts
@@ -160,8 +160,8 @@ export const transparentAppearance = (): string => html`
     }
   </style>
   <calcite-block-group>
-    <calcite-block heading="Heading" description="Description" collapsible> Block content </calcite-block>
-    <calcite-block heading="Heading" description="Description" collapsible expanded> Block content </calcite-block>
+    <calcite-block heading="Heading" description="Description" expandable> Block content </calcite-block>
+    <calcite-block heading="Heading" description="Description" expandable expanded> Block content </calcite-block>
   </calcite-block-group>
 `;
 

--- a/packages/components/src/custom-theme/block.ts
+++ b/packages/components/src/custom-theme/block.ts
@@ -3,6 +3,7 @@ import { html } from "../../support/formatting";
 export const blockTokens = {
   calciteBlockBorderColor: "",
   calciteBlockContentSpace: "",
+  calciteBlockBackgroundColor: "",
   calciteBlockHeaderBackgroundColor: "",
   calciteBlockHeaderBackgroundColorHover: "",
   calciteBlockTextColor: "",


### PR DESCRIPTION
**Related Issue:** #14006

## Summary

Adds `--calcite-block-background-color` to style the Block host background, including when the component is not collapsible.

Deprecates `--calcite-block-header-background-color` in favor of the new token and adds a story for transparent styling (the new token helps replace Accordion's `appearance="transparent"`.

deprecate(block): deprecate `--calcite-block-header-background-color` token