### PR TITLE
fix(button): focus no longer overrides hover/active state colors

### DIFF
--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -24,21 +24,24 @@ const rules = {
   "selector-attribute-name-disallowed-list": [
     ["hidden"],
     {
-      message: "hidden styles are included in the `base-component` mixin, so make sure it's used",
+      message:
+        "hidden styles are included in the `base-component` mixin, so make sure it's used",
       severity: "error",
     },
   ],
   "selector-disallowed-list": [
     ["/:host-context/"],
     {
-      message: ":host-context is not supported in all browsers, so it should be avoided",
+      message:
+        ":host-context is not supported in all browsers, so it should be avoided",
       severity: "error",
     },
   ],
   "selector-max-specificity": [
     "0,5,5",
     {
-      message: "selector is too complex, consider applying multiple classes dynamically during rendering",
+      message:
+        "selector is too complex, consider applying multiple classes dynamically during rendering",
     },
   ],
   "selector-pseudo-element-colon-notation": [
@@ -86,7 +89,10 @@ scssPatternRules.forEach((rule) => {
 const config = {
   defaultSeverity: "warning",
   extends: "stylelint-config-recommended-scss",
-  plugins: ["stylelint-use-logical-spec", "@esri/stylelint-plugin-calcite-components"],
+  plugins: [
+    "stylelint-use-logical-spec",
+    "@esri/stylelint-plugin-calcite-components",
+  ],
   rules,
 };
 

--- a/packages/components/.stylelintrc.cjs
+++ b/packages/components/.stylelintrc.cjs
@@ -24,24 +24,21 @@ const rules = {
   "selector-attribute-name-disallowed-list": [
     ["hidden"],
     {
-      message:
-        "hidden styles are included in the `base-component` mixin, so make sure it's used",
+      message: "hidden styles are included in the `base-component` mixin, so make sure it's used",
       severity: "error",
     },
   ],
   "selector-disallowed-list": [
     ["/:host-context/"],
     {
-      message:
-        ":host-context is not supported in all browsers, so it should be avoided",
+      message: ":host-context is not supported in all browsers, so it should be avoided",
       severity: "error",
     },
   ],
   "selector-max-specificity": [
     "0,5,5",
     {
-      message:
-        "selector is too complex, consider applying multiple classes dynamically during rendering",
+      message: "selector is too complex, consider applying multiple classes dynamically during rendering",
     },
   ],
   "selector-pseudo-element-colon-notation": [
@@ -89,10 +86,7 @@ scssPatternRules.forEach((rule) => {
 const config = {
   defaultSeverity: "warning",
   extends: "stylelint-config-recommended-scss",
-  plugins: [
-    "stylelint-use-logical-spec",
-    "@esri/stylelint-plugin-calcite-components",
-  ],
+  plugins: ["stylelint-use-logical-spec", "@esri/stylelint-plugin-calcite-components"],
   rules,
 };
 

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -119,7 +119,6 @@
 
     &:focus {
       @apply focus-outset;
-      background-color: var(--calcite-button-background-color, var(--calcite-internal-button-background-color));
     }
 
     &:active {
@@ -363,10 +362,6 @@
       --calcite-internal-button-border-color: var(--calcite-color-brand-hover);
       --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-brand);
-      --calcite-internal-button-text-color: var(--calcite-color-brand);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-brand-press);
       --calcite-internal-button-text-color: var(--calcite-color-brand-press);
@@ -387,10 +382,6 @@
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-hover);
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-      --calcite-internal-button-text-color: var(--calcite-color-status-danger);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-press);
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);
@@ -410,9 +401,6 @@
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-border-input);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-foreground-3);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-text-3);
     }
@@ -431,9 +419,6 @@
 
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-hover);
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-inverse);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-press);
@@ -461,10 +446,6 @@
       --calcite-internal-button-border-color: var(--calcite-color-brand-hover);
       --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-brand);
-      --calcite-internal-button-text-color: var(--calcite-color-brand);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-brand-press);
       --calcite-internal-button-text-color: var(--calcite-color-brand-press);
@@ -485,10 +466,6 @@
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-hover);
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-status-danger);
-      --calcite-internal-button-text-color: var(--calcite-color-status-danger);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-status-danger-press);
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);
@@ -508,9 +485,6 @@
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-border-input);
     }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-foreground-3);
-    }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-text-3);
     }
@@ -524,9 +498,6 @@
     --calcite-internal-button-loader-color: var(--calcite-color-text-1);
     &:hover {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-hover);
-    }
-    &:focus {
-      --calcite-internal-button-border-color: var(--calcite-color-inverse);
     }
     &:active {
       --calcite-internal-button-border-color: var(--calcite-color-inverse-press);
@@ -568,9 +539,6 @@
     &:hover {
       --calcite-internal-button-text-color: var(--calcite-color-brand-hover);
     }
-    &:focus {
-      --calcite-internal-button-text-color: var(--calcite-color-brand);
-    }
     &:active {
       --calcite-internal-button-text-color: var(--calcite-color-brand-press);
     }
@@ -587,9 +555,6 @@
     --calcite-internal-button-loader-color: var(--calcite-color-status-danger);
     &:hover {
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-hover);
-    }
-    &:focus {
-      --calcite-internal-button-text-color: var(--calcite-color-status-danger);
     }
     &:active {
       --calcite-internal-button-text-color: var(--calcite-color-status-danger-press);


### PR DESCRIPTION
**Related Issue:** #15134, #15136 

## Summary

- Removes redundant :focus color overrides that reset background/border/text to resting values, which suppressed hover styles.
- Fixes `outline` and `outline-fill` `neutral`, where focus incorrectly changed the border color.

Video of fixed hover + focus:

https://github.com/user-attachments/assets/3e83399f-7d17-49b2-b937-3ecb7e1cdd67


