### PR TITLE
refactor(useFormTrigger): move void controller to constructor

### DIFF
--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -63,8 +63,6 @@ export class Action extends LitElement {
 
   private interactiveContainer = useInteractive(this);
 
-  formTrigger = useFormTrigger()(this);
-
   private labelElRef = createRef<HTMLSpanElement>();
 
   //#endregion
@@ -210,6 +208,11 @@ export class Action extends LitElement {
   //#endregion
 
   //#region Lifecycle
+
+  constructor() {
+    super();
+    useFormTrigger()(this);
+  }
 
   override connectedCallback(): void {
     this.mutationObserver?.observe(this.el, { childList: true, subtree: true });

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -59,8 +59,6 @@ export class Button extends LitElement {
 
   private contentRef = createRef<HTMLSpanElement>();
 
-  formTrigger = useFormTrigger({ disabled: () => !!this.href })(this);
-
   labelEl?: Label["el"];
 
   /** watches for changing text content */
@@ -199,6 +197,7 @@ export class Button extends LitElement {
 
   constructor() {
     super();
+    useFormTrigger({ disabled: () => !!this.href })(this);
     useLabel(this);
   }
 

--- a/packages/components/src/controllers/useFormTrigger.browser.spec.tsx
+++ b/packages/components/src/controllers/useFormTrigger.browser.spec.tsx
@@ -38,7 +38,10 @@ class TestComponent extends LitElement {
   @method()
   async setFocus(): Promise<void> {}
 
-  formTrigger = useFormTrigger()(this);
+  constructor() {
+    super();
+    useFormTrigger()(this);
+  }
 
   override render(): JsxNode {
     return <div>🎯</div>;
@@ -114,9 +117,12 @@ describe("conditional disabling", () => {
     @method()
     async setFocus(): Promise<void> {}
 
-    formTrigger = useFormTrigger({
-      disabled: () => disabled,
-    })(this);
+    constructor() {
+      super();
+      useFormTrigger({
+        disabled: () => disabled,
+      })(this);
+    }
 
     override render(): JsxNode {
       return <div>🎯</div>;


### PR DESCRIPTION
**monday.com sync:** #12948982957

**Related Issue:** N/A

## Summary

This PR updates `useFormTrigger`, which was missed in #15075, to be invoked in the constructor instead, avoiding unnecessary boilerplate and potential confusion.