### PR TITLE
feat(block): add expandable icon color tokens

### DIFF
--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -351,15 +351,6 @@ describe("theme", () => {
           targetProp: "color",
           state: "hover",
         },
-        "--calcite-block-collapsible-icon-color": {
-          shadowSelector: `.${CSS.toggleIcon}`,
-          targetProp: "color",
-        },
-        "--calcite-block-collapsible-icon-color-hover": {
-          shadowSelector: `.${CSS.toggleIcon}`,
-          targetProp: "color",
-          state: "hover",
-        },
       },
     );
   });
@@ -429,6 +420,15 @@ describe("theme", () => {
           },
         ],
         "--calcite-block-icon-color-hover": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+          state: "hover",
+        },
+        "--calcite-block-collapsible-icon-color": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+        },
+        "--calcite-block-collapsible-icon-color-hover": {
           shadowSelector: `.${CSS.toggleIcon}`,
           targetProp: "color",
           state: "hover",

--- a/packages/components/src/components/block/block.browser.e2e.tsx
+++ b/packages/components/src/components/block/block.browser.e2e.tsx
@@ -342,6 +342,15 @@ describe("theme", () => {
           shadowSelector: `.${CSS.iconEnd}`,
           targetProp: "color",
         },
+        "--calcite-block-expandable-icon-color": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+        },
+        "--calcite-block-expandable-icon-color-hover": {
+          shadowSelector: `.${CSS.toggleIcon}`,
+          targetProp: "color",
+          state: "hover",
+        },
         "--calcite-block-collapsible-icon-color": {
           shadowSelector: `.${CSS.toggleIcon}`,
           targetProp: "color",

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -14,12 +14,14 @@
  * @prop --calcite-block-padding: [Deprecated] in v3.3.0, removal target v6.0.0 - Use `--calcite-block-content-space` instead. Specifies the padding of the component's `default` slot.
  * @prop --calcite-block-text-color:[Deprecated] in v3.3.0, removal target v6.0.0 - Specifies the component's text color.
  * @prop --calcite-block-description-text-color: Specifies the component's `description` text color.
- * @prop --calcite-block-icon-color: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `collapsible` icon, `iconStart` and `iconEnd` color.
- * @prop --calcite-block-icon-color-hover: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-collapsible-icon-color-hover` instead. Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-icon-color: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color`, `--calcite-block-icon-start-color` and `--calcite-block-icon-end-color` instead. Specifies the component's `expandable` icon, `iconStart` and `iconEnd` color.
+ * @prop --calcite-block-icon-color-hover: [Deprecated] in v5.1.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `expandable` icon color when hovered.
  * @prop --calcite-block-icon-start-color: Specifies the component's `iconStart` color.
  * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
- * @prop --calcite-block-collapsible-icon-color: Specifies the component's `collapsible` icon color.
- * @prop --calcite-block-collapsible-icon-color-hover: Specifies the component's `collapsible` icon color when hovered.
+ * @prop --calcite-block-expandable-icon-color: Specifies the component's `expandable` icon color.
+ * @prop --calcite-block-expandable-icon-color-hover: Specifies the component's `expandable` icon color when hovered.
+ * @prop --calcite-block-collapsible-icon-color: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color` instead. Specifies the component's `expandable` icon color.
+ * @prop --calcite-block-collapsible-icon-color-hover: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `expandable` icon color when hovered.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.
@@ -266,13 +268,19 @@ calcite-sort-handle {
   self-center
   justify-self-end
   ease-in-out;
-  color: var(--calcite-block-collapsible-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
+  color: var(
+    --calcite-block-expandable-icon-color,
+    var(--calcite-block-collapsible-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)))
+  );
 }
 
 .toggle:hover .toggle-icon {
   color: var(
-    --calcite-block-collapsible-icon-color-hover,
-    var(--calcite-block-icon-color-hover, var(--calcite-color-text-1))
+    --calcite-block-expandable-icon-color-hover,
+    var(
+      --calcite-block-collapsible-icon-color-hover,
+      var(--calcite-block-icon-color-hover, var(--calcite-color-text-1))
+    )
   );
 }
 

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -20,8 +20,8 @@
  * @prop --calcite-block-icon-end-color: Specifies the component's `iconEnd` color.
  * @prop --calcite-block-expandable-icon-color: Specifies the component's `expandable` icon color.
  * @prop --calcite-block-expandable-icon-color-hover: Specifies the component's `expandable` icon color when hovered.
- * @prop --calcite-block-collapsible-icon-color: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color` instead. Specifies the component's `expandable` icon color.
- * @prop --calcite-block-collapsible-icon-color-hover: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `expandable` icon color when hovered.
+ * @prop --calcite-block-collapsible-icon-color: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color` instead. Specifies the component's `expandable` or `collapsible` (deprecated) icon color.
+ * @prop --calcite-block-collapsible-icon-color-hover: [Deprecated] in v5.2.0, removal target v7.0.0 - Use `--calcite-block-expandable-icon-color-hover` instead. Specifies the component's `expandable` or `collapsible` (deprecated) icon color when hovered.
  */
 
 // AUTO-GENERATED — do not modify. Changes will be overwritten.


### PR DESCRIPTION
**Related Issue:** #15154

## Summary

- Adds `--calcite-block-expandable-icon-color` and `--calcite-block-expandable-icon-color-hover`
- Deprecates `--calcite-block-collapsible-icon-color` and `--calcite-block-collapsible-icon-color-hover` and marks them for removal in 7.0.0
- Retains the deprecated tokens as fallbacks to preserve existing consumer styling
- Adds e2e tests for the new tokens

deprecate(block): deprecate collapsible-icon-color tokens