### PR TITLE
fix(tile): preserve native Enter behavior for href tiles

### DIFF
--- a/packages/components/src/components/tile/tile.browser.e2e.tsx
+++ b/packages/components/src/components/tile/tile.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page, userEvent } from "vitest/browser";
 
@@ -86,31 +86,25 @@ describe("hidden", () => {
 });
 
 describe("link interactivity", () => {
-  const targetPage = "#test";
-  let navigateHandler: ReturnType<typeof vi.fn>;
-
-  beforeEach(() => {
-    navigateHandler = vi.fn().mockImplementation((event) => {
+  it("navigates when activated with Enter", async () => {
+    const targetPage = "#test";
+    const navigateHandler = vi.fn().mockImplementation((event) => {
       event.preventDefault();
     });
-    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
     window.navigation.addEventListener("navigate", navigateHandler);
-  });
 
-  afterEach(() => {
-    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
-    window.navigation.removeEventListener("navigate", navigateHandler);
-  });
+    try {
+      await mount(<calcite-tile href={`/${targetPage}`} />);
 
-  it("navigates when activated with Enter", async () => {
-    await mount(<calcite-tile href={`/${targetPage}`} />);
+      await userEvent.keyboard("{Tab}{Enter}");
 
-    await userEvent.keyboard("{Tab}{Enter}");
-
-    expect(navigateHandler).toHaveBeenCalledTimes(1);
-    expect(navigateHandler.mock.lastCall![0].destination.url).toBe(
-      `${window.location.origin}/${targetPage}`,
-    );
+      expect(navigateHandler).toHaveBeenCalledTimes(1);
+      expect(navigateHandler.mock.lastCall![0].destination.url).toBe(
+        `${window.location.origin}/${targetPage}`,
+      );
+    } finally {
+      window.navigation.removeEventListener("navigate", navigateHandler);
+    }
   });
 });
 

--- a/packages/components/src/components/tile/tile.browser.e2e.tsx
+++ b/packages/components/src/components/tile/tile.browser.e2e.tsx
@@ -1,7 +1,7 @@
 import { h } from "@arcgis/lumina";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 
 import {
   defaults,

--- a/packages/components/src/components/tile/tile.browser.e2e.tsx
+++ b/packages/components/src/components/tile/tile.browser.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from "@arcgis/lumina";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { page } from "vitest/browser";
 
@@ -83,6 +83,35 @@ describe("disabled", () => {
 
 describe("hidden", () => {
   hidden(() => mount("calcite-tile"));
+});
+
+describe("link interactivity", () => {
+  const targetPage = "#test";
+  let navigateHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    navigateHandler = vi.fn().mockImplementation((event) => {
+      event.preventDefault();
+    });
+    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
+    window.navigation.addEventListener("navigate", navigateHandler);
+  });
+
+  afterEach(() => {
+    // @ts-expect-error -- using new navigation API -- https://developer.mozilla.org/en-US/docs/Web/API/Navigation/navigate_event
+    window.navigation.removeEventListener("navigate", navigateHandler);
+  });
+
+  it("navigates when activated with Enter", async () => {
+    await mount(<calcite-tile href={`/${targetPage}`} />);
+
+    await userEvent.keyboard("{Tab}{Enter}");
+
+    expect(navigateHandler).toHaveBeenCalledTimes(1);
+    expect(navigateHandler.mock.lastCall![0].destination.url).toBe(
+      `${window.location.origin}/${targetPage}`,
+    );
+  });
 });
 
 describe("reflects", () => {

--- a/packages/components/src/components/tile/tile.tsx
+++ b/packages/components/src/components/tile/tile.tsx
@@ -216,7 +216,7 @@ export class Tile extends LitElement implements SelectableComponent {
   }
 
   private keyDownHandler(event: KeyboardEvent): void {
-    if (event.target === this.el && isActivationKey(event.key)) {
+    if (!this.href && event.target === this.el && isActivationKey(event.key)) {
       this.handleSelectEvent();
       event.preventDefault();
     }


### PR DESCRIPTION
**Related Issue:** #14557

## Summary
Fix Tile link keyboard activation by preserving native Enter behavior for href tiles.