### PR TITLE
refactor: tidy up Puppeteer test utils

### DIFF
--- a/packages/components/src/tests/commonTests/browser/reflects.ts
+++ b/packages/components/src/tests/commonTests/browser/reflects.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { propToAttr } from "../utils";
+import { camelToKebab as propToAttr } from "@arcgis/toolkit/string";
 
 type ReflectProps<E extends HTMLElement> = Array<{
   propertyName: Extract<keyof E, string>;

--- a/packages/components/src/tests/commonTests/puppeteer/utils.ts
+++ b/packages/components/src/tests/commonTests/puppeteer/utils.ts
@@ -1,16 +1,4 @@
-import { newE2EPage, E2EPage } from "@arcgis/lumina-compiler/puppeteerTesting";
-import type {
-  ComponentTag,
-  TagOrHTML,
-  ComponentTestSetup,
-  TagAndPage,
-  TagOrHTMLWithBeforeContent,
-  BeforeContent,
-  WithBeforeContent,
-  ComponentTestContent,
-} from "../types";
-
-export { propToAttr } from "../utils";
+import type { ComponentTag, TagOrHTML, TagOrHTMLWithBeforeContent, BeforeContent } from "../types";
 
 export function isHTML(tagOrHTML: string): boolean {
   return tagOrHTML.trim().startsWith("<");
@@ -32,40 +20,6 @@ export function getTag(tagOrHTML: string): ComponentTag {
   }
 
   return tagOrHTML as ComponentTag;
-}
-
-export async function simplePageSetup(componentTagOrHTML: TagOrHTML): Promise<E2EPage> {
-  const componentTag = getTag(componentTagOrHTML);
-  const page = await newE2EPage();
-  await page.setContent(isHTML(componentTagOrHTML) ? componentTagOrHTML : `<${componentTag}></${componentTag}>`);
-  return page;
-}
-
-export async function getTagAndPage(componentTestSetup: ComponentTestSetup): Promise<TagAndPage> {
-  if (typeof componentTestSetup === "function") {
-    componentTestSetup = await componentTestSetup();
-  }
-
-  if (typeof componentTestSetup === "string") {
-    const page = await simplePageSetup(componentTestSetup);
-    const tag = getTag(componentTestSetup);
-
-    return { page, tag };
-  }
-
-  return componentTestSetup;
-}
-
-export async function noopBeforeContent(): Promise<void> {
-  /* noop */
-}
-
-export function getBeforeContent<TestContent = ComponentTestContent>(
-  componentTestSetup: WithBeforeContent<TestContent>,
-): BeforeContent {
-  return typeof componentTestSetup === "string"
-    ? noopBeforeContent
-    : componentTestSetup?.beforeContent || noopBeforeContent;
 }
 
 export function getTagOrHTMLWithBeforeContent(componentTestSetup: TagOrHTML | TagOrHTMLWithBeforeContent): {

--- a/packages/components/src/tests/commonTests/types.ts
+++ b/packages/components/src/tests/commonTests/types.ts
@@ -5,11 +5,6 @@ export type ComponentHTML = string;
 export type TagOrHTML = ComponentTag | ComponentHTML;
 export type BeforeContent = (page: E2EPage) => Promise<void>;
 
-export type TagAndPage = {
-  tag: ComponentTag;
-  page: E2EPage;
-};
-
 export type TagOrHTMLWithBeforeContent = WithBeforeContent<{ tagOrHTML: TagOrHTML }>;
 
 export type WithBeforeContent<TestContent> = TestContent & {
@@ -22,32 +17,3 @@ export type WithBeforeContent<TestContent> = TestContent & {
    */
   beforeContent: BeforeContent;
 };
-
-export type ComponentTestContent = TagOrHTML | TagAndPage;
-export type ComponentTestSetupProvider = (() => ComponentTestContent) | (() => Promise<ComponentTestContent>);
-export type ComponentTestSetup = ComponentTestContent | ComponentTestSetupProvider;
-
-/** This interface is used to specify focus targets for different interactions. */
-export interface TabAndClickFocusTargets {
-  tab: string;
-  click:
-    | string
-    | {
-        pointer: string;
-        method: string;
-      };
-}
-
-export type FocusTarget = "host" | "child" | "none";
-
-export interface DisabledOptions {
-  /** Use this to specify whether the test should cover focusing. */
-  focusTarget?: FocusTarget | TabAndClickFocusTargets;
-
-  /**
-   * Use this to specify the main wrapped component in shadow DOM that handles disabling interaction.
-   *
-   *  Note: this should only be used for components that wrap a single component that implements disabled behavior.
-   */
-  shadowAriaAttributeTargetSelector?: string;
-}

--- a/packages/components/src/tests/commonTests/utils.ts
+++ b/packages/components/src/tests/commonTests/utils.ts
@@ -1,5 +1,0 @@
-import { kebabCase } from "change-case";
-
-export function propToAttr(name: string): string {
-  return kebabCase(name);
-}


### PR DESCRIPTION
**monday.com sync:** #12961113229

Related issue(s): N/A

* drops obsolete utils and types
* removes `utils.ts` by inlining prop-to-attr name helper