### PR TITLE
refactor(block, block-group, block-section, button, card, card-group, carousel, carousel-item, checkbox, chip, color-picker, combobox, combobox-item, combobox-item-group): remove tailwind from component styles

### DIFF
--- a/packages/components/src/components/block-group/block-group.scss
+++ b/packages/components/src/components/block-group/block-group.scss
@@ -1,7 +1,8 @@
 @use "../../styles/includes";
+@use "../../styles/component/sr-only";
 
 :host {
-  @apply block;
+  display: block;
 }
 
 .container {
@@ -9,7 +10,7 @@
 }
 
 .assistive-text {
-  @apply sr-only;
+  @include sr-only.sr-only();
 }
 
 @include includes.base-component();

--- a/packages/components/src/components/block-group/block-group.scss
+++ b/packages/components/src/components/block-group/block-group.scss
@@ -1,7 +1,7 @@
 @use "../../styles/includes";
 
 :host {
-  @apply block;
+  display: block;
 }
 
 .container {
@@ -9,7 +9,15 @@
 }
 
 .assistive-text {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-border-width-sm));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: var(--calcite-border-width-none);
 }
 
 @include includes.base-component();

--- a/packages/components/src/components/block-group/block-group.scss
+++ b/packages/components/src/components/block-group/block-group.scss
@@ -1,4 +1,5 @@
 @use "../../styles/includes";
+@use "../../styles/component/sr-only";
 
 :host {
   display: block;
@@ -9,15 +10,7 @@
 }
 
 .assistive-text {
-  position: absolute;
-  inline-size: var(--calcite-border-width-sm);
-  block-size: var(--calcite-border-width-sm);
-  padding: 0;
-  margin: calc(-1 * var(--calcite-border-width-sm));
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: var(--calcite-border-width-none);
+  @include sr-only.sr-only();
 }
 
 @include includes.base-component();

--- a/packages/components/src/components/block-section/block-section.scss
+++ b/packages/components/src/components/block-section/block-section.scss
@@ -12,6 +12,7 @@
  */
 
 @use "../../styles/includes";
