### PR TITLE
chore(button): update state colors to Calcite tokens and remove no-op focus styles

### DIFF
--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -24,21 +24,24 @@ const rules = {
   "selector-attribute-name-disallowed-list": [
     ["hidden"],
     {
-      message: "hidden styles are included in the `base-component` mixin, so make sure it's used",
+      message:
+        "hidden styles are included in the `base-component` mixin, so make sure it's used",
       severity: "error",
     },
   ],
   "selector-disallowed-list": [
     ["/:host-context/"],
     {
-      message: ":host-context is not supported in all browsers, so it should be avoided",
+      message:
+        ":host-context is not supported in all browsers, so it should be avoided",
       severity: "error",
     },
   ],
   "selector-max-specificity": [
     "0,5,5",
     {
-      message: "selector is too complex, consider applying multiple classes dynamically during rendering",
+      message:
+        "selector is too complex, consider applying multiple classes dynamically during rendering",
     },
   ],
   "selector-pseudo-element-colon-notation": [
@@ -86,7 +89,10 @@ scssPatternRules.forEach((rule) => {
 const config = {
   defaultSeverity: "warning",
   extends: "stylelint-config-recommended-scss",
-  plugins: ["stylelint-use-logical-spec", "@esri/stylelint-plugin-calcite-components"],
+  plugins: [
+    "stylelint-use-logical-spec",
+    "@esri/stylelint-plugin-calcite-components",
+  ],
   rules,
 };
 

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -489,6 +489,9 @@
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-border-input);
     }
+    &:focus {
+      --calcite-internal-button-border-color: var(--calcite-color-foreground-3);
+    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-text-3);
     }

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -356,23 +356,19 @@
   button,
   a {
     --calcite-internal-button-border-color: var(--calcite-color-brand);
-    --calcite-internal-button-text-color: theme("colors.brand");
+    --calcite-internal-button-text-color: var(--calcite-color-brand);
     --calcite-internal-button-loader-color: var(--calcite-color-brand);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-brand-hover);
-      --calcite-internal-button-text-color: theme("colors.brand-hover");
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-brand);
-      --calcite-internal-button-text-color: theme("colors.brand");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-brand-press);
-      --calcite-internal-button-text-color: theme("colors.brand-press");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.brand");
+      --calcite-internal-button-loader-color: var(--calcite-color-brand);
     }
   }
 }
@@ -380,30 +376,26 @@
   button,
   a {
     --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-    --calcite-internal-button-text-color: theme("colors.danger");
+    --calcite-internal-button-text-color: var(--calcite-color-status-danger);
     --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-hover);
-      --calcite-internal-button-text-color: theme("colors.danger-hover");
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-      --calcite-internal-button-text-color: theme("colors.danger");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-press);
-      --calcite-internal-button-text-color: theme("colors.danger-press");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.danger");
+      --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
     }
   }
 }
 :host([appearance="outline-fill"][kind="neutral"]) {
   button,
   a {
-    --calcite-internal-button-border-color: theme("borderColor.color.1");
+    --calcite-internal-button-border-color: var(--calcite-color-border-1);
     --calcite-internal-button-text-color: var(--calcite-color-text-1);
     --calcite-internal-button-loader-color: var(--calcite-color-text-1);
 
@@ -432,9 +424,6 @@
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-hover);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-inverse);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-press);
     }
@@ -454,23 +443,19 @@
   button,
   a {
     --calcite-internal-button-border-color: var(--calcite-color-brand);
-    --calcite-internal-button-text-color: theme("colors.brand");
+    --calcite-internal-button-text-color: var(--calcite-color-brand);
     --calcite-internal-button-loader-color: var(--calcite-color-brand);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-brand-hover);
-      --calcite-internal-button-text-color: theme("colors.brand-hover");
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-brand);
-      --calcite-internal-button-text-color: theme("colors.brand");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-brand-press);
-      --calcite-internal-button-text-color: theme("colors.brand-press");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.brand");
+      --calcite-internal-button-loader-color: var(--calcite-color-brand);
     }
   }
 }
@@ -478,23 +463,19 @@
   button,
   a {
     --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-    --calcite-internal-button-text-color: theme("colors.danger");
+    --calcite-internal-button-text-color: var(--calcite-color-status-danger);
     --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-hover);
-      --calcite-internal-button-text-color: theme("colors.danger-hover");
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-      --calcite-internal-button-text-color: theme("colors.danger");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-press);
-      --calcite-internal-button-text-color: theme("colors.danger-press");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.danger");
+      --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
     }
   }
 }
@@ -502,14 +483,11 @@
   button,
   a {
     --calcite-internal-button-text-color: var(--calcite-color-text-1);
-    --calcite-internal-button-border-color: theme("borderColor.color.1");
+    --calcite-internal-button-border-color: var(--calcite-color-border-1);
     --calcite-internal-button-loader-color: var(--calcite-color-text-1);
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-border-input);
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-foreground-3);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-text-3);
@@ -524,9 +502,6 @@
     --calcite-internal-button-loader-color: var(--calcite-color-text-1);
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-hover);
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-inverse);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-press);
@@ -563,19 +538,16 @@
 :host([appearance="transparent"][kind="brand"]) {
   button,
   a {
-    --calcite-internal-button-text-color: theme("colors.brand");
+    --calcite-internal-button-text-color: var(--calcite-color-brand);
     --calcite-internal-button-loader-color: var(--calcite-color-brand);
     &:hover {
-      --calcite-internal-button-text-color: theme("colors.brand-hover");
-    }
-    &:focus {
-      --calcite-internal-button-text-color: theme("colors.brand");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
     &:active {
-      --calcite-internal-button-text-color: theme("colors.brand-press");
+      --calcite-internal-button-text-color: var(--calcite-color-brand-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.brand");
+      --calcite-internal-button-loader-color: var(--calcite-color-brand);
     }
   }
 }
@@ -583,19 +555,16 @@
 :host([appearance="transparent"][kind="danger"]) {
   button,
   a {
-    --calcite-internal-button-text-color: theme("colors.danger");
+    --calcite-internal-button-text-color: var(--calcite-color-status-danger);
     --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
     &:hover {
-      --calcite-internal-button-text-color: theme("colors.danger-hover");
-    }
-    &:focus {
-      --calcite-internal-button-text-color: theme("colors.danger");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
     }
     &:active {
-      --calcite-internal-button-text-color: theme("colors.danger-press");
+      --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);
     }
     calcite-loader {
-      --calcite-internal-button-loader-color: theme("colors.danger");
+      --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
     }
   }
 }


### PR DESCRIPTION
**Related Issue:** #

## Summary
Updates `calcite-button` styling to use Calcite CSS color tokens in place of Tailwind theme() values, and removes some redundant state rules to simplify outline/transparent appearance variants.