### PR TITLE
test(labelable): restore test coverage

### DIFF
--- a/packages/components/src/tests/common/labelable.ts
+++ b/packages/components/src/tests/common/labelable.ts
@@ -223,10 +223,7 @@ export function labelable(
     });
 
     it("is labelable when sibling label is set prior to component", async () => {
-      const { el: label } = await mount(Label);
-      label.for = id;
-      await label.componentOnReady();
-
+      let label!: Label["el"];
       const result = await mountLabelable({
         afterConnect: async (el) => {
           label = createLabel();

--- a/packages/components/src/tests/common/labelable.ts
+++ b/packages/components/src/tests/common/labelable.ts
@@ -1,7 +1,7 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe, expect, it } from "vitest";
 import { type Locator, page } from "vitest/browser";
-import type { Label } from "../../components/label/label";
+import { Label } from "../../components/label/label";
 import { afterNextFrame } from "../utils/timing";
 
 type BooleanPropertyElement = HTMLElement & Record<string, boolean>;
@@ -223,14 +223,12 @@ export function labelable(
     });
 
     it("is labelable when sibling label is set prior to component", async () => {
-      let label!: Label["el"];
+      const { el: label } = await mount(Label);
+      label.for = id;
+      await label.componentOnReady();
+
       const result = await mountLabelable({
-        afterConnect: async (el) => {
-          label = createLabel();
-          label.for = id;
-          el.parentElement!.insertBefore(label, el);
-          await label.componentOnReady();
-        },
+        parent: label,
       });
       await waitForExplicitLabelAssociation(label);
 

--- a/packages/components/src/tests/common/labelable.ts
+++ b/packages/components/src/tests/common/labelable.ts
@@ -1,7 +1,8 @@
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe, expect, it } from "vitest";
 import { type Locator, page } from "vitest/browser";
-import { Label } from "../../components/label/label";
+import "../../components/label/label";
+import type { Label } from "../../components/label/label";
 import { afterNextFrame } from "../utils/timing";
 
 type BooleanPropertyElement = HTMLElement & Record<string, boolean>;

--- a/packages/components/src/tests/common/labelable.ts
+++ b/packages/components/src/tests/common/labelable.ts
@@ -213,7 +213,7 @@ export function labelable(
         afterConnect: async (el) => {
           label = createLabel();
           label.for = id;
-          el.parentElement!.insertBefore(label, el);
+          el.parentElement!.append(label);
           await label.componentOnReady();
         },
       });
@@ -228,8 +228,14 @@ export function labelable(
       await label.componentOnReady();
 
       const result = await mountLabelable({
-        parent: label,
+        afterConnect: async (el) => {
+          label = createLabel();
+          label.for = id;
+          el.parentElement!.insertBefore(label, el);
+          await label.componentOnReady();
+        },
       });
+
       await waitForExplicitLabelAssociation(label);
 
       await assertLabelable(result, label);


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

Restores coverage that was missed in https://github.com/Esri/calcite-design-system/pull/15121/changes#r3922032225.