### PR TITLE
fix(dropdown): restore dropdown item context for screen readers

### DIFF
--- a/packages/components/src/components/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown-item/dropdown-item.scss
@@ -112,7 +112,7 @@
 
 //focus
 :host(:focus),
-:host([active-descendant]) {
+:host([active]) {
   .container {
     @apply focus-inset no-underline;
   }

--- a/packages/components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.tsx
@@ -62,7 +62,7 @@ export class DropdownItem extends LitElement {
    *
    * @private
    */
-  @property({ reflect: true }) activeDescendant = false;
+  @property({ reflect: true }) active = false;
 
   /**
    * Specifies the URL of the linked resource, which can be set as an absolute or relative path.

--- a/packages/components/src/components/dropdown/assets/t9n/messages.en.json
+++ b/packages/components/src/components/dropdown/assets/t9n/messages.en.json
@@ -1,0 +1,11 @@
+{
+  "item": "{label}, {role}, {position} of {total}",
+  "itemWithState": "{label}, {role}, {state}, {position} of {total}",
+  "group": "{group}, {item}",
+  "menuItem": "menu item",
+  "menuItemCheckbox": "menu item checkbox",
+  "menuItemRadio": "menu item radio",
+  "link": "link",
+  "checked": "checked",
+  "unchecked": "unchecked"
+}

--- a/packages/components/src/components/dropdown/assets/t9n/messages.json
+++ b/packages/components/src/components/dropdown/assets/t9n/messages.json
@@ -1,0 +1,11 @@
+{
+  "item": "{label}, {role}, {position} of {total}",
+  "itemWithState": "{label}, {role}, {state}, {position} of {total}",
+  "group": "{group}, {item}",
+  "menuItem": "menu item",
+  "menuItemCheckbox": "menu item checkbox",
+  "menuItemRadio": "menu item radio",
+  "link": "link",
+  "checked": "checked",
+  "unchecked": "unchecked"
+}

--- a/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
+++ b/packages/components/src/components/dropdown/dropdown.browser.e2e.tsx
@@ -2,7 +2,6 @@ import { Fragment, h, JsxNode } from "@arcgis/lumina";
 import { mount } from "@arcgis/lumina-compiler/testing";
 import { describe, expect, it } from "vitest";
 import { page, userEvent } from "vitest/browser";
-import { isDropdownGroup } from "../dropdown-group/resources";
 import {
   accessible,
   defaults,
@@ -14,10 +13,12 @@ import {
   reflects,
   renders,
   scalePropagates,
+  t9n,
   themed,
   topLayer,
 } from "../../tests/common";
 import { mockConsole } from "../../tests/utils/logging";
+import type { DropdownItem } from "../dropdown-item/dropdown-item";
 import { CSS } from "./resources";
 import type { Dropdown } from "./dropdown";
 import { afterNextFrame } from "../../tests/utils/timing";
@@ -121,8 +122,12 @@ function renderDropdownWithGroupTitle(): JsxNode {
     <calcite-dropdown>
       <calcite-button slot="trigger">Open dropdown</calcite-button>
       <calcite-dropdown-group group-title="Group one" id="group-1">
-        <calcite-dropdown-item id="grouped-item-1">Dropdown Item Content</calcite-dropdown-item>
-        <calcite-dropdown-item id="grouped-item-2">Dropdown Item Content</calcite-dropdown-item>
+        <calcite-dropdown-item id="grouped-item-1">
+          First <span hidden>Hidden</span> Item
+        </calcite-dropdown-item>
+        <calcite-dropdown-item id="grouped-item-2" label="Second Item Label">
+          Ignored Item Content
+        </calcite-dropdown-item>
       </calcite-dropdown-group>
     </calcite-dropdown>
   );
@@ -132,9 +137,12 @@ function renderReferenceElementDropdownWithGroupTitle(): JsxNode {
   return (
     <>
       <calcite-dropdown reference-element="trigger">
-        <calcite-dropdown-group group-title="Group one" id="group-1">
-          <calcite-dropdown-item id="grouped-item-1">Dropdown Item Content</calcite-dropdown-item>
-          <calcite-dropdown-item id="grouped-item-2">Dropdown Item Content</calcite-dropdown-item>
+        <calcite-dropdown-group group-title="Group one" id="group-1" selection-mode="multiple">
+          <calcite-dropdown-item id="grouped-item-1" selected>
+            Repeated Item
+          </calcite-dropdown-item>
+          <calcite-dropdown-item id="grouped-item-2">Repeated Item</calcite-dropdown-item>
+          <calcite-dropdown-item id="grouped-item-3">Last Item</calcite-dropdown-item>
         </calcite-dropdown-group>
       </calcite-dropdown>
       <calcite-button id="trigger">Open dropdown</calcite-button>
@@ -192,6 +200,10 @@ describe("accessible", () => {
 
 describe("accessible reference element", () => {
   accessible(() => mount(renderReferenceElementDropdown));
+});
+
+describe("translation support", () => {
+  t9n(() => mount("calcite-dropdown"));
 });
 
 describe("focusable", () => {
@@ -327,192 +339,91 @@ describe("hover type", () => {
   });
 });
 
-describe("ariaActiveDescendantElement", () => {
-  function getSlottedTriggerLocator(): ReturnType<typeof page.elementLocator> {
-    const internalButton = page.getByRole("button", { name: "Open dropdown" }).element();
-    const triggerHost = (internalButton?.getRootNode() as ShadowRoot | null)?.host;
+describe("assistive text", () => {
+  it("announces localized item context in slotted-trigger mode", async () => {
+    await mount<Dropdown>(renderDropdownWithGroupTitle);
+    const trigger = page.getBySelector('calcite-button[slot="trigger"]');
+    const status = page.getByRole("status");
 
-    expect(triggerHost).toBeTruthy();
-
-    return page.elementLocator(triggerHost!);
-  }
-
-  function getSlottedTriggerElement(): HTMLElement | null {
-    return getSlottedTriggerLocator().element() as HTMLElement | null;
-  }
-
-  function getTriggerSlotElement(): HTMLSlotElement | null {
-    return getSlottedTriggerElement()?.assignedSlot as HTMLSlotElement | null;
-  }
-
-  function getTriggerSlotActiveDescendantId(): string | undefined {
-    return getTriggerSlotElement()?.ariaActiveDescendantElement?.id;
-  }
-
-  it("sets ariaActiveDescendantElement on the trigger slot when opened", async () => {
-    await mount<Dropdown>(renderDropdown);
-    const trigger = page.getByText("Open dropdown");
+    await expect.element(status).toHaveAttribute("aria-atomic", "true");
+    await expect.element(status).toHaveAttribute("aria-live", "polite");
+    await expect.element(status).toHaveTextContent("");
 
     await userEvent.click(trigger);
 
-    expect(getTriggerSlotActiveDescendantId()).toBe("item-1");
+    await expect
+      .element(status)
+      .toHaveTextContent(/^Group one, First Item, menu item radio, unchecked, 1 of 2$/);
+    await expect.element(trigger).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+
+    await expect
+      .element(status)
+      .toHaveTextContent(/^Group one, Second Item Label, menu item radio, unchecked, 2 of 2$/);
   });
 
-  it("updates ariaActiveDescendantElement on keyboard navigation", async () => {
-    await mount<Dropdown>(renderDropdown);
-    const trigger = page.getByText("Open dropdown");
-
-    await userEvent.click(trigger);
-
-    const triggerEl = getSlottedTriggerLocator();
-    await userEvent.type(triggerEl, "{ArrowDown}");
-
-    expect(getTriggerSlotActiveDescendantId()).toBe("item-2");
-  });
-
-  it("wraps ariaActiveDescendantElement on ArrowUp navigation", async () => {
-    await mount<Dropdown>(renderDropdown);
-    const trigger = page.getByText("Open dropdown");
-
-    await userEvent.click(trigger);
-
-    const triggerEl = getSlottedTriggerLocator();
-    await userEvent.type(triggerEl, "{ArrowUp}");
-
-    let activeDescendantId = getTriggerSlotActiveDescendantId();
-
-    expect(activeDescendantId).toBe("item-3");
-
-    await userEvent.type(triggerEl, "{ArrowUp}");
-
-    activeDescendantId = getTriggerSlotActiveDescendantId();
-
-    expect(activeDescendantId).toBe("item-2");
-  });
-
-  it("sets ariaActiveDescendantElement on the referenceElement trigger", async () => {
-    await mount<Dropdown>(renderReferenceElementDropdown);
+  it("announces state and only the latest item during rapid reference-element navigation", async () => {
+    await mount<Dropdown>(renderReferenceElementDropdownWithGroupTitle);
     const trigger = page.getBySelector("#trigger");
+    const status = page.getByRole("status");
 
     await userEvent.click(trigger);
 
-    expect((trigger.element() as HTMLElement | null)?.ariaActiveDescendantElement?.id).toBe(
-      "item-1",
-    );
+    await expect
+      .element(status)
+      .toHaveTextContent(/^Group one, Repeated Item, menu item checkbox, checked, 1 of 3$/);
+    await expect.element(trigger).toHaveFocus();
 
-    await userEvent.type(trigger, "{ArrowDown}");
-
-    expect((trigger.element() as HTMLElement | null)?.ariaActiveDescendantElement?.id).toBe(
-      "item-2",
+    const announcements: string[] = [];
+    const observer = new MutationObserver(() =>
+      announcements.push(status.element().textContent ?? ""),
     );
+    observer.observe(status.element(), { childList: true, subtree: true });
+
+    await userEvent.keyboard("{Home}");
+
+    await expect.poll(() => announcements).toContain("");
+    await expect
+      .element(status)
+      .toHaveTextContent(/^Group one, Repeated Item, menu item checkbox, checked, 1 of 3$/);
+    observer.disconnect();
+
+    await userEvent.keyboard("{ArrowDown}{ArrowDown}");
+
+    await expect
+      .element(status)
+      .toHaveTextContent(/^Group one, Last Item, menu item checkbox, unchecked, 3 of 3$/);
   });
 
-  it("sets ariaActiveDescendantElement on focused trigger slot node when multiple trigger nodes exist", async () => {
-    await mount<Dropdown>(
-      <calcite-dropdown>
-        <span id="trigger-label" slot="trigger">
-          Label
-        </span>
-        <calcite-button id="trigger-button" slot="trigger">
-          Open dropdown
-        </calcite-button>
-        <calcite-dropdown-group>
-          <calcite-dropdown-item id="item-1">Dropdown Item Content</calcite-dropdown-item>
-          <calcite-dropdown-item id="item-2">Dropdown Item Content</calcite-dropdown-item>
+  it("announces only while the trigger is focused and clears when closed", async () => {
+    const { el } = await mount<Dropdown>(
+      <calcite-dropdown type="hover">
+        <calcite-button slot="trigger">Open dropdown</calcite-button>
+        <calcite-dropdown-group group-title="Plain Item" selection-mode="none">
+          <calcite-dropdown-item id="item-1">Plain Item</calcite-dropdown-item>
+          <calcite-dropdown-item href="https://example.com" id="item-2">
+            Linked Item
+          </calcite-dropdown-item>
         </calcite-dropdown-group>
       </calcite-dropdown>,
     );
+    const trigger = page.getBySelector('calcite-button[slot="trigger"]');
+    const status = page.getByRole("status");
 
-    const triggerButton = page.getBySelector("#trigger-button");
-    const triggerLabel = page.getBySelector("#trigger-label");
-
-    await userEvent.click(triggerButton);
-
-    expect(getTriggerSlotActiveDescendantId()).toBe("item-1");
-    expect((triggerButton.element() as HTMLElement | null)?.ariaActiveDescendantElement).toBeNull();
-    expect((triggerLabel.element() as HTMLElement | null)?.ariaActiveDescendantElement).toBeNull();
-  });
-
-  it("associates grouped items with their title in slotted-trigger mode", async () => {
-    await mount<Dropdown>(renderDropdownWithGroupTitle);
-    const trigger = page.getByText("Open dropdown");
+    await userEvent.hover(trigger);
+    expect(el.open).toBe(true);
+    await expect.element(status).toHaveTextContent("");
 
     await userEvent.click(trigger);
+    await userEvent.keyboard("{Home}");
+    await expect.element(status).toHaveTextContent(/^Plain Item, menu item, 1 of 2$/);
 
-    const activeItem = page.getBySelector("#grouped-item-1").element() as HTMLElement | null;
-    const groupDescription = activeItem?.ariaDescribedByElements?.find(isDropdownGroup);
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.element(status).toHaveTextContent(/^Plain Item, Linked Item, link, 2 of 2$/);
 
-    expect(groupDescription?.getAttribute("aria-label")).toBe("Group one");
-  });
-
-  it("associates grouped items with their title in reference-element mode", async () => {
-    await mount<Dropdown>(renderReferenceElementDropdownWithGroupTitle);
-    const trigger = page.getBySelector("#trigger");
-
-    await userEvent.click(trigger);
-
-    const activeItem = page.getBySelector("#grouped-item-1").element() as HTMLElement | null;
-    const groupDescription = activeItem?.ariaDescribedByElements?.find(isDropdownGroup);
-
-    expect(groupDescription?.getAttribute("aria-label")).toBe("Group one");
-  });
-
-  it("keeps focus on the referenceElement trigger when opened", async () => {
-    await mount<Dropdown>(renderReferenceElementDropdown);
-    const trigger = page.getBySelector("#trigger");
-
-    await userEvent.click(trigger);
-
-    await expect.element(trigger).toHaveFocus();
-  });
-
-  it("clears ariaActiveDescendantElement from the referenceElement trigger when dropdown disconnects", async () => {
-    const { el } = await mount<Dropdown>(renderReferenceElementDropdown);
-    const trigger = page.getBySelector("#trigger");
-
-    await userEvent.click(trigger);
-
-    expect((trigger.element() as HTMLElement | null)?.ariaActiveDescendantElement?.id).toBe(
-      "item-1",
-    );
-
-    el.remove();
-
-    expect((trigger.element() as HTMLElement | null)?.ariaActiveDescendantElement).toBeNull();
-  });
-
-  it("moves ariaActiveDescendantElement to the new referenceElement while open", async () => {
-    const { el } = await mount<Dropdown>(
-      <>
-        <calcite-dropdown reference-element="trigger-one">
-          <calcite-dropdown-group>
-            <calcite-dropdown-item id="item-1">Dropdown Item Content</calcite-dropdown-item>
-            <calcite-dropdown-item id="item-2">Dropdown Item Content</calcite-dropdown-item>
-          </calcite-dropdown-group>
-        </calcite-dropdown>
-        <calcite-button id="trigger-one">Open dropdown one</calcite-button>
-        <calcite-button id="trigger-two">Open dropdown two</calcite-button>
-      </>,
-    );
-
-    const triggerOne = page.getBySelector("#trigger-one");
-    const triggerTwo = page.getBySelector("#trigger-two");
-    const component = el.manager.component;
-
-    await userEvent.click(triggerOne);
-
-    expect((triggerOne.element() as HTMLElement | null)?.ariaActiveDescendantElement?.id).toBe(
-      "item-1",
-    );
-
-    const updateComplete = component.updateComplete;
-    el.referenceElement = "trigger-two";
-    await waitForSettledUpdate(component, updateComplete);
-
-    expect((triggerOne.element() as HTMLElement | null)?.ariaActiveDescendantElement).toBeNull();
-    expect((triggerTwo.element() as HTMLElement | null)?.ariaActiveDescendantElement?.id).toBe(
-      "item-1",
-    );
+    el.open = false;
+    await expect.element(status).toHaveTextContent("");
   });
 });
 
@@ -767,30 +678,15 @@ describe("keyboard navigation", () => {
   const defaultItemIds = ["item-1", "item-2", "item-3"];
   const disabledAndHiddenItemIds = ["item-1", "item-1.5", "item-2", "item-2.5", "item-3", "item-4"];
 
-  const dropdownItemTextById: Record<string, string> = {
-    "item-1": "1",
-    "item-1.5": "1.5",
-    "item-2": "2",
-    "item-2.5": "2.5",
-    "item-3": "3",
-    "item-4": "4",
-  };
-
   function getDropdownItemLocator(itemId: string): ReturnType<typeof page.elementLocator> {
-    const itemText = dropdownItemTextById[itemId];
-    const itemContent = getDropdownLocator().getByText(itemText, { exact: true }).element();
-    const item = itemContent?.closest("calcite-dropdown-item");
-
-    expect(item).toBeTruthy();
-
-    return page.elementLocator(item!);
+    return getDropdownLocator().getBySelector(`[id="${itemId}"]`);
   }
 
   function getActiveItemId(itemIds: string[]): string {
     const activeItemId = itemIds.find((itemId) => {
       const item = getDropdownItemLocator(itemId);
 
-      return (item.element() as HTMLElement & { activeDescendant?: boolean }).activeDescendant;
+      return (item.element() as DropdownItem["el"]).active;
     });
 
     expect(activeItemId).toBeTruthy();
@@ -1023,13 +919,13 @@ describe("scrolling", () => {
         </calcite-dropdown-group>
       </calcite-dropdown>,
     );
-    const triggerSlot = page.getBySelector("calcite-dropdown slot[name='trigger']");
+    const status = page.getByRole("status");
     const focusedItem = page.getBySelector("#item-50");
 
     await userEvent.tab();
     await userEvent.keyboard("{ArrowUp}");
 
-    await expect.element(triggerSlot).toHaveProperty("ariaActiveDescendantElement.id", "item-50");
+    await expect.element(status).toHaveTextContent("50");
     await expect.element(focusedItem).toBeInViewport();
   });
 

--- a/packages/components/src/components/dropdown/dropdown.e2e.ts
+++ b/packages/components/src/components/dropdown/dropdown.e2e.ts
@@ -411,13 +411,7 @@ it("should focus the first item on open when there is no selected item", async (
   const openEventSpy = await page.spyOnEvent("calciteDropdownOpen");
   await element.click();
   await openEventSpy.next();
-  expect(
-    await page.evaluate(
-      () =>
-        document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-          .ariaActiveDescendantElement?.id,
-    ),
-  ).toEqual("item-1");
+  expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toEqual("item-1");
 });
 
 it("should focus the first item on open when an item is selected", async () => {
@@ -438,13 +432,7 @@ it("should focus the first item on open when an item is selected", async () => {
   await element.click();
   await dropdownOpenEventSpy.next();
 
-  expect(
-    await page.evaluate(
-      () =>
-        document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-          .ariaActiveDescendantElement?.id,
-    ),
-  ).toEqual("item-1");
+  expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toEqual("item-1");
 });
 
 it("should focus the first item on open (multi) when items are selected", async () => {
@@ -465,13 +453,7 @@ it("should focus the first item on open (multi) when items are selected", async 
   await element.click();
   await dropdownOpenEventSpy.next();
 
-  expect(
-    await page.evaluate(
-      () =>
-        document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-          .ariaActiveDescendantElement?.id,
-    ),
-  ).toEqual("item-1");
+  expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toEqual("item-1");
 });
 
 it("closes when a selection is made", async () => {
@@ -730,13 +712,7 @@ describe("Focus order with Tab key", () => {
     expect(await dropdownWrapper.isVisible()).toBe(true);
     expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
     expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     const closeEventSpy = await page.spyOnEvent("calciteDropdownClose");
     await element.press("Tab");
@@ -777,13 +753,7 @@ describe("Focus order with Tab key", () => {
     expect(await dropdownWrapper.isVisible()).toBe(true);
     expect(calciteDropdownOpen).toHaveReceivedEventTimes(1);
     expect(calciteDropdownClose).toHaveReceivedEventTimes(0);
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     const closeEventSpy = await page.spyOnEvent("calciteDropdownClose");
     await page.keyboard.down("Shift");
@@ -1014,90 +984,42 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     await openEventSpy.next();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
   });
 
   it("skips disabled and hidden items when navigating with arrow keys", async () => {
@@ -1126,68 +1048,32 @@ describe("keyboard navigation", () => {
     await page.waitForChanges();
     await openEventSpy.next();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
 
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
   });
 
   it("should open the dropdown and focus the first item with ArrowDown", async () => {
@@ -1214,33 +1100,15 @@ describe("keyboard navigation", () => {
     await openEventSpy.next();
 
     expect(await dropdown.getProperty("open")).toBe(true);
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
   });
 
   it("should open the dropdown and focus the last item with ArrowUp when no item is selected", async () => {
@@ -1267,33 +1135,15 @@ describe("keyboard navigation", () => {
     await openEventSpy.next();
 
     expect(await dropdown.getProperty("open")).toBe(true);
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-1");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-1");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
   });
 
   it("should open the dropdown and focus the last item with ArrowUp", async () => {
@@ -1320,32 +1170,14 @@ describe("keyboard navigation", () => {
     await openEventSpy.next();
 
     expect(await dropdown.getProperty("open")).toBe(true);
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
 
     await page.keyboard.press("ArrowUp");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-2");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-2");
 
     await page.keyboard.press("ArrowDown");
     await page.waitForChanges();
-    expect(
-      await page.evaluate(
-        () =>
-          document.querySelector("calcite-dropdown")!.shadowRoot!.querySelector("slot[name='trigger']")!
-            .ariaActiveDescendantElement?.id,
-      ),
-    ).toBe("item-3");
+    expect(await page.evaluate(() => document.querySelector("calcite-dropdown-item[active]")?.id)).toBe("item-3");
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -59,6 +59,10 @@ declare global {
 
 const manager = referenceElementManager({ click: true, hover: true });
 
+function replacePlaceholders(template: string, replacements: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => replacements[key] ?? match);
+}
+
 /**
  * @slot - A slot for adding `calcite-dropdown-group` elements. Every `calcite-dropdown-item` must have a parent `calcite-dropdown-group`, even if the `groupTitle` property is not set.
  * @slot trigger - [deprecated] in v5.1.0, removal target v7.0.0 - Use the `referenceElement` property instead. A slot for the element that triggers the component.
@@ -128,8 +132,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   //#endregion
 
   //#region State Properties
-
-  @state() activeItemElement?: DropdownItem["el"];
 
   @state() assistiveText = "";
 
@@ -716,7 +718,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
       item.active = item === activeItem;
     });
 
-    this.activeItemElement = activeItem ?? undefined;
     void this.updateAssistiveText(activeItem);
   }
 
@@ -724,59 +725,59 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
     const updateId = ++this.assistiveTextUpdateId;
     this.assistiveText = "";
 
-    if (
-      !activeItem ||
-      !this.open ||
-      !(this.referenceEl instanceof HTMLElement) ||
-      !this.referenceEl.matches(":focus-within")
-    ) {
+    if (!activeItem || !this.canUpdateAssistiveText()) {
       return;
     }
 
-    await nextFrame();
+    await this.updateComplete;
 
-    if (
-      !this.open ||
-      this.activeItemElement !== activeItem ||
-      updateId !== this.assistiveTextUpdateId ||
-      !this.referenceEl.matches(":focus-within") ||
-      this.messages._loading
-    ) {
+    if (updateId !== this.assistiveTextUpdateId || !this.canUpdateAssistiveText()) {
       return;
     }
 
+    this.assistiveText = this.getAssistiveText(activeItem);
+  }
+
+  private canUpdateAssistiveText(): boolean {
+    return (
+      this.open &&
+      this.referenceEl instanceof HTMLElement &&
+      this.referenceEl.matches(":focus-within") &&
+      !this.messages._loading
+    );
+  }
+
+  private getAssistiveText(activeItem: DropdownItem["el"]): string {
     const { messages } = this;
     const group = activeItem.closest("calcite-dropdown-group");
     const itemLabel = (activeItem.label ?? activeItem.innerText).replaceAll(/\s+/g, " ").trim();
     const traversableItems = this.getTraversableItems();
     const position = traversableItems.indexOf(activeItem) + 1;
     const total = traversableItems.length;
+    const roleBySelectionMode = {
+      multiple: messages.menuItemCheckbox,
+      none: messages.menuItem,
+      single: messages.menuItemRadio,
+    };
 
     numberStringFormatter.numberFormatOptions = { locale: messages._lang };
 
-    const role = activeItem.href
-      ? messages.link
-      : activeItem.selectionMode === "single"
-        ? messages.menuItemRadio
-        : activeItem.selectionMode === "multiple"
-          ? messages.menuItemCheckbox
-          : messages.menuItem;
     const itemTemplate =
       activeItem.selectionMode === "none" || activeItem.href
         ? messages.item
         : messages.itemWithState;
-    const itemAnnouncement = itemTemplate
-      .replace("{label}", itemLabel)
-      .replace("{role}", role)
-      .replace("{state}", activeItem.selected ? messages.checked : messages.unchecked)
-      .replace("{position}", numberStringFormatter.localize(position.toString()))
-      .replace("{total}", numberStringFormatter.localize(total.toString()));
+    const itemAnnouncement = replacePlaceholders(itemTemplate, {
+      label: itemLabel,
+      position: numberStringFormatter.localize(position.toString()),
+      role: activeItem.href ? messages.link : roleBySelectionMode[activeItem.selectionMode],
+      state: activeItem.selected ? messages.checked : messages.unchecked,
+      total: numberStringFormatter.localize(total.toString()),
+    });
     const groupTitle = group?.groupTitle?.trim();
 
-    this.assistiveText =
-      groupTitle && groupTitle !== itemLabel
-        ? messages.group.replace("{group}", groupTitle).replace("{item}", itemAnnouncement)
-        : itemAnnouncement;
+    return groupTitle && groupTitle !== itemLabel
+      ? replacePlaceholders(messages.group, { group: groupTitle, item: itemAnnouncement })
+      : itemAnnouncement;
   }
 
   private navigateActiveItem(direction: "next" | "previous" | "first" | "last"): void {
@@ -814,7 +815,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
     // ensure element is rendered/visible before focus or scrollIntoView
     // https://github.com/Esri/calcite-design-system/issues/10703 should help improve this
     await this.updateComplete;
-    await nextFrame();
     await nextFrame();
 
     target.scrollIntoView({ block: "nearest" });

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -1,5 +1,4 @@
 import { PropertyValues } from "lit";
-import { createRef } from "lit/directives/ref.js";
 import {
   createEvent,
   h,
@@ -44,8 +43,13 @@ import {
   useReferenceElement,
 } from "../../controllers/useReferenceElement";
 import { referenceElementManager } from "../../controllers/useReferenceElement/manager";
+import { useT9n } from "../../controllers/useT9n";
+import { numberStringFormatter } from "../../utils/locale";
+import { CSS_UTILITY } from "../../utils/resources";
+import T9nStrings from "./assets/t9n/messages.en.json";
 import { CSS, SLOTS } from "./resources";
 import { styles } from "./dropdown.scss";
+import { styles as screenReaderStyles } from "../../styles/component/screen-reader.scss";
 
 declare global {
   interface DeclareElements {
@@ -64,7 +68,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   static override shadowRootOptions = { mode: "open" as const, delegatesFocus: true };
 
-  static override styles = styles;
+  static override styles = [styles, screenReaderStyles];
 
   //#endregion
 
@@ -91,11 +95,15 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   private activeItemIndex = -1;
 
+  private assistiveTextUpdateId = 0;
+
   private groups: DropdownGroup["el"][] = [];
 
   private items: DropdownItem["el"][] = [];
 
   private mutationObserver = createObserver("mutation", () => this.updateItems());
+
+  messages = useT9n<typeof T9nStrings>({ blocking: true });
 
   transitionProp = "opacity" as const;
 
@@ -104,8 +112,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   );
 
   private scrollerEl?: HTMLDivElement;
-
-  private triggerSlotRef = createRef<HTMLSlotElement>();
 
   transitionEl: HTMLDivElement | undefined;
 
@@ -123,7 +129,9 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   //#region State Properties
 
-  @state() activeDescendantElement?: DropdownItem["el"];
+  @state() activeItemElement?: DropdownItem["el"];
+
+  @state() assistiveText = "";
 
   @state() referenceEl?: ReferenceElement;
 
@@ -149,6 +157,9 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
    * Value must be greater than `0`, and does not include `groupTitle`s from `calcite-dropdown-group`.
    */
   @property({ reflect: true }) maxItems = 0;
+
+  /** Use this property to override individual strings used by the component. */
+  @property() messageOverrides?: typeof this.messages._overrides;
 
   /**
    * Specifies the distance to position the component away from the `referenceElement`.
@@ -340,13 +351,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   override updated(changes: PropertyValues<this>): void {
     if (changes.has("referenceEl") && this.referenceElementType) {
-      const previousReferenceEl = changes.get("referenceEl");
-
-      if (previousReferenceEl instanceof HTMLElement) {
-        previousReferenceEl.ariaActiveDescendantElement = null;
-      }
-
-      this.syncActiveDescendantOwnerElement();
       connectFloatingUI(this);
     }
   }
@@ -357,16 +361,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   }
 
   override disconnectedCallback(): void {
-    const triggerSlotEl = this.triggerSlotRef.value;
-
-    if (triggerSlotEl) {
-      triggerSlotEl.ariaActiveDescendantElement = null;
-    }
-
-    if (this.referenceEl instanceof HTMLElement) {
-      this.referenceEl.ariaActiveDescendantElement = null;
-    }
-
     this.mutationObserver?.disconnect();
     this.resizeObserver?.disconnect();
     disconnectFloatingUI(this);
@@ -544,12 +538,13 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   }
 
   onBeforeClose(): void {
+    this.assistiveTextUpdateId++;
+    this.assistiveText = "";
     this.calciteDropdownBeforeClose.emit();
   }
 
   onClose(): void {
     this.calciteDropdownClose.emit();
-    this.syncActiveDescendantOwnerElement();
     hideFloatingUI(this);
     this.topLayer.hide();
   }
@@ -566,7 +561,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
     }
 
     this.referenceEl = el;
-    this.syncActiveDescendantOwnerElement();
 
     connectFloatingUI(this);
   }
@@ -574,10 +568,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
   private setFloatingEl(el: HTMLDivElement): void {
     this.floatingEl = el;
     connectFloatingUI(this);
-  }
-
-  private handleTriggerSlotChange(): void {
-    this.syncActiveDescendantOwnerElement();
   }
 
   private keyDownHandler(event: KeyboardEvent): void {
@@ -710,7 +700,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
       return;
     }
 
-    this.updateActiveDescendantElement(traversableItems[this.activeItemIndex]);
+    this.updateActiveItem(traversableItems[this.activeItemIndex]);
   }
 
   private setActiveItemByIndex(index: number): void {
@@ -718,34 +708,75 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
     const traversableItems = this.getTraversableItems();
     const activeItem = index >= 0 ? traversableItems[index] : null;
 
-    this.updateActiveDescendantElement(activeItem);
+    this.updateActiveItem(activeItem);
   }
 
-  private updateActiveDescendantElement(activeItem: DropdownItem["el"] | null): void {
+  private updateActiveItem(activeItem: DropdownItem["el"] | null): void {
     this.items.forEach((item) => {
-      item.activeDescendant = item === activeItem;
+      item.active = item === activeItem;
     });
 
-    this.activeDescendantElement = activeItem ?? undefined;
-    this.syncActiveDescendantOwnerElement();
+    this.activeItemElement = activeItem ?? undefined;
+    void this.updateAssistiveText(activeItem);
   }
 
-  private syncActiveDescendantOwnerElement(): void {
-    const { referenceEl, referenceElementType } = this;
-    const triggerSlotEl = this.triggerSlotRef.value;
-    const activeDescendantEl = this.open ? (this.activeDescendantElement ?? null) : null;
-    const referenceOwnerEl = referenceEl instanceof HTMLElement ? referenceEl : null;
-    const isReferenceMode = Boolean(referenceElementType);
+  private async updateAssistiveText(activeItem: DropdownItem["el"] | null): Promise<void> {
+    const updateId = ++this.assistiveTextUpdateId;
+    this.assistiveText = "";
 
-    if (triggerSlotEl) {
-      triggerSlotEl.ariaActiveDescendantElement = isReferenceMode ? null : activeDescendantEl;
-    }
-
-    if (!referenceOwnerEl) {
+    if (
+      !activeItem ||
+      !this.open ||
+      !(this.referenceEl instanceof HTMLElement) ||
+      !this.referenceEl.matches(":focus-within")
+    ) {
       return;
     }
 
-    referenceOwnerEl.ariaActiveDescendantElement = isReferenceMode ? activeDescendantEl : null;
+    await nextFrame();
+
+    if (
+      !this.open ||
+      this.activeItemElement !== activeItem ||
+      updateId !== this.assistiveTextUpdateId ||
+      !this.referenceEl.matches(":focus-within") ||
+      this.messages._loading
+    ) {
+      return;
+    }
+
+    const { messages } = this;
+    const group = activeItem.closest("calcite-dropdown-group");
+    const itemLabel = (activeItem.label ?? activeItem.innerText).replaceAll(/\s+/g, " ").trim();
+    const traversableItems = this.getTraversableItems();
+    const position = traversableItems.indexOf(activeItem) + 1;
+    const total = traversableItems.length;
+
+    numberStringFormatter.numberFormatOptions = { locale: messages._lang };
+
+    const role = activeItem.href
+      ? messages.link
+      : activeItem.selectionMode === "single"
+        ? messages.menuItemRadio
+        : activeItem.selectionMode === "multiple"
+          ? messages.menuItemCheckbox
+          : messages.menuItem;
+    const itemTemplate =
+      activeItem.selectionMode === "none" || activeItem.href
+        ? messages.item
+        : messages.itemWithState;
+    const itemAnnouncement = itemTemplate
+      .replace("{label}", itemLabel)
+      .replace("{role}", role)
+      .replace("{state}", activeItem.selected ? messages.checked : messages.unchecked)
+      .replace("{position}", numberStringFormatter.localize(position.toString()))
+      .replace("{total}", numberStringFormatter.localize(total.toString()));
+    const groupTitle = group?.groupTitle?.trim();
+
+    this.assistiveText =
+      groupTitle && groupTitle !== itemLabel
+        ? messages.group.replace("{group}", groupTitle).replace("{item}", itemAnnouncement)
+        : itemAnnouncement;
   }
 
   private navigateActiveItem(direction: "next" | "previous" | "first" | "last"): void {
@@ -839,6 +870,14 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
 
   //#region Rendering
 
+  private renderAssistiveText(): JsxNode {
+    return (
+      <div ariaAtomic="true" ariaLive="polite" class={CSS_UTILITY.screenReaderText} role="status">
+        {this.assistiveText}
+      </div>
+    );
+  }
+
   override render(): JsxNode {
     const { open } = this;
     return (
@@ -857,8 +896,6 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
               ariaExpanded={open}
               ariaHasPopup="menu"
               name={SLOTS.trigger}
-              onSlotChange={this.handleTriggerSlotChange}
-              ref={this.triggerSlotRef}
             />
           </div>
         ) : null}
@@ -888,6 +925,7 @@ export class Dropdown extends LitElement implements FloatingUIComponent, Referen
             <slot onSlotChange={this.updateGroups} />
           </div>
         </div>
+        {this.renderAssistiveText()}
       </this.interactiveContainer>
     );
   }

--- a/t9nmanifest.txt
+++ b/t9nmanifest.txt
@@ -16,6 +16,7 @@ packages\components\src\components\color-picker\assets\t9n
 packages\components\src\components\combobox\assets\t9n
 packages\components\src\components\date-picker\assets\t9n
 packages\components\src\components\dialog\assets\t9n
+packages\components\src\components\dropdown\assets\t9n
 packages\components\src\components\filter\assets\t9n
 packages\components\src\components\flow-item\assets\t9n
 packages\components\src\components\handle\assets\t9n


### PR DESCRIPTION
**Related Issue:** #14888

## Summary

Restores assistive context while keeping DOM focus on the dropdown trigger.

- Replaces the ineffective `ariaActiveDescendantElement` relationship with a polite live region.
- Announces the active item's label, role, checked state, position, and group title.
- Localizes announcement templates and numbers.
- Prevents announcements when the trigger does not own focus.
- Renames the internal visual state from `activeDescendant` to `active`.
- Updates browser and legacy tests for the new behavior.

## Background

`aria-activedescendant` was assigned to an unfocused slot or a focused button, neither of which can validly manage virtual focus for the separate menu. As a result, JAWS and NVDA did not receive item or group context.

Focus must remain on the trigger for the dropdown's single-component interaction model, so this change communicates navigation through a live region while preserving the existing menu structure and keyboard behavior.