### PR TITLE
fix(date-picker): update the calendar view when a programmatic range value follows a manual selection

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -198,6 +198,7 @@ describe("value", () => {
     const { el, component } = await mount<DatePicker>(
       <calcite-date-picker active-range="start" range value={["2024-01-01", "2024-01-02"]} />,
     );
+    const monthSelectMenus = page.getByRole("combobox", { name: "Month menu" });
     await waitForCalendarUpdate(el, component);
 
     await userEvent.click(
@@ -207,8 +208,8 @@ describe("value", () => {
 
     // User selection preserved the view instead of shifting it to February/March.
     expect(el.value).toEqual(["2024-02-10", ""]);
-    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "January");
-    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "February");
+    await expect.element(monthSelectMenus.first()).toHaveProperty("value", "January");
+    await expect.element(monthSelectMenus.nth(1)).toHaveProperty("value", "February");
 
     await userEvent.click(
       page.getBySelector("calcite-date-picker-day[current-month][id='20240215']"),
@@ -216,14 +217,14 @@ describe("value", () => {
     await waitForCalendarUpdate(el, component);
 
     expect(el.value).toEqual(["2024-02-10", "2024-02-15"]);
-    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "January");
-    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "February");
+    await expect.element(monthSelectMenus.first()).toHaveProperty("value", "January");
+    await expect.element(monthSelectMenus.nth(1)).toHaveProperty("value", "February");
 
     el.value = ["2025-10-15", "2025-11-03"];
     await waitForCalendarUpdate(el, component);
 
-    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "October");
-    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "November");
+    await expect.element(monthSelectMenus.first()).toHaveProperty("value", "October");
+    await expect.element(monthSelectMenus.nth(1)).toHaveProperty("value", "November");
   });
 
   async function waitForCalendarUpdate(el: DatePicker["el"], component: DatePicker): Promise<void> {
@@ -239,10 +240,6 @@ describe("value", () => {
     return Array.from(
       getMonth(el)?.shadowRoot!.querySelectorAll("calcite-date-picker-day[selected]") || [],
     );
-  }
-
-  function getMonthSelectMenu(): Locator {
-    return page.getByRole("combobox", { name: "Month menu" });
   }
 
   function expectDate(actual: Date | undefined, expected: Date): void {

--- a/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
+++ b/packages/components/src/components/date-picker/date-picker.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { describe, expect, it } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { Locator, page } from "vitest/browser";
+import { Locator, page, userEvent } from "vitest/browser";
 import {
   defaults,
   focusable,
@@ -194,6 +194,38 @@ describe("value", () => {
     expect(getSelectedDays(el)).toHaveLength(0);
   });
 
+  it("updates the calendar view when a programmatic range value follows a manual selection", async () => {
+    const { el, component } = await mount<DatePicker>(
+      <calcite-date-picker active-range="start" range value={["2024-01-01", "2024-01-02"]} />,
+    );
+    await waitForCalendarUpdate(el, component);
+
+    await userEvent.click(
+      page.getBySelector("calcite-date-picker-day[current-month][id='20240210']"),
+    );
+    await waitForCalendarUpdate(el, component);
+
+    // User selection preserved the view instead of shifting it to February/March.
+    expect(el.value).toEqual(["2024-02-10", ""]);
+    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "January");
+    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "February");
+
+    await userEvent.click(
+      page.getBySelector("calcite-date-picker-day[current-month][id='20240215']"),
+    );
+    await waitForCalendarUpdate(el, component);
+
+    expect(el.value).toEqual(["2024-02-10", "2024-02-15"]);
+    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "January");
+    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "February");
+
+    el.value = ["2025-10-15", "2025-11-03"];
+    await waitForCalendarUpdate(el, component);
+
+    await expect.element(getMonthSelectMenu().first()).toHaveProperty("value", "October");
+    await expect.element(getMonthSelectMenu().nth(1)).toHaveProperty("value", "November");
+  });
+
   async function waitForCalendarUpdate(el: DatePicker["el"], component: DatePicker): Promise<void> {
     await component.updateComplete;
     await (getMonth(el) as DatePickerMonth | null)?.updateComplete;
@@ -207,6 +239,10 @@ describe("value", () => {
     return Array.from(
       getMonth(el)?.shadowRoot!.querySelectorAll("calcite-date-picker-day[selected]") || [],
     );
+  }
+
+  function getMonthSelectMenu(): Locator {
+    return page.getByRole("combobox", { name: "Month menu" });
   }
 
   function expectDate(actual: Date | undefined, expected: Date): void {

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -204,6 +204,10 @@ export class DatePicker extends LitElement {
       this.valueAsDateWatcher(this.valueAsDate);
     }
 
+    if (this.rangeValueChangedByUser && (changes.has("value") || changes.has("valueAsDate"))) {
+      this.rangeValueChangedByUser = false;
+    }
+
     const minSource = getMinMaxSource(changes, "min");
     const maxSource = getMinMaxSource(changes, "max");
 

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -196,6 +196,20 @@ export class DatePicker extends LitElement {
   }
 
   override willUpdate(changes: PropertyValues<this>): void {
+    const previousValueAsDate = changes.get("valueAsDate");
+    const valueAsDate = this.valueAsDate;
+    const isReflectedUserRangeValue =
+      this.rangeValueChangedByUser &&
+      !changes.has("value") &&
+      Array.isArray(previousValueAsDate) &&
+      Array.isArray(valueAsDate) &&
+      previousValueAsDate.every((date, index) => sameDate(date, valueAsDate[index]));
+    const isUserRangeValueUpdate = changes.has("value") && changes.has("valueAsDate");
+
+    if (this.rangeValueChangedByUser && !isUserRangeValueUpdate && !isReflectedUserRangeValue) {
+      this.rangeValueChangedByUser = false;
+    }
+
     if (changes.has("value")) {
       this.valueHandler(this.value);
     }
@@ -204,7 +218,7 @@ export class DatePicker extends LitElement {
       this.valueAsDateWatcher(this.valueAsDate);
     }
 
-    if (this.rangeValueChangedByUser && (changes.has("value") || changes.has("valueAsDate"))) {
+    if (isReflectedUserRangeValue) {
       this.rangeValueChangedByUser = false;
     }
 

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -1,4 +1,5 @@
 import { isServer, PropertyValues } from "lit";
+import { isEqual } from "es-toolkit";
 import {
   createEvent,
   Fragment,
@@ -198,15 +199,14 @@ export class DatePicker extends LitElement {
   override willUpdate(changes: PropertyValues<this>): void {
     const previousValueAsDate = changes.get("valueAsDate");
     const valueAsDate = this.valueAsDate;
-    const isReflectedUserRangeValue =
+    const isForwardedRangeValue =
       this.rangeValueChangedByUser &&
       !changes.has("value") &&
-      Array.isArray(previousValueAsDate) &&
-      Array.isArray(valueAsDate) &&
-      previousValueAsDate.every((date, index) => sameDate(date, valueAsDate[index]));
+      this.range &&
+      isEqual(previousValueAsDate, valueAsDate);
     const isUserRangeValueUpdate = changes.has("value") && changes.has("valueAsDate");
 
-    if (this.rangeValueChangedByUser && !isUserRangeValueUpdate && !isReflectedUserRangeValue) {
+    if (this.rangeValueChangedByUser && !isUserRangeValueUpdate && !isForwardedRangeValue) {
       this.rangeValueChangedByUser = false;
     }
 
@@ -218,7 +218,7 @@ export class DatePicker extends LitElement {
       this.valueAsDateWatcher(this.valueAsDate);
     }
 
-    if (isReflectedUserRangeValue) {
+    if (isForwardedRangeValue) {
       this.rangeValueChangedByUser = false;
     }
 


### PR DESCRIPTION
**Related Issue:** #14875

## Summary
Update the calendar view when a programmatic range value follows a manual selection.