### PR TITLE
fix(input-date-picker): make vertical dropdown toggle not visible in readOnly mode

### DIFF
--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -272,12 +272,6 @@ describe("clearable", () => {
     expect(getClearButtons()).toHaveLength(0);
   });
 
-  it("does not render vertical actions when range is readOnly", async () => {
-    await mount<InputDatePicker>(<calcite-input-date-picker layout="vertical" range readOnly />);
-
-    expect(page.getBySelector(`.${CSS.verticalActionsContainer}`).elements()).toHaveLength(0);
-  });
-
   it("clears single value when clear button is clicked", async () => {
     const { el } = await mount<InputDatePicker>(
       <calcite-input-date-picker clearable value="2024-05-05" />,

--- a/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.browser.e2e.tsx
@@ -272,6 +272,12 @@ describe("clearable", () => {
     expect(getClearButtons()).toHaveLength(0);
   });
 
+  it("does not render vertical actions when range is readOnly", async () => {
+    await mount<InputDatePicker>(<calcite-input-date-picker layout="vertical" range readOnly />);
+
+    expect(page.getBySelector(`.${CSS.verticalActionsContainer}`).elements()).toHaveLength(0);
+  });
+
   it("clears single value when clear button is clicked", async () => {
     const { el } = await mount<InputDatePicker>(
       <calcite-input-date-picker clearable value="2024-05-05" />,

--- a/packages/components/src/components/input-date-picker/input-date-picker.scss
+++ b/packages/components/src/components/input-date-picker/input-date-picker.scss
@@ -407,6 +407,19 @@
   --calcite-internal-input-text-icon-border-block-start-width: var(--calcite-border-width-none);
 }
 
+:host([range][layout="vertical"][read-only]) {
+  :is(.input--start, .input--end) {
+    --calcite-internal-input-text-input-border-inline-end-width: var(--calcite-border-width-sm);
+  }
+
+  .divider-container {
+    box-sizing: border-box;
+    border-inline-end-width: var(--calcite-border-width-sm);
+    inline-size: 100%;
+    padding-inline: var(--calcite-space-none);
+  }
+}
+
 calcite-date-picker {
   --calcite-date-picker-border-color: var(--calcite-input-date-picker-calendar-border-color);
   --calcite-date-picker-corner-radius: var(--calcite-input-date-picker-calendar-corner-radius);

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -197,7 +197,15 @@ export const readOnlyHasNoDropdownAffordance = (): string => html`
 `;
 
 export const readOnlyVerticalRangeHasNoDropdownAffordance = (): string => html`
-  <calcite-input-date-picker layout="vertical" range read-only value="2020-12-12"></calcite-input-date-picker>
+  <calcite-input-date-picker
+    id="read-only-vertical-range"
+    layout="vertical"
+    range
+    read-only
+  ></calcite-input-date-picker>
+  <script>
+    document.querySelector("#read-only-vertical-range").value = ["2020-12-12", "2020-12-14"];
+  </script>
 `;
 
 export const validationMessageAllScales = (): string => html`

--- a/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
+++ b/packages/components/src/components/input-date-picker/input-date-picker.stories.ts
@@ -196,6 +196,10 @@ export const readOnlyHasNoDropdownAffordance = (): string => html`
   <calcite-input-date-picker read-only value="2020-12-12"></calcite-input-date-picker>
 `;
 
+export const readOnlyVerticalRangeHasNoDropdownAffordance = (): string => html`
+  <calcite-input-date-picker layout="vertical" range read-only value="2020-12-12"></calcite-input-date-picker>
+`;
+
 export const validationMessageAllScales = (): string => html`
   <style>
     .container {

--- a/packages/components/src/components/input-date-picker/input-date-picker.tsx
+++ b/packages/components/src/components/input-date-picker/input-date-picker.tsx
@@ -1320,7 +1320,7 @@ export class InputDatePicker extends LitElement implements FloatingUIComponent, 
               </div>
             )}
           </div>
-          {this.range && this.layout === "vertical" ? (
+          {this.range && this.layout === "vertical" && !this.readOnly ? (
             <div
               class={CSS.verticalActionsContainer}
               onClick={this.onVerticalActionsContainerClick}


### PR DESCRIPTION
**Related Issue:** #14838

## Summary
Vertical dropdown toggle is not visible in `readOnly` mode.