### PR TITLE
refactor(tab, tab-nav, tab-title, table, table-cell, table-header, table-row, tabs, text-area, tile, time-picker, tooltip, tree, tree-item): remove tailwind from component styles

### DIFF
--- a/packages/components/src/components/tab-nav/tab-nav.scss
+++ b/packages/components/src/components/tab-nav/tab-nav.scss
@@ -21,7 +21,8 @@
 @use "@esri/calcite-design-tokens/dist/scss/core";
 
 :host {
-  @apply relative flex;
+  position: relative;
+  display: flex;
 }
 
 :host([bordered]) {
@@ -99,19 +100,21 @@
 }
 
 .tab-titles-slot-wrapper {
-  @apply flex-1;
+  flex: 1 1 0%;
 }
 
 .container,
 .tab-titles-slot-wrapper {
-  @apply flex w-full
-  justify-start
-  whitespace-nowrap
-  overflow-hidden;
+  display: flex;
+  inline-size: 100%;
+  justify-content: flex-start;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .scroll-button {
-  @apply absolute bottom-0 top-0;
+  position: absolute;
+  inset-block: 0;
 
   calcite-button {
     --calcite-button-text-color: var(--calcite-tab-text-color, var(--calcite-color-text-3));
@@ -122,7 +125,7 @@
 }
 
 .scroll-button-container {
-  @apply flex;
+  display: flex;
   inset-block-start: var(--calcite-border-width-md);
   inset-block-end: var(--calcite-border-width-md);
   inset-inline-end: 0;

--- a/packages/components/src/components/tab-title/tab-title.scss
+++ b/packages/components/src/components/tab-title/tab-title.scss
@@ -33,20 +33,28 @@
 @use "../../styles/includes";
 
 :host {
-  @apply block outline-none;
+  display: block;
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-space-base);
   margin-inline-start: theme("margin.0");
 }
 
 :host([layout="inline"]) {
-  @apply flex-initial;
+  flex: 0 1 auto;
 }
 
 :host([layout="center"]) {
-  @apply flex-auto;
+  flex: 1 1 auto;
 }
 
 .content {
-  @apply flex items-center justify-center h-full mb-0.5 relative box-border;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  block-size: 100%;
+  margin-block-end: var(--calcite-space-base);
+  position: relative;
+  box-sizing: border-box;
 }
 
 .scale-s {
@@ -54,7 +62,9 @@
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
 
   .content {
-    @apply text-n2h py-1;
+    font-size: var(--calcite-font-size-relative-sm);
+    line-height: var(--calcite-font-line-height-sm);
+    padding-block: var(--calcite-space-2xs);
   }
 }
 
@@ -63,7 +73,9 @@
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xxs);
 
   .content {
-    @apply text-n1h py-2;
+    font-size: var(--calcite-font-size-relative-base);
+    line-height: var(--calcite-font-line-height-base);
+    padding-block: var(--calcite-space-sm);
   }
 }
 
