### PR TITLE
fix(tile): restore top/bottom slot spacing

### DIFF
--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -201,8 +201,14 @@ export class Tile extends LitElement implements SelectableComponent {
   }
 
   private handleSlotChange(event: Event): void {
-    const slotName = (event.target as HTMLSlotElement).dataset.name;
-    this[`has${slotName}`] = slotChangeHasAssignedElement(event);
+    const hasAssignedElement = slotChangeHasAssignedElement(event);
+    const slotName = (event.target as HTMLSlotElement).name;
+
+    if (slotName === SLOTS.contentBottom) {
+      this.hasContentBottom = hasAssignedElement;
+    } else if (slotName === SLOTS.contentTop) {
+      this.hasContentTop = hasAssignedElement;
+    }
   }
 
   private setContainerEl(el): void {


### PR DESCRIPTION
**Related Issue:** #15100

## Summary

Fixes visual regression introduced in https://github.com/Esri/calcite-design-system/pull/11216.