+@use "../../styles/component/focus";
 
 :host {
   box-sizing: border-box;
@@ -117,8 +118,7 @@ calcite-switch {
   line-height: var(--calcite-font-line-height-relative-snug);
 
   &:focus {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    @include focus.focus-normal();
     // required to ensure the focus ring is visible when slotted with other block-section components in block
     z-index: var(--calcite-z-index);
   }
@@ -130,7 +130,6 @@ calcite-switch {
 .section-header__text {
   margin-block: 0;
   flex: 1 1 auto;
-
   text-align: initial;
   overflow-wrap: anywhere;
 }
@@ -152,7 +151,6 @@ calcite-switch {
   .chevron-icon {
     display: flex;
     align-items: center;
-
     color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
   }
 

--- a/packages/components/src/components/block-section/block-section.scss
+++ b/packages/components/src/components/block-section/block-section.scss
@@ -12,9 +12,11 @@
  */
 
 @use "../../styles/includes";
+@use "../../styles/component/focus";
 
 :host {
-  @apply box-border block;
+  box-sizing: border-box;
+  display: block;
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
 }
 
@@ -28,9 +30,9 @@ calcite-switch {
 }
 
 :host([expanded]) {
-  @apply border-0
-    border-b
-    border-solid;
+  border-width: 0;
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-style: solid;
 
   border-block-end-color: var(--calcite-block-section-border-color, var(--calcite-color-border-3));
 
@@ -64,7 +66,7 @@ calcite-switch {
 }
 
 :host(:last-child) {
-  @apply border-b-0;
+  border-block-end-width: var(--calcite-border-width-none);
 }
 
 :host([scale="s"]) {
@@ -102,13 +104,13 @@ calcite-switch {
 }
 
 .toggle {
-  @apply focus-base
-  flex
-  cursor-pointer
-  select-none
-  items-center
-  w-full
-  border-0;
+  outline-color: transparent;
+  display: flex;
+  cursor: pointer;
+  user-select: none;
+  align-items: center;
+  inline-size: 100%;
+  border-width: var(--calcite-border-width-none);
   font-family: inherit;
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
   background-color: var(--calcite-block-section-background-color, var(--calcite-color-foreground-1));
@@ -117,7 +119,7 @@ calcite-switch {
   line-height: var(--calcite-font-line-height-relative-snug);
 
   &:focus {
-    @apply focus-normal;
+    @include focus.focus-normal();
     // required to ensure the focus ring is visible when slotted with other block-section components in block
     z-index: var(--calcite-z-index);
   }
@@ -127,27 +129,29 @@ calcite-switch {
 }
 
 .section-header__text {
-  @apply my-0
-    flex-auto;
-
+  margin-block: 0;
+  flex: 1 1 auto;
   text-align: initial;
   overflow-wrap: anywhere;
 }
 
 .toggle-container {
-  @apply flex items-center relative;
-
+  display: flex;
+  align-items: center;
+  position: relative;
   word-break: break-word;
 
   .toggle--switch__content {
-    @apply flex flex-auto items-center;
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
   }
 
   .icon--end,
   .icon--start,
   .chevron-icon {
-    @apply flex items-center;
-
+    display: flex;
+    align-items: center;
     color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
   }
 
@@ -163,7 +167,8 @@ calcite-switch {
 }
 
 .status-icon {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
 }
 
 .status-icon.valid {

--- a/packages/components/src/components/block-section/block-section.scss
+++ b/packages/components/src/components/block-section/block-section.scss
@@ -14,7 +14,8 @@
 @use "../../styles/includes";
 
 :host {
-  @apply box-border block;
+  box-sizing: border-box;
+  display: block;
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
 }
 
@@ -28,10 +29,9 @@ calcite-switch {
 }
 
 :host([expanded]) {
-  @apply border-0
-    border-b
-    border-solid;
-
+  border-width: var(--calcite-border-width-none);
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-style: solid;
   border-block-end-color: var(--calcite-block-section-border-color, var(--calcite-color-border-3));
 
   .toggle {
@@ -64,7 +64,7 @@ calcite-switch {
 }
 
 :host(:last-child) {
-  @apply border-b-0;
+  border-block-end-width: var(--calcite-border-width-none);
 }
 
 :host([scale="s"]) {
@@ -102,13 +102,13 @@ calcite-switch {
 }
 
 .toggle {
-  @apply focus-base
-  flex
-  cursor-pointer
-  select-none
-  items-center
-  w-full
-  border-0;
+  outline-color: transparent;
+  display: flex;
+  cursor: pointer;
+  user-select: none;
+  align-items: center;
+  inline-size: 100%;
+  border-width: var(--calcite-border-width-none);
   font-family: inherit;
   color: var(--calcite-block-section-header-text-color, var(--calcite-color-text-2));
   background-color: var(--calcite-block-section-background-color, var(--calcite-color-foreground-1));
@@ -117,7 +117,8 @@ calcite-switch {
   line-height: var(--calcite-font-line-height-relative-snug);
 
   &:focus {
-    @apply focus-normal;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
     // required to ensure the focus ring is visible when slotted with other block-section components in block
     z-index: var(--calcite-z-index);
   }
@@ -127,26 +128,30 @@ calcite-switch {
 }
 
 .section-header__text {
-  @apply my-0
-    flex-auto;
+  margin-block: 0;
+  flex: 1 1 auto;
 
   text-align: initial;
   overflow-wrap: anywhere;
 }
 
 .toggle-container {
-  @apply flex items-center relative;
-
+  display: flex;
+  align-items: center;
+  position: relative;
   word-break: break-word;
 
   .toggle--switch__content {
-    @apply flex flex-auto items-center;
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
   }
 
   .icon--end,
   .icon--start,
   .chevron-icon {
-    @apply flex items-center;
+    display: flex;
+    align-items: center;
 
     color: var(--calcite-block-section-text-color, var(--calcite-color-text-3));
   }
@@ -163,7 +168,8 @@ calcite-switch {
 }
 
 .status-icon {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
 }
 
 .status-icon.valid {

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -31,8 +31,10 @@
 // --calcite-internal-block-padding-block
 // --calcite-internal-block-padding-inline
 
+@use "../../styles/component/focus";
 @use "../../styles/includes";
 @use "../../styles/shared/animation";
+@use "../../styles/component/transition-color";
 @use "sass:meta";
 
 :host([scale="s"]) {
@@ -127,8 +129,15 @@
 
 :host {
   @extend %component-host;
-  @apply transition-margin ease-cubic flex flex-shrink-0 flex-grow-0
-    flex-col border-0 border-b border-solid p-0;
+  transition-timing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88);
+  display: flex;
+  flex-shrink: 0;
+  flex-grow: 0;
+  flex-direction: column;
+  border-width: 0;
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-style: solid;
+  padding: 0;
   flex-basis: auto;
   border-color: var(--calcite-block-border-color, var(--calcite-color-border-3));
   background-color: var(--calcite-block-background-color, var(--calcite-color-foreground-1));
@@ -137,7 +146,7 @@
 @include includes.disabled();
 
 .header {
-  @apply justify-start;
+  justify-content: flex-start;
 }
 .header--has-content {
   padding: var(--calcite-internal-block-header-content-padding);
@@ -152,7 +161,8 @@
 }
 
 .header-container {
-  @apply grid items-stretch;
+  display: grid;
+  align-items: stretch;
   grid-template: auto / auto 1fr auto auto auto auto;
   grid-template-areas: "handle header icon-end menu actions-end";
 }
@@ -175,15 +185,15 @@
 }
 
 .toggle {
-  @apply focus-base
-    flex
-    cursor-pointer
-    flex-nowrap
-    items-center
-    justify-between
-    border-none
-    m-0
-    p-0;
+  outline-color: transparent;
+  display: flex;
+  cursor: pointer;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: space-between;
+  border-style: none;
+  margin: 0;
+  padding: 0;
   font-family: inherit;
   text-align: initial;
   background-color: var(--calcite-block-header-background-color, transparent);
@@ -192,7 +202,7 @@
     background-color: var(--calcite-block-header-background-color-hover, var(--calcite-color-foreground-2));
   }
   &:focus {
-    @apply focus-inset;
+    @include focus.focus-inset();
   }
   &:active {
     background-color: var(--calcite-block-header-background-color-press, var(--calcite-color-foreground-3));
@@ -200,7 +210,7 @@
 }
 
 calcite-loader[inline] {
-  @apply self-center;
+  align-self: center;
 }
 
 calcite-sort-handle {
@@ -211,29 +221,28 @@ calcite-sort-handle {
 }
 
 .title {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
 }
 
 .header .title .heading {
-  @apply word-break
-    p-0;
-
+  @include includes.word-break();
+  padding: 0;
   color: var(--calcite-block-heading-text-color, var(--calcite-color-text-1));
   font-weight: var(--calcite-font-weight-normal);
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .description {
-  @apply word-break
-    p-0;
-
+  @include includes.word-break();
+  padding: 0;
   color: var(--calcite-block-description-text-color, var(--calcite-color-text-3));
   font-weight: var(--calcite-font-weight-regular);
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .icon {
-  @apply flex;
+  display: flex;
 }
 
 .status-icon.valid {
@@ -257,15 +266,16 @@ calcite-sort-handle {
 }
 
 .icon-end-container {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
   grid-area: icon-end;
 }
 
 .toggle-icon {
-  @apply transition-color
-  self-center
-  justify-self-end
-  ease-in-out;
+  @include transition-color.transition-color();
+  align-self: center;
+  justify-self: end;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   color: var(--calcite-block-collapsible-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
@@ -277,11 +287,17 @@ calcite-sort-handle {
 }
 
 .container {
-  @apply flex flex-col h-full relative;
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  position: relative;
 }
 
 .content {
-  @apply flex-1 relative min-h-0 opacity-0;
+  flex: 1 1 0%;
+  position: relative;
+  min-block-size: 0;
+  opacity: 0;
   transition: opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
 }
 
@@ -292,7 +308,8 @@ calcite-sort-handle {
 
 .content-end,
 .content-start {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
 
   // Deprecated
   color: var(--calcite-block-text-color, var(--calcite-color-text-3));
@@ -305,7 +322,7 @@ calcite-action-menu {
 }
 
 :host([expanded]) {
-  @apply my-2;
+  margin-block: var(--calcite-space-sm);
 
   .header .title .heading {
     color: var(

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -31,8 +31,10 @@
 // --calcite-internal-block-padding-block
 // --calcite-internal-block-padding-inline
 
+@use "../../styles/component/focus";
 @use "../../styles/includes";
 @use "../../styles/shared/animation";
+@use "../../styles/component/transition-color";
 @use "sass:meta";
 
 :host([scale="s"]) {
@@ -127,8 +129,6 @@
 
 :host {
   @extend %component-host;
-  transition-property: margin;
-  transition-duration: var(--calcite-animation-timing);
   transition-timing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88);
   display: flex;
   flex-shrink: 0;
@@ -202,11 +202,7 @@
     background-color: var(--calcite-block-header-background-color-hover, var(--calcite-color-foreground-2));
   }
   &:focus {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(
-      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-    );
+    @include focus.focus-inset();
   }
   &:active {
     background-color: var(--calcite-block-header-background-color-press, var(--calcite-color-foreground-3));
@@ -230,20 +226,18 @@ calcite-sort-handle {
 }
 
 .header .title .heading {
-  overflow-wrap: break-word;
-  word-break: break-word;
-  padding: 0;
+  @include includes.word-break();
 
+  padding: 0;
   color: var(--calcite-block-heading-text-color, var(--calcite-color-text-1));
   font-weight: var(--calcite-font-weight-normal);
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .description {
-  overflow-wrap: break-word;
-  word-break: break-word;
-  padding: 0;
+  @include includes.word-break();
 
+  padding: 0;
   color: var(--calcite-block-description-text-color, var(--calcite-color-text-3));
   font-weight: var(--calcite-font-weight-regular);
   line-height: var(--calcite-font-line-height-relative-snug);
@@ -280,8 +274,8 @@ calcite-sort-handle {
 }
 
 .toggle-icon {
-  transition-property: color;
-  transition-duration: var(--calcite-animation-timing);
+  @include transition-color.transition-color();
+
   align-self: center;
   justify-self: end;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/packages/components/src/components/block/block.scss
+++ b/packages/components/src/components/block/block.scss
@@ -127,8 +127,17 @@
 
 :host {
   @extend %component-host;
-  @apply transition-margin ease-cubic flex flex-shrink-0 flex-grow-0
-    flex-col border-0 border-b border-solid p-0;
+  transition-property: margin;
+  transition-duration: var(--calcite-animation-timing);
+  transition-timing-function: cubic-bezier(0.215, 0.44, 0.42, 0.88);
+  display: flex;
+  flex-shrink: 0;
+  flex-grow: 0;
+  flex-direction: column;
+  border-width: var(--calcite-border-width-none);
+  border-block-end-width: var(--calcite-border-width-sm);
+  border-style: solid;
+  padding: 0;
   flex-basis: auto;
   border-color: var(--calcite-block-border-color, var(--calcite-color-border-3));
   background-color: var(--calcite-block-background-color, var(--calcite-color-foreground-1));
@@ -137,7 +146,7 @@
 @include includes.disabled();
 
 .header {
-  @apply justify-start;
+  justify-content: flex-start;
 }
 .header--has-content {
   padding: var(--calcite-internal-block-header-content-padding);
@@ -152,7 +161,8 @@
 }
 
 .header-container {
-  @apply grid items-stretch;
+  display: grid;
+  align-items: stretch;
   grid-template: auto / auto 1fr auto auto auto auto;
   grid-template-areas: "handle header icon-end menu actions-end";
 }
@@ -175,15 +185,15 @@
 }
 
 .toggle {
-  @apply focus-base
-    flex
-    cursor-pointer
-    flex-nowrap
-    items-center
-    justify-between
-    border-none
-    m-0
-    p-0;
+  outline-color: transparent;
+  display: flex;
+  cursor: pointer;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: space-between;
+  border-style: none;
+  margin: 0;
+  padding: 0;
   font-family: inherit;
   text-align: initial;
   background-color: var(--calcite-block-header-background-color, transparent);
@@ -192,7 +202,11 @@
     background-color: var(--calcite-block-header-background-color-hover, var(--calcite-color-foreground-2));
   }
   &:focus {
-    @apply focus-inset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
   &:active {
     background-color: var(--calcite-block-header-background-color-press, var(--calcite-color-foreground-3));
@@ -200,7 +214,7 @@
 }
 
 calcite-loader[inline] {
-  @apply self-center;
+  align-self: center;
 }
 
 calcite-sort-handle {
@@ -211,12 +225,14 @@ calcite-sort-handle {
 }
 
 .title {
-  @apply flex flex-col;
+  display: flex;
+  flex-direction: column;
 }
 
 .header .title .heading {
-  @apply word-break
-    p-0;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  padding: 0;
 
   color: var(--calcite-block-heading-text-color, var(--calcite-color-text-1));
   font-weight: var(--calcite-font-weight-normal);
@@ -224,8 +240,9 @@ calcite-sort-handle {
 }
 
 .description {
-  @apply word-break
-    p-0;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  padding: 0;
 
   color: var(--calcite-block-description-text-color, var(--calcite-color-text-3));
   font-weight: var(--calcite-font-weight-regular);
@@ -233,7 +250,7 @@ calcite-sort-handle {
 }
 
 .icon {
-  @apply flex;
+  display: flex;
 }
 
 .status-icon.valid {
@@ -257,15 +274,17 @@ calcite-sort-handle {
 }
 
 .icon-end-container {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
   grid-area: icon-end;
 }
 
 .toggle-icon {
-  @apply transition-color
-  self-center
-  justify-self-end
-  ease-in-out;
+  transition-property: color;
+  transition-duration: var(--calcite-animation-timing);
+  align-self: center;
+  justify-self: end;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   color: var(--calcite-block-collapsible-icon-color, var(--calcite-block-icon-color, var(--calcite-color-text-3)));
 }
 
@@ -277,11 +296,17 @@ calcite-sort-handle {
 }
 
 .container {
-  @apply flex flex-col h-full relative;
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  position: relative;
 }
 
 .content {
-  @apply flex-1 relative min-h-0 opacity-0;
+  flex: 1 1 0%;
+  position: relative;
+  min-block-size: 0;
+  opacity: 0;
   transition: opacity var(--calcite-internal-animation-timing-slow) animation.$easing-function;
 }
 
@@ -292,7 +317,8 @@ calcite-sort-handle {
 
 .content-end,
 .content-start {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
 
   // Deprecated
   color: var(--calcite-block-text-color, var(--calcite-color-text-3));
@@ -305,7 +331,7 @@ calcite-action-menu {
 }
 
 :host([expanded]) {
-  @apply my-2;
+  margin-block: var(--calcite-space-sm);
 
   .header .title .heading {
     color: var(

--- a/packages/components/src/components/block/block.tsx
+++ b/packages/components/src/components/block/block.tsx
@@ -22,6 +22,7 @@ import { SortHandle } from "../sort-handle/sort-handle";
 import { useSetFocus } from "../../controllers/useSetFocus";
 import { styles as sortableStyles } from "../../styles/component/sortable.scss";
 import { styles as headerStyles } from "../../styles/component/header.scss";
+import { styles as transitionMarginStyles } from "../../styles/component/transition-margin.scss";
 import { SortMenuItem } from "../sort-handle/types";
 import { BlockSection } from "../block-section/block-section";
 import { useInteractive } from "../../controllers/useInteractive";
@@ -49,7 +50,7 @@ declare global {
 export class Block extends LitElement {
   //#region Static Members
 
-  static override styles = [headerStyles, styles, sortableStyles];
+  static override styles = [headerStyles, styles, sortableStyles, transitionMarginStyles];
 
   //#endregion
 

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -30,8 +30,9 @@
 @use "../../styles/includes";
 
 :host {
-  @apply inline-block w-auto align-middle;
-
+  display: inline-block;
+  inline-size: auto;
+  vertical-align: middle;
   border-radius: var(
     --calcite-button-corner-radius,
     var(--calcite-internal-button-corner-radius, var(--calcite-corner-radius))
@@ -42,23 +43,21 @@
     --calcite-internal-button-content-margin: theme("margin.2");
     --calcite-internal-button-padding-x: 7px;
     --calcite-internal-button-padding-y: 3px;
-
-    @apply appearance-none
-    border-none
-    box-border
-    cursor-pointer
-    flex
-    focus-base
-    font-inherit
-    font-normal
-    h-full
-    items-center
-    justify-center
-    no-underline
-    relative
-    select-none
-    text-center
-    w-full;
+    appearance: none;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    outline-color: transparent;
+    font-family: inherit;
+    font-weight: var(--calcite-font-weight-normal);
+    block-size: 100%;
+    align-items: center;
+    justify-content: center;
+    text-decoration-line: none;
+    position: relative;
+    user-select: none;
+    text-align: center;
+    inline-size: 100%;
     box-shadow: var(--calcite-button-shadow, var(--calcite-shadow-none));
     background-color: var(
       --calcite-button-background-color,
@@ -110,7 +109,7 @@
       outline-color var(--calcite-internal-animation-timing-fast) ease-in-out;
 
     &:hover {
-      @apply no-underline;
+      text-decoration-line: none;
       background-color: var(
         --calcite-button-background-color,
         var(--calcite-internal-button-background-color-hover, var(--calcite-color-transparent))
@@ -118,7 +117,9 @@
     }
 
     &:focus {
-      @apply focus-outset;
+      outline: var(--calcite-border-width-md) solid
+        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+      outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
     }
 
     &:active {
@@ -129,7 +130,9 @@
     }
 
     span {
-      @apply truncate;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     calcite-loader {
@@ -179,40 +182,40 @@
 
 // button width
 :host([width="auto"]) {
-  @apply w-auto;
+  inline-size: auto;
 }
 
 :host([width="half"]) {
-  @apply w-2/4;
+  inline-size: 50%;
 }
 
 :host([width="full"]) {
-  @apply w-full;
+  inline-size: 100%;
 }
 
 // alignment
 :host([alignment="center"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-center;
+    justify-content: center;
   }
 }
 :host([alignment="start"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-start;
+    justify-content: flex-start;
   }
 }
 :host([alignment="end"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-end;
+    justify-content: flex-end;
   }
 }
 :host([alignment*="space-between"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-between;
+    justify-content: space-between;
   }
 }
 :host([alignment="icon-start-space-between"]:not([width="auto"])) {
@@ -276,9 +279,9 @@
 }
 
 .calcite-button--loader {
-  @apply flex;
+  display: flex;
   calcite-loader {
-    @apply m-0;
+    margin: 0;
   }
 }
 
@@ -295,7 +298,7 @@
   a:not(.content--slotted) {
     .icon--start,
     .icon--end {
-      @apply hidden;
+      display: none;
     }
   }
 }
@@ -306,8 +309,7 @@
   a {
     --calcite-internal-button-border-color: var(--calcite-color-transparent);
 
-    @apply border-solid;
-
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -347,7 +349,7 @@
   --calcite-internal-button-background-color-press: var(--calcite-color-foreground-3);
   button,
   a {
-    @apply border-solid;
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -431,7 +433,7 @@
   --calcite-internal-button-background-color-press: var(--calcite-color-transparent-press);
   button,
   a {
-    @apply border-solid;
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -608,7 +610,8 @@
 // generate button scales (scenario: text exists)
 :host([scale="s"]) button.content--slotted,
 :host([scale="s"]) a.content--slotted {
-  @apply text-n2h;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
 }
 
 // accommodate for transparent buttons not having borders
@@ -625,7 +628,9 @@
 :host([scale="m"]) button.content--slotted,
 :host([scale="m"]) a.content--slotted {
   --calcite-internal-button-padding-x: 11px;
-  @apply text-n1h;
+
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
 }
 
 :host([scale="m"]) button,
@@ -641,7 +646,9 @@
 :host([scale="l"]) button.content--slotted,
 :host([scale="l"]) a.content--slotted {
   --calcite-internal-button-padding-x: 15px;
-  @apply text-0h;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
 }
 
 :host([scale="l"]) {
@@ -660,7 +667,10 @@
 :host([scale="s"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 3px;
-  @apply text-0h w-6;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  inline-size: var(--calcite-space-2xl);
   min-block-size: theme("height.6");
 }
 
@@ -668,14 +678,20 @@
 :host([scale="m"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 7px;
-  @apply text-0h w-8;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  inline-size: var(--calcite-space-3xl);
   min-block-size: theme("height.8");
 }
 :host([scale="l"]) button:not(.content--slotted),
 :host([scale="l"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 9px;
-  @apply text-0h w-11;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  inline-size: var(--calcite-space-4xl);
   min-block-size: theme("height.11");
 }
 
@@ -698,7 +714,10 @@
 :host([scale="s"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="s"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 23px;
-  @apply text-0h h-6;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  block-size: var(--calcite-space-2xl);
 }
 // accommodate for transparent buttons not having borders
 :host([scale="s"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
@@ -708,7 +727,10 @@
 :host([scale="m"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="m"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding.8");
-  @apply text-0h h-8;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  block-size: var(--calcite-space-3xl);
 }
 // accommodate for transparent buttons not having borders
 :host([scale="m"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
@@ -718,7 +740,10 @@
 :host([scale="l"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="l"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 43px;
-  @apply text-0h h-11;
+
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+  block-size: var(--calcite-space-4xl);
   // add space between when only 2 icons
   .icon--start + .icon--end {
     margin-inline-start: theme("margin.4");

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -27,11 +27,15 @@
 // --calcite-internal-button-padding-y
 // --calcite-internal-button-text-color
 
+@use "../../styles/component/focus";
 @use "../../styles/includes";
+@use "../../styles/component/text";
+@use "../../styles/component/truncate";
 
 :host {
-  @apply inline-block w-auto align-middle;
-
+  display: inline-block;
+  inline-size: auto;
+  vertical-align: middle;
   border-radius: var(
     --calcite-button-corner-radius,
     var(--calcite-internal-button-corner-radius, var(--calcite-corner-radius))
@@ -43,22 +47,21 @@
     --calcite-internal-button-padding-x: 7px;
     --calcite-internal-button-padding-y: 3px;
 
-    @apply appearance-none
-    border-none
-    box-border
-    cursor-pointer
-    flex
-    focus-base
-    font-inherit
-    font-normal
-    h-full
-    items-center
-    justify-center
-    no-underline
-    relative
-    select-none
-    text-center
-    w-full;
+    appearance: none;
+    box-sizing: border-box;
+    cursor: pointer;
+    display: flex;
+    outline-color: transparent;
+    font-family: inherit;
+    font-weight: var(--calcite-font-weight-normal);
+    block-size: 100%;
+    align-items: center;
+    justify-content: center;
+    text-decoration-line: none;
+    position: relative;
+    user-select: none;
+    text-align: center;
+    inline-size: 100%;
     box-shadow: var(--calcite-button-shadow, var(--calcite-shadow-none));
     background-color: var(
       --calcite-button-background-color,
@@ -110,7 +113,7 @@
       outline-color var(--calcite-internal-animation-timing-fast) ease-in-out;
 
     &:hover {
-      @apply no-underline;
+      text-decoration-line: none;
       background-color: var(
         --calcite-button-background-color,
         var(--calcite-internal-button-background-color-hover, var(--calcite-color-transparent))
@@ -118,7 +121,7 @@
     }
 
     &:focus {
-      @apply focus-outset;
+      @include focus.focus-outset();
     }
 
     &:active {
@@ -129,7 +132,7 @@
     }
 
     span {
-      @apply truncate;
+      @include truncate.truncate();
     }
 
     calcite-loader {
@@ -179,40 +182,40 @@
 
 // button width
 :host([width="auto"]) {
-  @apply w-auto;
+  inline-size: auto;
 }
 
 :host([width="half"]) {
-  @apply w-2/4;
+  inline-size: 50%;
 }
 
 :host([width="full"]) {
-  @apply w-full;
+  inline-size: 100%;
 }
 
 // alignment
 :host([alignment="center"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-center;
+    justify-content: center;
   }
 }
 :host([alignment="start"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-start;
+    justify-content: flex-start;
   }
 }
 :host([alignment="end"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-end;
+    justify-content: flex-end;
   }
 }
 :host([alignment*="space-between"]:not([width="auto"])) {
   a,
   button {
-    @apply justify-between;
+    justify-content: space-between;
   }
 }
 :host([alignment="icon-start-space-between"]:not([width="auto"])) {
@@ -276,9 +279,9 @@
 }
 
 .calcite-button--loader {
-  @apply flex;
+  display: flex;
   calcite-loader {
-    @apply m-0;
+    margin: 0;
   }
 }
 
@@ -295,7 +298,7 @@
   a:not(.content--slotted) {
     .icon--start,
     .icon--end {
-      @apply hidden;
+      display: none;
     }
   }
 }
@@ -306,8 +309,7 @@
   a {
     --calcite-internal-button-border-color: var(--calcite-color-transparent);
 
-    @apply border-solid;
-
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -347,7 +349,7 @@
   --calcite-internal-button-background-color-press: var(--calcite-color-foreground-3);
   button,
   a {
-    @apply border-solid;
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -431,7 +433,7 @@
   --calcite-internal-button-background-color-press: var(--calcite-color-transparent-press);
   button,
   a {
-    @apply border-solid;
+    border-style: solid;
     border-width: var(--calcite-button-border-size, 1px);
   }
 }
@@ -608,7 +610,7 @@
 // generate button scales (scenario: text exists)
 :host([scale="s"]) button.content--slotted,
 :host([scale="s"]) a.content--slotted {
-  @apply text-n2h;
+  @include text.text-n2h();
 }
 
 // accommodate for transparent buttons not having borders
@@ -625,7 +627,8 @@
 :host([scale="m"]) button.content--slotted,
 :host([scale="m"]) a.content--slotted {
   --calcite-internal-button-padding-x: 11px;
-  @apply text-n1h;
+
+  @include text.text-n1h();
 }
 
 :host([scale="m"]) button,
@@ -641,7 +644,8 @@
 :host([scale="l"]) button.content--slotted,
 :host([scale="l"]) a.content--slotted {
   --calcite-internal-button-padding-x: 15px;
-  @apply text-0h;
+
+  @include text.text-0h();
 }
 
 :host([scale="l"]) {
@@ -660,7 +664,9 @@
 :host([scale="s"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 3px;
-  @apply text-0h w-6;
+
+  @include text.text-0h();
+  inline-size: var(--calcite-space-2xl);
   min-block-size: theme("height.6");
 }
 
@@ -668,14 +674,18 @@
 :host([scale="m"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 7px;
-  @apply text-0h w-8;
+
+  @include text.text-0h();
+  inline-size: var(--calcite-space-3xl);
   min-block-size: theme("height.8");
 }
 :host([scale="l"]) button:not(.content--slotted),
 :host([scale="l"]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 9px;
-  @apply text-0h w-11;
+
+  @include text.text-0h();
+  inline-size: var(--calcite-space-4xl);
   min-block-size: theme("height.11");
 }
 
@@ -698,7 +708,9 @@
 :host([scale="s"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="s"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 23px;
-  @apply text-0h h-6;
+
+  @include text.text-0h();
+  block-size: var(--calcite-space-2xl);
 }
 // accommodate for transparent buttons not having borders
 :host([scale="s"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
@@ -708,7 +720,9 @@
 :host([scale="m"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="m"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding.8");
-  @apply text-0h h-8;
+
+  @include text.text-0h();
+  block-size: var(--calcite-space-3xl);
 }
 // accommodate for transparent buttons not having borders
 :host([scale="m"][icon-start][icon-end][appearance="transparent"]) button:not(.content--slotted),
@@ -718,7 +732,10 @@
 :host([scale="l"][icon-start][icon-end]) button:not(.content--slotted),
 :host([scale="l"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 43px;
-  @apply text-0h h-11;
+
+  @include text.text-0h();
+  block-size: var(--calcite-space-4xl);
+
   // add space between when only 2 icons
   .icon--start + .icon--end {
     margin-inline-start: theme("margin.4");

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -27,7 +27,10 @@
 // --calcite-internal-button-padding-y
 // --calcite-internal-button-text-color
 
+@use "../../styles/component/focus";
 @use "../../styles/includes";
+@use "../../styles/component/text";
+@use "../../styles/component/truncate";
 
 :host {
   display: inline-block;
@@ -43,6 +46,7 @@
     --calcite-internal-button-content-margin: theme("margin.2");
     --calcite-internal-button-padding-x: 7px;
     --calcite-internal-button-padding-y: 3px;
+
     appearance: none;
     box-sizing: border-box;
     cursor: pointer;
@@ -117,9 +121,7 @@
     }
 
     &:focus {
-      outline: var(--calcite-border-width-md) solid
-        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-      outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+      @include focus.focus-outset();
     }
 
     &:active {
@@ -130,9 +132,7 @@
     }
 
     span {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      @include truncate.truncate();
     }
 
     calcite-loader {
@@ -610,8 +610,7 @@
 // generate button scales (scenario: text exists)
 :host([scale="s"]) button.content--slotted,
 :host([scale="s"]) a.content--slotted {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-sm);
+  @include text.text-n2h();
 }
 
 // accommodate for transparent buttons not having borders
@@ -629,8 +628,7 @@
 :host([scale="m"]) a.content--slotted {
   --calcite-internal-button-padding-x: 11px;
 
-  font-size: var(--calcite-font-size-relative-base);
-  line-height: var(--calcite-font-line-height-base);
+  @include text.text-n1h();
 }
 
 :host([scale="m"]) button,
@@ -647,8 +645,7 @@
 :host([scale="l"]) a.content--slotted {
   --calcite-internal-button-padding-x: 15px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
 }
 
 :host([scale="l"]) {
@@ -668,8 +665,8 @@
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 3px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   inline-size: var(--calcite-space-2xl);
   min-block-size: theme("height.6");
 }
@@ -679,8 +676,8 @@
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 7px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   inline-size: var(--calcite-space-3xl);
   min-block-size: theme("height.8");
 }
@@ -689,8 +686,8 @@
   --calcite-internal-button-padding-x: theme("padding[0.5]");
   --calcite-internal-button-padding-y: 9px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   inline-size: var(--calcite-space-4xl);
   min-block-size: theme("height.11");
 }
@@ -715,8 +712,8 @@
 :host([scale="s"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 23px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   block-size: var(--calcite-space-2xl);
 }
 // accommodate for transparent buttons not having borders
@@ -728,8 +725,8 @@
 :host([scale="m"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: theme("padding.8");
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   block-size: var(--calcite-space-3xl);
 }
 // accommodate for transparent buttons not having borders
@@ -741,9 +738,10 @@
 :host([scale="l"][icon-start][icon-end]) a:not(.content--slotted) {
   --calcite-internal-button-padding-x: 43px;
 
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
+
   block-size: var(--calcite-space-4xl);
+
   // add space between when only 2 icons
   .icon--start + .icon--end {
     margin-inline-start: theme("margin.4");

--- a/packages/components/src/components/card-group/card-group.scss
+++ b/packages/components/src/components/card-group/card-group.scss
@@ -10,7 +10,7 @@
 @use "../../styles/includes";
 
 :host {
-  @apply block;
+  display: block;
 }
 
 .container {

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -33,11 +33,14 @@
 // --calcite-internal-card-heading-font-size
 // --calcite-internal-card-slotted-content-padding
 
-@use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
+@use "../../styles/component/focus";
+@use "../../styles/includes";
+@use "../../styles/text";
 
 :host {
-  @apply block max-w-full;
+  display: block;
+  max-inline-size: 100%;
 }
 
 :host([scale="s"]) {
@@ -80,12 +83,12 @@
 }
 
 .content-wrapper {
-  @apply relative
-    flex
-    h-full
-    flex-col
-    justify-between
-    overflow-hidden;
+  position: relative;
+  display: flex;
+  block-size: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
   border: var(--calcite-border-width-sm) solid var(--calcite-card-border-color, var(--calcite-color-border-3));
   border-radius: var(--calcite-card-corner-radius, var(--calcite-corner-radius-sharp));
   background-color: var(--calcite-card-background-color, var(--calcite-color-foreground-1));
@@ -94,35 +97,43 @@
 }
 
 ::slotted(*) {
-  @apply pointer-events-auto;
+  pointer-events: auto;
 }
 
 :host(:not([selectable])) {
   .content-wrapper {
     &:not(.non-interactive) {
-      @apply focus-base;
+      outline-color: transparent;
     }
     &:not(.non-interactive):focus {
-      @apply focus-outset;
+      @include focus.focus-outset();
     }
   }
 }
 
 .container {
-  @apply relative flex flex-auto flex-col;
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
 }
 
 :host([loading]) .content-wrapper *:not(calcite-loader):not(.calcite-card-loader-container) {
-  @apply pointer-events-none;
+  pointer-events: none;
   opacity: core.$calcite-opacity-0;
 }
 
 :host([loading]) .calcite-card-loader-container {
-  @apply absolute inset-0 flex items-center;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
 }
 
 .header {
-  @apply flex flex-row items-start;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
 }
 
 .header-text-container {
@@ -150,7 +161,9 @@
 }
 
 .card-content {
-  @apply h-auto text-n2-wrap;
+  block-size: auto;
+
+  @include text.text-n2-wrap();
 }
 
 .has-slotted-content {
@@ -182,21 +195,27 @@
 }
 
 @include includes.slotted("thumbnail", "img") {
-  @apply min-w-full max-w-full;
+  min-inline-size: 100%;
+  max-inline-size: 100%;
 }
 
 @include includes.slotted("footer-start", "*") {
-  @apply text-n2-wrap self-center;
+  @include text.text-n2-wrap();
+
+  align-self: center;
   margin-inline-end: auto;
 }
 
 @include includes.slotted("footer-end", "*") {
-  @apply text-n2-wrap self-center;
+  @include text.text-n2-wrap();
+
+  align-self: center;
 }
 
 // deprecated
 .checkbox-wrapper-deprecated {
-  @apply absolute pointer-events-auto;
+  position: absolute;
+  pointer-events: auto;
   inset-block-start: var(--calcite-spacing-sm);
   inset-inline-end: var(--calcite-spacing-sm);
   margin: 0;
@@ -275,21 +294,22 @@
 /* end deprecated */
 
 .thumbnail-wrapper {
-  @apply flex;
+  display: flex;
 }
 
 .content-wrapper.inline {
-  @apply flex-row;
+  flex-direction: row;
 
   & > .container {
-    @apply w-3/5;
+    inline-size: 60%;
   }
   & > .thumbnail-wrapper {
-    @apply items-start w-2/5;
+    align-items: flex-start;
+    inline-size: 40%;
   }
 
   @include includes.slotted("thumbnail", "img") {
-    @apply w-full;
+    inline-size: 100%;
   }
 }
 

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -33,8 +33,10 @@
 // --calcite-internal-card-heading-font-size
 // --calcite-internal-card-slotted-content-padding
 
-@use "../../styles/includes";
 @use "@esri/calcite-design-tokens/dist/scss/core";
+@use "../../styles/component/focus";
+@use "../../styles/includes";
+@use "../../styles/text";
 
 :host {
   display: block;
@@ -104,9 +106,7 @@
       outline-color: transparent;
     }
     &:not(.non-interactive):focus {
-      outline: var(--calcite-border-width-md) solid
-        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-      outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+      @include focus.focus-outset();
     }
   }
 }
@@ -162,8 +162,8 @@
 
 .card-content {
   block-size: auto;
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-relative-snug);
+
+  @include text.text-n2-wrap();
 }
 
 .has-slotted-content {
@@ -200,15 +200,15 @@
 }
 
 @include includes.slotted("footer-start", "*") {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-relative-snug);
+  @include text.text-n2-wrap();
+
   align-self: center;
   margin-inline-end: auto;
 }
 
 @include includes.slotted("footer-end", "*") {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-relative-snug);
+  @include text.text-n2-wrap();
+
   align-self: center;
 }
 

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -37,7 +37,8 @@
 @use "@esri/calcite-design-tokens/dist/scss/core";
 
 :host {
-  @apply block max-w-full;
+  display: block;
+  max-inline-size: 100%;
 }
 
 :host([scale="s"]) {
@@ -80,12 +81,12 @@
 }
 
 .content-wrapper {
-  @apply relative
-    flex
-    h-full
-    flex-col
-    justify-between
-    overflow-hidden;
+  position: relative;
+  display: flex;
+  block-size: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
   border: var(--calcite-border-width-sm) solid var(--calcite-card-border-color, var(--calcite-color-border-3));
   border-radius: var(--calcite-card-corner-radius, var(--calcite-corner-radius-sharp));
   background-color: var(--calcite-card-background-color, var(--calcite-color-foreground-1));
@@ -94,35 +95,45 @@
 }
 
 ::slotted(*) {
-  @apply pointer-events-auto;
+  pointer-events: auto;
 }
 
 :host(:not([selectable])) {
   .content-wrapper {
     &:not(.non-interactive) {
-      @apply focus-base;
+      outline-color: transparent;
     }
     &:not(.non-interactive):focus {
-      @apply focus-outset;
+      outline: var(--calcite-border-width-md) solid
+        var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+      outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
     }
   }
 }
 
 .container {
-  @apply relative flex flex-auto flex-col;
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
 }
 
 :host([loading]) .content-wrapper *:not(calcite-loader):not(.calcite-card-loader-container) {
-  @apply pointer-events-none;
+  pointer-events: none;
   opacity: core.$calcite-opacity-0;
 }
 
 :host([loading]) .calcite-card-loader-container {
-  @apply absolute inset-0 flex items-center;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
 }
 
 .header {
-  @apply flex flex-row items-start;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
 }
 
 .header-text-container {
@@ -150,7 +161,9 @@
 }
 
 .card-content {
-  @apply h-auto text-n2-wrap;
+  block-size: auto;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .has-slotted-content {
@@ -182,21 +195,27 @@
 }
 
 @include includes.slotted("thumbnail", "img") {
-  @apply min-w-full max-w-full;
+  min-inline-size: 100%;
+  max-inline-size: 100%;
 }
 
 @include includes.slotted("footer-start", "*") {
-  @apply text-n2-wrap self-center;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-relative-snug);
+  align-self: center;
   margin-inline-end: auto;
 }
 
 @include includes.slotted("footer-end", "*") {
-  @apply text-n2-wrap self-center;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-relative-snug);
+  align-self: center;
 }
 
 // deprecated
 .checkbox-wrapper-deprecated {
-  @apply absolute pointer-events-auto;
+  position: absolute;
+  pointer-events: auto;
   inset-block-start: var(--calcite-spacing-sm);
   inset-inline-end: var(--calcite-spacing-sm);
   margin: 0;
@@ -275,21 +294,22 @@
 /* end deprecated */
 
 .thumbnail-wrapper {
-  @apply flex;
+  display: flex;
 }
 
 .content-wrapper.inline {
-  @apply flex-row;
+  flex-direction: row;
 
   & > .container {
-    @apply w-3/5;
+    inline-size: 60%;
   }
   & > .thumbnail-wrapper {
-    @apply items-start w-2/5;
+    align-items: flex-start;
+    inline-size: 40%;
   }
 
   @include includes.slotted("thumbnail", "img") {
-    @apply w-full;
+    inline-size: 100%;
   }
 }
 

--- a/packages/components/src/components/carousel-item/carousel-item.scss
+++ b/packages/components/src/components/carousel-item/carousel-item.scss
@@ -1,16 +1,16 @@
 @use "../../styles/includes";
 
 :host {
-  @apply flex;
+  display: flex;
 }
 
 .container {
-  @apply hidden;
+  display: none;
   inline-size: var(--calcite-container-size-content-fluid);
 }
 
 :host([selected]) .container {
-  @apply block;
+  display: block;
 }
 
 @include includes.base-component();

--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -40,10 +40,15 @@
 // --calcite-internal-carousel-pagination-space
 // --calcite-internal-carousel-pagination-space-wide
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/component/sr-only";
+@use "../../styles/component/text";
 
 :host {
-  @apply flex w-full;
+  display: flex;
+  inline-size: 100%;
+
   --calcite-internal-carousel-pagination-space: 1.5rem;
   --calcite-internal-carousel-pagination-space-wide: 3.5rem;
   --calcite-internal-carousel-pagination-background-color: var(
@@ -113,16 +118,18 @@
 }
 
 .container {
-  @apply focus-base
-   relative
-    flex
-    flex-col
-    overflow-hidden
-    text-color-2
-    text-n1h
-    w-full;
+  outline-color: transparent;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--calcite-color-text-2);
+  inline-size: 100%;
+
+  @include text.text-n1h();
+
   &:focus {
-    @apply focus-inset;
+    @include focus.focus-inset();
   }
 }
 
@@ -132,18 +139,18 @@
 }
 
 .item-container {
-  @apply flex
-    items-start
-    justify-center
-    overflow-auto
-    flex-auto
-    p-1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: auto;
+  flex: 1 1 auto;
+  padding: var(--calcite-space-2xs);
   animation-name: none;
   animation-duration: var(--calcite-animation-timing);
 }
 
 .container--overlaid .item-container {
-  @apply p-0;
+  padding: 0;
 }
 
 .item-container--forward {
@@ -159,20 +166,22 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-aria-live {
-  @apply sr-only;
+  @include sr-only.sr-only();
 }
 
 .pagination {
-  @apply flex
-  flex-row
-  items-center
-  justify-center
-  m-3;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: var(--calcite-space-md);
   inline-size: auto;
 }
 
 .pagination-items {
-  @apply flex flex-row items-center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .container--overlaid .pagination {
@@ -191,7 +200,8 @@ calcite-carousel-item:not([selected]) {
 .container--edged {
   .page-next,
   .page-previous {
-    @apply h-12 w-12;
+    block-size: var(--calcite-size-xl);
+    inline-size: var(--calcite-size-xl);
     position: absolute;
     inset-block-start: 50%;
     transform: translateY(-50%);
@@ -239,27 +249,29 @@ calcite-carousel-item:not([selected]) {
 
 .pagination-item {
   @include includes.transition-default();
-  @apply focus-base
-    m-0
-    h-8
-    w-8
-    cursor-pointer
-    items-center
-    border-none
-    bg-transparent;
+
+  outline-color: transparent;
+  margin: 0;
+  block-size: var(--calcite-space-3xl);
+  inline-size: var(--calcite-space-3xl);
+  cursor: pointer;
+  align-items: center;
+  border-style: none;
   -webkit-appearance: none;
   display: flex;
   align-content: center;
   justify-content: center;
   background-color: var(--calcite-internal-carousel-pagination-background-color);
   color: var(--calcite-internal-carousel-pagination-icon-color);
+
   &:hover {
     background-color: var(--calcite-internal-carousel-pagination-background-color-hover);
     color: var(--calcite-internal-carousel-pagination-icon-color-hover);
   }
   &:focus {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);
-    @apply focus-inset;
+
+    @include focus-inset.focus-inset();
   }
   &:active {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);
@@ -276,7 +288,10 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-item--individual {
-  @apply w-0 p-0 opacity-0 pointer-events-none;
+  inline-size: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
   visibility: hidden;
   transition:
     var(--calcite-animation-timing) ease-in-out inline-size,
@@ -284,7 +299,9 @@ calcite-carousel-item:not([selected]) {
     var(--calcite-animation-timing) ease-in-out opacity;
 
   &.pagination-item--visible {
-    @apply w-8 opacity-100 pointer-events-auto;
+    inline-size: var(--calcite-space-3xl);
+    opacity: 1;
+    pointer-events: auto;
     visibility: visible;
   }
 }

--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -43,7 +43,9 @@
 @use "../../styles/includes";
 
 :host {
-  @apply flex w-full;
+  display: flex;
+  inline-size: 100%;
+
   --calcite-internal-carousel-pagination-space: 1.5rem;
   --calcite-internal-carousel-pagination-space-wide: 3.5rem;
   --calcite-internal-carousel-pagination-background-color: var(
@@ -113,16 +115,21 @@
 }
 
 .container {
-  @apply focus-base
-   relative
-    flex
-    flex-col
-    overflow-hidden
-    text-color-2
-    text-n1h
-    w-full;
+  outline-color: transparent;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--calcite-color-text-2);
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
+  inline-size: 100%;
   &:focus {
-    @apply focus-inset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
 }
 
@@ -132,18 +139,18 @@
 }
 
 .item-container {
-  @apply flex
-    items-start
-    justify-center
-    overflow-auto
-    flex-auto
-    p-1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: auto;
+  flex: 1 1 auto;
+  padding: var(--calcite-space-2xs);
   animation-name: none;
   animation-duration: var(--calcite-animation-timing);
 }
 
 .container--overlaid .item-container {
-  @apply p-0;
+  padding: 0;
 }
 
 .item-container--forward {
@@ -159,20 +166,30 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-aria-live {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-border-width-sm));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 .pagination {
-  @apply flex
-  flex-row
-  items-center
-  justify-center
-  m-3;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: var(--calcite-space-md);
   inline-size: auto;
 }
 
 .pagination-items {
-  @apply flex flex-row items-center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .container--overlaid .pagination {
@@ -191,7 +208,8 @@ calcite-carousel-item:not([selected]) {
 .container--edged {
   .page-next,
   .page-previous {
-    @apply h-12 w-12;
+    block-size: var(--calcite-size-xl);
+    inline-size: var(--calcite-size-xl);
     position: absolute;
     inset-block-start: 50%;
     transform: translateY(-50%);
@@ -239,14 +257,13 @@ calcite-carousel-item:not([selected]) {
 
 .pagination-item {
   @include includes.transition-default();
-  @apply focus-base
-    m-0
-    h-8
-    w-8
-    cursor-pointer
-    items-center
-    border-none
-    bg-transparent;
+  outline-color: transparent;
+  margin: 0;
+  block-size: var(--calcite-space-3xl);
+  inline-size: var(--calcite-space-3xl);
+  cursor: pointer;
+  align-items: center;
+  border-style: none;
   -webkit-appearance: none;
   display: flex;
   align-content: center;
@@ -259,7 +276,11 @@ calcite-carousel-item:not([selected]) {
   }
   &:focus {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);
-    @apply focus-inset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(
+      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+    );
   }
   &:active {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);
@@ -276,7 +297,10 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-item--individual {
-  @apply w-0 p-0 opacity-0 pointer-events-none;
+  inline-size: 0;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
   visibility: hidden;
   transition:
     var(--calcite-animation-timing) ease-in-out inline-size,
@@ -284,7 +308,9 @@ calcite-carousel-item:not([selected]) {
     var(--calcite-animation-timing) ease-in-out opacity;
 
   &.pagination-item--visible {
-    @apply w-8 opacity-100 pointer-events-auto;
+    inline-size: var(--calcite-space-3xl);
+    opacity: 1;
+    pointer-events: auto;
     visibility: visible;
   }
 }

--- a/packages/components/src/components/carousel/carousel.scss
+++ b/packages/components/src/components/carousel/carousel.scss
@@ -40,7 +40,10 @@
 // --calcite-internal-carousel-pagination-space
 // --calcite-internal-carousel-pagination-space-wide
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/component/sr-only";
+@use "../../styles/component/text";
 
 :host {
   display: flex;
@@ -121,15 +124,12 @@
   flex-direction: column;
   overflow: hidden;
   color: var(--calcite-color-text-2);
-  font-size: var(--calcite-font-size-relative-base);
-  line-height: var(--calcite-font-line-height-base);
   inline-size: 100%;
+
+  @include text.text-n1h();
+
   &:focus {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(
-      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-    );
+    @include focus.focus-inset();
   }
 }
 
@@ -166,15 +166,7 @@ calcite-carousel-item:not([selected]) {
 }
 
 .pagination-aria-live {
-  position: absolute;
-  inline-size: var(--calcite-border-width-sm);
-  block-size: var(--calcite-border-width-sm);
-  padding: 0;
-  margin: calc(-1 * var(--calcite-border-width-sm));
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+  @include sr-only.sr-only();
 }
 
 .pagination {
@@ -257,6 +249,7 @@ calcite-carousel-item:not([selected]) {
 
 .pagination-item {
   @include includes.transition-default();
+
   outline-color: transparent;
   margin: 0;
   block-size: var(--calcite-space-3xl);
@@ -270,17 +263,15 @@ calcite-carousel-item:not([selected]) {
   justify-content: center;
   background-color: var(--calcite-internal-carousel-pagination-background-color);
   color: var(--calcite-internal-carousel-pagination-icon-color);
+
   &:hover {
     background-color: var(--calcite-internal-carousel-pagination-background-color-hover);
     color: var(--calcite-internal-carousel-pagination-icon-color-hover);
   }
   &:focus {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(
-      calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-    );
+
+    @include focus-inset.focus-inset();
   }
   &:active {
     background-color: var(--calcite-internal-carousel-pagination-background-color-press);

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -10,6 +10,7 @@
  * @prop --calcite-checkbox-icon-color: Specifies the component's icon color.
  */
 
+@use "../../styles/focus";
 @use "../../styles/includes";
 
 :host([scale="s"]) {
@@ -44,6 +45,7 @@
 
   .check-svg {
     @include includes.transition-default();
+
     background-color: var(--calcite-color-foreground-1);
     pointer-events: none;
     box-sizing: border-box;
@@ -72,8 +74,7 @@
     }
   }
   .toggle:focus {
-    outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
-    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+    @include focus.focus-outset-danger();
   }
 }
 
@@ -117,9 +118,7 @@
   &:active,
   &:focus,
   &:focus-visible {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+    @include focus.focus-outset();
   }
 
   &::after,

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -10,6 +10,7 @@
  * @prop --calcite-checkbox-icon-color: Specifies the component's icon color.
  */
 
+@use "../../styles/focus";
 @use "../../styles/includes";
 
 :host([scale="s"]) {
@@ -35,22 +36,23 @@
 }
 
 :host {
-  @apply relative
-    inline-flex
-    cursor-pointer
-    select-none;
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+  user-select: none;
   -webkit-tap-highlight-color: transparent;
 
   .check-svg {
     @include includes.transition-default();
-    @apply bg-foreground-1
-      pointer-events-none
-      box-border
-      block
-      overflow-hidden
-      fill-current
-      stroke-current
-      stroke-1;
+
+    background-color: var(--calcite-color-foreground-1);
+    pointer-events: none;
+    box-sizing: border-box;
+    display: block;
+    overflow: hidden;
+    fill: currentColor;
+    stroke: currentColor;
+    stroke-width: 1;
     box-shadow: inset 0 0 0 1px var(--calcite-checkbox-border-color, var(--calcite-color-border-input));
     color: var(--calcite-checkbox-icon-color, theme("backgroundColor.background"));
   }
@@ -71,14 +73,14 @@
     }
   }
   .toggle:focus {
-    @apply focus-outset-danger;
+    @include focus.focus-outset-danger();
   }
 }
 
 :host([checked]),
 :host([indeterminate]) {
   .check-svg {
-    @apply bg-brand;
+    background-color: var(--calcite-color-brand);
     box-shadow: inset 0 0 0 1px var(--calcite-color-brand);
   }
 
@@ -109,12 +111,13 @@
 }
 
 .toggle {
-  @apply focus-base relative;
+  outline-color: transparent;
+  position: relative;
 
   &:active,
   &:focus,
   &:focus-visible {
-    @apply focus-outset;
+    @include focus.focus-outset();
   }
 
   &::after,

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -35,22 +35,23 @@
 }
 
 :host {
-  @apply relative
-    inline-flex
-    cursor-pointer
-    select-none;
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+  user-select: none;
+
   -webkit-tap-highlight-color: transparent;
 
   .check-svg {
     @include includes.transition-default();
-    @apply bg-foreground-1
-      pointer-events-none
-      box-border
-      block
-      overflow-hidden
-      fill-current
-      stroke-current
-      stroke-1;
+    background-color: var(--calcite-color-foreground-1);
+    pointer-events: none;
+    box-sizing: border-box;
+    display: block;
+    overflow: hidden;
+    fill: currentColor;
+    stroke: currentColor;
+    stroke-width: 1;
     box-shadow: inset 0 0 0 1px var(--calcite-checkbox-border-color, var(--calcite-color-border-input));
     color: var(--calcite-checkbox-icon-color, theme("backgroundColor.background"));
   }
@@ -71,14 +72,15 @@
     }
   }
   .toggle:focus {
-    @apply focus-outset-danger;
+    outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
   }
 }
 
 :host([checked]),
 :host([indeterminate]) {
   .check-svg {
-    @apply bg-brand;
+    background-color: var(--calcite-color-brand);
     box-shadow: inset 0 0 0 1px var(--calcite-color-brand);
   }
 
@@ -109,12 +111,15 @@
 }
 
 .toggle {
-  @apply focus-base relative;
+  outline-color: transparent;
+  position: relative;
 
   &:active,
   &:focus,
   &:focus-visible {
-    @apply focus-outset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
   }
 
   &::after,

--- a/packages/components/src/components/chip/chip.scss
+++ b/packages/components/src/components/chip/chip.scss
@@ -48,8 +48,8 @@
 @use "../../styles/includes";
 
 :host {
-  @apply inline-flex
-    cursor-default;
+  display: inline-flex;
+  cursor: default;
   border-radius: var(--calcite-chip-corner-radius, 9999px);
 }
 
@@ -374,15 +374,13 @@
 
 // Sub-element styles
 .container {
-  @apply inline-flex
-  h-full
-  max-w-full
-  items-center
-  focus-base
-  justify-center
-  box-border
-  font-medium;
-
+  display: inline-flex;
+  max-inline-size: 100%;
+  align-items: center;
+  outline-color: transparent;
+  justify-content: center;
+  box-sizing: border-box;
+  font-weight: var(--calcite-font-weight-medium);
   background-color: var(--calcite-internal-chip-background-color);
   border-color: var(--calcite-internal-chip-border-color);
   border-radius: var(--calcite-chip-corner-radius, 9999px);
@@ -400,7 +398,7 @@
   }
 
   &.selectable {
-    @apply cursor-pointer;
+    cursor: pointer;
 
     &:hover {
       background-color: var(--calcite-internal-chip-selectable-hover-background-color);
@@ -412,11 +410,15 @@
     }
   }
   &:not(.non-interactive):focus {
-    @apply focus-outset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
   }
 
   &.text--slotted .title {
-    @apply truncate;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &:not(.text--slotted) .title,
@@ -437,7 +439,8 @@
 }
 
 .image-container {
-  @apply inline-flex overflow-hidden;
+  display: inline-flex;
+  overflow: hidden;
   align-items: center;
   justify-content: center;
   pointer-events: none;
@@ -448,7 +451,10 @@
 }
 
 .chip-icon {
-  @apply relative my-0 inline-flex ease-in-out;
+  position: relative;
+  margin-block: 0;
+  display: inline-flex;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   color: var(
     --calcite-chip-icon-color,
     var(--calcite-chip-text-color, var(--calcite-icon-color, var(--calcite-ui-icon-color, currentColor)))
@@ -483,7 +489,9 @@
 }
 
 .multiple .select-icon {
-  @apply flex justify-center items-center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .multiple .select-icon,
@@ -512,7 +520,11 @@
 }
 
 slot[name="image"]::slotted(*) {
-  @apply rounded-half flex h-full w-full overflow-hidden;
+  border-radius: 50%;
+  display: flex;
+  block-size: 100%;
+  inline-size: 100%;
+  overflow: hidden;
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/chip/chip.scss
+++ b/packages/components/src/components/chip/chip.scss
@@ -45,11 +45,13 @@
 // --calcite-internal-chip-title-space
 // --calcite-internal-close-size
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/truncate";
 
 :host {
-  @apply inline-flex
-    cursor-default;
+  display: inline-flex;
+  cursor: default;
   border-radius: var(--calcite-chip-corner-radius, 9999px);
 }
 
@@ -374,15 +376,13 @@
 
 // Sub-element styles
 .container {
-  @apply inline-flex
-  h-full
-  max-w-full
-  items-center
-  focus-base
-  justify-center
-  box-border
-  font-medium;
-
+  display: inline-flex;
+  max-inline-size: 100%;
+  align-items: center;
+  outline-color: transparent;
+  justify-content: center;
+  box-sizing: border-box;
+  font-weight: var(--calcite-font-weight-medium);
   background-color: var(--calcite-internal-chip-background-color);
   border-color: var(--calcite-internal-chip-border-color);
   border-radius: var(--calcite-chip-corner-radius, 9999px);
@@ -400,7 +400,7 @@
   }
 
   &.selectable {
-    @apply cursor-pointer;
+    cursor: pointer;
 
     &:hover {
       background-color: var(--calcite-internal-chip-selectable-hover-background-color);
@@ -412,11 +412,11 @@
     }
   }
   &:not(.non-interactive):focus {
-    @apply focus-outset;
+    @include focus.focus-outset();
   }
 
   &.text--slotted .title {
-    @apply truncate;
+    @include truncate.truncate();
   }
 
   &:not(.text--slotted) .title,
@@ -437,7 +437,8 @@
 }
 
 .image-container {
-  @apply inline-flex overflow-hidden;
+  display: inline-flex;
+  overflow: hidden;
   align-items: center;
   justify-content: center;
   pointer-events: none;
@@ -448,7 +449,10 @@
 }
 
 .chip-icon {
-  @apply relative my-0 inline-flex ease-in-out;
+  position: relative;
+  margin-block: 0;
+  display: inline-flex;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   color: var(
     --calcite-chip-icon-color,
     var(--calcite-chip-text-color, var(--calcite-icon-color, var(--calcite-ui-icon-color, currentColor)))
@@ -483,7 +487,9 @@
 }
 
 .multiple .select-icon {
-  @apply flex justify-center items-center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .multiple .select-icon,
@@ -512,7 +518,11 @@
 }
 
 slot[name="image"]::slotted(*) {
-  @apply rounded-half flex h-full w-full overflow-hidden;
+  border-radius: 50%;
+  display: flex;
+  block-size: 100%;
+  inline-size: 100%;
+  overflow: hidden;
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/chip/chip.scss
+++ b/packages/components/src/components/chip/chip.scss
@@ -45,7 +45,9 @@
 // --calcite-internal-chip-title-space
 // --calcite-internal-close-size
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/truncate";
 
 :host {
   display: inline-flex;
@@ -410,15 +412,11 @@
     }
   }
   &:not(.non-interactive):focus {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+    @include focus.focus-outset();
   }
 
   &.text--slotted .title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    @include truncate.truncate();
   }
 
   &:not(.text--slotted) .title,

--- a/packages/components/src/components/color-picker/color-picker.scss
+++ b/packages/components/src/components/color-picker/color-picker.scss
@@ -31,7 +31,10 @@
 @use "../../styles/includes";
 
 :host {
-  @apply text-n2h inline-block font-normal;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
+  display: inline-block;
+  font-weight: var(--calcite-font-weight-normal);
   inline-size: var(--calcite-internal-color-picker-min-width);
   min-inline-size: var(--calcite-internal-color-picker-min-width);
 }
@@ -52,7 +55,8 @@
   --calcite-internal-color-picker-min-width: 304px;
   --calcite-color-picker-spacing: var(--calcite-spacing-lg);
 
-  @apply text-n1h;
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
 
   .section {
     &:first-of-type {
@@ -61,16 +65,18 @@
   }
 
   .control-section {
-    @apply flex flex-col flex-wrap items-baseline;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: baseline;
   }
 
   .color-hex-options {
     inline-size: 100%;
-
-    @apply flex
-      flex-shrink
-      flex-col
-      justify-around;
+    display: flex;
+    flex-shrink: 1;
+    flex-direction: column;
+    justify-content: space-around;
   }
 
   .color-mode-container {
@@ -127,7 +133,10 @@ calcite-swatch {
 }
 
 .control-and-scope {
-  @apply flex relative cursor-pointer touch-none;
+  display: flex;
+  position: relative;
+  cursor: pointer;
+  touch-action: none;
 }
 
 .color-field,
@@ -139,23 +148,28 @@ calcite-swatch {
 }
 
 .scope {
-  @apply text-n1
-    focus-base
-    absolute
-    z-default
-    rounded-full
-    bg-transparent
-    w-px
-    h-px
-    pointer-events-none;
+  font-size: var(--calcite-font-size-relative-base);
+  outline-color: transparent;
+  position: absolute;
+  z-index: var(--calcite-z-index);
+  border-radius: 9999px;
+  background-color: transparent;
+  inline-size: var(--calcite-space-px);
+  block-size: var(--calcite-space-px);
+  pointer-events: none;
   &:focus {
-    @apply focus-outset;
+    outline: var(--calcite-border-width-md) solid
+      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
     outline-offset: 6px;
   }
 }
 
 .hex-and-channels-group {
-  @apply flex flex-col flex-wrap w-full;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  inline-size: 100%;
 }
 
 .section {
@@ -168,13 +182,16 @@ calcite-swatch {
 }
 
 .sliders {
-  @apply flex flex-col justify-between;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   margin-inline-start: var(--calcite-color-picker-spacing);
   gap: var(--calcite-spacing-xxs);
 }
 
 .preview-and-sliders {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
   padding: var(--calcite-color-picker-spacing);
 }
 
@@ -184,9 +201,9 @@ calcite-swatch {
 }
 
 .header {
-  @apply flex
-    items-center
-    justify-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   color: var(--calcite-color-picker-text-color, var(--calcite-color-text-1));
 }
 
@@ -195,7 +212,7 @@ calcite-swatch {
 }
 
 .channels {
-  @apply flex;
+  display: flex;
 }
 
 .channel {

--- a/packages/components/src/components/color-picker/color-picker.scss
+++ b/packages/components/src/components/color-picker/color-picker.scss
@@ -28,11 +28,13 @@
 //
 // --calcite-internal-color-picker-min-width
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/component/text";
 
 :host {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-sm);
+  @include text.text-n2h();
+
   display: inline-block;
   font-weight: var(--calcite-font-weight-normal);
   inline-size: var(--calcite-internal-color-picker-min-width);
@@ -55,8 +57,7 @@
   --calcite-internal-color-picker-min-width: 304px;
   --calcite-color-picker-spacing: var(--calcite-spacing-lg);
 
-  font-size: var(--calcite-font-size-relative-base);
-  line-height: var(--calcite-font-line-height-base);
+  @include text.text-n1h();
 
   .section {
     &:first-of-type {
@@ -154,13 +155,12 @@ calcite-swatch {
   z-index: var(--calcite-z-index);
   border-radius: 9999px;
   background-color: transparent;
-  inline-size: var(--calcite-space-px);
-  block-size: var(--calcite-space-px);
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
   pointer-events: none;
   &:focus {
-    outline: var(--calcite-border-width-md) solid
-      var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-    outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+    @include focus.focus-outset();
+
     outline-offset: 6px;
   }
 }

--- a/packages/components/src/components/color-picker/color-picker.scss
+++ b/packages/components/src/components/color-picker/color-picker.scss
@@ -28,10 +28,15 @@
 //
 // --calcite-internal-color-picker-min-width
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/component/text";
 
 :host {
-  @apply text-n2h inline-block font-normal;
+  @include text.text-n2h();
+
+  display: inline-block;
+  font-weight: var(--calcite-font-weight-normal);
   inline-size: var(--calcite-internal-color-picker-min-width);
   min-inline-size: var(--calcite-internal-color-picker-min-width);
 }
@@ -52,7 +57,7 @@
   --calcite-internal-color-picker-min-width: 304px;
   --calcite-color-picker-spacing: var(--calcite-spacing-lg);
 
-  @apply text-n1h;
+  @include text.text-n1h();
 
   .section {
     &:first-of-type {
@@ -61,16 +66,18 @@
   }
 
   .control-section {
-    @apply flex flex-col flex-wrap items-baseline;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: baseline;
   }
 
   .color-hex-options {
     inline-size: 100%;
-
-    @apply flex
-      flex-shrink
-      flex-col
-      justify-around;
+    display: flex;
+    flex-shrink: 1;
+    flex-direction: column;
+    justify-content: space-around;
   }
 
   .color-mode-container {
@@ -127,7 +134,10 @@ calcite-swatch {
 }
 
 .control-and-scope {
-  @apply flex relative cursor-pointer touch-none;
+  display: flex;
+  position: relative;
+  cursor: pointer;
+  touch-action: none;
 }
 
 .color-field,
@@ -139,23 +149,26 @@ calcite-swatch {
 }
 
 .scope {
-  @apply text-n1
-    focus-base
-    absolute
-    z-default
-    rounded-full
-    bg-transparent
-    w-px
-    h-px
-    pointer-events-none;
+  font-size: var(--calcite-font-size-relative-base);
+  outline-color: transparent;
+  position: absolute;
+  z-index: var(--calcite-z-index);
+  border-radius: 9999px;
+  background-color: transparent;
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
+  pointer-events: none;
   &:focus {
-    @apply focus-outset;
+    @include focus.focus-outset();
     outline-offset: 6px;
   }
 }
 
 .hex-and-channels-group {
-  @apply flex flex-col flex-wrap w-full;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  inline-size: 100%;
 }
 
 .section {
@@ -168,13 +181,16 @@ calcite-swatch {
 }
 
 .sliders {
-  @apply flex flex-col justify-between;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   margin-inline-start: var(--calcite-color-picker-spacing);
   gap: var(--calcite-spacing-xxs);
 }
 
 .preview-and-sliders {
-  @apply flex items-center;
+  display: flex;
+  align-items: center;
   padding: var(--calcite-color-picker-spacing);
 }
 
@@ -184,9 +200,9 @@ calcite-swatch {
 }
 
 .header {
-  @apply flex
-    items-center
-    justify-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   color: var(--calcite-color-picker-text-color, var(--calcite-color-text-1));
 }
 
@@ -195,7 +211,7 @@ calcite-swatch {
 }
 
 .channels {
-  @apply flex;
+  display: flex;
 }
 
 .channel {

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.scss
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.scss
@@ -8,10 +8,11 @@
  */
 
 @use "../../styles/includes";
+@use "../../styles/outline-none";
+@use "../../styles/text";
 
 .scale--s {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-sm);
+  @include text.text-n2h();
 
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-sm);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xxs);
@@ -31,8 +32,7 @@
 }
 
 .scale--m {
-  font-size: var(--calcite-font-size-relative-base);
-  line-height: var(--calcite-font-line-height-base);
+  @include text.text-n1h();
 
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-md);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xs);
@@ -52,8 +52,7 @@
 }
 
 .scale--l {
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
 
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-lg);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-sm-plus);
@@ -82,8 +81,7 @@
 
 :host(:focus),
 .list:focus {
-  outline: var(--calcite-border-width-md) solid transparent;
-  outline-offset: var(--calcite-border-width-md);
+  @include outline-none.outline-none();
 }
 
 .separator {
@@ -100,12 +98,12 @@
 }
 
 .title {
+  @include includes.word-break();
+
   --calcite-combobox-item-indent-value: calc(
     var(--calcite-combobox-item-horizontal-spacing-unit) * var(--calcite-combobox-item-spacing-indent-multiplier)
   );
   border: 0 solid;
-  overflow-wrap: break-word;
-  word-break: break-word;
   display: block;
   flex: 1 1 0%;
   font-weight: var(--calcite-font-weight-bold);

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.scss
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.scss
@@ -8,9 +8,12 @@
  */
 
 @use "../../styles/includes";
+@use "../../styles/outline-none";
+@use "../../styles/text";
 
 .scale--s {
-  @apply text-n2h;
+  @include text.text-n2h();
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-sm);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xxs);
 
@@ -29,7 +32,8 @@
 }
 
 .scale--m {
-  @apply text-n1h;
+  @include text.text-n1h();
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-md);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xs);
 
@@ -48,7 +52,8 @@
 }
 
 .scale--l {
-  @apply text-0h;
+  @include text.text-0h();
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-lg);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-sm-plus);
 
@@ -68,12 +73,15 @@
 
 :host,
 .list {
-  @apply m-0 flex flex-col p-0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
 }
 
 :host(:focus),
 .list:focus {
-  @apply outline-none;
+  @include outline-none.outline-none();
 }
 
 .separator {
@@ -82,18 +90,23 @@
 }
 
 .label {
-  @apply box-border flex w-full min-w-0 max-w-full;
+  box-sizing: border-box;
+  display: flex;
+  inline-size: 100%;
+  min-inline-size: 0;
+  max-inline-size: 100%;
 }
 
 .title {
+  @include includes.word-break();
+
   --calcite-combobox-item-indent-value: calc(
     var(--calcite-combobox-item-horizontal-spacing-unit) * var(--calcite-combobox-item-spacing-indent-multiplier)
   );
   border: 0 solid;
-  @apply word-break
-    block
-    flex-1
-    font-bold;
+  display: block;
+  flex: 1 1 0%;
+  font-weight: var(--calcite-font-weight-bold);
   padding-block: var(--calcite-combobox-item-vertical-spacing-unit);
   padding-inline-start: calc(
     var(--calcite-combobox-item-indent-value) + var(--calcite-combobox-item-horizontal-spacing-unit)

--- a/packages/components/src/components/combobox-item-group/combobox-item-group.scss
+++ b/packages/components/src/components/combobox-item-group/combobox-item-group.scss
@@ -10,7 +10,9 @@
 @use "../../styles/includes";
 
 .scale--s {
-  @apply text-n2h;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-sm);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xxs);
 
@@ -29,7 +31,9 @@
 }
 
 .scale--m {
-  @apply text-n1h;
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-md);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-xs);
 
@@ -48,7 +52,9 @@
 }
 
 .scale--l {
-  @apply text-0h;
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+
   --calcite-combobox-item-horizontal-spacing-unit: var(--calcite-spacing-lg);
   --calcite-combobox-item-vertical-spacing-unit: var(--calcite-spacing-sm-plus);
 
@@ -68,12 +74,16 @@
 
 :host,
 .list {
-  @apply m-0 flex flex-col p-0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
 }
 
 :host(:focus),
 .list:focus {
-  @apply outline-none;
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-border-width-md);
 }
 
 .separator {
@@ -82,7 +92,11 @@
 }
 
 .label {
-  @apply box-border flex w-full min-w-0 max-w-full;
+  box-sizing: border-box;
+  display: flex;
+  inline-size: 100%;
+  min-inline-size: 0;
+  max-inline-size: 100%;
 }
 
 .title {
@@ -90,10 +104,11 @@
     var(--calcite-combobox-item-horizontal-spacing-unit) * var(--calcite-combobox-item-spacing-indent-multiplier)
   );
   border: 0 solid;
-  @apply word-break
-    block
-    flex-1
-    font-bold;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  display: block;
+  flex: 1 1 0%;
+  font-weight: var(--calcite-font-weight-bold);
   padding-block: var(--calcite-combobox-item-vertical-spacing-unit);
   padding-inline-start: calc(
     var(--calcite-combobox-item-indent-value) + var(--calcite-combobox-item-horizontal-spacing-unit)

--- a/packages/components/src/components/combobox-item/combobox-item.scss
+++ b/packages/components/src/components/combobox-item/combobox-item.scss
@@ -24,12 +24,16 @@
 // --calcite-internal-combobox-item-spacing-unit-l
 // --calcite-internal-combobox-item-spacing-unit-s
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/outline-none";
+@use "../../styles/text";
 
 @include includes.base-component();
 
 .scale--s {
-  @apply text-n2h;
+  @include text.text-n2h();
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.2");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
@@ -37,7 +41,8 @@
 }
 
 .scale--m {
-  @apply text-n1h;
+  @include text.text-n1h();
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[1.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.3");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
@@ -45,7 +50,8 @@
 }
 
 .scale--l {
-  @apply text-0h;
+  @include text.text-0h();
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[2.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.4");
   --calcite-combobox-item-selector-icon-size: theme("spacing.6");
@@ -59,49 +65,52 @@
 }
 
 :host(:focus) {
-  @apply shadow-none;
+  box-shadow: 0 0 #0000;
 }
 
 @include includes.disabled();
 
 :host,
 ul {
-  @apply m-0 flex flex-col p-0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
 }
 
 :host(:focus),
 ul:focus {
-  @apply outline-none;
+  @include outline-none.outline-none();
 }
 
 .label {
-  @apply focus-base
-  relative
-  box-border
-  flex
-  w-full
-  min-w-full
-  cursor-pointer
-  items-center
-  no-underline
-  ease-in-out;
   @include includes.word-break();
+
+  outline-color: transparent;
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  inline-size: 100%;
+  min-inline-size: 100%;
+  cursor: pointer;
+  align-items: center;
+  text-decoration-line: none;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   justify-content: space-around;
   gap: var(--calcite-internal-combobox-item-spacing-unit-l);
   padding-block: var(--calcite-internal-combobox-item-spacing-unit-s);
   padding-inline-end: var(--calcite-internal-combobox-item-spacing-unit-l);
   padding-inline-start: var(--calcite-combobox-item-indent-value);
-
   color: var(--calcite-combobox-text-color, var(--calcite-color-text-3));
   transition-duration: var(--calcite-animation-timing);
 }
 
 :host([disabled]) .label {
-  @apply cursor-default;
+  cursor: default;
 }
 
 .label--active {
-  @apply focus-inset;
+  @include focus.focus-inset();
 }
 
 .label:hover {
@@ -124,9 +133,8 @@ ul:focus {
 }
 
 .icon {
-  @apply inline-flex
-    ease-in-out;
-
+  display: inline-flex;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   color: var(--calcite-color-border-input);
 }
 
@@ -165,7 +173,7 @@ ul:focus {
 
 :host([selected]) {
   .heading {
-    @apply font-medium;
+    font-weight: var(--calcite-font-weight-medium);
   }
 }
 

--- a/packages/components/src/components/combobox-item/combobox-item.scss
+++ b/packages/components/src/components/combobox-item/combobox-item.scss
@@ -29,7 +29,9 @@
 @include includes.base-component();
 
 .scale--s {
-  @apply text-n2h;
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.2");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
@@ -37,7 +39,9 @@
 }
 
 .scale--m {
-  @apply text-n1h;
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[1.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.3");
   --calcite-combobox-item-selector-icon-size: theme("spacing.4");
@@ -45,7 +49,9 @@
 }
 
 .scale--l {
-  @apply text-0h;
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[2.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.4");
   --calcite-combobox-item-selector-icon-size: theme("spacing.6");
@@ -59,32 +65,38 @@
 }
 
 :host(:focus) {
-  @apply shadow-none;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 @include includes.disabled();
 
 :host,
 ul {
-  @apply m-0 flex flex-col p-0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
 }
 
 :host(:focus),
 ul:focus {
-  @apply outline-none;
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-border-width-md);
 }
 
 .label {
-  @apply focus-base
-  relative
-  box-border
-  flex
-  w-full
-  min-w-full
-  cursor-pointer
-  items-center
-  no-underline
-  ease-in-out;
+  outline-color: transparent;
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  inline-size: 100%;
+  min-inline-size: 100%;
+  cursor: pointer;
+  align-items: center;
+  text-decoration-line: none;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   @include includes.word-break();
   justify-content: space-around;
   gap: var(--calcite-internal-combobox-item-spacing-unit-l);
@@ -97,11 +109,15 @@ ul:focus {
 }
 
 :host([disabled]) .label {
-  @apply cursor-default;
+  cursor: default;
 }
 
 .label--active {
-  @apply focus-inset;
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+  outline-offset: calc(
+    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
 }
 
 .label:hover {
@@ -124,8 +140,8 @@ ul:focus {
 }
 
 .icon {
-  @apply inline-flex
-    ease-in-out;
+  display: inline-flex;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 
   color: var(--calcite-color-border-input);
 }
@@ -165,7 +181,7 @@ ul:focus {
 
 :host([selected]) {
   .heading {
-    @apply font-medium;
+    font-weight: var(--calcite-font-weight-medium);
   }
 }
 

--- a/packages/components/src/components/combobox-item/combobox-item.scss
+++ b/packages/components/src/components/combobox-item/combobox-item.scss
@@ -24,13 +24,15 @@
 // --calcite-internal-combobox-item-spacing-unit-l
 // --calcite-internal-combobox-item-spacing-unit-s
 
+@use "../../styles/focus";
 @use "../../styles/includes";
+@use "../../styles/outline-none";
+@use "../../styles/text";
 
 @include includes.base-component();
 
 .scale--s {
-  font-size: var(--calcite-font-size-relative-sm);
-  line-height: var(--calcite-font-line-height-sm);
+  @include text.text-n2h();
 
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing.1");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.2");
@@ -39,8 +41,7 @@
 }
 
 .scale--m {
-  font-size: var(--calcite-font-size-relative-base);
-  line-height: var(--calcite-font-line-height-base);
+  @include text.text-n1h();
 
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[1.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.3");
@@ -49,8 +50,7 @@
 }
 
 .scale--l {
-  font-size: var(--calcite-font-size-relative-md);
-  line-height: var(--calcite-font-line-height-md);
+  @include text.text-0h();
 
   --calcite-internal-combobox-item-spacing-unit-s: theme("spacing[2.5]");
   --calcite-internal-combobox-item-spacing-unit-l: theme("spacing.4");
@@ -65,9 +65,7 @@
 }
 
 :host(:focus) {
-  --tw-shadow: 0 0 #0000;
-  --tw-shadow-colored: 0 0 #0000;
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: 0 0 #0000;
 }
 
 @include includes.disabled();
@@ -82,11 +80,12 @@ ul {
 
 :host(:focus),
 ul:focus {
-  outline: var(--calcite-border-width-md) solid transparent;
-  outline-offset: var(--calcite-border-width-md);
+  @include outline-none.outline-none();
 }
 
 .label {
+  @include includes.word-break();
+
   outline-color: transparent;
   position: relative;
   box-sizing: border-box;
@@ -97,13 +96,11 @@ ul:focus {
   align-items: center;
   text-decoration-line: none;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  @include includes.word-break();
   justify-content: space-around;
   gap: var(--calcite-internal-combobox-item-spacing-unit-l);
   padding-block: var(--calcite-internal-combobox-item-spacing-unit-s);
   padding-inline-end: var(--calcite-internal-combobox-item-spacing-unit-l);
   padding-inline-start: var(--calcite-combobox-item-indent-value);
-
   color: var(--calcite-combobox-text-color, var(--calcite-color-text-3));
   transition-duration: var(--calcite-animation-timing);
 }
@@ -113,11 +110,7 @@ ul:focus {
 }
 
 .label--active {
-  outline: var(--calcite-border-width-md) solid
-    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-  outline-offset: calc(
-    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-  );
+  @include focus.focus-inset();
 }
 
 .label:hover {
@@ -142,7 +135,6 @@ ul:focus {
 .icon {
   display: inline-flex;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-
   color: var(--calcite-color-border-input);
 }
 

--- a/packages/components/src/components/combobox/combobox.scss
+++ b/packages/components/src/components/combobox/combobox.scss
@@ -29,11 +29,13 @@
 @use "../../styles/shared/floating-ui";
 
 :host {
-  @apply relative block;
+  position: relative;
+  display: block;
 }
 
 :host([scale="s"]) {
-  @apply text-n2;
+  font-size: var(--calcite-font-size-relative-sm);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.2");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.1");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-2xs);
@@ -44,7 +46,8 @@
 }
 
 :host([scale="m"]) {
-  @apply text-n1;
+  font-size: var(--calcite-font-size-relative-base);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.3");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.2");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-sm);
@@ -55,7 +58,8 @@
 }
 
 :host([scale="l"]) {
-  @apply text-0;
+  font-size: var(--calcite-font-size-relative-md);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.4");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.3");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-sm-plus);
@@ -66,7 +70,10 @@
 }
 
 .wrapper {
-  @apply focus-base flex border border-solid;
+  outline-color: transparent;
+  display: flex;
+  border-width: var(--calcite-border-width-sm);
+  border-style: solid;
   padding-block: calc(var(--calcite-internal-combobox-spacing-unit-s) / 4);
   padding-inline: var(--calcite-internal-combobox-spacing-unit-l) var(--calcite-internal-combobox-padding-inline-end);
   border-radius: var(--calcite-combobox-corner-radius, var(--calcite-corner-radius));
@@ -83,7 +90,11 @@
 
 :host(:focus-within) .wrapper,
 .wrapper--active {
-  @apply focus-inset;
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+  outline-offset: calc(
+    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
 }
 
 :host([read-only]) {
@@ -97,33 +108,53 @@
 }
 
 :host([status="invalid"]) .wrapper {
-  @apply border-color-danger;
+  border-color: var(--calcite-color-status-danger);
 }
 
 :host([status="invalid"]:focus-within) .wrapper {
-  @apply focus-inset-danger;
+  outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+  outline-offset: calc(
+    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
 }
 
 .wrapper--single {
   padding-block: 0;
   padding-inline: var(--calcite-internal-combobox-spacing-unit-l) var(--calcite-internal-combobox-padding-inline-end);
-  @apply cursor-pointer flex-nowrap;
+  cursor: pointer;
+  flex-wrap: nowrap;
 }
 
 .grid-input {
-  @apply flex flex-grow flex-wrap items-center relative truncate p-0;
-
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0;
   gap: var(--calcite-internal-combobox-spacing-unit-s);
   margin-inline-end: var(--calcite-internal-combobox-spacing-unit-s);
 
   &.selection-display--fit,
   &.selection-display--single {
-    @apply flex-nowrap overflow-hidden;
+    flex-wrap: nowrap;
+    overflow: hidden;
   }
 }
 
 .input {
-  @apply appearance-none bg-transparent border-none flex-grow font-inherit text-color-1 text-ellipsis overflow-hidden p-0;
+  appearance: none;
+  background-color: transparent;
+  border-style: none;
+  flex-grow: 1;
+  font-family: inherit;
+  color: var(--calcite-color-text-1);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 0;
   font-size: inherit;
   block-size: var(--calcite-combobox-input-height);
   line-height: var(--calcite-combobox-input-height);
@@ -132,25 +163,29 @@
   min-inline-size: 4.8125rem;
 
   &:focus {
-    @apply outline-none;
+    outline: var(--calcite-border-width-md) solid transparent;
+    outline-offset: var(--calcite-border-width-md);
   }
 
   &:placeholder-shown {
-    @apply text-ellipsis;
+    text-overflow: ellipsis;
   }
 }
 
 .input--single {
-  @apply p-0;
+  padding: 0;
   margin-block: var(--calcite-internal-combobox-input-margin-block);
 }
 
 .wrapper--active .input-single {
-  @apply cursor-text;
+  cursor: text;
 }
 
 .input--hidden {
-  @apply pointer-events-none w-0 min-w-0 opacity-0;
+  pointer-events: none;
+  inline-size: 0;
+  min-inline-size: 0;
+  opacity: 0;
 }
 
 .input--icon {
@@ -163,15 +198,25 @@
 }
 
 .input-wrap {
-  @apply flex flex-grow items-center;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
 }
 
 .input-wrap--single {
-  @apply flex-1 overflow-hidden;
+  flex: 1 1 0%;
+  overflow: hidden;
 }
 
 .label {
-  @apply pointer-events-none max-w-full flex-auto truncate p-0 font-normal;
+  pointer-events: none;
+  max-inline-size: 100%;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0;
+  font-weight: var(--calcite-font-weight-normal);
   block-size: var(--calcite-combobox-input-height);
   line-height: var(--calcite-combobox-input-height);
 }
@@ -182,11 +227,13 @@
 
 .icon-end,
 .icon-start {
-  @apply flex cursor-pointer items-center;
+  display: flex;
+  cursor: pointer;
+  align-items: center;
 }
 
 .icon-end {
-  @apply flex-none;
+  flex: none;
 
   .icon {
     color: var(--calcite-combobox-icon-color, var(--calcite-color-text-3));
@@ -215,22 +262,34 @@
 }
 
 .screen-readers-only {
-  @apply sr-only;
+  position: absolute;
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-border-width-sm));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 .list-container {
-  @apply max-h-menu overflow-y-auto;
+  max-block-size: 45vh;
+  overflow-y: auto;
   inline-size: var(--calcite-dropdown-width, 100%);
   background-color: var(--calcite-combobox-background-color, var(--calcite-color-foreground-1));
 }
 
 .list {
-  @apply m-0 block p-0;
+  margin: 0;
+  display: block;
+  padding: 0;
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .list--hide {
-  @apply h-0 overflow-hidden;
+  block-size: 0;
+  overflow: hidden;
 }
 
 calcite-chip {
@@ -243,11 +302,12 @@ calcite-chip {
 }
 
 .chip--invisible {
-  @apply absolute invisible;
+  position: absolute;
+  visibility: hidden;
 }
 
 .item {
-  @apply block;
+  display: block;
 }
 
 .select-all {
@@ -278,7 +338,7 @@ calcite-chip {
 }
 
 .disabled {
-  @apply opacity-50;
+  opacity: 0.5;
 }
 
 @include includes.disabled();

--- a/packages/components/src/components/combobox/combobox.scss
+++ b/packages/components/src/components/combobox/combobox.scss
@@ -25,8 +25,12 @@
 // --calcite-internal-combobox-spacing-unit-l
 // --calcite-internal-combobox-spacing-unit-s
 
-@use "../../styles/includes";
 @use "../../styles/shared/floating-ui";
+@use "../../styles/focus";
+@use "../../styles/includes";
+@use "../../styles/component/outline-none";
+@use "../../styles/sr-only";
+@use "../../styles/truncate";
 
 :host {
   position: relative;
@@ -90,11 +94,7 @@
 
 :host(:focus-within) .wrapper,
 .wrapper--active {
-  outline: var(--calcite-border-width-md) solid
-    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
-  outline-offset: calc(
-    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-  );
+  @include focus.focus-inset();
 }
 
 :host([read-only]) {
@@ -112,10 +112,7 @@
 }
 
 :host([status="invalid"]:focus-within) .wrapper {
-  outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
-  outline-offset: calc(
-    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
-  );
+  @include focus.focus-inset-danger();
 }
 
 .wrapper--single {
@@ -126,6 +123,8 @@
 }
 
 .grid-input {
+  @include truncate.truncate();
+
   display: flex;
   flex-grow: 1;
   flex-wrap: wrap;
@@ -163,8 +162,7 @@
   min-inline-size: 4.8125rem;
 
   &:focus {
-    outline: var(--calcite-border-width-md) solid transparent;
-    outline-offset: var(--calcite-border-width-md);
+    @include outline-none.outline-none();
   }
 
   &:placeholder-shown {
@@ -209,12 +207,11 @@
 }
 
 .label {
+  @include truncate.truncate();
+
   pointer-events: none;
   max-inline-size: 100%;
   flex: 1 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   padding: 0;
   font-weight: var(--calcite-font-weight-normal);
   block-size: var(--calcite-combobox-input-height);
@@ -262,15 +259,7 @@
 }
 
 .screen-readers-only {
-  position: absolute;
-  inline-size: var(--calcite-border-width-sm);
-  block-size: var(--calcite-border-width-sm);
-  padding: 0;
-  margin: calc(-1 * var(--calcite-border-width-sm));
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+  @include sr-only.sr-only();
 }
 
 .list-container {

--- a/packages/components/src/components/combobox/combobox.scss
+++ b/packages/components/src/components/combobox/combobox.scss
@@ -25,15 +25,21 @@
 // --calcite-internal-combobox-spacing-unit-l
 // --calcite-internal-combobox-spacing-unit-s
 
-@use "../../styles/includes";
 @use "../../styles/shared/floating-ui";
+@use "../../styles/focus";
+@use "../../styles/includes";
+@use "../../styles/component/outline-none";
+@use "../../styles/sr-only";
+@use "../../styles/truncate";
 
 :host {
-  @apply relative block;
+  position: relative;
+  display: block;
 }
 
 :host([scale="s"]) {
-  @apply text-n2;
+  font-size: var(--calcite-font-size-relative-sm);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.2");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.1");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-2xs);
@@ -44,7 +50,8 @@
 }
 
 :host([scale="m"]) {
-  @apply text-n1;
+  font-size: var(--calcite-font-size-relative-base);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.3");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.2");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-sm);
@@ -55,7 +62,8 @@
 }
 
 :host([scale="l"]) {
-  @apply text-0;
+  font-size: var(--calcite-font-size-relative-md);
+
   --calcite-internal-combobox-spacing-unit-l: theme("spacing.4");
   --calcite-internal-combobox-spacing-unit-s: theme("spacing.3");
   --calcite-internal-combobox-padding-inline-end: var(--calcite-space-sm-plus);
@@ -66,7 +74,10 @@
 }
 
 .wrapper {
-  @apply focus-base flex border border-solid;
+  outline-color: transparent;
+  display: flex;
+  border-width: var(--calcite-border-width-sm);
+  border-style: solid;
   padding-block: calc(var(--calcite-internal-combobox-spacing-unit-s) / 4);
   padding-inline: var(--calcite-internal-combobox-spacing-unit-l) var(--calcite-internal-combobox-padding-inline-end);
   border-radius: var(--calcite-combobox-corner-radius, var(--calcite-corner-radius));
@@ -83,7 +94,7 @@
 
 :host(:focus-within) .wrapper,
 .wrapper--active {
-  @apply focus-inset;
+  @include focus.focus-inset();
 }
 
 :host([read-only]) {
@@ -97,33 +108,49 @@
 }
 
 :host([status="invalid"]) .wrapper {
-  @apply border-color-danger;
+  border-color: var(--calcite-color-status-danger);
 }
 
 :host([status="invalid"]:focus-within) .wrapper {
-  @apply focus-inset-danger;
+  @include focus.focus-inset-danger();
 }
 
 .wrapper--single {
   padding-block: 0;
   padding-inline: var(--calcite-internal-combobox-spacing-unit-l) var(--calcite-internal-combobox-padding-inline-end);
-  @apply cursor-pointer flex-nowrap;
+  cursor: pointer;
+  flex-wrap: nowrap;
 }
 
 .grid-input {
-  @apply flex flex-grow flex-wrap items-center relative truncate p-0;
+  @include truncate.truncate();
 
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  position: relative;
+  padding: 0;
   gap: var(--calcite-internal-combobox-spacing-unit-s);
   margin-inline-end: var(--calcite-internal-combobox-spacing-unit-s);
 
   &.selection-display--fit,
   &.selection-display--single {
-    @apply flex-nowrap overflow-hidden;
+    flex-wrap: nowrap;
+    overflow: hidden;
   }
 }
 
 .input {
-  @apply appearance-none bg-transparent border-none flex-grow font-inherit text-color-1 text-ellipsis overflow-hidden p-0;
+  appearance: none;
+  background-color: transparent;
+  border-style: none;
+  flex-grow: 1;
+  font-family: inherit;
+  color: var(--calcite-color-text-1);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: 0;
   font-size: inherit;
   block-size: var(--calcite-combobox-input-height);
   line-height: var(--calcite-combobox-input-height);
@@ -132,25 +159,28 @@
   min-inline-size: 4.8125rem;
 
   &:focus {
-    @apply outline-none;
+    @include outline-none.outline-none();
   }
 
   &:placeholder-shown {
-    @apply text-ellipsis;
+    text-overflow: ellipsis;
   }
 }
 
 .input--single {
-  @apply p-0;
+  padding: 0;
   margin-block: var(--calcite-internal-combobox-input-margin-block);
 }
 
 .wrapper--active .input-single {
-  @apply cursor-text;
+  cursor: text;
 }
 
 .input--hidden {
-  @apply pointer-events-none w-0 min-w-0 opacity-0;
+  pointer-events: none;
+  inline-size: 0;
+  min-inline-size: 0;
+  opacity: 0;
 }
 
 .input--icon {
@@ -163,15 +193,24 @@
 }
 
 .input-wrap {
-  @apply flex flex-grow items-center;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
 }
 
 .input-wrap--single {
-  @apply flex-1 overflow-hidden;
+  flex: 1 1 0%;
+  overflow: hidden;
 }
 
 .label {
-  @apply pointer-events-none max-w-full flex-auto truncate p-0 font-normal;
+  @include truncate.truncate();
+
+  pointer-events: none;
+  max-inline-size: 100%;
+  flex: 1 1 auto;
+  padding: 0;
+  font-weight: var(--calcite-font-weight-normal);
   block-size: var(--calcite-combobox-input-height);
   line-height: var(--calcite-combobox-input-height);
 }
@@ -182,11 +221,13 @@
 
 .icon-end,
 .icon-start {
-  @apply flex cursor-pointer items-center;
+  display: flex;
+  cursor: pointer;
+  align-items: center;
 }
 
 .icon-end {
-  @apply flex-none;
+  flex: none;
 
   .icon {
     color: var(--calcite-combobox-icon-color, var(--calcite-color-text-3));
@@ -215,22 +256,26 @@
 }
 
 .screen-readers-only {
-  @apply sr-only;
+  @include sr-only.sr-only();
 }
 
 .list-container {
-  @apply max-h-menu overflow-y-auto;
+  max-block-size: 45vh;
+  overflow-y: auto;
   inline-size: var(--calcite-dropdown-width, 100%);
   background-color: var(--calcite-combobox-background-color, var(--calcite-color-foreground-1));
 }
 
 .list {
-  @apply m-0 block p-0;
+  margin: 0;
+  display: block;
+  padding: 0;
   line-height: var(--calcite-font-line-height-relative-snug);
 }
 
 .list--hide {
-  @apply h-0 overflow-hidden;
+  block-size: 0;
+  overflow: hidden;
 }
 
 calcite-chip {
@@ -243,11 +288,12 @@ calcite-chip {
 }
 
 .chip--invisible {
-  @apply absolute invisible;
+  position: absolute;
+  visibility: hidden;
 }
 
 .item {
-  @apply block;
+  display: block;
 }
 
 .select-all {
@@ -278,7 +324,7 @@ calcite-chip {
 }
 
 .disabled {
-  @apply opacity-50;
+  opacity: 0.5;
 }
 
 @include includes.disabled();

--- a/packages/components/src/styles/component/focus.scss
+++ b/packages/components/src/styles/component/focus.scss
@@ -1,0 +1,30 @@
+@mixin focus-inset() {
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+  outline-offset: calc(
+    calc(-1 * var(--calcite-space-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
+}
+
+@mixin focus-normal() {
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+}
+
+@mixin focus-outset() {
+  outline: var(--calcite-border-width-md) solid
+    var(--calcite-color-focus, var(--calcite-ui-focus-color, var(--calcite-color-brand)));
+  outline-offset: calc(var(--calcite-space-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+}
+
+@mixin focus-inset-danger() {
+  outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+  outline-offset: calc(
+    calc(-1 * var(--calcite-spacing-base)) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1))
+  );
+}
+
+@mixin focus-outset-danger() {
+  outline: var(--calcite-border-width-md) solid var(--calcite-color-status-danger);
+  outline-offset: calc(var(--calcite-spacing-base) * calc(1 - 2 * clamp(0, var(--calcite-offset-invert-focus), 1)));
+}

--- a/packages/components/src/styles/component/outline-none.scss
+++ b/packages/components/src/styles/component/outline-none.scss
@@ -1,0 +1,4 @@
+@mixin outline-none() {
+  outline: var(--calcite-border-width-md) solid transparent;
+  outline-offset: var(--calcite-border-width-md);
+}

--- a/packages/components/src/styles/component/sr-only.scss
+++ b/packages/components/src/styles/component/sr-only.scss
@@ -1,0 +1,11 @@
+@mixin sr-only() {
+  position: absolute;
+  inline-size: var(--calcite-border-width-sm);
+  block-size: var(--calcite-border-width-sm);
+  padding: 0;
+  margin: calc(-1 * var(--calcite-border-width-sm));
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/packages/components/src/styles/component/text.scss
+++ b/packages/components/src/styles/component/text.scss
@@ -1,0 +1,19 @@
+@mixin text-0h() {
+  font-size: var(--calcite-font-size-relative-md);
+  line-height: var(--calcite-font-line-height-md);
+}
+
+@mixin text-n1h() {
+  font-size: var(--calcite-font-size-relative-base);
+  line-height: var(--calcite-font-line-height-base);
+}
+
+@mixin text-n2h() {
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-sm);
+}
+
+@mixin text-n2-wrap() {
+  font-size: var(--calcite-font-size-relative-sm);
+  line-height: var(--calcite-font-line-height-relative-snug);
+}

--- a/packages/components/src/styles/component/transition-color.scss
+++ b/packages/components/src/styles/component/transition-color.scss
@@ -1,0 +1,5 @@
+@mixin transition-color() {
+  transition-property: color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: var(--calcite-animation-timing);
+}

--- a/packages/components/src/styles/component/transition-margin.scss
+++ b/packages/components/src/styles/component/transition-margin.scss
@@ -1,0 +1,5 @@
+:host {
+  transition-property: margin;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: var(--calcite-animation-timing);
+}

--- a/packages/components/src/styles/component/truncate.scss
+++ b/packages/components/src/styles/component/truncate.scss
@@ -1,0 +1,5 @@
+@mixin truncate() {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
**monday.com sync:** #13064746503

**Related Issue:** [#14641](https://github.com/Esri/calcite-design-system/issues/14641)

## Summary
Remove tailwind styles from:

`block`, `block-group`, `block-section`, `button`, `card`, `card-group`, `carousel`, `carousel-item`, `checkbox`, `chip`, `color-picker`, `combobox`, `combobox-item`, `combobox-item-group`.