@@ -72,44 +84,51 @@
   --calcite-internal-tab-title-close-margin-start: var(--calcite-spacing-xs);
 
   .content {
-    @apply text-0h py-2.5;
+    font-size: var(--calcite-font-size-relative-md);
+    line-height: var(--calcite-font-line-height-md);
+    padding-block: var(--calcite-space-sm-plus);
   }
 }
 
 :host([closable]) .content {
-  @apply border-b-color-transparent;
+  border-block-end-color: transparent;
 }
 
 :host([layout="inline"]),
 :host([layout="center"]) {
   .content {
-    @apply px-1;
+    padding-inline: var(--calcite-space-2xs);
   }
 }
 
 :host([layout="center"]) .scale-s,
 :host([layout="center"]) .scale-m,
 :host([layout="center"]) .scale-l {
-  @apply justify-center my-0 text-center;
+  justify-content: center;
+  margin-block: 0;
+  text-align: center;
 
   .content {
-    @apply flex-auto flex-grow;
+    flex: 1 1 auto;
+    flex-grow: 1;
   }
 }
 
 .container {
   @include includes.transition-default();
-  @apply relative
-  box-border
-  content-center
-  cursor-pointer
-  flex
-  focus-base
-  h-full
-  justify-between
-  px-0
-  text-n1h
-  w-full;
+
+  position: relative;
+  box-sizing: border-box;
+  align-content: center;
+  cursor: pointer;
+  display: flex;
+  outline-color: transparent;
+  block-size: 100%;
+  justify-content: space-between;
+  padding-inline: 0;
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
+  inline-size: 100%;
 
   color: var(--calcite-tab-text-color, var(--calcite-color-text-3));
   background-color: var(--calcite-tab-background-color, transparent);
@@ -117,10 +136,9 @@
 
 .selected-indicator {
   @include includes.transition-default();
-  @apply absolute
-    block
-    w-full
-    h-0.5;
+  position: absolute;
+  display: block;
+  block-size: var(--calcite-space-base);
   inset-block-end: 0;
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -129,10 +147,9 @@
 
 :host([bordered][selected]) .container::after {
   @include includes.transition-default();
-  @apply absolute
-    block
-    w-full
-    h-0.5;
+  position: absolute;
+  display: block;
+  block-size: var(--calcite-space-base);
   inset-block-end: -1px;
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -172,10 +189,11 @@
 }
 
 .calcite-tab-title--icon {
-  @apply relative
-    m-0
-    inline-flex
-    self-center;
+  position: relative;
+  margin: 0;
+  display: inline-flex;
+  align-self: center;
+
   & svg {
     @include includes.transition-default();
   }
@@ -208,7 +226,7 @@
 }
 
 .content--has-text {
-  @apply p-1;
+  padding: var(--calcite-space-2xs);
 
   .calcite-tab-title--icon {
     &.icon-start {
@@ -293,7 +311,7 @@
 }
 
 :host([closed]) {
-  @apply hidden;
+  display: none;
 }
 
 :host([selected][bordered]) .container {
@@ -310,10 +328,14 @@
 }
 
 :host(:focus) .container {
-  @apply focus-inset;
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+  outline-offset: calc(
+    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
 
   &:focus-within {
-    @apply focus-base;
+    outline-color: transparent;
   }
 }
 
@@ -328,19 +350,19 @@
 :host([layout="center"][bordered]) {
   .scale-m {
     .content {
-      @apply px-3;
+      padding-inline: var(--calcite-space-md);
     }
   }
 
   .scale-s {
     .content {
-      @apply px-2;
+      padding-inline: var(--calcite-space-sm);
     }
   }
 
   .scale-l {
     .content {
-      @apply px-4;
+      padding-inline: var(--calcite-space-lg);
     }
   }
 }
@@ -394,6 +416,7 @@
 @include includes.base-component();
 @include includes.disabled() {
   .container {
-    @apply pointer-events-none opacity-50;
+    pointer-events: none;
+    opacity: 0.5;
   }
 }

--- a/packages/components/src/components/tab/tab.scss
+++ b/packages/components/src/components/tab/tab.scss
@@ -16,22 +16,24 @@
 @use "../../styles/includes";
 
 :host {
-  @apply hidden;
+  display: none;
 }
 
 :host,
 .container,
 .content {
-  @apply h-full w-full;
+  block-size: 100%;
+  inline-size: 100%;
 }
 
 :host([selected]),
 :host([selected]) .container {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
 }
 
 .content {
-  @apply box-border;
+  box-sizing: border-box;
 
   padding-block: var(
     --calcite-tab-content-space-y,
@@ -61,10 +63,18 @@
 }
 
 .container {
-  @apply focus-base hidden h-full w-full overflow-auto;
+  outline-color: transparent;
+  display: none;
+  block-size: 100%;
+  inline-size: 100%;
+  overflow: auto;
 
   &:focus {
-    @apply focus-inset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
 }
 

--- a/packages/components/src/components/table-cell/table-cell.scss
+++ b/packages/components/src/components/table-cell/table-cell.scss
@@ -13,23 +13,33 @@
 @use "../../styles/includes";
 
 :host {
-  @apply contents;
+  display: contents;
 }
 
 :host([alignment="center"]) td:not(.selection-cell):not(.number-cell) {
-  @apply text-center;
+  text-align: center;
 }
 
 :host([alignment="end"]) td:not(.selection-cell):not(.number-cell) {
-  @apply text-end;
+  text-align: end;
 }
 
 .assistive-text {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-space-px);
+  block-size: var(--calcite-space-px);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-space-px));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: var(--calcite-border-width-none);
 }
 
 td {
-  @apply text-start align-middle  whitespace-normal;
+  text-align: start;
+  vertical-align: middle;
+  white-space: normal;
   color: var(--calcite-table-cell-text-color, var(--calcite-color-text-1));
   background-color: var(
     --calcite-internal-table-cell-background-color,
@@ -43,19 +53,23 @@ td {
   padding: var(--calcite-internal-table-cell-padding);
 
   &:not(.static-cell) {
-    @apply focus-base;
+    outline-color: transparent;
     &:focus {
-      @apply focus-inset;
+      outline: var(--calcite-border-width-md) solid
+        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+      outline-offset: calc(
+        calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+      );
     }
   }
 }
 
 td.start.content-cell {
-  @apply align-top;
+  vertical-align: top;
 }
 
 td.end.content-cell {
-  @apply align-bottom;
+  vertical-align: bottom;
 }
 
 td.last-cell {
@@ -67,7 +81,7 @@ td.last-cell {
 }
 
 .footer-cell {
-  @apply font-medium;
+  font-weight: var(--calcite-font-weight-medium);
   color: var(--calcite-table-cell-text-color, var(--calcite-color-text-1));
   background-color: var(
     --calcite-table-cell-background-color,
@@ -81,7 +95,7 @@ td.last-cell {
 
 .number-cell,
 .selection-cell {
-  @apply text-center;
+  text-align: center;
   border-inline-end: var(--calcite-border-width-sm) solid
     var(--calcite-table-cell-border-color, var(--calcite-table-border-color, var(--calcite-color-border-2)));
   inline-size: 2rem;
@@ -102,7 +116,7 @@ td.last-cell {
 .selection-cell {
   color: var(--calcite-table-selection-cell-icon-color, var(--calcite-color-text-3));
   &:not(.footer-cell) {
-    @apply cursor-pointer;
+    cursor: pointer;
     background-color: var(
       --calcite-table-selection-cell-background-color,
       var(--calcite-table-cell-background-color, transparent)
@@ -133,9 +147,10 @@ td.last-cell {
 }
 
 .selection-cell {
-  @apply align-middle;
+  vertical-align: middle;
   & ::slotted(calcite-icon) {
-    @apply pointer-events-none mt-1;
+    pointer-events: none;
+    margin-block-start: var(--calcite-space-2xs);
   }
 }
 

--- a/packages/components/src/components/table-header/table-header.scss
+++ b/packages/components/src/components/table-header/table-header.scss
@@ -13,23 +13,34 @@
 @use "../../styles/includes";
 
 :host {
-  @apply contents;
+  display: contents;
 }
 
 :host([alignment="center"]) th {
-  @apply text-center;
+  text-align: center;
 }
 
 :host([alignment="end"]) th {
-  @apply text-end;
+  text-align: end;
 }
 
 .assistive-text {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-space-px);
+  block-size: var(--calcite-space-px);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-space-px));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: var(--calcite-border-width-none);
 }
 
 th {
-  @apply text-start font-medium align-top whitespace-normal;
+  text-align: start;
+  font-weight: var(--calcite-font-weight-medium);
+  vertical-align: top;
+  white-space: normal;
   border-block-end: var(--calcite-border-width-sm) solid
     var(--calcite-table-header-border-color, var(--calcite-table-border-color, var(--calcite-color-border-2)));
   padding-block: calc(var(--calcite-internal-table-cell-padding) * 1.5);
@@ -42,9 +53,13 @@ th {
   border-inline-end: var(--calcite-border-width-sm) solid
     var(--calcite-table-cell-border-color, var(--calcite-table-border-color, var(--calcite-color-border-2)));
   &:not(.static-cell) {
-    @apply focus-base;
+    outline-color: transparent;
     &:not(.static-cell):focus-within {
-      @apply focus-inset;
+      outline: var(--calcite-border-width-md) solid
+        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+      outline-offset: calc(
+        calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+      );
     }
   }
 }
@@ -55,15 +70,15 @@ th:not(.body-row):not(.footer-row) {
 }
 
 th:not(.center):not(.end).content-cell {
-  @apply align-top;
+  vertical-align: top;
 }
 
 th.center {
-  @apply align-middle;
+  vertical-align: middle;
 }
 
 th.end.content-cell {
-  @apply align-bottom;
+  vertical-align: bottom;
 }
 
 th.body-row,
@@ -82,14 +97,15 @@ th.last-cell {
 }
 
 .cell--multiple-selection {
-  @apply cursor-pointer align-middle;
+  cursor: pointer;
+  vertical-align: middle;
   color: var(--calcite-table-selection-cell-icon-color, var(--calcite-color-text-3));
   background-color: var(--calcite-table-selection-cell-background-color, var(--calcite-color-foreground-2));
   &.selected-cell {
     background-color: var(--calcite-table-selection-cell-background-color-selected, var(--calcite-color-foreground-2));
   }
   &:not(.end) {
-    @apply align-middle;
+    vertical-align: middle;
   }
 }
 
@@ -111,7 +127,9 @@ th.last-cell {
 }
 .number-cell calcite-icon,
 .selection-cell calcite-icon {
-  @apply ms-auto me-auto align-middle;
+  margin-inline-start: auto;
+  margin-inline-end: auto;
+  vertical-align: middle;
 }
 
 .heading {

--- a/packages/components/src/components/table-row/table-row.scss
+++ b/packages/components/src/components/table-row/table-row.scss
@@ -22,14 +22,15 @@
 @use "../../styles/includes";
 
 :host {
-  @apply contents;
+  display: contents;
 }
 
 @include includes.base-component();
 
 @include includes.disabled() {
   tr {
-    @apply opacity-disabled pointer-events-none;
+    opacity: var(--calcite-opacity-disabled);
+    pointer-events: none;
   }
 }
 

--- a/packages/components/src/components/table/table.scss
+++ b/packages/components/src/components/table/table.scss
@@ -66,7 +66,7 @@
 @use "../../styles/includes";
 
 :host {
-  @apply flex;
+  display: flex;
   --calcite-internal-table-border-collapse: collapse;
 }
 
@@ -104,13 +104,14 @@
 }
 
 .container {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
   inline-size: var(--calcite-container-size-content-fluid);
   block-size: var(--calcite-container-size-content-fluid);
 }
 
 .table-container {
-  @apply whitespace-nowrap;
+  white-space: nowrap;
   line-height: var(--calcite-font-line-height-relative-tight);
   border: var(--calcite-border-width-sm) solid var(--calcite-table-border-color, var(--calcite-color-border-2));
   border-radius: var(--calcite-table-corner-radius, var(--calcite-corner-radius-sharp));
@@ -123,7 +124,15 @@
 }
 
 .assistive-text {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-space-px);
+  block-size: var(--calcite-space-px);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-space-px));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: var(--calcite-border-width-none);
 }
 
 table {
@@ -136,13 +145,13 @@ table {
 /* ⚠️ browser-specific styling is not a best practice and should be avoided ⚠️ */
 @-moz-document url-prefix() {
   table {
-    @apply border-separate;
+    border-collapse: separate;
     border-spacing: 0;
   }
 }
 
 .table--fixed {
-  @apply table-fixed;
+  table-layout: fixed;
 }
 
 .bordered {
@@ -161,26 +170,29 @@ table {
 }
 
 .selection-actions {
-  @apply flex flex-row;
+  display: flex;
+  flex-direction: row;
   gap: var(--calcite-internal-table-selection-action-spacing);
   margin-inline-start: auto;
 }
 
 .selection-area {
-  @apply flex flex-row items-center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   padding-block: var(--calcite-internal-table-cell-padding);
 }
 
 .selection-area calcite-chip:last-of-type {
-  @apply me-2;
+  margin-inline-end: var(--calcite-space-sm);
 }
 
 .selection-area calcite-chip:last-of-type:not(:first-of-type) {
-  @apply ms-2;
+  margin-inline-start: var(--calcite-space-sm);
 }
 
 .selection-area calcite-button {
-  @apply me-4;
+  margin-inline-end: var(--calcite-space-lg);
 }
 
 .selection-chip {
@@ -206,7 +218,10 @@ table {
 }
 
 .pagination-area {
-  @apply flex flex-row w-full justify-center;
+  display: flex;
+  flex-direction: row;
+  inline-size: 100%;
+  justify-content: center;
   padding-block: var(--calcite-internal-table-cell-padding);
 }
 
@@ -222,7 +237,7 @@ calcite-pagination {
 }
 
 .dismiss-button {
-  @apply me-4;
+  margin-inline-end: var(--calcite-space-lg);
   --calcite-button-background-color: var(--calcite-table-selection-dismiss-button-background-color);
   --calcite-button-border-color: var(--calcite-table-selection-dismiss-button-border-color);
   --calcite-button-corner-radius: var(--calcite-table-selection-dismiss-button-corner-radius);

--- a/packages/components/src/components/tabs/tabs.scss
+++ b/packages/components/src/components/tabs/tabs.scss
@@ -10,7 +10,8 @@
 @use "../../styles/includes";
 
 :host {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
   background-color: var(--calcite-tab-background-color, var(--calcite-color-transparent));
 }
 
@@ -25,7 +26,10 @@
 }
 
 section {
-  @apply border flex flex-grow overflow-hidden;
+  border-width: var(--calcite-border-width-sm);
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
 
   border-block-start-style: solid;
   border-block-start-color: var(--calcite-tab-border-color, var(--calcite-color-border-1));
@@ -42,25 +46,25 @@ section {
 }
 
 :host([position="bottom"]) {
-  @apply flex-col-reverse;
+  flex-direction: column-reverse;
 
   section {
-    @apply flex-col-reverse
-      border-t-0
-      border-b;
+    flex-direction: column-reverse;
+    border-block-start-width: var(--calcite-border-width-none);
+    border-block-end-width: var(--calcite-border-width-sm);
   }
 }
 
 :host([bordered][scale="s"]) section {
-  @apply p-3;
+  padding: var(--calcite-space-md);
 }
 
 :host([bordered][scale="m"]) section {
-  @apply p-2;
+  padding: var(--calcite-space-sm);
 }
 
 :host([bordered][scale="l"]) section {
-  @apply p-4;
+  padding: var(--calcite-space-lg);
 }
 
 :host([position="bottom"]:not([bordered])) section {
@@ -70,12 +74,12 @@ section {
 
 @media (forced-colors: active) {
   :host([bordered]) section {
-    @apply border-t-0
-      border-b;
+    border-block-start-width: var(--calcite-border-width-none);
+    border-block-end-width: var(--calcite-border-width-sm);
   }
   :host([position="bottom"][bordered]) section {
-    @apply border-t
-      border-b-0;
+    border-block-start-width: var(--calcite-border-width-sm);
+    border-block-end-width: var(--calcite-border-width-none);
   }
 }
 

--- a/packages/components/src/components/text-area/text-area.scss
+++ b/packages/components/src/components/text-area/text-area.scss
@@ -36,7 +36,11 @@
 @use "../../styles/includes";
 
 :host {
-  @apply inline-block relative w-full h-full box-border;
+  display: inline-block;
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
+  box-sizing: border-box;
   --calcite-internal-text-area-border-color: var(--calcite-text-area-border-color, var(--calcite-color-border-input));
   --calcite-internal-text-area-footer-border-color: var(
     --calcite-text-area-footer-border-color,
@@ -61,7 +65,9 @@
 }
 
 .wrapper {
-  @apply h-full w-full box-border;
+  block-size: 100%;
+  inline-size: 100%;
+  box-sizing: border-box;
   box-shadow: var(--calcite-internal-text-area-shadow);
   border-radius: var(--calcite-internal-text-area-corner-radius);
 }
@@ -79,7 +85,11 @@
 }
 
 .text-area {
-  @apply relative block box-border w-full m-0;
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  inline-size: 100%;
+  margin: 0;
   --calcite-internal-text-area-border-block-end-color: var(--calcite-internal-text-area-border-color);
   border: var(--calcite-border-width-sm) solid var(--calcite-internal-text-area-border-color);
   border-block-end-color: var(--calcite-internal-text-area-border-block-end-color);
@@ -95,22 +105,29 @@
   background-color: var(--calcite-text-area-background-color, var(--calcite-color-foreground-1));
   border-radius: var(--calcite-internal-text-area-corner-radius) var(--calcite-internal-text-area-corner-radius) 0 0;
   &::placeholder {
-    @apply font-normal;
+    font-weight: var(--calcite-font-weight-normal);
   }
 
   @media screen and (max-width: 480px) {
-    @apply resize-none;
+    resize: none;
   }
 
   &:focus {
-    @apply focus-inset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
 
   &.text-area--invalid {
     --calcite-internal-text-area-border-color: var(--calcite-color-status-danger);
 
     &:focus {
-      @apply focus-inset-danger;
+      outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+      outline-offset: calc(
+        calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+      );
     }
   }
 
@@ -143,7 +160,9 @@
 }
 
 .footer {
-  @apply flex box-border items-center;
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
   line-height: var(--calcite-font-line-height-base);
   border: var(--calcite-border-width-sm) solid var(--calcite-internal-text-area-footer-border-color);
   border-block-start: var(--calcite-border-width-none);
@@ -151,7 +170,10 @@
 }
 
 .character-limit {
-  @apply flex justify-end items-center whitespace-nowrap;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  white-space: nowrap;
 
   font-size: var(--calcite-text-area-font-size, var(--calcite-font-size--1));
   font-weight: var(--calcite-font-weight-regular);
@@ -175,36 +197,46 @@
 
 .content,
 .hide {
-  @apply hidden;
+  display: none;
 }
 
 .container {
-  @apply flex justify-between w-full;
+  display: flex;
+  justify-content: space-between;
+  inline-size: 100%;
 }
 
 .footer--end-only {
-  @apply justify-end;
+  justify-content: flex-end;
 }
 
 .assistive-text {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-space-px);
+  block-size: var(--calcite-space-px);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-space-px));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: var(--calcite-border-width-none);
 }
 
 .text-area.text-area--only {
-  @apply h-full;
+  block-size: 100%;
   min-block-size: var(--calcite-text-area-min-height, 0);
 }
 
 :host([resize="none"]) .text-area {
-  @apply resize-none;
+  resize: none;
 }
 
 :host([resize="horizontal"]) .text-area {
-  @apply resize-x;
+  resize: horizontal;
 }
 
 :host([resize="vertical"]) .text-area {
-  @apply resize-y;
+  resize: vertical;
 }
 
 :host([scale="s"]) {
@@ -249,7 +281,10 @@
   --calcite-internal-text-area-border-color: var(--calcite-color-status-danger);
 
   .text-area:focus {
-    @apply focus-inset-danger;
+    outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
 }
 

--- a/packages/components/src/components/tile/tile.scss
+++ b/packages/components/src/components/tile/tile.scss
@@ -104,7 +104,8 @@ calcite-link {
 }
 
 .heading {
-  @apply m-0 p-0;
+  margin: 0;
+  padding: 0;
   color: var(--calcite-tile-heading-text-color, var(--calcite-color-text-1));
   font-weight: var(--calcite-font-weight-medium);
   line-height: 1.20313rem;

--- a/packages/components/src/components/time-picker/time-picker.scss
+++ b/packages/components/src/components/time-picker/time-picker.scss
@@ -17,16 +17,16 @@
 @use "../../styles/includes";
 
 :host {
-  @apply inline-block;
+  display: inline-block;
 }
 
 .time-picker {
-  @apply flex
-    select-none
-    items-center
-    border-solid
-    border
-    font-medium;
+  display: flex;
+  user-select: none;
+  align-items: center;
+  border-style: solid;
+  border-width: var(--calcite-border-width-sm);
+  font-weight: var(--calcite-font-weight-medium);
   border-color: var(--calcite-time-picker-border-color, var(--calcite-color-border-3));
   border-radius: var(--calcite-time-picker-corner-radius, var(--calcite-border-radius-round));
   color: var(--calcite-time-picker-color, var(--calcite-color-text-1));
@@ -35,8 +35,8 @@
   overflow: hidden;
 
   .column {
-    @apply flex
-      flex-col;
+    display: flex;
+    flex-direction: column;
   }
 
   .meridiem--start {
@@ -44,16 +44,16 @@
   }
 
   .button {
-    @apply inline-flex
-      cursor-pointer
-      items-center
-      justify-center;
+    display: inline-flex;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
 
     background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
 
     &:hover,
     &:focus {
-      @apply outline-none;
+      outline: var(--calcite-border-width-md) solid transparent;
       z-index: var(--calcite-z-index-header);
       outline-offset: 0;
       background-color: var(--calcite-time-picker-button-background-color-hover, var(--calcite-color-foreground-2));
@@ -79,10 +79,10 @@
   }
 
   .input {
-    @apply inline-flex
-      cursor-pointer
-      items-center
-      justify-center;
+    display: inline-flex;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
 
     font-weight: var(--calcite-font-weight-medium);
     background-color: var(--calcite-time-picker-background-color, var(--calcite-color-foreground-1));
@@ -93,8 +93,8 @@
     }
     &:focus,
     &:hover:focus {
-      @apply outline-none;
-      outline-offset: 0;
+      outline: var(--calcite-border-width-md) solid transparent;
+      outline-offset: var(--calcite-border-width-none);
     }
     &.inputFocus,
     &:hover.inputFocus {
@@ -104,7 +104,7 @@
   }
 
   &.scale-s {
-    @apply text-n1;
+    font-size: var(--calcite-font-size-relative-base);
     .button,
     .input {
       padding-inline: var(--calcite-spacing-sm);
@@ -118,7 +118,7 @@
   }
 
   &.scale-m {
-    @apply text-0;
+    font-size: var(--calcite-font-size-relative-md);
     .button,
     .input {
       padding-inline: var(--calcite-spacing-md);
@@ -132,7 +132,7 @@
   }
 
   &.scale-l {
-    @apply text-1;
+    font-size: var(--calcite-font-size-relative-lg);
     .button,
     .input {
       padding-inline: var(--calcite-spacing-lg);

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -21,7 +21,7 @@
 @use "../../styles/shared/floating-ui";
 
 :host {
-  @apply contents;
+  display: contents;
   --calcite-internal-tooltip-padding-block: var(--calcite-spacing-sm);
   --calcite-internal-tooltip-padding-inline: var(--calcite-spacing-md);
 }
@@ -45,22 +45,26 @@
   --calcite-internal-tooltip-padding-inline: var(--calcite-spacing-sm);
 
   .container {
-    @apply text-n3-wrap;
+    font-size: var(--calcite-font-size-relative-xs);
+    line-height: var(--calcite-font-line-height-relative-snug);
   }
 }
 
 :host([scale="l"]) {
   .container {
-    @apply text-n1-wrap;
+    font-size: var(--calcite-font-size-relative-base);
+    line-height: var(--calcite-font-line-height-relative-snug);
   }
 }
 
 .container {
-  @apply text-n2-wrap
-    relative
-    overflow-hidden
-    font-medium
-    word-break;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-relative-snug);
+  position: relative;
+  overflow: hidden;
+  font-weight: var(--calcite-font-weight-medium);
+  overflow-wrap: break-word;
+  word-break: break-word;
   padding-block: var(--calcite-internal-tooltip-padding-block);
   padding-inline: var(--calcite-internal-tooltip-padding-inline);
   border-radius: var(--calcite-tooltip-corner-radius, var(--calcite-corner-radius-round));
@@ -69,8 +73,8 @@
 }
 
 .position-container .calcite-floating-ui-anim {
-  @apply border
-    border-solid;
+  border-width: var(--calcite-border-width-sm);
+  border-style: solid;
   box-shadow: var(--calcite-shadow-md);
   background-color: var(--calcite-tooltip-background-color, var(--calcite-color-foreground-1));
   border-color: var(--calcite-tooltip-border-color, var(--calcite-color-border-3));

--- a/packages/components/src/components/tree-item/tree-item.scss
+++ b/packages/components/src/components/tree-item/tree-item.scss
@@ -27,7 +27,8 @@
   --calcite-internal-tree-item-padding-block: 0.25rem;
   --calcite-internal-tree-item-children-container-padding: 1.25rem;
   --calcite-internal-tree-item-line-left-position: 0.75rem;
-  @apply text-n2h;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
 }
 
 :host(:is([scale="s"], [scale="m"])) {
@@ -39,7 +40,8 @@
   --calcite-internal-tree-item-padding-block: 0.5rem;
   --calcite-internal-tree-item-children-container-padding: 1.5rem;
   --calcite-internal-tree-item-line-left-position: 1rem;
-  @apply text-n1h;
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
 }
 
 :host([scale="l"]) {
@@ -48,13 +50,14 @@
   --calcite-internal-tree-item-padding-block: 0.625rem;
   --calcite-internal-tree-item-children-container-padding: 2.25rem;
   --calcite-internal-tree-item-line-left-position: 1.5rem;
-  @apply text-0h;
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
 }
 
 :host {
-  @apply block
-    max-w-full
-    cursor-pointer;
+  display: block;
+  max-inline-size: 100%;
+  cursor: pointer;
 
   .children-container ::slotted(*) {
     padding-inline-start: var(--calcite-internal-tree-item-children-container-padding);
@@ -63,7 +66,7 @@
 }
 
 .node-actions-container {
-  @apply flex;
+  display: flex;
 
   .node-container,
   .checkbox-container {
@@ -87,11 +90,13 @@
 :host([lines]) {
   .children-container::after {
     @include includes.transition-default();
-    @apply absolute
-        top-0
-        w-px
-        transition-colors
-        z-default;
+    position: absolute;
+    inset-block-start: 0;
+    inline-size: var(--calcite-space-px);
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: var(--calcite-animation-timing);
+    z-index: var(--calcite-z-index);
     // ensure lines don't overlap focus outline
     block-size: 100%;
     inset-inline-start: var(--calcite-internal-tree-item-line-left-position);
@@ -101,11 +106,13 @@
 }
 
 :host(:not([lines])) .node-container::after {
-  @apply hidden;
+  display: none;
 }
 
 ::slotted(*) {
-  @apply min-w-0 max-w-full break-words;
+  min-inline-size: 0;
+  max-inline-size: 100%;
+  overflow-wrap: break-word;
   color: inherit;
   text-decoration: none !important;
 
@@ -115,36 +122,50 @@
 }
 
 ::slotted(a) {
-  @apply w-full no-underline;
+  inline-size: 100%;
+  text-decoration-line: none;
 }
 
 // focus styles
 :host {
-  @apply outline-none;
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-border-width-md);
 
   .node-container {
-    @apply focus-base;
+    outline-color: transparent;
   }
   &:focus,
   &:active {
     .node-container {
-      @apply focus-inset;
+      outline: var(--calcite-border-width-md) solid
+        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+      outline-offset: calc(
+        calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+      );
     }
   }
 }
 
 :host(:focus:not([disabled])) {
   .node-container {
-    @apply focus-inset outline-none;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
 
   .checkbox {
-    @apply outline-none;
+    outline: var(--calcite-border-width-md) solid transparent;
+    outline-offset: var(--calcite-border-width-md);
   }
 }
 
 .actions-end {
-  @apply flex self-stretch flex-row items-center;
+  display: flex;
+  align-self: stretch;
+  flex-direction: row;
+  align-items: center;
   gap: var(--calcite-internal-tree-item-action-spacing);
 }
 
@@ -159,7 +180,9 @@
 }
 
 .checkbox-label {
-  @apply pointer-events-none flex items-center;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
 }
 
 .children-container {
@@ -185,10 +208,14 @@
 }
 
 .node-container {
-  @apply relative flex grow items-center min-w-0;
+  position: relative;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  min-inline-size: 0;
   .selection-icon {
     @include includes.transition-default();
-    @apply opacity-0;
+    opacity: 0;
     color: var(--calcite-color-border-1);
   }
 }
@@ -197,7 +224,7 @@
 :host([selected]) .node-container:hover,
 :host(:focus:not([disabled])) .node-container {
   .selection-icon {
-    @apply opacity-100;
+    opacity: 1;
   }
 }
 
@@ -205,7 +232,7 @@
 :host([selected]) .node-container:hover {
   --calcite-internal-tree-item-text-color: var(--calcite-tree-text-color-selected, var(--calcite-color-text-1));
 
-  @apply font-medium;
+  font-weight: var(--calcite-font-weight-medium);
   color: var(--calcite-internal-tree-item-text-color);
 
   .icon-start {
@@ -213,7 +240,7 @@
   }
 
   .selection-icon {
-    @apply opacity-100;
+    opacity: 1;
     color: var(--calcite-tree-selected-icon-color, var(--calcite-color-brand));
   }
 }
@@ -221,15 +248,15 @@
 // dropdown with children
 :host([has-children]) .node-container {
   .selection-icon {
-    @apply hidden;
+    display: none;
   }
 }
 
 .chevron {
   @include includes.transition-default();
-  @apply text-color-3
-    relative
-    self-center;
+  color: var(--calcite-color-text-3);
+  position: relative;
+  align-self: center;
   flex: 0 0 auto;
   transform: rotate(0deg);
 

--- a/packages/components/src/components/tree/tree.scss
+++ b/packages/components/src/components/tree/tree.scss
@@ -1,11 +1,12 @@
 @use "../../styles/includes";
 
 :host {
-  @apply block;
+  display: block;
 }
 
 :host(:focus) {
-  @apply outline-none;
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-border-width-md);
 }
 
 @include includes.base-component();


### PR DESCRIPTION
**Related Issue:** [#14648](https://github.com/Esri/calcite-design-system/issues/14648)

## Summary
Remove tailwind styles from:
 
`tab`, `tab-nav`, `tab-title`, `table`, `table-cell`, `table-header`, `table-row`, `tabs`, `text-area`, `tile`, `time-picker`, `tooltip`, `tree`, `tree-item`.
