### PR TITLE
fix(tab-nav): do not prevent vertical page scrolling when tab titles do not overflow

### DIFF
--- a/packages/components/src/components/tab-nav/tab-nav.browser.e2e.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.browser.e2e.tsx
@@ -34,6 +34,24 @@ describe("translation support", () => {
   t9n(() => mount("calcite-tab-nav"));
 });
 
+describe("wheel interactions", () => {
+  it("does not prevent page scrolling when tab titles do not overflow", async () => {
+    await mount(
+      <calcite-tab-nav>
+        <calcite-tab-title selected>Tab title</calcite-tab-title>
+      </calcite-tab-nav>,
+    );
+    const tabTitleContainer = page
+      .getBySelector(`.${CSS.tabTitleSlotWrapper}`)
+      .element() as HTMLDivElement;
+    const event = new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 100 });
+
+    tabTitleContainer.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
 describe("theme", () => {
   describe("default", () => {
     themed(() => mount("calcite-tab-nav"), {

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -354,6 +354,12 @@ export class TabNav extends LitElement {
   }
 
   private onTabTitleWheel(event: WheelEvent): void {
+    const tabTitleContainer = event.currentTarget as HTMLDivElement;
+
+    if (tabTitleContainer.scrollWidth <= tabTitleContainer.clientWidth) {
+      return;
+    }
+
     event.preventDefault();
 
     const { deltaX, deltaY } = event;
@@ -373,7 +379,7 @@ export class TabNav extends LitElement {
     }
 
     const scrollByX = (this.effectiveDir === "rtl" ? -1 : 1) * scrollBy;
-    (event.currentTarget as HTMLDivElement).scrollBy(scrollByX, 0);
+    tabTitleContainer.scrollBy(scrollByX, 0);
   }
 
   private onSlotChange(): void {


### PR DESCRIPTION
**Related Issue:** #14746

## Summary
Does not prevent vertical page scrolling when tab titles do not overflow, but allows for horizontal scroll when they do.