### PR TITLE
fix(slider): honor numbering-system negative sign direction

### DIFF
--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -996,7 +996,7 @@ export class InputNumber
           : ""
         : sanitizedValue;
 
-    let newLocalizedValue = numberStringFormatter.localize(newValue);
+    let newLocalizedValue = numberStringFormatter.localize(newValue, this.readOnly);
 
     if (origin !== "connected" && !hasTrailingDecimalSeparator) {
       newLocalizedValue = addLocalizedTrailingDecimalZeros(

--- a/packages/components/src/components/input-number/input-number.tsx
+++ b/packages/components/src/components/input-number/input-number.tsx
@@ -996,7 +996,7 @@ export class InputNumber
           : ""
         : sanitizedValue;
 
-    let newLocalizedValue = numberStringFormatter.localize(newValue, this.readOnly);
+    let newLocalizedValue = numberStringFormatter.localize(newValue);
 
     if (origin !== "connected" && !hasTrailingDecimalSeparator) {
       newLocalizedValue = addLocalizedTrailingDecimalZeros(

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -1085,7 +1085,7 @@ export class Input
             : ""
           : sanitizedValue;
 
-      let newLocalizedValue = numberStringFormatter.localize(newValue);
+      let newLocalizedValue = numberStringFormatter.localize(newValue, this.readOnly);
 
       if (origin !== "connected" && !hasTrailingDecimalSeparator) {
         newLocalizedValue = addLocalizedTrailingDecimalZeros(

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -1085,7 +1085,7 @@ export class Input
             : ""
           : sanitizedValue;
 
-      let newLocalizedValue = numberStringFormatter.localize(newValue, this.readOnly);
+      let newLocalizedValue = numberStringFormatter.localize(newValue);
 
       if (origin !== "connected" && !hasTrailingDecimalSeparator) {
         newLocalizedValue = addLocalizedTrailingDecimalZeros(

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -145,7 +145,7 @@ export class Slider extends LitElement implements LabelableComponent {
       useGrouping: this.groupSeparator,
     };
 
-    return numberStringFormatter.localize(value.toString());
+    return numberStringFormatter.localize(value.toString(), true);
   };
 
   formSupport = useForm<this>({

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -196,6 +196,12 @@ export class NumberStringFormat {
     );
   };
 
+  /**
+   * Localizes a number string.
+   *
+   * @param numberString - number string to localize.
+   * @param includeDirectionalMarks - when true, preserves `Intl.NumberFormat` directional marks for read-only display.
+   */
   localize = (numberString: string, includeDirectionalMarks = false): string => {
     return this._numberFormatOptions
       ? sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string =>

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -50,6 +50,7 @@ const isNumberingSystemSupported = (numberingSystem?: string): numberingSystem i
   !!(numberingSystems && numberingSystems.includes(numberingSystem as NumberingSystem));
 
 const browserNumberingSystem = new Intl.NumberFormat().resolvedOptions().numberingSystem;
+const bidirectionalMarks = /[\u061C\u200E\u200F]/g;
 
 // for consistent browser behavior, we normalize numberingSystem to prevent the browser-inferred value
 // @see https://github.com/Esri/calcite-design-system/issues/3079#issuecomment-1168964195
@@ -209,6 +210,7 @@ export class NumberStringFormat {
 
   #normalizeDigitsAndSign(value: string): string {
     return value
+      .replace(bidirectionalMarks, "")
       .replace(new RegExp(`[${this._minusSign}]`, "g"), "-")
       .replace(new RegExp(`[${this._digits.join("")}]`, "g"), this._getDigitIndex!);
   }

--- a/packages/components/src/utils/locale.ts
+++ b/packages/components/src/utils/locale.ts
@@ -196,12 +196,12 @@ export class NumberStringFormat {
     );
   };
 
-  localize = (numberString: string): string => {
+  localize = (numberString: string, includeDirectionalMarks = false): string => {
     return this._numberFormatOptions
       ? sanitizeExponentialNumberString(numberString, (nonExpoNumString: string): string =>
           isValidNumber(nonExpoNumString.trim())
             ? new BigDecimal(nonExpoNumString.trim())
-                .format(this)
+                .format(this, includeDirectionalMarks)
                 .replace(new RegExp(`[${this._actualGroup}]`, "g"), this._group)
             : nonExpoNumString,
         )

--- a/packages/components/src/utils/number.browser.spec.ts
+++ b/packages/components/src/utils/number.browser.spec.ts
@@ -137,6 +137,28 @@ describe("BigDecimal", () => {
     expect(new BigDecimal("123.0123456789").format(numberStringFormatter)).toBe("123.0123456789");
   });
 
+  it("preserves bidirectional marks when formatting negative arabext numbers", () => {
+    numberStringFormatter.numberFormatOptions = {
+      locale: "en",
+      numberingSystem: "arabext",
+      useGrouping: true,
+    };
+
+    const number = new BigDecimal("-12345678.9");
+    const expectedIntegerParts = numberStringFormatter.numberFormatter.formatToParts(-12345678n);
+    const expectedValue = `${expectedIntegerParts.map((part) => part.value).join("")}${
+      numberStringFormatter.decimal
+    }${numberStringFormatter.numberFormatter.format(9)}`;
+
+    expect(number.format(numberStringFormatter)).toBe(expectedValue);
+    expect(number.formatToParts(numberStringFormatter)).toEqual([
+      ...expectedIntegerParts,
+      { type: "decimal", value: numberStringFormatter.decimal },
+      { type: "fraction", value: "9" },
+    ]);
+    expect(numberStringFormatter.delocalize(number.format(numberStringFormatter))).toBe("-12345678.9");
+  });
+
   supportedNlsLocales.forEach((locale) => {
     it(`correctly localizes number parts - ${locale}`, () => {
       numberStringFormatter.numberFormatOptions = {

--- a/packages/components/src/utils/number.browser.spec.ts
+++ b/packages/components/src/utils/number.browser.spec.ts
@@ -137,6 +137,8 @@ describe("BigDecimal", () => {
     expect(new BigDecimal("123.0123456789").format(numberStringFormatter)).toBe("123.0123456789");
   });
 
+  const testValue = "-12345678.9";
+
   it("includes bidirectional marks for read-only formatting", () => {
     numberStringFormatter.numberFormatOptions = {
       locale: "en",
@@ -144,13 +146,15 @@ describe("BigDecimal", () => {
       useGrouping: true,
     };
 
-    const number = new BigDecimal("-12345678.9");
+    const number = new BigDecimal(testValue);
     const expectedIntegerParts = numberStringFormatter.numberFormatter.formatToParts(-12345678n);
     const expectedValue = `${expectedIntegerParts.map((part) => part.value).join("")}${
       numberStringFormatter.decimal
     }${numberStringFormatter.numberFormatter.format(9)}`;
+    const expectedFormattedValue = "-۱۲٬۳۴۵٬۶۷۸٫۹";
 
-    expect(number.format(numberStringFormatter)).toBe("-۱۲٬۳۴۵٬۶۷۸٫۹");
+    expect(number.format(numberStringFormatter)).toBe(expectedFormattedValue);
+    expect(numberStringFormatter.localize(testValue)).toBe(expectedFormattedValue);
     expect(number.formatToParts(numberStringFormatter)).toEqual([
       { type: "minusSign", value: "-" },
       { type: "integer", value: "۱۲" },
@@ -162,12 +166,13 @@ describe("BigDecimal", () => {
       { type: "fraction", value: "9" },
     ]);
     expect(number.format(numberStringFormatter, true)).toBe(expectedValue);
+    expect(numberStringFormatter.localize(testValue, true)).toBe(expectedValue);
     expect(number.formatToParts(numberStringFormatter, true)).toEqual([
       ...expectedIntegerParts,
       { type: "decimal", value: numberStringFormatter.decimal },
       { type: "fraction", value: "9" },
     ]);
-    expect(numberStringFormatter.delocalize(number.format(numberStringFormatter, true))).toBe("-12345678.9");
+    expect(numberStringFormatter.delocalize(number.format(numberStringFormatter, true))).toBe(testValue);
   });
 
   supportedNlsLocales.forEach((locale) => {
@@ -179,7 +184,7 @@ describe("BigDecimal", () => {
         useGrouping: true,
       };
 
-      const parts = new BigDecimal("-12345678.9").formatToParts(numberStringFormatter);
+      const parts = new BigDecimal(testValue).formatToParts(numberStringFormatter);
       const groupPart = parts.find((part) => part.type === "group")!.value;
       expect(groupPart.trim().length === 0 || groupPart === " " ? "\u00A0" : groupPart).toBe(
         numberStringFormatter.group,

--- a/packages/components/src/utils/number.browser.spec.ts
+++ b/packages/components/src/utils/number.browser.spec.ts
@@ -137,7 +137,7 @@ describe("BigDecimal", () => {
     expect(new BigDecimal("123.0123456789").format(numberStringFormatter)).toBe("123.0123456789");
   });
 
-  it("preserves bidirectional marks when formatting negative arabext numbers", () => {
+  it("includes bidirectional marks for read-only formatting", () => {
     numberStringFormatter.numberFormatOptions = {
       locale: "en",
       numberingSystem: "arabext",
@@ -150,13 +150,24 @@ describe("BigDecimal", () => {
       numberStringFormatter.decimal
     }${numberStringFormatter.numberFormatter.format(9)}`;
 
-    expect(number.format(numberStringFormatter)).toBe(expectedValue);
+    expect(number.format(numberStringFormatter)).toBe("-۱۲٬۳۴۵٬۶۷۸٫۹");
     expect(number.formatToParts(numberStringFormatter)).toEqual([
+      { type: "minusSign", value: "-" },
+      { type: "integer", value: "۱۲" },
+      { type: "group", value: "٬" },
+      { type: "integer", value: "۳۴۵" },
+      { type: "group", value: "٬" },
+      { type: "integer", value: "۶۷۸" },
+      { type: "decimal", value: numberStringFormatter.decimal },
+      { type: "fraction", value: "9" },
+    ]);
+    expect(number.format(numberStringFormatter, true)).toBe(expectedValue);
+    expect(number.formatToParts(numberStringFormatter, true)).toEqual([
       ...expectedIntegerParts,
       { type: "decimal", value: numberStringFormatter.decimal },
       { type: "fraction", value: "9" },
     ]);
-    expect(numberStringFormatter.delocalize(number.format(numberStringFormatter))).toBe("-12345678.9");
+    expect(numberStringFormatter.delocalize(number.format(numberStringFormatter, true))).toBe("-12345678.9");
   });
 
   supportedNlsLocales.forEach((locale) => {

--- a/packages/components/src/utils/number.ts
+++ b/packages/components/src/utils/number.ts
@@ -55,11 +55,7 @@ export class BigDecimal {
 
   formatToParts(formatter: NumberStringFormat): Intl.NumberFormatPart[] {
     const { integers, decimals } = this.getIntegersAndDecimals();
-    const parts = formatter.numberFormatter.formatToParts(BigInt(integers));
-
-    if (this.isNegative) {
-      parts.unshift({ type: "minusSign", value: formatter.minusSign });
-    }
+    const parts = formatter.numberFormatter.formatToParts(BigInt(`${this.isNegative ? "-" : ""}${integers}`));
 
     if (decimals.length) {
       parts.push({ type: "decimal", value: formatter.decimal });
@@ -71,9 +67,10 @@ export class BigDecimal {
 
   format(formatter: NumberStringFormat): string {
     const { integers, decimals } = this.getIntegersAndDecimals();
-    const integersFormatted = `${this.isNegative ? formatter.minusSign : ""}${formatter.numberFormatter.format(
-      BigInt(integers),
-    )}`;
+    const integersFormatted = formatter.numberFormatter
+      .formatToParts(BigInt(`${this.isNegative ? "-" : ""}${integers}`))
+      .map((part) => part.value)
+      .join("");
     const decimalsFormatted = decimals.length
       ? `${formatter.decimal}${decimals
           .split("")

--- a/packages/components/src/utils/number.ts
+++ b/packages/components/src/utils/number.ts
@@ -53,9 +53,9 @@ export class BigDecimal {
     return `${this.isNegative ? "-" : ""}${integers}${decimals.length ? "." + decimals : ""}`;
   }
 
-  formatToParts(formatter: NumberStringFormat): Intl.NumberFormatPart[] {
+  formatToParts(formatter: NumberStringFormat, includeDirectionalMarks = false): Intl.NumberFormatPart[] {
     const { integers, decimals } = this.getIntegersAndDecimals();
-    const parts = formatter.numberFormatter.formatToParts(BigInt(`${this.isNegative ? "-" : ""}${integers}`));
+    const parts = getLocalizedIntegerParts(formatter, integers, this.isNegative, includeDirectionalMarks);
 
     if (decimals.length) {
       parts.push({ type: "decimal", value: formatter.decimal });
@@ -65,10 +65,9 @@ export class BigDecimal {
     return parts;
   }
 
-  format(formatter: NumberStringFormat): string {
+  format(formatter: NumberStringFormat, includeDirectionalMarks = false): string {
     const { integers, decimals } = this.getIntegersAndDecimals();
-    const integersFormatted = formatter.numberFormatter
-      .formatToParts(BigInt(`${this.isNegative ? "-" : ""}${integers}`))
+    const integersFormatted = getLocalizedIntegerParts(formatter, integers, this.isNegative, includeDirectionalMarks)
       .map((part) => part.value)
       .join("");
     const decimalsFormatted = decimals.length
@@ -95,6 +94,23 @@ export class BigDecimal {
   divide(n: string): BigDecimal {
     return BigDecimal._divRound(this.value * BigDecimal.SHIFT, new BigDecimal(n).value);
   }
+}
+
+function getLocalizedIntegerParts(
+  formatter: NumberStringFormat,
+  integers: string,
+  isNegative: boolean,
+  includeDirectionalMarks: boolean,
+): Intl.NumberFormatPart[] {
+  const parts = formatter.numberFormatter.formatToParts(
+    BigInt(`${includeDirectionalMarks && isNegative ? "-" : ""}${integers}`),
+  );
+
+  if (isNegative && !includeDirectionalMarks) {
+    parts.unshift({ type: "minusSign", value: formatter.minusSign });
+  }
+
+  return parts;
 }
 
 export function isValidNumber(numberString?: string | null): boolean {

--- a/packages/components/src/utils/number.ts
+++ b/packages/components/src/utils/number.ts
@@ -53,6 +53,12 @@ export class BigDecimal {
     return `${this.isNegative ? "-" : ""}${integers}${decimals.length ? "." + decimals : ""}`;
   }
 
+  /**
+   * Formats the number into localized parts.
+   *
+   * @param formatter - number formatter instance to localize the number value.
+   * @param includeDirectionalMarks - when true, preserves `Intl.NumberFormat` directional marks for read-only display.
+   */
   formatToParts(formatter: NumberStringFormat, includeDirectionalMarks = false): Intl.NumberFormatPart[] {
     const { integers, decimals } = this.getIntegersAndDecimals();
     const parts = getLocalizedIntegerParts(formatter, integers, this.isNegative, includeDirectionalMarks);
@@ -65,6 +71,12 @@ export class BigDecimal {
     return parts;
   }
 
+  /**
+   * Formats the number as a localized string.
+   *
+   * @param formatter - number formatter instance to localize the number value.
+   * @param includeDirectionalMarks - when true, preserves `Intl.NumberFormat` directional marks for read-only display.
+   */
   format(formatter: NumberStringFormat, includeDirectionalMarks = false): string {
     const { integers, decimals } = this.getIntegersAndDecimals();
     const integersFormatted = getLocalizedIntegerParts(formatter, integers, this.isNegative, includeDirectionalMarks)
@@ -96,6 +108,18 @@ export class BigDecimal {
   }
 }
 
+/**
+ * Gets localized integer parts while preserving the editable formatting path by default.
+ *
+ * When `includeDirectionalMarks` is true, the sign is included in the value formatted by `Intl.NumberFormat` so any
+ * directional marks emitted by the browser are preserved. Otherwise, the integer is formatted without a sign and the
+ * localized minus sign is prepended manually.
+ *
+ * @param formatter - number formatter instance to localize the integer value.
+ * @param integers - absolute integer string to format.
+ * @param isNegative - whether the formatted number should include a minus sign.
+ * @param includeDirectionalMarks - when true, preserves `Intl.NumberFormat` directional marks for read-only display.
+ */
 function getLocalizedIntegerParts(
   formatter: NumberStringFormat,
   integers: string,


### PR DESCRIPTION
Related issue(s): #3167 

Fixes negative sign direction when specifying `numbering-system="arab"`. 

**Note**: This also adds an option to number formatting utils for preserving the negative sign.
