### PR TITLE
fix: omit `aria-busy` when false

### DIFF
--- a/packages/components/src/components/action/action.browser.e2e.tsx
+++ b/packages/components/src/components/action/action.browser.e2e.tsx
@@ -189,6 +189,30 @@ describe("type property", () => {
 });
 
 describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-action text="hello world" />);
+    const button = page.getByRole("button");
+
+    await expect.element(button).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(button).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("should omit aria-busy on drag handle when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-action drag-handle text="hello world" />);
+    const button = page.getByRole("button");
+
+    await expect.element(button).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(button).toHaveAttribute("aria-busy", "true");
+  });
+
   it("should use text prop for a11y attributes when text is not enabled", async () => {
     await mount(<calcite-action text="hello world" />);
 

--- a/packages/components/src/components/action/action.browser.e2e.tsx
+++ b/packages/components/src/components/action/action.browser.e2e.tsx
@@ -15,6 +15,7 @@ import {
   themed,
 } from "../../tests/commonTests/browser";
 import { page } from "vitest/browser";
+import type { Action } from "./action";
 
 describe("accessible", () => {
   accessible(() => mount(<calcite-action text="hello world" />));
@@ -190,7 +191,7 @@ describe("type property", () => {
 
 describe("a11y attributes", () => {
   it("should omit aria-busy when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-action text="hello world" />);
+    const { reRender, el } = await mount<Action>(<calcite-action text="hello world" />);
     const button = page.getByRole("button");
 
     await expect.element(button).not.toHaveAttribute("aria-busy");
@@ -202,7 +203,7 @@ describe("a11y attributes", () => {
   });
 
   it("should omit aria-busy on drag handle when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-action drag-handle text="hello world" />);
+    const { reRender, el } = await mount<Action>(<calcite-action drag-handle text="hello world" />);
     const button = page.getByRole("button");
 
     await expect.element(button).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/action/action.tsx
+++ b/packages/components/src/components/action/action.tsx
@@ -21,6 +21,7 @@ import { CSS, IDS } from "./resources";
 import { styles } from "./action.scss";
 import { styles as screenReaderStyles } from "../../styles/component/screen-reader.scss";
 import { CSS_UTILITY } from "../../utils/resources";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -354,7 +355,7 @@ export class Action extends LitElement {
       return (
         // Needs to be a span because of https://github.com/SortableJS/Sortable/issues/1486 & https://bugzilla.mozilla.org/show_bug.cgi?id=568313
         <span
-          ariaBusy={loading}
+          ariaBusy={toAriaBoolean(loading, undefined)}
           ariaControlsElements={ariaControlsElements}
           ariaDescribedByElements={this.aria?.describedByElements}
           ariaExpanded={this.aria?.expanded}
@@ -375,7 +376,7 @@ export class Action extends LitElement {
 
     return (
       <button
-        ariaBusy={loading}
+        ariaBusy={toAriaBoolean(loading, undefined)}
         ariaChecked={this.aria?.checked}
         ariaControlsElements={ariaControlsElements}
         ariaDescribedByElements={this.aria?.describedByElements}

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -158,7 +158,7 @@ describe("disabled", () => {
 
 describe("a11y attributes", () => {
   it("should omit aria-busy when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-block-group label="Blocks" />);
+    const { reRender, el } = await mount<BlockGroup>(<calcite-block-group label="Blocks" />);
     const group = page.getByRole("group", { name: "Blocks" });
 
     await expect.element(group).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/block-group/block-group.browser.e2e.tsx
+++ b/packages/components/src/components/block-group/block-group.browser.e2e.tsx
@@ -156,6 +156,20 @@ describe("disabled", () => {
   });
 });
 
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-block-group label="Blocks" />);
+    const group = page.getByRole("group", { name: "Blocks" });
+
+    await expect.element(group).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(group).toHaveAttribute("aria-busy", "true");
+  });
+});
+
 describe("expandMode", () => {
   const nestedBlockHTML = (expandMode: BlockGroup["expandMode"]): TemplateResult => {
     return (

--- a/packages/components/src/components/block-group/block-group.tsx
+++ b/packages/components/src/components/block-group/block-group.tsx
@@ -32,6 +32,7 @@ import type { BlockDragDetail } from "./types";
 import { updateBlockChildren } from "./utils";
 import type { SortHandle } from "../sort-handle/sort-handle";
 import { isBlock } from "../block/resources";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -610,7 +611,12 @@ export class BlockGroup extends LitElement {
             </span>
           ) : null}
           {loading ? <calcite-scrim class={CSS.scrim} loading={loading} /> : null}
-          <div ariaBusy={loading} ariaLabel={label || ""} class={CSS.groupContainer} role="group">
+          <div
+            ariaBusy={toAriaBoolean(loading, undefined)}
+            ariaLabel={label || ""}
+            class={CSS.groupContainer}
+            role="group"
+          >
             <slot onSlotChange={this.handleDefaultSlotChange} />
           </div>
         </div>

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -253,6 +253,32 @@ describe("disabled", () => {
   disabled(() => mount(<calcite-block description="description" expandable heading="heading" />));
 });
 
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-block heading="heading" />);
+    const container = page.getByRole("article");
+
+    await expect.element(container).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(container).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("should omit aria-busy on sortable blocks when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-block drag-handle heading="heading" />);
+    const container = page.getByRole("article");
+
+    await expect.element(container).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(container).toHaveAttribute("aria-busy", "true");
+  });
+});
+
 describe("theme", () => {
   describe("default", () => {
     themed(

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -24,6 +24,7 @@ import { defaultEndMenuPlacement } from "../../utils/floating-ui";
 import { mockConsole } from "../../tests/utils/logging";
 import { CSS as DropdownCSS } from "../dropdown/resources";
 import { CSS, SLOTS } from "./resources";
+import type { Block } from "./block";
 
 mockConsole();
 
@@ -255,7 +256,7 @@ describe("disabled", () => {
 
 describe("a11y attributes", () => {
   it("should omit aria-busy when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-block heading="heading" />);
+    const { reRender, el } = await mount<Block>(<calcite-block heading="heading" />);
     const container = page.getByRole("article");
 
     await expect.element(container).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -268,7 +268,7 @@ describe("a11y attributes", () => {
   });
 
   it("should omit aria-busy on sortable blocks when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-block drag-handle heading="heading" />);
+    const { reRender, el } = await mount<Block>(<calcite-block drag-handle heading="heading" />);
     const container = page.getByRole("article");
 
     await expect.element(container).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -26,6 +26,7 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { styles } from "./block.scss";
 import type { BlockToggleDisplay } from "./types";
 import type { BlockGroup } from "../block-group/block-group";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -700,7 +701,7 @@ export class Block extends LitElement {
       <this.interactiveContainer disabled={this.disabled}>
         <article
           aria-label={label}
-          ariaBusy={loading}
+          ariaBusy={toAriaBoolean(loading, undefined)}
           class={{
             [CSS.container]: true,
           }}

--- a/packages/components/src/components/button/button.browser.e2e.tsx
+++ b/packages/components/src/components/button/button.browser.e2e.tsx
@@ -15,6 +15,7 @@ import {
   themed,
 } from "../../tests/commonTests/browser";
 import { page } from "vitest/browser";
+import type { Button } from "./button";
 
 describe("labelable", () => {
   labelable((mountOptions) => mount("calcite-button", mountOptions));
@@ -180,7 +181,7 @@ describe("disabled", () => {
 
 describe("a11y attributes", () => {
   it("should omit aria-busy when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-button>Continue</calcite-button>);
+    const { reRender, el } = await mount<Button>(<calcite-button>Continue</calcite-button>);
     const button = page.getByRole("button");
 
     await expect.element(button).not.toHaveAttribute("aria-busy");
@@ -192,7 +193,9 @@ describe("a11y attributes", () => {
   });
 
   it("should omit aria-busy on links when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-button href="/">Continue</calcite-button>);
+    const { reRender, el } = await mount<Button>(
+      <calcite-button href="/">Continue</calcite-button>,
+    );
     const link = page.getByRole("link");
 
     await expect.element(link).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/button/button.browser.e2e.tsx
+++ b/packages/components/src/components/button/button.browser.e2e.tsx
@@ -1,6 +1,6 @@
 import { h } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { CSS } from "./resources";
 import {
   defaults,
@@ -176,6 +176,32 @@ describe("translation support", () => {
 
 describe("disabled", () => {
   disabled(() => mount("calcite-button"));
+});
+
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-button>Continue</calcite-button>);
+    const button = page.getByRole("button");
+
+    await expect.element(button).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(button).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("should omit aria-busy on links when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-button href="/">Continue</calcite-button>);
+    const link = page.getByRole("link");
+
+    await expect.element(link).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(link).toHaveAttribute("aria-busy", "true");
+  });
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -27,6 +27,7 @@ import T9nStrings from "./assets/t9n/messages.en.json";
 import { ButtonAlignment } from "./types";
 import { CSS } from "./resources";
 import { styles } from "./button.scss";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -301,7 +302,7 @@ export class Button extends LitElement {
     return (
       <this.interactiveContainer disabled={this.disabled}>
         <DynamicHtmlTag
-          ariaBusy={this.loading}
+          ariaBusy={toAriaBoolean(this.loading, undefined)}
           ariaExpanded={
             this.el.ariaExpanded
               ? (this.el.ariaExpanded as LuminaJsx.HTMLElementTags["button"]["ariaExpanded"])

--- a/packages/components/src/components/card/card.browser.e2e.tsx
+++ b/packages/components/src/components/card/card.browser.e2e.tsx
@@ -1,6 +1,7 @@
 import { h } from "@arcgis/lumina";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
+import { page } from "vitest/browser";
 import {
   defaults,
   hidden,
@@ -90,6 +91,20 @@ describe("slots", () => {
 
 describe("translation support", () => {
   t9n(() => mount("calcite-card"));
+});
+
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount("calcite-card");
+    const container = page.getBySelector(`calcite-card .${CSS.container}`);
+
+    await expect.element(container).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(container).toHaveAttribute("aria-busy", "true");
+  });
 });
 
 describe("theme", () => {

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -21,6 +21,7 @@ import { useInteractive } from "../../controllers/useInteractive";
 import { CSS, ICONS, SLOTS } from "./resources";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { styles } from "./card.scss";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -295,7 +296,10 @@ export class Card extends LitElement {
             </div>
           ) : null}
           {thumbnailStart && this.renderThumbnail()}
-          <section ariaBusy={this.loading} class={{ [CSS.container]: true }}>
+          <section
+            ariaBusy={toAriaBoolean(this.loading, undefined)}
+            class={{ [CSS.container]: true }}
+          >
             {this.renderHeader()}
             <div
               class={{

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -20,7 +20,7 @@ import type { ListItem } from "../list-item/list-item";
 import { afterNextFrame, afterNextTask } from "../../tests/utils/timing";
 import { waitForEvent } from "../../tests/commonTests/browser/utils";
 import { DEBOUNCE } from "../../utils/resources";
-import { List } from "./list";
+import type { List } from "./list";
 import { CSS } from "./resources";
 import { placeholderImage } from "../../../.storybook/placeholder-image";
 
@@ -235,7 +235,7 @@ describe("disabled", () => {
 
 describe("a11y attributes", () => {
   it("should omit aria-busy when not loading and set it when loading", async () => {
-    const { reRender, el } = await mount(<calcite-list label="Items" />);
+    const { reRender, el } = await mount<List>(<calcite-list label="Items" />);
     const table = page.getByRole(`treegrid`);
 
     await expect.element(table).not.toHaveAttribute("aria-busy");

--- a/packages/components/src/components/list/list.browser.e2e.tsx
+++ b/packages/components/src/components/list/list.browser.e2e.tsx
@@ -233,6 +233,20 @@ describe("disabled", () => {
   );
 });
 
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount(<calcite-list label="Items" />);
+    const table = page.getByRole(`treegrid`);
+
+    await expect.element(table).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(table).toHaveAttribute("aria-busy", "true");
+  });
+});
+
 describe("sticky group heading", () => {
   it("keeps the first list-item-group heading fixed while the list scrolls", async () => {
     const { el } = await mount(

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -46,6 +46,7 @@ import { styles } from "./list.scss";
 import type { SortHandle } from "../sort-handle/sort-handle";
 import { logger } from "../../utils/logger";
 import { isListItem } from "../list-item/resources";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -1261,7 +1262,7 @@ export class List extends LitElement {
           {this.renderItemAriaLive()}
           {loading ? <calcite-scrim class={CSS.scrim} loading={loading} /> : null}
           <div
-            ariaBusy={loading}
+            ariaBusy={toAriaBoolean(loading, undefined)}
             ariaLabel={label || ""}
             class={CSS.table}
             onKeyDown={this.handleListKeydown}

--- a/packages/components/src/components/panel/panel.browser.e2e.tsx
+++ b/packages/components/src/components/panel/panel.browser.e2e.tsx
@@ -260,6 +260,20 @@ describe("slots", () => {
   slots(() => mount("calcite-panel"), SLOTS);
 });
 
+describe("a11y attributes", () => {
+  it("should omit aria-busy when not loading and set it when loading", async () => {
+    const { reRender, el } = await mount("calcite-panel");
+    const container = page.getByRole("article");
+
+    await expect.element(container).not.toHaveAttribute("aria-busy");
+
+    el.loading = true;
+    await reRender();
+
+    await expect.element(container).toHaveAttribute("aria-busy", "true");
+  });
+});
+
 describe("header slots", () => {
   it("renders one border when header-top is the only header content", async () => {
     const { component } = await mount(

--- a/packages/components/src/components/panel/panel.tsx
+++ b/packages/components/src/components/panel/panel.tsx
@@ -38,6 +38,7 @@ import { FocusTrapOptions, useFocusTrap } from "../../controllers/useFocusTrap";
 import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, ICONS, IDS, SLOTS } from "./resources";
 import { styles } from "./panel.scss";
+import { toAriaBoolean } from "../../utils/aria";
 
 declare global {
   interface DeclareElements {
@@ -838,7 +839,7 @@ export class Panel extends LitElement {
 
     const panelNode = (
       <div
-        ariaBusy={loading}
+        ariaBusy={toAriaBoolean(loading, undefined)}
         ariaDescription={hasDialogRole && description ? description : undefined}
         ariaLabel={hasDialogRole && heading ? heading : undefined}
         ariaLive={hasDialogRole ? "polite" : undefined}

--- a/packages/components/src/utils/aria.browser.spec.ts
+++ b/packages/components/src/utils/aria.browser.spec.ts
@@ -6,6 +6,13 @@ describe("toAriaBoolean()", () => {
     expect(toAriaBoolean(true)).toBe("true");
     expect(toAriaBoolean(false)).toBe("false");
   });
+
+  it("supports custom false values", () => {
+    expect(toAriaBoolean(false, undefined)).toBeUndefined();
+    expect(toAriaBoolean(false, null)).toBeNull();
+    expect(toAriaBoolean(true, undefined)).toBe("true");
+    expect(toAriaBoolean(true, null)).toBe("true");
+  });
 });
 
 describe("ariaValueFromSize", () => {

--- a/packages/components/src/utils/aria.ts
+++ b/packages/components/src/utils/aria.ts
@@ -25,6 +25,7 @@ type AriaBoolean<FalseValue extends AriaFalseValue = "false"> = "true" | FalseVa
  *
  * @param value The boolean value to convert.
  * @param falseValue The value returned when `value` is `false`.
+ * @returns A valid ARIA boolean string value: `"true"` or the provided `falseValue`.
  */
 export function toAriaBoolean(value: boolean): AriaBoolean;
 export function toAriaBoolean<FalseValue extends AriaFalseValue>(

--- a/packages/components/src/utils/aria.ts
+++ b/packages/components/src/utils/aria.ts
@@ -13,14 +13,25 @@ export function ariaValueFromSize(
   return selectedValue != null ? `${selectedValue}` : undefined;
 }
 
+type AriaFalseValue = "false" | undefined | null;
+type AriaBoolean<FalseValue extends AriaFalseValue = "false"> = "true" | FalseValue;
+
 /**
- * This helper makes sure that boolean aria attributes are properly converted to a string.
+ * Converts a boolean to a valid string value for a boolean ARIA attribute.
  *
- * It should only be used for aria attributes that require a string value of "true" or "false".
+ * By default, `false` is converted to `"false"`. A custom false value can be provided when the
+ * attribute should instead be omitted: use `null` for DOM ARIA properties or `undefined` for JSX.
+ * The custom false value does not affect `true`, which is always converted to `"true"`.
  *
- * @param value The value.
- * @returns The string conversion of a boolean value ("true" | "false").
+ * @param value The boolean value to convert.
+ * @param falseValue The value returned when `value` is `false`.
  */
-export function toAriaBoolean(value: boolean): string {
-  return Boolean(value).toString();
+export function toAriaBoolean(value: boolean): AriaBoolean;
+export function toAriaBoolean<FalseValue extends AriaFalseValue>(
+  value: boolean,
+  falseValue: FalseValue,
+): AriaBoolean<FalseValue>;
+export function toAriaBoolean(value: boolean, ...falseValues: [] | [AriaFalseValue]): AriaBoolean<AriaFalseValue> {
+  const falseValue = falseValues.length === 0 ? "false" : falseValues[0];
+  return value ? "true" : falseValue;
 }


### PR DESCRIPTION
**Related Issue:** #13547

## Summary

Updates and applies `toAriaBoolean` to ensure the reflected `aria-busy` attr is removed when not applicable.